### PR TITLE
Fix FObject property validation - Add null check

### DIFF
--- a/src/foam/core/AbstractFObjectPropertyInfo.java
+++ b/src/foam/core/AbstractFObjectPropertyInfo.java
@@ -123,7 +123,10 @@ public abstract class AbstractFObjectPropertyInfo
   @Override
   public void validateObj(X x, FObject obj) {
     if ( isSet(obj) ) {
-      ((FObject) get(obj)).validate(x);
+      var value = get(obj);
+      if ( value != null ) {
+        ((FObject) value).validate(x);
+      }
     }
   }
 


### PR DESCRIPTION
## Ref
- https://github.com/foam-framework/foam2/pull/5108

## Changes
- Add null check before validate call on the FObject.