### PR TITLE
Fix hierarchical spid context

### DIFF
--- a/src/foam/core/SubX.java
+++ b/src/foam/core/SubX.java
@@ -38,14 +38,20 @@ public class SubX extends ProxyX {
 
   @Override
   public X put(Object key, Object value) {
-    getX().put(key, value);
-    return this;
+    if ( getX() instanceof ProxyX ) {
+      getX().put(key, value);
+      return this;
+    }
+    return new SubX(root_, parent_).put(key, value);
   }
 
   @Override
   public X putFactory(Object key, XFactory factory) {
-    getX().putFactory(key, factory);
-    return this;
+    if ( getX() instanceof ProxyX ) {
+      getX().putFactory(key, factory);
+      return this;
+    }
+    return new SubX(root_, parent_).putFactory(key, factory);
   }
 
   @Override

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -323,7 +323,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         // Support hierarchical SPID context
         var subX = rtn.cd(user.getSpid());
         if ( subX != null ) {
-          rtn = subX;
+          rtn = reset(subX);
         }
         rtn = rtn
           .put("subject", subject)


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-3871
- https://github.com/foam-framework/foam2/pull/5037

## Issues
- bepay user cannot login due to 'bepay' subX is frozen and discards subsequent mutation

## Changes
- Create new subX when calling put/putFactory on a frozen subX to support session with hierarchical SPID context