### PR TITLE
System auth service update

### DIFF
--- a/src/foam/nanos/auth/SystemAuthService.js
+++ b/src/foam/nanos/auth/SystemAuthService.js
@@ -19,11 +19,9 @@ foam.CLASS({
       name: 'check',
       javaCode: `
         User user = ((Subject) x.get("subject")).getUser();
-        boolean isAdmin = user != null
-          && ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID
-          || "admin".equals(user.getGroup())
-          || "system".equals(user.getGroup()));
-        return isAdmin || getDelegate().check(x, permission);
+        Group group = (Group) x.get("group");
+        boolean isSystem = user != null && user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID;
+        return isSystem || group != null && group.implies(x, new AuthPermission("*")) || getDelegate().check(x, permission);
       `
     }
   ]


### PR DESCRIPTION
System auth service now applies short cut if context group applies "*" (All access) permission. 

This by passes the authorization check delegate cascade improving performance, avoiding unnecessary logic and allows for refined permission checks inside of other system authorization logic.