### PR TITLE
Fixed CSS bug for tableViews inside SectionedDetailView

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -17,6 +17,7 @@ foam.CLASS({
     ^ {
       /* Add for fixing UI issue in Safari */
       display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(0,1fr));
     }
 
     ^ m3 {


### PR DESCRIPTION
Fixes Table view without breaking(i think...tested the parts it broke before) other parts of SectionedDetailPropertyView

Old: 
![image](https://user-images.githubusercontent.com/81172969/114034581-4c4d4180-984c-11eb-9516-3b039eba8e52.png)

Fixed: 
<img width="1450" alt="image" src="https://user-images.githubusercontent.com/81172969/114093981-c0f2a100-9889-11eb-85e7-33bcf9c0f097.png">


