### PR TITLE
Make tab choice view not require translations by passing a default parameter

### DIFF
--- a/src/foam/u2/view/TabChoiceView.js
+++ b/src/foam/u2/view/TabChoiceView.js
@@ -82,7 +82,7 @@ foam.CLASS({
           start('label').
             attrs({for: id}).
             start('span').
-              translate(c[1]).
+              translate(c[1], c[1]).
             end().
           end();
       }.bind(this)));


### PR DESCRIPTION
That way the tab choice view is generic enough to be used without needing knowledge of translations + locales