### PR TITLE
detach wizard listeners after close

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -660,6 +660,7 @@ FOAM_FILES([
   { name: "foam/u2/crunch/wizardflow/ShowPreexistingAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/SaveAllAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/lite/CapableDefaultConfigAgent", flags: ['web'] },
+  { name: "foam/u2/crunch/wizardflow/DetachAgent", flags: ['web'] },
   { name: "foam/u2/crunch/CapabilityRequirementView", flags: ['web'] },
   { name: "foam/u2/crunch/CapabilityCardView", flags: ['web'] },
   { name: "foam/u2/crunch/CapabilityFeatureView", flags: ['web'] },

--- a/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
+++ b/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
@@ -32,7 +32,7 @@ foam.CLASS({
 
   methods: [
     function save(wizardlet) {
-      if ( wizardlet.loading ) return Promise.resolve();
+      // if ( wizardlet.loading ) return Promise.resolve(); // breaks creating a user - after general addmission
       if ( ! wizardlet.isAvailable ) return Promise.resolve();
       var wData = wizardlet.data ? wizardlet.data.clone() : null;
       wizardlet.loading = true;

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -45,6 +45,7 @@ foam.CLASS({
     'foam.u2.crunch.wizardflow.StepWizardAgent',
     'foam.u2.crunch.wizardflow.PutFinalJunctionsAgent',
     'foam.u2.crunch.wizardflow.PutFinalPayloadsAgent',
+    'foam.u2.crunch.wizardflow.DetachAgent',
     'foam.u2.crunch.wizardflow.TestAgent',
     'foam.u2.crunch.wizardflow.LoadTopConfig',
     'foam.u2.crunch.wizardflow.CapableDefaultConfigAgent',
@@ -113,6 +114,7 @@ foam.CLASS({
           .add(this.AutoSaveWizardletsAgent)
           .add(this.StepWizardAgent)
           .add(this.PutFinalPayloadsAgent)
+          .add(this.DetachAgent)
           // .add(this.TestAgent)
           ;
       }

--- a/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
+++ b/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
@@ -15,7 +15,8 @@ foam.CLASS({
 
   exports: [
     'pushView',
-    'popView'
+    'popView',
+    'wizardCloseSub'
   ],
 
   requires: [
@@ -23,6 +24,14 @@ foam.CLASS({
   ],
 
   properties: [
+    {
+      class: 'FObjectProperty',
+      name: 'wizardCloseSub',
+      of: 'foam.core.FObject',
+      factory: function() {
+        return foam.core.FObject.create();
+      }
+    },
     {
       name: 'popupMode',
       class: 'Boolean',

--- a/src/foam/u2/crunch/wizardflow/DetachAgent.js
+++ b/src/foam/u2/crunch/wizardflow/DetachAgent.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.CLASS({
+  package: 'foam.u2.crunch.wizardflow',
+  name: 'DetachAgent',
+  flags: ['web'],
+  documentation: `
+    todo.
+  `,
+
+  imports: [
+    'wizardCloseSub'
+  ],
+
+  implements: [
+    'foam.core.ContextAgent'
+  ],
+
+  methods: [
+    async function execute() {
+      this.wizardCloseSub.detach();
+    }
+  ]
+});

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -14,6 +14,10 @@ foam.CLASS({
     'foam.u2.wizard.Wizardlet'
   ],
 
+  imports: [
+    'wizardCloseSub'
+  ],
+
   requires: [
     'foam.u2.detail.AbstractSectionedDetailView',
     'foam.u2.wizard.WizardletAware',
@@ -184,6 +188,7 @@ foam.CLASS({
           this.data$
             .map(data => {
               var updateSlot = data.getUpdateSlot();
+              this.wizardCloseSub.onDetach(updateSlot);
               return this.WizardletAutoSaveSlot.create({
                 other: filter(updateSlot, v => v && ! self.loading),
                 delay: self.SAVE_DELAY
@@ -193,6 +198,7 @@ foam.CLASS({
           return s;
         }
         var sl = this.FObjectRecursionSlot.create({ obj$: this.data$ });
+        this.wizardCloseSub.onDetach(sl);
         return filter(this.WizardletAutoSaveSlot.create({
           other: filter(sl, () => ! self.loading),
           delay: self.SAVE_DELAY


### PR DESCRIPTION
Eric's(@KernelDeimos) idea and implementation. Tested and works nicely.


fixes : Removes the sub on properties after the wizard is closed.

has this issue:
![image](https://user-images.githubusercontent.com/10802216/114304913-a85dd300-9aa3-11eb-9cca-6392f4c4365a.png)
