### PR TITLE
[NP-3951] - Capability store status clean up

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -659,6 +659,7 @@ FOAM_FILES([
   { name: "foam/u2/crunch/wizardflow/LoadTopConfig", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/ShowPreexistingAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/SaveAllAgent", flags: ['web'] },
+  { name: "foam/u2/crunch/wizardflow/CapabilityStoreAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/lite/CapableDefaultConfigAgent", flags: ['web'] },
   { name: "foam/u2/crunch/CapabilityRequirementView", flags: ['web'] },
   { name: "foam/u2/crunch/CapabilityCardView", flags: ['web'] },

--- a/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
+++ b/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
@@ -42,7 +42,6 @@ foam.CLASS({
         wizardlet.capability.id, wData, null
       );
       return p.then((ucj) => {
-        this.crunchService.pub('grantedJunction');
         if ( wizardlet.reloadAfterSave ) this.load_(wizardlet, ucj);
         else {
           wizardlet.status = ucj.status;
@@ -55,7 +54,6 @@ foam.CLASS({
       return this.crunchService.updateJunction( null,
         wizardlet.capability.id, null, null
       ).then((ucj) => {
-        this.crunchService.pub('updateJunction');
         return ucj;
       });
     },

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -183,7 +183,7 @@ foam.CLASS({
     {
       name: 'statusUpdate',
       isMerged: true,
-      mergeDelay: 100,
+      mergeDelay: 2000,
       code: function() {
         if ( this.cjStatus != this.CapabilityJunctionStatus.PENDING &&
               this.cjStatus != this.CapabilityJunctionStatus.PENDING_REVIEW ) {
@@ -194,6 +194,9 @@ foam.CLASS({
             this.auth.cache = {};
             this.crunchService.pub('grantedJunction');
             this.cjStatus = this.CapabilityJunctionStatus.GRANTED;
+          }
+          else if ( ucj && ucj.status === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
+            this.cjStatus = this.CapabilityJunctionStatus.ACTION_REQUIRED;
           } else {
             this.statusUpdate();
           }

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -52,6 +52,7 @@ foam.CLASS({
     'foam.u2.crunch.wizardflow.MaybeDAOPutAgent',
     'foam.u2.crunch.wizardflow.ShowPreexistingAgent',
     'foam.u2.crunch.wizardflow.SaveAllAgent',
+    'foam.u2.crunch.wizardflow.CapabilityStoreAgent',
     'foam.util.async.Sequence',
     'foam.u2.borders.MarginBorder',
     'foam.u2.crunch.CapabilityInterceptView',
@@ -113,6 +114,7 @@ foam.CLASS({
           .add(this.AutoSaveWizardletsAgent)
           .add(this.StepWizardAgent)
           .add(this.PutFinalPayloadsAgent)
+          .add(this.CapabilityStoreAgent)
           // .add(this.TestAgent)
           ;
       }

--- a/src/foam/u2/crunch/wizardflow/CapabilityStoreAgent.js
+++ b/src/foam/u2/crunch/wizardflow/CapabilityStoreAgent.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.CLASS({
+  package: 'foam.u2.crunch.wizardflow',
+  name: 'CapabilityStoreAgent',
+  flags: ['web'],
+  documentation: `
+    This agent publishes to topics used to update capability store entries.
+  `,
+
+  imports: [
+    'rootCapability',
+    'crunchService'
+  ],
+
+  requires: [
+    'foam.nanos.crunch.CapabilityJunctionStatus'
+  ],
+
+  methods: [
+    async function execute() {
+      let ucj = await this.crunchService.getJunction(null, this.rootCapability.id);
+      this.crunchService.pub('updateJunction');
+      if ( ucj && ucj.status === this.CapabilityJunctionStatus.GRANTED ) {
+        this.crunchService.pub('grantedJunction');
+      }
+    }
+  ]
+});

--- a/src/foam/u2/crunch/wizardflow/PutFinalJunctionsAgent.js
+++ b/src/foam/u2/crunch/wizardflow/PutFinalJunctionsAgent.js
@@ -38,7 +38,6 @@ foam.CLASS({
         filteredWizard => {
           return this.crunchService.updateJunction(null, filteredWizard.capability.id, null, null)
             .then((ucj) => {
-              this.crunchService.pub('updateJunction');
               return ucj;
             })
         }

--- a/src/foam/u2/crunch/wizardflow/PutFinalPayloadsAgent.js
+++ b/src/foam/u2/crunch/wizardflow/PutFinalPayloadsAgent.js
@@ -38,7 +38,6 @@ foam.CLASS({
         filteredWizard => {
           return filteredWizard.save()
             .then((data) => {
-              this.crunchService.pub('updateJunction');
               return Promise.resolve();
             })
         }


### PR DESCRIPTION
- Preview pop-up no longer shows up after closing the wizard in ACTION_REQUIRED state.
- When successfully completing a capability, status will visibly change to GRANTED in the UI (excluding Business Registration), and then will refresh the store.
- Exiting signing officer capability wizard with partially filled in information will put its status in ACTION_REQUIRED in the ui.
- After onboarding approval gets sent back for the user to re-submit, the user no longer need to refresh the page to be able to make changes.

Ref: https://nanopay.atlassian.net/browse/NP-3951