### PR TITLE
Reload the page when UCJ status changed from PENDING to ACTION_REQUIRED

### DIFF
--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -196,7 +196,7 @@ foam.CLASS({
             this.cjStatus = this.CapabilityJunctionStatus.GRANTED;
           }
           else if ( ucj && ucj.status === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
-            this.window.location.reload();
+            this.crunchService.pub('grantedJunction');
           } else {
             this.statusUpdate();
           }

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -196,7 +196,7 @@ foam.CLASS({
             this.cjStatus = this.CapabilityJunctionStatus.GRANTED;
           }
           else if ( ucj && ucj.status === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
-            this.cjStatus = this.CapabilityJunctionStatus.ACTION_REQUIRED;
+            this.window.location.reload();
           } else {
             this.statusUpdate();
           }


### PR DESCRIPTION
- Since the back-office agent is able to put the signing officer ucj back in ACTION_REQUIRED, we want to reload the page so the user can see the signing officer capability in the store. If we don't do this, they will see the onboarding with all valid data.