### PR TITLE
Append UID to RadioView name

### DIFF
--- a/src/foam/u2/view/RadioView.js
+++ b/src/foam/u2/view/RadioView.js
@@ -142,7 +142,7 @@ foam.CLASS({
           start('input').
             attrs({
               type: 'radio',
-              name: self.getAttribute('name'),
+              name: self.getAttribute('name') + self.$UID,
               value: c[1],
               checked: self.slot(function (data) { return data == c[0]; }),
               disabled: self.isDisabled$


### PR DESCRIPTION
Append uid to RadioView name to prevent bug where values don't show up when having duplicate names in the same SectionDetailView.