### PR TITLE
Fix context for service created in sub context

### DIFF
--- a/src/foam/nanos/boot/NSpecFactory.java
+++ b/src/foam/nanos/boot/NSpecFactory.java
@@ -45,10 +45,11 @@ public class NSpecFactory
     creatingThread_ = Thread.currentThread();
 
     PM     pm     = new PM(this.getClass(), spec_.getName());
+    X      nx     = x_ instanceof SubX ? x_ : x_.getX();
 
     try {
       logger.info("Creating Service", spec_.getName());
-      var service = spec_.createService(x_.getX().put(NSpec.class, spec_).put("logger", logger), null);
+      var service = spec_.createService(nx.put(NSpec.class, spec_).put("logger", logger), null);
       if ( service instanceof DAO ) {
         if ( ns_ == null ) {
           ns_ = new ProxyDAO();
@@ -61,7 +62,7 @@ public class NSpecFactory
       Object ns = ns_;
       while ( ns != null ) {
         if ( ns instanceof ContextAware && ! ( ns instanceof ProxyX ) ) {
-          ((ContextAware) ns).setX(x_.getX());
+          ((ContextAware) ns).setX(nx);
         }
         if ( ns instanceof NSpecAware ) {
           if ( ((NSpecAware) ns).getNSpec() == null ) {
@@ -82,7 +83,7 @@ public class NSpecFactory
     } catch (Throwable t) {
       logger.error("Error Creating Service", spec_.getName(), t);
     } finally {
-      pm.log(x_.getX());
+      pm.log(nx);
       creatingThread_ = null;
     }
   }


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-3871
- https://github.com/kgrgreer/foam3/pull/23

## Issues
- The context of services created in a sub context cannot access to services in parent/root

## Changes
- Use x_ instead of the delegate since the delegate of a sub context only contains services add to the sub context