### PR TITLE
set the proper image logo

### DIFF
--- a/src/foam/util/Emails/EmailsUtility.java
+++ b/src/foam/util/Emails/EmailsUtility.java
@@ -111,24 +111,24 @@ public class EmailsUtility {
       }
 
       String url = appConfig.getUrl().replaceAll("/$", "");
-      templateArgs.put("logo", (url + "/" + theme.getLogo()));
+      templateArgs.put("logo", theme.getLogo());
       templateArgs.put("appLink", url);
       templateArgs.put("appName", (theme.getAppName()));
 
       templateArgs.put("locale", user.getLanguage().getCode().toString());
-  
+
       foam.nanos.auth.Address address = supportConfig.getSupportAddress();
       templateArgs.put("supportAddress", address == null ? "" : address.toSummary());
       templateArgs.put("supportPhone", (supportConfig.getSupportPhone()));
       templateArgs.put("supportEmail", (supportConfig.getSupportEmail()));
-  
+
       // personal support user
       User psUser = supportConfig.findPersonalSupportUser(x);
       templateArgs.put("personalSupportPhone", psUser == null ? "" : psUser.getPhoneNumber());
       templateArgs.put("personalSupportEmail", psUser == null ? "" : psUser.getEmail());
       templateArgs.put("personalSupportFirstName", psUser == null ? "" : psUser.getFirstName());
       templateArgs.put("personalSupportFullName", psUser == null ? "" : psUser.getLegalName());
-      
+
       emailMessage.setTemplateArguments(templateArgs);
     }
 


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-3685

fixed broken image logo in email templates 

old : 
<img width="472" alt="Screen Shot 2021-04-13 at 2 55 03 PM" src="https://user-images.githubusercontent.com/33228583/114605599-3edaf180-9c68-11eb-82c8-d262a91b8241.png">


new :
<img width="453" alt="Screen Shot 2021-04-13 at 2 49 43 PM" src="https://user-images.githubusercontent.com/33228583/114604903-7d23e100-9c67-11eb-99a7-d7bb718ec8dc.png">
<img width="384" alt="Screen Shot 2021-04-13 at 2 50 04 PM" src="https://user-images.githubusercontent.com/33228583/114604934-89a83980-9c67-11eb-8cae-fbf170dfbb59.png">
<img width="408" alt="Screen Shot 2021-04-13 at 2 54 43 PM" src="https://user-images.githubusercontent.com/33228583/114605542-2ff43f00-9c68-11eb-90f3-1eb435a1c457.png">
