### PR TITLE
Changed debugAgent to filter out off-less wizardlets

### DIFF
--- a/src/foam/u2/crunch/wizardflow/DebugAgent.js
+++ b/src/foam/u2/crunch/wizardflow/DebugAgent.js
@@ -183,7 +183,7 @@ foam.CLASS({
   methods: [
     async function execute() {
       for ( let wizardlet of this.wizardlets ) {
-        if ( wizardlet.isVisible ) {
+        if ( wizardlet.of ) {
           wizardlet.sections.push(this.WizardletSection.create({
             title: 'Developer Tools',
             isAvailable: true,


### PR DESCRIPTION
Would break when you select only one option in the min max with debug mode on.

To be done instead of invisible wizardlets because a wizardlet could be invisible just because it wasn't selected in a min-max. Therefore we wouldn't see the crunch debugger appear in sections which derive from a min max choice. Would also break canGoNext on single choices.