### PR TITLE
[NP-3972] fix richChoiceView placeholder

### DIFF
--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -706,6 +706,10 @@ foam.CLASS({
           name: 'defaultSelectionPrompt'
         },
         {
+          class: 'String',
+          name: 'defaultSelectionPromptSource'
+        },
+        {
           name: 'fullObject',
           documentation: `
             The full object. It's not used here in the default selection view,
@@ -725,13 +729,9 @@ foam.CLASS({
             'text-overflow': 'ellipsis'
           });
 
-          var summary = this.fullObject$.map(o => {
-            return ( o && o.toSummary() ) || this.defaultSelection;
-          });
-          var summaryWithoutSlot = this.fullObject && this.fullObject.toSummary()
-            ? this.fullObject.toSummary()
-            : this.defaultSelectionPrompt;
-          return this.translate(summaryWithoutSlot, summary);
+          return this.add(this.fullObject$.map(o => {
+            return ( o && o.toSummary() ) || this.defaultSelectionPrompt;
+          }));
         }
       ]
     },

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -706,10 +706,6 @@ foam.CLASS({
           name: 'defaultSelectionPrompt'
         },
         {
-          class: 'String',
-          name: 'defaultSelectionPromptSource'
-        },
-        {
           name: 'fullObject',
           documentation: `
             The full object. It's not used here in the default selection view,


### PR DESCRIPTION
Placeholders were not being displayed because the arguments passed to the translation method were incorrect. But I found there was no need to translate texts that had already been translated, so I simply removed  the translation part to fix the issue.

**Owner**

![Screen Shot 2021-04-15 at 5 40 08 PM](https://user-images.githubusercontent.com/58435071/114942020-e7788500-9e11-11eb-8825-aca495c0eff0.png)

![Screen Shot 2021-04-15 at 5 41 56 PM](https://user-images.githubusercontent.com/58435071/114942021-e8111b80-9e11-11eb-802c-c9c8faabedfe.png)

**Business sector**

![Screen Shot 2021-04-16 at 10 11 53 AM](https://user-images.githubusercontent.com/58435071/115037287-513d7100-9e9c-11eb-9c3f-61b930649a51.png)

![Screen Shot 2021-04-16 at 10 12 19 AM](https://user-images.githubusercontent.com/58435071/115037289-51d60780-9e9c-11eb-8af5-741f23e82c16.png)



