### PR TITLE
Fix subX leaking system group

### DIFF
--- a/src/foam/core/SubX.java
+++ b/src/foam/core/SubX.java
@@ -24,8 +24,10 @@ public class SubX extends ProxyX {
   /**
    * Keys of all services added to the subX.
    *
-   * Storing {@code serviceKeys} allows preventing {@code get(key)} call from
-   * propagating to the parent context when overriding a service as null.
+   * Storing {@code serviceKeys} to allow overriding a service as null. Eg,
+   * subX.put("group", null) would override "group" as null so that the next
+   * subX.get("group") call returns null instead of propagating the lookup of
+   * "group" key in the parent context.
    */
   protected Set serviceKeys_;
 
@@ -126,8 +128,8 @@ public class SubX extends ProxyX {
   }
 
   /**
-   * Remove a service/object from the subX. Therefore allowing the next
-   * {@code get(key)} call to propagate the lookup to the parent context.
+   * Remove a service/object from the subX so that {@code subX.get(key)} call
+   * can propagate the lookup to the parent context properly.
    *
    * @param key Key to be removed
    * @return SubX

--- a/src/foam/core/SubX.java
+++ b/src/foam/core/SubX.java
@@ -124,4 +124,17 @@ public class SubX extends ProxyX {
       setX(((ProxyX) getX()).getX());
     }
   }
+
+  /**
+   * Remove a service/object from the subX. Therefore allowing the next
+   * {@code get(key)} call to propagate the lookup to the parent context.
+   *
+   * @param key Key to be removed
+   * @return SubX
+   */
+  public X rm(Object key) {
+    var subX = (SubX) put(key, null);
+    subX.serviceKeys_.remove(key);
+    return subX;
+  }
 }

--- a/src/foam/core/SubX.java
+++ b/src/foam/core/SubX.java
@@ -6,6 +6,8 @@
 
 package foam.core;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class SubX extends ProxyX {
@@ -19,6 +21,19 @@ public class SubX extends ProxyX {
    */
   protected String parent_;
 
+  /**
+   * Keys of all services added to the subX.
+   *
+   * Storing {@code serviceKeys} allows preventing {@code get(key)} call from
+   * propagating to the parent context when overriding a service as null.
+   */
+  protected Set serviceKeys_;
+
+  /**
+   * Key of {@code serviceKeys} to put in the subX
+   */
+  public static final String SERVICE_KEYS = "_SubX_";
+
   public SubX(Supplier<X> root, String parent) {
     this(root, parent, new ProxyX());
   }
@@ -26,7 +41,11 @@ public class SubX extends ProxyX {
   public SubX(Supplier<X> root, String parent, X delegate) {
     root_ = root;
     parent_ = parent;
-    setX(delegate);
+
+    serviceKeys_ = (Set) delegate.get(SERVICE_KEYS);
+    if ( serviceKeys_ == null ) serviceKeys_ = new HashSet();
+
+    setX(delegate.put(SERVICE_KEYS, serviceKeys_));
   }
 
   private X getParent() {
@@ -37,31 +56,38 @@ public class SubX extends ProxyX {
   @Override
   public Object get(X x, Object key) {
     var ret = getX().get(x, key);
-    return ret != null ? ret : getParent().get(x, key);
+    return ret != null || serviceKeys_.contains(key) ? ret
+      : getParent().get(x, key);
   }
 
   @Override
   public X put(Object key, Object value) {
+    serviceKeys_.add(key);
     if ( getX() instanceof ProxyX ) {
       getX().put(key, value);
       return this;
     }
-    return new SubX(root_, parent_, new ProxyX(getX())).put(key, value);
+
+    var delegate = new ProxyX(getX()).put(SERVICE_KEYS, new HashSet(serviceKeys_));
+    return new SubX(root_, parent_, delegate).put(key, value);
   }
 
   @Override
   public X putFactory(Object key, XFactory factory) {
+    serviceKeys_.add(key);
     if ( getX() instanceof ProxyX ) {
       getX().putFactory(key, factory);
       return this;
     }
-    return new SubX(root_, parent_, new ProxyX(getX())).putFactory(key, factory);
+
+    var delegate = new ProxyX(getX()).put(SERVICE_KEYS, new HashSet(serviceKeys_));
+    return new SubX(root_, parent_, delegate).putFactory(key, factory);
   }
 
   @Override
   public int getInt(Object key, int defaultValue) {
     Number i = (Number) getX().get(key);
-    if ( i == null ) {
+    if ( i == null && ! serviceKeys_.contains(key) ) {
       i = (Number) getParent().get(key);
     }
     return i == null ? defaultValue : i.intValue();
@@ -70,7 +96,7 @@ public class SubX extends ProxyX {
   @Override
   public boolean getBoolean(Object key, boolean defaultValue) {
     Boolean b = (Boolean) getX().get(key);
-    if ( b == null ) {
+    if ( b == null && ! serviceKeys_.contains(key) ) {
       b = (Boolean) getParent().get(key);
     }
     return b == null ? defaultValue : b;


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-4183

## Issues
- bepayX.get("group") was reset to null when applying session but on the next call of bepayX.get("group") it returns `system` group instead of null because it propagates the lookup to the parent context.

## Changes
- Keep track of services added to subX and prevent propagating to parent context (for null override)
- Add rm method to SubX for removing the service from the subX