### PR TITLE
fix duplicate comment being saved

### DIFF
--- a/src/foam/nanos/ticket/TicketAddCommentDAO.js
+++ b/src/foam/nanos/ticket/TicketAddCommentDAO.js
@@ -31,6 +31,7 @@ foam.CLASS({
       ((DAO) x.get("ticketCommentDAO")).put_(x, tc);
       ticket = (Ticket) ticket.fclone();
       ticket.setComment("");
+      ticket = (Ticket) getDelegate().put_(x, ticket);
     }
     return ticket;
       `


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-857
Ticket get saved with comment, when the ui looks for it finds it with comments and on cancel it saves the comment again.