### PR TITLE
[NP-4094] Make a wizard context import on wizardlet optional

### DIFF
--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -15,7 +15,7 @@ foam.CLASS({
   ],
 
   imports: [
-    'wizardCloseSub'
+    'wizardCloseSub?'
   ],
 
   requires: [
@@ -199,8 +199,14 @@ foam.CLASS({
             });
           });
         slotSlot.valueSub(() => { s.set(slotSlot.get().get()); });
-        this.wizardCloseSub.onDetach(s);
-        this.wizardCloseSub.onDetach(slotSlot);
+        if ( this.wizardCloseSub ) {
+          this.wizardCloseSub.onDetach(s);
+          this.wizardCloseSub.onDetach(slotSlot);
+        } else {
+          console.error(
+            'wizardlet update listener will not detach! ' +
+            'This wizardlet my be used from an invalid context');
+        }
         return s;
       }
     },


### PR DESCRIPTION
Since capabilities have a `wizardlet` property to specify a different wizardlet from the default, any imports requiring a wizard context will sometimes produce an error.

This PR makes one such import optional, and logs an error if it doesn't exist when it should.