### PR TITLE
Align section headers

### DIFF
--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -70,6 +70,10 @@ foam.CLASS({
       margin: 0px;
     }
 
+    ^heading {
+      display: flex;
+      align-items: center;
+    }
   `,
 
   properties: [


### PR DESCRIPTION
Minor fix to section header alignment

Before: 
<img width="372" alt="Screen Shot 2021-04-21 at 1 22 50 PM" src="https://user-images.githubusercontent.com/15328924/115595446-ed081c00-a2a4-11eb-945b-3be1d764e248.png">

After:
<img width="416" alt="Screen Shot 2021-04-21 at 1 22 40 PM" src="https://user-images.githubusercontent.com/15328924/115595466-f3969380-a2a4-11eb-8d1d-3a2270169fc9.png">

