### PR TITLE
fix paste for fragmentedtextfield

### DIFF
--- a/src/foam/u2/AttrSlot.js
+++ b/src/foam/u2/AttrSlot.js
@@ -34,7 +34,8 @@ foam.CLASS({
 
   methods: [
     function get() {
-      return this.value = this.element.getAttribute(this.property);
+      this.value = this.element.getAttribute(this.property);
+      return this.value;
     },
 
     function set(value) {


### PR DESCRIPTION
fix paste for fragmentedtextfield - the value passed to set was outdated since value of the element was updated after the initial assignment
<img width="925" alt="Screen Shot 2021-04-21 at 10 39 29 AM" src="https://user-images.githubusercontent.com/32865869/115610078-5e03ff80-a2b6-11eb-8331-7f645d18b882.png">
