### PR TITLE
[NP-4184] - Add confirmation to approval request UCJ view reference

### DIFF
--- a/src/foam/comics/DAOUpdateController.js
+++ b/src/foam/comics/DAOUpdateController.js
@@ -63,7 +63,9 @@ foam.CLASS({
     {
       name: 'delete',
       isEnabled: function(obj) { return !! obj; },
-      confirmationRequired: true,
+      confirmationRequired: function() {
+        return true;
+      },
       code: function() {
         var self = this;
         this.dao.remove(this.obj).then(function() {

--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -64,10 +64,11 @@ foam.CLASS({
       generateJava: false
     },
     {
-      class: 'Boolean',
+      class: 'Function',
       generateJava: false,
       name: 'confirmationRequired',
-      documentation: 'If confirmation is required. Recommended for destructive actions.'
+      documentation: 'If confirmation is required. Recommended for destructive actions.',
+      value: null
     },
     {
       class: 'String',
@@ -136,14 +137,21 @@ foam.CLASS({
       generateJava: false,
       name: 'availablePermissions',
       documentation: `Permissions required for the action to be available.
-If empty than no permissions are required.`
+If empty then no permissions are required.`
     },
     {
       class: 'StringArray',
       generateJava: false,
       name: 'enabledPermissions',
       documentation: `Permissions required for the action to be enabled.
-If empty than no permissions are required.`,
+If empty then no permissions are required.`,
+    },
+    {
+      class: 'StringArray',
+      generateJava: false,
+      name: 'confirmationRequiredPermissions',
+      documentation: `Permissions required for the action to be confirmation required state.
+If empty then no permissions are required.`
     },
     {
       name: 'enabledPermissionsSlot_',
@@ -152,6 +160,11 @@ If empty than no permissions are required.`,
     },
     {
       name: 'availablePermissionsSlot_',
+      generateJava: false,
+      transient: true
+    },
+    {
+      name: 'confirmationRequiredPermissionsSlot_',
       generateJava: false,
       transient: true
     },
@@ -234,6 +247,10 @@ If empty than no permissions are required.`,
 
     function createIsAvailable$(x, data) {
       return this.createSlotFor_(x, data, this.isAvailable, 'available');
+    },
+    
+    function createConfirmationRequired$(x, data) {
+      return this.createSlotFor_(x, data, this.confirmationRequired, 'confirmationRequired');
     },
 
     function getRunning$(data) {

--- a/src/foam/flow/widgets/TryItSnippet.js
+++ b/src/foam/flow/widgets/TryItSnippet.js
@@ -74,7 +74,9 @@ foam.CLASS({
     {
       name: 'run',
       tableWidth: 90,
-      confirmationRequired: true,
+      confirmationRequired: function() {
+        return true;
+      },
       code: function() {
         return this.script.run();
       }

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -470,6 +470,8 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.approval.ApprovalRequ
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.approval.ApprovalRequest.TRACKING",target:"Rastreamento"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.approval.ApprovalRequest.BACK_LABEL",target:"Voltar"})
 
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.ActionView.CONFIRM",target:"Confirme"})
+
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOSummaryView.BACK.label",target:"Voltar"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOSummaryView.EDIT.label",target:"Editar"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOSummaryView.COPY.label",target:"Cópia"})

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -208,6 +208,7 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollWizardletVi
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollWizardletView.SAVE.label",target:"Salve"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.SAVE_LABEL",target:"Salve"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.NO_ACTION_LABEL",target:"Feito"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.REJECT_LABEL",target:"Rejeitar"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.DAOWizardlet.OF.label",target:"do"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.DAOWizardlet.DATA.label",target:"dados"})
 

--- a/src/foam/nanos/crunch/AgentCapabilityJunctionDAOSummaryView.js
+++ b/src/foam/nanos/crunch/AgentCapabilityJunctionDAOSummaryView.js
@@ -52,7 +52,8 @@ foam.CLASS({
         'foam.u2.ControllerMode',
         'foam.u2.crunch.wizardflow.SaveAllAgent',
         'foam.u2.stack.Stack',
-        'foam.u2.stack.StackView'
+        'foam.u2.stack.StackView',
+        'foam.u2.wizard.StepWizardConfig'
       ],
 
       properties: [
@@ -76,6 +77,12 @@ foam.CLASS({
             .reconfigure('ConfigureFlowAgent', {
               popupMode: false
             })
+            .reconfigure('StepWizardAgent', {
+              config: this.StepWizardConfig.create({
+                approvalMode: true
+              })
+            })
+            .remove('LoadTopConfig')
             .remove('RequirementsPreviewAgent')
             .remove('SkipGrantedAgent')
             .remove('WizardStateAgent')

--- a/src/foam/nanos/notification/NotificationRowView.js
+++ b/src/foam/nanos/notification/NotificationRowView.js
@@ -126,7 +126,9 @@
             }
           })
         },
-        confirmationRequired: true
+        confirmationRequired: function() {
+          return true;
+        },
       },
       function hideNotificationType(X) {
         var self = X.rowView;

--- a/src/foam/nanos/script/Script.js
+++ b/src/foam/nanos/script/Script.js
@@ -490,7 +490,9 @@ foam.CLASS({
     {
       name: 'run',
       tableWidth: 90,
-      confirmationRequired: true,
+      confirmationRequired: function() {
+        return true;
+      },
       code: function() {
         var self = this;
         this.output = '';

--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -363,7 +363,9 @@ foam.CLASS({
     {
       name: 'close',
       tableWidth: 70,
-      confirmationRequired: true,
+      confirmationRequired: function() {
+        return true;
+      },
       isAvailable: function(status, id) {
         return status != 'CLOSED' &&
                id > 0;

--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -317,7 +317,7 @@ foam.CLASS({
     },
     {
       name: 'buttonState',
-      factory: function() { return this.action && this.action.confirmationRequired ? this.ButtonState.CONFIRM : this.ButtonState.NO_CONFIRM; }
+      factory: function() { return this.ButtonState.NO_CONFIRM; }
     },
     {
       name: 'data',
@@ -346,7 +346,7 @@ foam.CLASS({
         that data is deleted in some way.
       `,
       factory: function() {
-        return this.action.confirmationRequired;
+        return false;
       }
     },
     {
@@ -378,12 +378,19 @@ foam.CLASS({
       this.addContent();
 
       if ( this.action ) {
+        if ( this.action.confirmationRequired ) {
+          var cRSlot$ = this.action.createConfirmationRequired$(this.__context__, this.data);
+          this.onDetach(cRSlot$.sub(() => this.setConfirm(cRSlot$.get())));
+          this.setConfirm(cRSlot$.get());
+        }
         this.attrs({name: this.action.name, 'aria-label': this.action.ariaLabel });
 
         this.enableClass(this.myClass('unavailable'), this.action.createIsAvailable$(this.__context__, this.data), true);
         this.attrs({ disabled: this.action.createIsEnabled$(this.__context__, this.data).map((e) => e ? false : 'disabled') });
 
-        this.addClass(this.myClass(this.styleClass_));
+        this.addClass(this.slot(function(styleClass_) {
+          return this.myClass(styleClass_);
+        }));
         this.addClass(this.myClass(this.size.label.toLowerCase()));
       }
     },
@@ -460,6 +467,19 @@ foam.CLASS({
         this.removeAllChildren();
         this.addContent();
         this.buttonState = this.ButtonState.CONFIRM;
+      }
+    },
+    {
+      name: 'setConfirm',
+      code: function(confirm) {
+        let newState = confirm ? this.ButtonState.CONFIRM : this.ButtonState.NO_CONFIRM;
+        let stateChange = this.buttonState != newState;
+        this.buttonState = newState;
+        this.isDestructive = confirm;
+        if ( stateChange ) {
+          this.removeAllChildren();
+          this.addContent();
+        }
       }
     }
   ]

--- a/src/foam/u2/wizard/IncrementalStepWizardView.js
+++ b/src/foam/u2/wizard/IncrementalStepWizardView.js
@@ -290,7 +290,9 @@ foam.CLASS({
       isAvailable: function () {
         return this.showDiscardOption;
       },
-      confirmationRequired: true,
+      confirmationRequired: function() {
+        return true;
+      },
       code: function(x) {
         this.onClose(x, false);
       }

--- a/src/foam/u2/wizard/ScrollWizardletView.js
+++ b/src/foam/u2/wizard/ScrollWizardletView.js
@@ -99,7 +99,9 @@ foam.CLASS({
   actions: [
     {
       name: 'exit',
-      confirmationRequired: true,
+      confirmationRequired: function() {
+        return true;
+      },
       code: function(x) {
         x.stack.back();
       }

--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -16,6 +16,7 @@ foam.CLASS({
   messages: [
     { name: 'NO_ACTION_LABEL', message: 'Done' },
     { name: 'SAVE_LABEL', message: 'Save' },
+    { name: 'REJECT_LABEL', message: 'Reject' }
   ],
 
   requires: [
@@ -142,6 +143,17 @@ foam.CLASS({
       factory: function () {
         return this.sequence && this.sequence.contains('SaveAllAgent');
       }
+    },
+    {
+      name: 'willReject',
+      documentation: `
+        Used to put submit button in confirmationRequired mode and change the
+        button test from 'Done' to 'Reject' when in approvalMode and the wizard 
+        has at least on invalid wizardlet.
+      `,
+      expression: function( data$config$approvalMode, data$allValid ) {
+        return data$config$approvalMode && ! data$allValid;
+      }
     }
   ],
 
@@ -200,11 +212,12 @@ foam.CLASS({
               .addClass(this.myClass('actions'))
               .startContext({ data: self })
                 .tag(this.SUBMIT, {
-                  label: this.hasAction
-                    ? this.ACTION_LABEL
-                    : this.willSave
-                      ? this.SAVE_LABEL
-                      : this.NO_ACTION_LABEL
+                  label: this.slot(function(hasAction, willReject, willSave) {
+                    if ( willReject ) return this.REJECT_LABEL;
+                    if ( hasAction ) return this.ACTION_LABEL;
+                    if ( willSave ) return this.SAVE_LABEL;
+                    return this.NO_ACTION_LABEL;
+                  })
                 })
               .endContext()
             .end()
@@ -281,6 +294,9 @@ foam.CLASS({
     {
       name: 'submit',
       label: 'Done',
+      confirmationRequired: function(willReject) {
+        return willReject;
+      },
       isEnabled: function (data$config, data$allValid) {
         return ! data$config.requireAll || data$allValid;
       },

--- a/src/foam/u2/wizard/StepWizardConfig.js
+++ b/src/foam/u2/wizard/StepWizardConfig.js
@@ -27,6 +27,15 @@ foam.CLASS({
       name: 'requireAll'
     },
     {
+      class: 'Boolean',
+      name: 'approvalMode',
+      documentation: `
+        Set to true when ScrollingWizard is used to view UCJ data 
+        accociated to an Approval Request.
+      `,
+      value: false
+    },
+    {
       class: 'foam.u2.ViewSpec',
       name: 'wizardView',
       flags: ['web'], // Temporary


### PR DESCRIPTION
Ref: https://nanopay.atlassian.net/browse/NP-4184

- Changed Action's confirmationRequired property to be an expression.
- Added approvalMode to wizard config to toggle confirmationRequired on the submit button. (linked to wizardlet validity)

**Viewing onboarding approval view reference:**
<img width="1440" alt="Screen Shot 2021-04-22 at 8 59 28 PM" src="https://user-images.githubusercontent.com/57911258/115819741-816d9e00-a3cd-11eb-835d-9b85940bcc85.png">
**After invalidating a field**
<img width="1440" alt="Screen Shot 2021-04-22 at 8 59 35 PM" src="https://user-images.githubusercontent.com/57911258/115819747-83376180-a3cd-11eb-9ac0-0927d98d8c61.png">
**After clicking on Reject**
<img width="1440" alt="Screen Shot 2021-04-22 at 8 59 46 PM" src="https://user-images.githubusercontent.com/57911258/115819749-83cff800-a3cd-11eb-877f-985d70dc668a.png">
