### PR TITLE
Relevant Capability Id

### DIFF
--- a/src/documentation/crunch-doc.flow
+++ b/src/documentation/crunch-doc.flow
@@ -90,7 +90,7 @@ configure the wizard to disallow skipping sections.
 <code>
 p({
   "class": "foam.nanos.crunch.Capability",
-  "id": "4EB60BAE-E915-4464-9D1B-4099F22E9144",
+  "id": "crunch.example",
   "name": "Example Capability",
   "of": "foam.nanos.crunch.example.ExampleData",
   "wizardConfig": {

--- a/src/foam/nanos/bench/BenchmarkRunner.java
+++ b/src/foam/nanos/bench/BenchmarkRunner.java
@@ -238,7 +238,6 @@ public class BenchmarkRunner
         stats.put(FAIL, fail.get());
         stats.put(TOTAL, pass.get() + fail.get());
         stats.put(OPS, String.format("%.02f", (complete / duration)));
-        stats.put("DURATION", String.format("%.02f", duration));
         stats.put(OPSPT, String.format("%.02f", (complete / duration) / (float) threads));
         stats.put(MEMORY, String.format("%.02f", (((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())) / 1024.0 / 1024.0 / 1024.0)));
 

--- a/src/foam/nanos/bench/BenchmarkRunner.java
+++ b/src/foam/nanos/bench/BenchmarkRunner.java
@@ -238,6 +238,7 @@ public class BenchmarkRunner
         stats.put(FAIL, fail.get());
         stats.put(TOTAL, pass.get() + fail.get());
         stats.put(OPS, String.format("%.02f", (complete / duration)));
+        stats.put("DURATION", String.format("%.02f", duration));
         stats.put(OPSPT, String.format("%.02f", (complete / duration) / (float) threads));
         stats.put(MEMORY, String.format("%.02f", (((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())) / 1024.0 / 1024.0 / 1024.0)));
 

--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -28,6 +28,19 @@ foam.CLASS({
     { name: 'ERROR_CAPABILITY_NOT_FOUND', message: 'Capability not found ' }
   ],
 
+  constants: [
+    {
+      name: 'TARGET_CAPABILITY_ID_CHANGE',
+      type: 'String',
+      value: 'usercapabilityjunction.update.targetid'
+    },
+    {
+      name: 'SOURCE_CAPABILITY_ID_CHANGE',
+      type: 'String',
+      value: 'usercapabilityjunction.update.sourceid'
+    }
+  ],
+
   methods: [
     {
       name: 'checkOwnership',
@@ -111,8 +124,9 @@ foam.CLASS({
         UserCapabilityJunction old = (UserCapabilityJunction) super.find_(x, ucj.getId());
 
         // do not allow updates to sourceId/targetId properties
-        if ( old != null && ucj.getSourceId() != old.getSourceId() ) throw new RuntimeException(this.ERROR_TWO);
-        if ( old != null && ! ucj.getTargetId().equals(old.getTargetId()) ) throw new RuntimeException(this.ERROR_THREE);
+        AuthService auth = (AuthService) x.get("auth");
+        if ( old != null && ucj.getSourceId() != old.getSourceId() && ! auth.check(x, SOURCE_CAPABILITY_ID_CHANGE) ) throw new RuntimeException(this.ERROR_TWO);
+        if ( old != null && ucj.getTargetId() != old.getTargetId() && ! auth.check(x, TARGET_CAPABILITY_ID_CHANGE) ) throw new RuntimeException(this.ERROR_THREE);
 
         // if ucj data is set but does not match expected data, do not put
         Capability capability = (Capability) ucj.findTargetId(x);

--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -206,7 +206,7 @@ foam.CLASS({
       `,
       javaCode: `
         Logger logger = (Logger) x.get("logger");
-        if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+        if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
           logger.debug(this.getClass().getSimpleName(), "ucjRefine.saveDataToDAO(x, f-1a5, " + putObject + "). - subject", x.get("subject"));
           logger.debug(this.getClass().getSimpleName(), "ucjRefine.saveDataToDAO(x, f-1a5, " + putObject + "). - user", ((foam.nanos.auth.Subject) x.get("subject")).getUser());
           logger.debug(this.getClass().getSimpleName(), "ucjRefine.saveDataToDAO(x, f-1a5, " + putObject + "). - realuser", ((foam.nanos.auth.Subject) x.get("subject")).getRealUser());
@@ -220,14 +220,14 @@ foam.CLASS({
         if ( daoKey == null ) return null;
 
         DAO dao = (DAO) x.get(daoKey);
-        if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+        if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
           logger.debug(this.getClass().getSimpleName(), "ucjRefine.saveDataToDAO(x, f-1a5, " + putObject + "). - is dao null", dao == null);
         }
         if ( dao == null ) return null;
 
         FObject objectToSave;                                                  // Identify or create data to go into dao.
         String contextDAOFindKey = (String) capability.getContextDAOFindKey();
-        if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+        if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
           logger.debug(this.getClass().getSimpleName(), "ucjRefine.saveDataToDAO(x, f-1a5, " + putObject + "). - contextdaofindkey", contextDAOFindKey);
         }
 
@@ -235,7 +235,7 @@ foam.CLASS({
           if ( contextDAOFindKey.toLowerCase().contains("subject") ) {         // 1- Case if subject lookup
             String[] words = foam.util.StringUtil.split(contextDAOFindKey, '.');
             objectToSave = getSubject(x);
-            if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+            if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
               logger.debug(this.getClass().getSimpleName(), "getSubject(x). - objectToSave", objectToSave);
             }
 
@@ -244,19 +244,19 @@ foam.CLASS({
 
             if ( words[1].toLowerCase().equals("user") ) {
               objectToSave = ((Subject) objectToSave).getUser();
-              if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+              if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
                 logger.debug(this.getClass().getSimpleName(), "contextdaofindkey == subject.user - objectToSave", objectToSave);
               }
             } else if ( words[1].toLowerCase().equals("realuser") ) {
 
-              if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+              if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
                 logger.debug(this.getClass().getSimpleName(), "contextdaofindkey == subject.realUser - objectToSave", objectToSave);
               }
               objectToSave = ((Subject) objectToSave).getRealUser();
             }
             try {
               objectToSave = dao.find(((User)objectToSave).getId());
-              if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+              if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
                 logger.debug(this.getClass().getSimpleName(), "dao.find(objectToSave) - objectToSave", objectToSave);
               }
             } catch(Exception e) {
@@ -264,7 +264,7 @@ foam.CLASS({
             }
           } else {                                                              // 2- Case if anything other then subject specified
             objectToSave = (FObject) x.get(contextDAOFindKey);
-            if ( capability.getId().equals("554af38a-8225-87c8-dfdf-eeb15f71215f-1a5") ) {
+            if ( capability.getId().equals("crunch.onboarding.signing-officer-information") ) {
               logger.debug(this.getClass().getSimpleName(), "this is just wrong", objectToSave);
             }
 

--- a/src/foam/nanos/crunch/doc.flow
+++ b/src/foam/nanos/crunch/doc.flow
@@ -53,7 +53,7 @@ re-sending (or aborting) the request.
 <foam class="foam.flow.widgets.TryItSnippet" server="true">
 import foam.nanos.crunch.CapabilityIntercept;
 var ex = new CapabilityIntercept();
-ex.addCapabilityId("4EB60BAE-E915-4464-9D1B-4099F22E9144");
+ex.addCapabilityId("crunch.example");
 throw ex;
 </foam>
 
@@ -73,7 +73,7 @@ user already has it granted.
 
 <foam class="foam.flow.widgets.TryItSnippet" server="true">
 var intercept = foam.nanos.crunch.CapabilityIntercept.create({
-  capabilities: ['4EB60BAE-E915-4464-9D1B-4099F22E9144']
+  capabilities: ['crunch.example']
 });
 x.crunchController.handleIntercept(intercept);
 </foam>

--- a/src/foam/nanos/crunch/example/capabilities.jrl
+++ b/src/foam/nanos/crunch/example/capabilities.jrl
@@ -1,6 +1,6 @@
 p({
   "class": "foam.nanos.crunch.Capability",
-  "id": "4EB60BAE-E915-4464-9D1B-4099F22E9144",
+  "id": "crunch.example",
   "name": "Example Capability",
   "enabled": true,
   "visible": false

--- a/src/foam/u2/crunch/CapabilityCardView.js
+++ b/src/foam/u2/crunch/CapabilityCardView.js
@@ -157,30 +157,9 @@ foam.CLASS({
               isRenewable => this.isRenewable = isRenewable
             );
           }
-          if ( this.cjStatus === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
-            this.auth.check(this.ctrl.__subContext__, 'certifydatareviewed.rw.reviewed').then(result => {
-              if ( ! result &&
-                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
-                ) ) {
-                this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
-              }
-            }).catch(err => {
-              if ( err.data && err.data.id === 'foam.nanos.crunch.CapabilityIntercept' &&
-                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
-                ) ) {
-                this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
-              } else throw err;
-            });
-
-            if ( ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-20' ) {
+          if ( this.cjStatus === this.CapabilityJunctionStatus.ACTION_REQUIRED &&
+               ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-20') {
               this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
-            }
           }
         });
       }

--- a/src/foam/u2/crunch/CapabilityCardView.js
+++ b/src/foam/u2/crunch/CapabilityCardView.js
@@ -160,19 +160,19 @@ foam.CLASS({
           if ( this.cjStatus === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
             this.auth.check(this.ctrl.__subContext__, 'certifydatareviewed.rw.reviewed').then(result => {
               if ( ! result &&
-                ( ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-49' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-13' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-12' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-11'
+                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
                 ) ) {
                 this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
               }
             }).catch(err => {
               if ( err.data && err.data.id === 'foam.nanos.crunch.CapabilityIntercept' &&
-                ( ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-49' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-13' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-12' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-11'
+                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
                 ) ) {
                 this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
               } else throw err;

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -152,30 +152,9 @@ foam.CLASS({
               isRenewable => this.isRenewable = isRenewable
             );
           }
-          if ( this.cjStatus === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
-            this.auth.check(this.ctrl.__subContext__, 'certifydatareviewed.rw.reviewed').then(result => {
-              if ( ! result &&
-                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
-                ) ) {
-                this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
-              }
-            }).catch(err => {
-              if ( err.data && err.data.id === 'foam.nanos.crunch.CapabilityIntercept' &&
-                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
-                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
-                ) ) {
-                this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
-              } else throw err;
-            });
-
-            if ( ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-20' ) {
+          if ( this.cjStatus === this.CapabilityJunctionStatus.ACTION_REQUIRED &&
+               ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-20' ) {
               this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
-            }
           }
         });
       }

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -155,19 +155,19 @@ foam.CLASS({
           if ( this.cjStatus === this.CapabilityJunctionStatus.ACTION_REQUIRED ) {
             this.auth.check(this.ctrl.__subContext__, 'certifydatareviewed.rw.reviewed').then(result => {
               if ( ! result &&
-                ( ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-49' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-13' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-12' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-11'
+                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
                 ) ) {
                 this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
               }
             }).catch(err => {
               if ( err.data && err.data.id === 'foam.nanos.crunch.CapabilityIntercept' &&
-                ( ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-49' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-13' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-12' ||
-                  ucj.targetId == '554af38a-8225-87c8-dfdf-eeb15f71215f-11'
+                ( ucj.targetId == 'crunch.onboarding.br.brazil-onboarding' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-us-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-international-payments' ||
+                  ucj.targetId == 'crunch.onboarding.unlock-ca-ca-payments'
                 ) ) {
                 this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
               } else throw err;


### PR DESCRIPTION
Update references to arbitrary alphanumeric capability ids with relevant strings that describe the capability and allows  updating user capability junction target ids if permitted.

Current references to capabilities are for logging purposes: **_"logs for a bug where sometimes signing officer address isn’t saved properly but its impossible to reproduce so the logs are there in case it happens again"_**

Removed references to project specific capability ids since they're no longer required with the flow they relate to.