### PR TITLE
Updates visual styling for table edit and context menus

### DIFF
--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -75,20 +75,14 @@ foam.CLASS({
       cursor: pointer;
     }
 
-    /*
-     * Unstlyed
-     */
-
-    ^unstlyed {
+    /* Unstyled */
+    ^unstyled {
       background-color: none;
       border: none;
       color: inherit;
     }
 
-    /*
-     * Primary
-     */
-
+    /* Primary */
     ^primary {
       background-color: /*%PRIMARY3%*/ #406dea;
       border-color: /*%SECONDARY1%*/ #4a33f4;
@@ -113,9 +107,7 @@ foam.CLASS({
       border: 1px solid /*%PRIMARY4%*/ #a7beff;
     }
 
-    /*
-     * Primary destructive
-     */
+    /* Primary destructive */
 
     ^primary-destructive {
       background-color: /*%DESTRUCTIVE3%*/ #d9170e;
@@ -140,9 +132,7 @@ foam.CLASS({
     }
 
 
-    /*
-     * Secondary
-     */
+    /* Secondary */
 
     ^secondary {
       background-color: white;
@@ -170,9 +160,7 @@ foam.CLASS({
     }
 
 
-    /*
-     * Secondary destructive
-     */
+    /* Secondary destructive */
 
     ^secondary-destructive {
       background-color: white;
@@ -192,9 +180,7 @@ foam.CLASS({
     }
 
 
-    /*
-     * Tertiary
-     */
+    /* Tertiary */
 
     ^tertiary {
       background: none;
@@ -220,9 +206,7 @@ foam.CLASS({
     }
 
 
-    /*
-     * Tertiary destructive
-     */
+    /* Tertiary destructive */
 
     ^tertiary-destructive {
       background-color: transparent;
@@ -244,9 +228,7 @@ foam.CLASS({
     }
 
 
-    /*
-     * Sizes
-     */
+    /* Sizes */
 
     ^small {
       font-size: 10px;

--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -75,6 +75,15 @@ foam.CLASS({
       cursor: pointer;
     }
 
+    /*
+     * Unstlyed
+     */
+
+    ^unstlyed {
+      background-color: none;
+      border: none;
+      color: inherit;
+    }
 
     /*
      * Primary

--- a/src/foam/u2/md/OverlayDropdown.js
+++ b/src/foam/u2/md/OverlayDropdown.js
@@ -24,16 +24,18 @@ foam.CLASS({
     }
 
     ^ {
-      background: white;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.38);
+      background-color: /*%WHITE%*/ #ffffff;
+      border: 1px solid #DADDE2;
+      box-sizing: border-box;
+      box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1), 0px 4px 6px rgba(0, 0, 0, 0.05);
+      border-radius: 4px;
       display: block;
-      font-size: 13px;
+      font-size: 14px;
       font-weight: 400;
       overflow-x: hidden;
       overflow-y: hidden;
       position: absolute;
-      padding-bottom: -20px;
-      margin-bottom: -20px;
+      padding: 8px;
       z-index: 1010;
       transform: translate(-100%, 12px);
     }

--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -379,17 +379,17 @@ foam.CLASS({
     function onDragOver(e) {
       e.preventDefault();
       e.stopPropagation();
-      e.currentTarget.style.setProperty('background-color', this.theme.primary5 ? this.theme.primary5 : this.ON_DRAG_OVER_BG_COLOR);
+      e.currentTarget.style.setProperty('background-color', this.theme ? this.theme.primary5 : this.ON_DRAG_OVER_BG_COLOR);
     },
     function onDragLeave(e) {
       e.preventDefault();
       e.stopPropagation();
-      e.currentTarget.style.setProperty( 'background-color', this.theme.white ? this.theme.white : '#ffffff' );
+      e.currentTarget.style.setProperty( 'background-color', this.theme ? this.theme.white : '#ffffff' );
     },
     function onDrop(e) {
       e.preventDefault();
       e.stopPropagation();
-      e.currentTarget.style.setProperty('background-color', this.theme.white ? this.theme.white : '#ffffff');
+      e.currentTarget.style.setProperty('background-color', this.theme ? this.theme.white : '#ffffff');
       this.onDragAndDropParentFunction(this.index, parseInt(e.dataTransfer.getData('draggableId')));
     }
   ]

--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -19,12 +19,12 @@ foam.CLASS({
       max-width: 200px;
     }
     ^search {
-      margin: 5px;
-      margin-bottom: 8px;
+      margin: 0px;
+      padding: 0px 8px;
+      padding-bottom: 16px;
     }
-
-    input[type="search"] {
-      width: 290px;
+    ^ input[type='search']{
+      width: 100%;
     }
   `,
   properties: [
@@ -281,7 +281,7 @@ foam.CLASS({
           return this.resetProperties(views, startUnselectedIndex-1, draggableIndex);
       }
 
-      while(startUnselectedIndex < views.length) {
+      while ( startUnselectedIndex < views.length ) {
         var currentProp = this.columnHandler.checkIfArrayAndReturnRootPropertyHeader(views[draggableIndex].prop.rootProperty);
         var comparedToProp =  this.columnHandler.checkIfArrayAndReturnRootPropertyHeader(views[startUnselectedIndex].prop.rootProperty);
         if ( currentProp.toLowerCase().localeCompare(comparedToProp.toLowerCase()) < 0 ) {
@@ -298,6 +298,7 @@ foam.CLASS({
   package: 'foam.u2.view',
   name: 'RootColumnConfigPropView',
   extends: 'foam.u2.Controller',
+  imports: ['theme'],
   properties: [
     // {
     //   class: 'Boolean',
@@ -337,11 +338,6 @@ foam.CLASS({
   ],
   constants: [
     {
-      name: 'DEFAULT_BG_COLOR',
-      type: 'String',
-      value: 'rgb(249, 249, 249)'
-    },
-    {
       name: 'ON_DRAG_OVER_BG_COLOR',
       type: 'String',
       value: '#e5f1fc'
@@ -376,24 +372,24 @@ foam.CLASS({
     }
   ],
   listeners: [
-    function onDragStart(e){
+    function onDragStart(e) {
       e.dataTransfer.setData('draggableId', this.index);
       e.stopPropagation();
     },
-    function onDragOver(e){
+    function onDragOver(e) {
       e.preventDefault();
       e.stopPropagation();
-      e.currentTarget.style.setProperty("background-color", this.ON_DRAG_OVER_BG_COLOR);
+      e.currentTarget.style.setProperty('background-color', this.theme.primary5 ? this.theme.primary5 : this.ON_DRAG_OVER_BG_COLOR);
     },
-    function onDragLeave(e){
+    function onDragLeave(e) {
       e.preventDefault();
       e.stopPropagation();
-      e.currentTarget.style.setProperty("background-color", this.DEFAULT_BG_COLOR);
+      e.currentTarget.style.setProperty( 'background-color', this.theme.white ? this.theme.white : '#ffffff' );
     },
     function onDrop(e) {
       e.preventDefault();
       e.stopPropagation();
-      e.currentTarget.style.setProperty("background-color", this.DEFAULT_BG_COLOR);
+      e.currentTarget.style.setProperty('background-color', this.theme.white ? this.theme.white : '#ffffff');
       this.onDragAndDropParentFunction(this.index, parseInt(e.dataTransfer.getData('draggableId')));
     }
   ]
@@ -404,6 +400,8 @@ foam.CLASS({
   package: 'foam.u2.view',
   name: 'ColumnViewHeader',
   extends: 'foam.u2.View',
+
+  requires: ['foam.u2.CheckBox'],
   css: `
 
   ^selected {
@@ -411,17 +409,23 @@ foam.CLASS({
   }
   ^some-padding {
     text-align: left;
-    padding: 3px;
-    height: 14px;
+    font-size: 14px;
+    line-height: 24px;
+    padding: 4px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  ^some-padding:hover {
+    background-color: /*%PRIMARY5%*/ #E5F1FC;
+    border-radius: 4px;
+  }
+  ^label {
+    display: flex;
+    align-items: center;
+    justify-content: start;
   }
   `,
-  constants: [
-    {
-      name: 'CHECK_MARK',
-      type: 'String',
-      value: '\u2713'
-    }
-  ],
   properties: [
     'onSelectionChangedParentFunction',
     {
@@ -438,23 +442,25 @@ foam.CLASS({
       var self = this;
       this.SUPER();
       this
-        .on('click', this.toggleExpanded)
-        .start()
+        .on('click', this.toggleSelection)
           .start()
             .addClass(this.myClass('some-padding'))
             .style({
-              'padding-left' : self.data.level * 15 + 15 + 'px',
-              'padding-right' : '15px'
+              'padding-left': self.data.level * 16 + 8 + 'px',
+              'padding-right': '8px'
             })
-            .start('span')
-              .show(this.data.isPropertySelected$)
-              .add(this.CHECK_MARK)
+            .start()
+              .addClass(this.myClass('label'))
+              .start()
+                .add(this.CheckBox.create({ data$: this.data.isPropertySelected$ }))
+                .on('click', this.toggleSelection)
+              .end()
+              .start()
+                .style({'padding-left' : '12px'})
+                .add(this.columnHandler.checkIfArrayAndReturnRootPropertyHeader(this.data.rootProperty))
+              .end()
             .end()
-            .start('span')
-              .style({'padding-left' : this.data.isPropertySelected$.map(function(s) { return s ? '4px' : '13px';})})
-              .add(this.columnHandler.checkIfArrayAndReturnRootPropertyHeader(this.data.rootProperty))
-            .end()
-            .start('span')
+            .start()
               .show(this.data.hasSubProperties)
               .style({
                 'vertical-align': 'middle',
@@ -467,20 +473,23 @@ foam.CLASS({
               .on('click', this.toggleExpanded)
               .add('\u2303')
             .end()
-          .end()
-        .end();
+          .end();
     }
   ],
   listeners: [
-    function toggleExpanded(e) {
+    function toggleSelection(e) {
       e.stopPropagation();
-      this.data.expanded = ! this.data.expanded;
+      // this.data.expanded = ! this.data.expanded;
       if ( ! this.data.hasSubProperties || foam.core.Reference.isInstance(this.data.prop) ) {
         this.data.isPropertySelected = ! this.data.isPropertySelected;
         if ( ! this.data.isPropertySelected )
           this.data.expanded = false;
         this.onSelectionChangedParentFunction(this.data.isPropertySelected, this.data.index);
       }
+    },
+    function toggleExpanded(e) {
+      e.stopPropagation();
+      this.data.expanded = ! this.data.expanded;
     }
   ]
 });
@@ -493,6 +502,7 @@ foam.CLASS({
     'foam.u2.view.RootColumnConfigPropView',
     'foam.u2.view.SubColumnSelectConfig'
   ],
+
   properties: [
     {
       name: 'views',

--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -22,7 +22,6 @@ foam.CLASS({
       top:              0;
       left:             0;
       z-index:          100;
-      background:       rgba(0, 0, 0, 0.4);
     }
     ^ .foam-u2-ActionView-closeButton {
       width: 24px;
@@ -42,6 +41,20 @@ foam.CLASS({
       outline: none;
       border: none;
       background: transparent;
+    }
+    ^container {
+      border-radius: 5px;
+      border: 1px solid /*%GREY4%*/ #e7eaec;
+      background-color: /*%WHITE%*/ #f9f9f9;
+      box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1), 0px 4px 6px rgba(0, 0, 0, 0.05);
+      right: 60px;
+      top: 120px;
+      position: fixed;
+      height: fit-content;
+      padding: 16px 8px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
     }
   `,
   properties: [
@@ -69,16 +82,9 @@ foam.CLASS({
         .show(this.selectColumnsExpanded$)
         .addClass(this.myClass('drop-down-bg'))
           .start()
+            .addClass(this.myClass('container'))
             .style({
-              'border-radius': '5px',
-              'border': '1px solid /*%GREY4%*/ #e7eaec',
-              'background-color': '#f9f9f9',
-              'right': '60px',
-              'top': '120px',
-              'position': 'fixed',
-              'height': 'fit-content',
               'max-height': window.innerHeight - 100 > 0 ? window.innerHeight - 100 : window.innerHeight + 'px',
-              'width': '300px'
             })
             .add(this.columnConfigPropView)
           .end()

--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -43,18 +43,18 @@ foam.CLASS({
       background: transparent;
     }
     ^container {
+      align-items: flex-start;
+      background-color: /*%WHITE%*/ #f9f9f9;
       border-radius: 5px;
       border: 1px solid /*%GREY4%*/ #e7eaec;
-      background-color: /*%WHITE%*/ #f9f9f9;
       box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1), 0px 4px 6px rgba(0, 0, 0, 0.05);
-      right: 60px;
-      top: 120px;
-      position: fixed;
-      height: fit-content;
-      padding: 16px 8px;
       display: flex;
       flex-direction: column;
-      align-items: flex-start;
+      height: fit-content;
+      padding: 16px 8px;
+      position: fixed;
+      right: 60px;
+      top: 120px;
     }
   `,
   properties: [

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -126,23 +126,22 @@ foam.CLASS({
     }
 
     ^disabled-button-container>button {
-      width: -webkit-fill-available;
-      width: fill-available;
       background-color: /*%WHITE%*/ #FFFFFF;
+      color: /*%GREY4%*/ grey;
+      justify-content: flex-start;
       text-align: left;
       white-space: nowrap;
-      justify-content: flex-start;
-      color: /*%GREY4%*/ grey;
+      width: fill-available;
+      width: -webkit-fill-available;
     }
 
     ^button-container>button {
-      width: -webkit-fill-available;
-      width: fill-available;
       background-color: /*%WHITE%*/ #FFFFFF;
+      justify-content: flex-start;
       text-align: left;
       white-space: nowrap;
-      justify-content: flex-start;
-      background-color: /*%WHITE%*/ white;
+      width: fill-available;
+      width: -webkit-fill-available;
     }
 
     ^button-container>button:hover {

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -126,25 +126,27 @@ foam.CLASS({
     }
 
     ^disabled-button-container>button {
-      background-color: white!important;
-      color: grey;
-      border-color: white!important;
-      box-shadow: none!important;
+      width: -webkit-fill-available;
+      width: fill-available;
+      background-color: /*%WHITE%*/ #FFFFFF;
+      text-align: left;
+      white-space: nowrap;
+      justify-content: flex-start;
+      color: /*%GREY4%*/ grey;
     }
 
     ^button-container>button {
-      background-color: white!important;
-      color: /*%BLACK%*/ #1e1f21;
-      border-color: white!important;
-      box-shadow: none!important;
+      width: -webkit-fill-available;
+      width: fill-available;
+      background-color: /*%WHITE%*/ #FFFFFF;
+      text-align: left;
+      white-space: nowrap;
+      justify-content: flex-start;
+      background-color: /*%WHITE%*/ white;
     }
 
     ^button-container>button:hover {
-      border-color: white!important;
-    }
-
-    ^disabled-button-container>button:hover {
-      border-color: white!important;
+      background-color: /*%PRIMARY5%*/ #E5F1FC;
     }
   `,
 
@@ -197,7 +199,7 @@ foam.CLASS({
         this
             .start()
               .addClass(action.createIsEnabled$(self.__context__, self.obj).map( e => e ? self.myClass('button-container') : self.myClass('disabled-button-container')))
-              .add(action)
+              .tag(action, { buttonStyle: 'UNSTYLED' })
               .attrs({
                 disabled: action.createIsEnabled$(self.__context__, self.obj).map(function(e) {
                   return ! e;


### PR DESCRIPTION
- Updated styling for table edit menu and context menu
- Drop-downs in edit menu no longer select the parent element when clicked
- Added Css to unstyled buttons to override browser styling

Edit menu: 
![image](https://user-images.githubusercontent.com/81172969/115913615-d7c6f500-a43e-11eb-9adc-03f13205b82c.png)

Context Menu: 
![image](https://user-images.githubusercontent.com/81172969/115913668-e7463e00-a43e-11eb-8909-3258e792f80a.png)

