### PR TITLE
Made actions reset after every table entry

### DIFF
--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -516,6 +516,11 @@ foam.CLASS({
           // Context menu actions
           view.contextMenuActions.forEach(actionsMerger);
 
+          // storing the base actions for resetting after merges
+          var baseActions = {
+            ...actions
+          };
+
           // with this code error created slot.get cause promise return
           // FIX ME
           var slot = this.slot(function(data, data$delegate, order, updateValues) {
@@ -693,7 +698,7 @@ foam.CLASS({
                   }
 
                   // Object actions
-                  obj.cls_.getOwnAxiomsByClass(foam.core.Action).forEach(actionsMerger);
+                  obj.cls_.getAxiomsByClass(foam.core.Action).forEach(actionsMerger);
                   tableRowElement
                     .start()
                       .addClass(view.myClass('td')).
@@ -706,6 +711,11 @@ foam.CLASS({
                       }).
                     end();
                   tbodyElement.add(tableRowElement);
+
+                  // reset actions back to base state
+                  actions = {
+                    ...baseActions
+                  }
                 }
               });
 

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -508,19 +508,6 @@ foam.CLASS({
           var view = this;
           view.props = this.returnPropertiesForColumns(view, view.columns_);
 
-          var actions = {};
-          var actionsMerger = action => { actions[action.name] = action; };
-
-          // Model actions
-          view.of.getAxiomsByClass(foam.core.Action).forEach(actionsMerger);
-          // Context menu actions
-          view.contextMenuActions.forEach(actionsMerger);
-
-          // storing the base actions for resetting after merges
-          var baseActions = {
-            ...actions
-          };
-
           // with this code error created slot.get cause promise return
           // FIX ME
           var slot = this.slot(function(data, data$delegate, order, updateValues) {
@@ -698,7 +685,7 @@ foam.CLASS({
                   }
 
                   // Object actions
-                  obj.cls_.getAxiomsByClass(foam.core.Action).forEach(actionsMerger);
+                  var actions = view.getActionsForRow(obj);
                   tableRowElement
                     .start()
                       .addClass(view.myClass('td')).
@@ -711,11 +698,6 @@ foam.CLASS({
                       }).
                     end();
                   tbodyElement.add(tableRowElement);
-
-                  // reset actions back to base state
-                  actions = {
-                    ...baseActions
-                  }
                 }
               });
 
@@ -743,6 +725,23 @@ foam.CLASS({
       },
       function returnMementoColumnNameDisregardSorting(c) {
         return c && this.shouldColumnBeSorted(c) ? c.substr(0, c.length - 1) : c;
+      },
+      function returnMementoColumnNameDisregardSorting(c) {
+        return c && this.shouldColumnBeSorted(c) ? c.substr(0, c.length - 1) : c;
+      },
+      {
+        name: 'getActionsForRow',
+        code: function(obj) {
+          var actions = {};
+          var actionsMerger = action => { actions[action.name] = action; };
+
+          // Model actions
+          obj.cls_.getAxiomsByClass(foam.core.Action).forEach(actionsMerger);
+          // Context menu actions
+          this.contextMenuActions.forEach(actionsMerger);
+
+          return actions;
+        }
       }
   ]
 });


### PR DESCRIPTION
Previously, if actions were overwritten by a subclass after the merger, those overwritten actions would remain and so following instances would inherit actions they shouldn't have in the context menu.

Also use `getAxiomsByClass` instead of `getOwnAxiomsByClass` so that we just collect the actions from the class each time. Now that we reset the actions at the end of each iteration to use the actions in the  `of` property + `contextMenuActions` actions, we shouldn't have merger conflicts.

Example of bug: If `entryA` is `NatureCodeApprovalRequest` and entry B is `ComplianceApprovalRequest`. `entryB` comes after `entryA` in the dao table. B is not a subclass of A. `entryA` overrides the approve method. When both `entryA` and `entryB` are in the table in the order of AB, in the context menu `B.Approve` would end up using `NatureCodeApprovalRequest.approve`. This shouldn't happen as `ComplianceApprovalRequest` is NOT a subclass of `NatureCodeApprovalRequest`