### PR TITLE
[NP-4300] Handle network failures in wizard

### DIFF
--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -209,6 +209,7 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollWizardletVi
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.SAVE_LABEL",target:"Salve"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.NO_ACTION_LABEL",target:"Feito"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.REJECT_LABEL",target:"Rejeitar"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.ScrollingStepWizardView.NETWORK_FAILURE_MESSAGE",target:"Há um problema de conexão com o servidor. Por favor, aguarde."})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.DAOWizardlet.OF.label",target:"do"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.wizard.DAOWizardlet.DATA.label",target:"dados"})
 

--- a/src/foam/nanos/theme/ThemeGlyphs.js
+++ b/src/foam/nanos/theme/ThemeGlyphs.js
@@ -83,6 +83,24 @@ foam.CLASS({
         </svg>
         ` };
       }
+    },
+    {
+      name: 'networkError',
+      class: 'GlyphProperty',
+      of: 'foam.core.Glyph',
+      factory: function () {
+        return { template: `
+          <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="/*%FILL%*/ #ffffff">
+            <g><path d="M0,0h24v24H0V0z" fill="none"/></g>
+            <g>
+              <g>
+                <path d="M12,4C7.31,4,3.07,5.9,0,8.98L12,21l5-5.01V8h5.92C19.97,5.51,16.16,4,12,4z"/>
+                <rect height="2" width="2" x="19" y="18"/><rect height="6" width="2" x="19" y="10"/>
+              </g>
+            </g>
+          </svg>
+        ` };
+      }
     }
   ]
 });

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -188,6 +188,9 @@ foam.CLASS({
       await this.wao.load(this);
       return this;
     },
+    function reportNetworkFailure() {
+      this.indicator = this.WizardletIndicator.NETWORK_FAILURE;
+    },
     {
       name: 'getDataUpdateSub',
       documentation: `

--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -18,7 +18,7 @@ foam.CLASS({
     { name: 'SAVE_LABEL', message: 'Save' },
     { name: 'REJECT_LABEL', message: 'Reject' },
     {
-      name: 'NETWORK_FALURE_MESSAGE',
+      name: 'NETWORK_FAILURE_MESSAGE',
       message: 'There is a problem connecting to the server. Please wait.'
     }
   ],
@@ -227,7 +227,7 @@ foam.CLASS({
                 return data$someFailures
                   ? this.E()
                     .addClass(this.myClass('network-failure-banner'))
-                    .add(this.NETWORK_FALURE_MESSAGE)
+                    .add(this.NETWORK_FAILURE_MESSAGE)
                   : this.E();
               }))
               .add(this.slot(function (data$wizardlets) {

--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -16,7 +16,11 @@ foam.CLASS({
   messages: [
     { name: 'NO_ACTION_LABEL', message: 'Done' },
     { name: 'SAVE_LABEL', message: 'Save' },
-    { name: 'REJECT_LABEL', message: 'Reject' }
+    { name: 'REJECT_LABEL', message: 'Reject' },
+    {
+      name: 'NETWORK_FALURE_MESSAGE',
+      message: 'There is a problem connecting to the server. Please wait.'
+    }
   ],
 
   requires: [
@@ -74,6 +78,21 @@ foam.CLASS({
     ^heading {
       display: flex;
       align-items: center;
+    }
+
+    ^network-failure-banner {
+      position: sticky;
+      top: 0;
+      background-color: %DESTRUCTIVE2%f0;
+      color: %WHITE%;
+      height: 30px;
+      font-size: 18px;
+      line-height: 30px;
+      text-align: center;
+      z-index: 1000;
+      padding: 15px;
+      border-radius: 8px;
+      backdrop-filter: blur(10px);
     }
   `,
 
@@ -148,7 +167,7 @@ foam.CLASS({
       name: 'willReject',
       documentation: `
         Used to put submit button in confirmationRequired mode and change the
-        button test from 'Done' to 'Reject' when in approvalMode and the wizard 
+        button test from 'Done' to 'Reject' when in approvalMode and the wizard
         has at least on invalid wizardlet.
       `,
       expression: function( data$config$approvalMode, data$allValid ) {
@@ -204,6 +223,13 @@ foam.CLASS({
               .addClass(this.myClass('mainView'))
               // TODO: deprecate this hide-X-entry class
               .addClass(this.hideX ? this.myClass('hide-X-entry') : this.myClass('entry'))
+              .add(this.slot(function (data$someFailures) {
+                return data$someFailures
+                  ? this.E()
+                    .addClass(this.myClass('network-failure-banner'))
+                    .add(this.NETWORK_FALURE_MESSAGE)
+                  : this.E();
+              }))
               .add(this.slot(function (data$wizardlets) {
                 return self.renderWizardlets(this.E(), data$wizardlets);
               }))
@@ -297,7 +323,8 @@ foam.CLASS({
       confirmationRequired: function(willReject) {
         return willReject;
       },
-      isEnabled: function (data$config, data$allValid) {
+      isEnabled: function (data$config, data$allValid, data$someFailures) {
+        if ( data$someFailures ) return false;
         return ! data$config.requireAll || data$allValid;
       },
       code: function (x) {

--- a/src/foam/u2/wizard/StepWizardController.js
+++ b/src/foam/u2/wizard/StepWizardController.js
@@ -11,6 +11,7 @@ foam.CLASS({
   requires: [
     'foam.core.FObject',
     'foam.u2.wizard.WizardPosition',
+    'foam.u2.wizard.WizardletIndicator',
     'foam.u2.wizard.StepWizardConfig'
   ],
 
@@ -139,6 +140,10 @@ foam.CLASS({
     {
       name: 'allValid',
       class: 'Boolean'
+    },
+    {
+      name: 'someFailures',
+      class: 'Boolean'
     }
   ],
 
@@ -177,6 +182,12 @@ foam.CLASS({
         var isValid$ = w.isValid$;
         this.wsub.onDetach(isValid$.sub(() => {
           this.onWizardletValidity();
+        }));
+
+        // Bind indicator listener for wizardlet validity
+        var indicator$ = w.indicator$;
+        this.wsub.onDetach(indicator$.sub(() => {
+          this.onWizardletIndicator(wizardletIndex, indicator$.get());
         }));
 
       });
@@ -319,6 +330,14 @@ foam.CLASS({
     },
     function onWizardletValidity() {
       this.allValid = this.wizardlets.filter(w => ! w.isValid).length == 0;
+    },
+    function onWizardletIndicator(wizardletIndex, value) {
+      if ( value == this.WizardletIndicator.NETWORK_FAILURE ) {
+        this.someFailures = true;
+        return;
+      }
+      this.someFailures = !! this.wizardlets.filter(
+        w => w.indicator == this.WizardletIndicator.NETWORK_FAILURE).length;
     },
     function onSectionAvailability(sectionPosition, value) {
       // If a previous position became available, move the wizard back

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -36,7 +36,10 @@ foam.CLASS({
             fill: this.theme.white
           }),
         };
-      } else if ( wizardlet.indicator == this.WizardletIndicator.SAVING ) {
+      } else if (
+        wizardlet.indicator == this.WizardletIndicator.SAVING ||
+        wizardlet.indicator == this.WizardletIndicator.NETWORK_FAILURE
+      ) {
         args = {
           ...args,
           indicateProcessing: true,
@@ -44,16 +47,6 @@ foam.CLASS({
           borderColorHover: 'rgba(0,0,0,0)',
           label: '' + number
         };
-      } else if ( wizardlet.indicator == this.WizardletIndicator.NETWORK_FAILURE ) {
-        args = {
-          ...args,
-          borderColor: this.theme.destructive2,
-          borderColorHover: this.theme.destructive2,
-          backgroundColor: this.theme.destructive2,
-          icon: this.theme.glyphs.networkError.getDataUrl({
-            fill: this.theme.white
-          })
-        }
       } else {
         args = {
           ...args,

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -40,10 +40,20 @@ foam.CLASS({
         args = {
           ...args,
           indicateProcessing: true,
-          borderColor: this.theme.grey2,
-          borderColorHover: this.theme.grey2,
+          borderColor: 'rgba(0,0,0,0)',
+          borderColorHover: 'rgba(0,0,0,0)',
           label: '' + number
         };
+      } else if ( wizardlet.indicator == this.WizardletIndicator.NETWORK_FAILURE ) {
+        args = {
+          ...args,
+          borderColor: this.theme.destructive2,
+          borderColorHover: this.theme.destructive2,
+          backgroundColor: this.theme.destructive2,
+          icon: this.theme.glyphs.networkError.getDataUrl({
+            fill: this.theme.white
+          })
+        }
       } else {
         args = {
           ...args,
@@ -244,45 +254,6 @@ foam.CLASS({
         })
         .translate(title, title);
     },
-    function configureIndicator(wizardlet, isCurrent, number) {
-      var args = {
-        size: 24, borderThickness: 2,
-      };
-      if ( wizardlet.indicator == this.WizardletIndicator.COMPLETED ) {
-        args = {
-          ...args,
-          borderColor: this.theme.approval3,
-          backgroundColor: this.theme.approval3,
-          borderColorHover: this.theme.approval3,
-          icon: this.theme.glyphs.checkmark.getDataUrl({
-            fill: this.theme.white
-          }),
-        };
-      } else if ( wizardlet.indicator == this.WizardletIndicator.SAVING ) {
-        args = {
-          ...args,
-          indicateProcessing: true,
-          borderColor: this.theme.grey2,
-          borderColorHover: this.theme.grey2,
-          label: '' + number
-        };
-      } else {
-        args = {
-          ...args,
-          borderColor: this.theme.grey2,
-          borderColorHover: this.theme.grey2,
-          label: '' + number
-        };
-      }
-      if ( isCurrent ) {
-        args = {
-          ...args,
-          borderColor: this.theme.black,
-          borderColorHover: this.theme.black
-        };
-      }
-      return args;
-    }
   ],
 
   listeners: [
@@ -301,6 +272,6 @@ foam.CLASS({
         var scrollTop = this.childNodes[0].childNodes[currI].el().offsetTop;
         this.parentNode.el().scrollTop = scrollTop - padding;
       }
-    },
+    }
   ]
 });

--- a/src/foam/u2/wizard/WizardletIndicator.js
+++ b/src/foam/u2/wizard/WizardletIndicator.js
@@ -16,6 +16,9 @@ foam.ENUM({
     },
     {
       name: 'SAVING'
+    },
+    {
+      name: 'NETWORK_FAILURE'
     }
   ]
 });


### PR DESCRIPTION
Failures on a DAO put leads to a wizardlet being stuck in `loading` state, preventing any further saves or loads.

This PR adds a more controlled failure mode for wizardlets and the wizard. Any exception during save and load will be reported as a network error and begin a re-try interval. The wizard will display a sticky banner, and will also not allow the user to click the primary action of the wizard ("done"/"save"/"submit")
![Screen Shot 2021-04-28 at 2 11 50 PM](https://user-images.githubusercontent.com/7225168/116452427-b8a7d900-a82b-11eb-8ca7-effdbad5d7d6.png)
