### PR TITLE
[NP-4324] Add wizard documentation

### DIFF
--- a/src/documentation/crunch-doc.flow
+++ b/src/documentation/crunch-doc.flow
@@ -80,8 +80,6 @@ the intercept.
 The options available for StepWizardConfig are in the scope of wizard documentation.
 </p>
 
-<!-- TODO: link wizard documentation -->
-
 <p>
 As an example, the following journal entry describes a capability that will
 configure the wizard to disallow skipping sections.

--- a/src/files.js
+++ b/src/files.js
@@ -831,6 +831,7 @@ FOAM_FILES([
   { name: "foam/flow/widgets/PropertyShortSummary" },
   { name: "foam/flow/widgets/ModelSummary" },
   { name: "foam/flow/widgets/EnumSummary" },
+  { name: "foam/flow/widgets/TabbedModelDocumentation" },
   { name: "foam/flow/widgets/DocumentationIncomplete" },
   { name: "foam/flow/widgets/TryItSnippet" },
 

--- a/src/foam/flow/widgets/AxiomShortSummary.js
+++ b/src/foam/flow/widgets/AxiomShortSummary.js
@@ -12,6 +12,12 @@ foam.CLASS({
     Brief summary of axioms for overview documentation.
   `,
 
+  css: `
+    ^preformatted {
+      white-space: pre;
+    }
+  `,
+
   properties: [
     {
       name: 'of',
@@ -53,7 +59,10 @@ foam.CLASS({
               .start('tr')
                 .start('td').add(ax.name).end()
                 .callOn(self, 'generateAxiomClassFields', [ax])
-                .start('td').add(ax.documentation).end()
+                .start('td')
+                  .addClass(self.myClass('preformatted'))
+                  .add(ax.documentation)
+                .end()
               .end()
           })
         .end()

--- a/src/foam/flow/widgets/ModelSummary.js
+++ b/src/foam/flow/widgets/ModelSummary.js
@@ -4,6 +4,27 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+foam.ENUM({
+  package: 'foam.flow.widgets',
+  name: 'ModelType',
+
+  values: [
+    {
+      name: 'CLASS',
+      background: '#D57D11',
+      color: '#FFFFFF'
+    },
+    {
+      name: 'ENUM',
+      color: '#865300'
+    },
+    {
+      name: 'INTERFACE',
+      color: '#007328'
+    }
+  ]
+});
+
 foam.CLASS({
   package: 'foam.flow.widgets',
   name: 'ModelSummary',
@@ -18,13 +39,30 @@ foam.CLASS({
 
   requires: [
     'foam.core.PromiseSlot',
-    'foam.u2.Element'
+    'foam.flow.widgets.ModelType',
+    'foam.u2.Element',
+    'foam.u2.view.ReadOnlyEnumView'
   ],
 
   properties: [
     {
       name: 'of',
       class: 'Class'
+    },
+    {
+      name: 'modelType',
+      class: 'Enum',
+      of: 'foam.flow.widgets.ModelType',
+      expression: function (of) {
+        const typeMapping = [
+          [foam.core.AbstractInterface, this.ModelType.INTERFACE],
+          [foam.core.AbstractEnum, this.ModelType.ENUM]
+        ];
+        for ( let mapping of typeMapping ) {
+          if ( mapping[0].isSubClass(of) ) return mapping[1];
+        }
+        return this.ModelType.CLASS;
+      }
     },
     {
       name: 'showProperties',
@@ -50,7 +88,7 @@ foam.CLASS({
     {
       name: 'adapters',
       factory: () => ({
-        implements: arry => arry.map(impl => impl.path).join(', ')
+        implements: arry => (arry || []).map(impl => impl.path).join(', ')
       })
     },
     {
@@ -72,6 +110,12 @@ foam.CLASS({
           .start('tr')
             .start('th').add('Property').end()
             .start('th').add('Value').end()
+          .end()
+          .start('tr')
+            .start('td').add('type').end()
+            .start('td')
+              .tag(this.ReadOnlyEnumView, { data$: this.modelType$ })
+            .end()
           .end()
           .forEach(this.visibleModelProps, function (p) {
             var value = self.of.model_[p];

--- a/src/foam/flow/widgets/TabbedModelDocumentation.js
+++ b/src/foam/flow/widgets/TabbedModelDocumentation.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.flow.widgets',
+  name: 'TabbedModelDocumentation',
+  extends: 'foam.u2.Element',
+  documentation: `
+    Display ModelSummary, PropertyShortSummary, and MethodShortSummary in a
+    single tabbed view.
+  `,
+
+  requires: [
+    'foam.flow.widgets.PropertyShortSummary',
+    'foam.flow.widgets.MethodShortSummary',
+    'foam.flow.widgets.ModelSummary',
+    'foam.u2.Tab',
+    'foam.u2.Tabs'
+  ],
+
+  properties: [
+    {
+      name: 'of',
+      class: 'Class'
+    },
+    {
+      name: 'defaultTab',
+      class: 'String',
+      value: 'summary'
+    }
+  ],
+
+  messages: [
+    { name: 'TAB_SUMMARY', message: 'Summary' }
+  ],
+
+  methods: [
+    function initE() {
+      var self = this;
+      this
+        .start(this.Tabs)
+          .start(this.Tab, {
+            label: this.TAB_SUMMARY,
+            selected: this.defaultTab == 'summary'
+          })
+            .tag(this.ModelSummary, { of$: this.of$ })
+          .end()
+          .start(this.Tab, {
+            label: foam.core.Model.METHODS.label,
+            selected: this.defaultTab == 'methods'
+          })
+            .tag(this.MethodShortSummary, { of$: this.of$ })
+          .end()
+          .start(this.Tab, {
+            label: foam.core.Model.PROPERTIES.label,
+            selected: this.defaultTab == 'properties'
+          })
+            .tag(this.PropertyShortSummary, { of$: this.of$ })
+          .end()
+        .end()
+        ;
+    },
+    function matchRef(id) {
+      if ( typeof id !== 'string' ) return id;
+      if ( this.capabilityDAO ) {
+        return this.PromiseSlot.create({
+          promise: this.capabilityDAO.find(id)
+        }).map(found => found
+          ? this.Element.create({ nodeName: 'a' })
+            .attrs({
+              href: '#admin.crunchlab:'+id,
+              target: '_blank'
+            })
+            .add(id)
+          : id
+        );
+      }
+    }
+  ]
+});

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -84,12 +84,19 @@ foam.CLASS({
         Specify the availability of this wizardlet. If true, wizardlet is
         available iff at least one section is available. If false, wizardlet
         does not display even if some sections are available.
+
+        Wizardlet availability determines whether or not the wizardlet will be
+        saved. An invisible wizardlet can still be available.
       `
     },
 
     {
       name: 'isVisible',
       class: 'Boolean',
+      documentation: `
+        Specify the visibility of this wizardlet. If true, 'createView' will
+        be called on any of this wizardlets visible sections.
+      `,
       expression: function (of, isAvailable, atLeastOneSectionVisible_) {
         return isAvailable && of && atLeastOneSectionVisible_;
       }
@@ -102,6 +109,10 @@ foam.CLASS({
     },
     {
       name: 'loading',
+      documentation: `
+        Indicates that the wizardlet's 'data' is being saved or modified by a
+        WAO.
+      `,
       class: 'Boolean',
       postSet: function (_, n) {
         if ( ! n ) this.LoadingLevel = this.LoadingLevel.IDLE;
@@ -136,6 +147,10 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.u2.wizard.WAO',
       flags: ['web'],
+      documentation: `
+        A wizardlet's WAO (Wizardlet Access Object) implements the behavior of
+        the save and load operations.
+      `,
       factory: function () {
         this.ProxyWAO.create();
       }
@@ -155,7 +170,11 @@ foam.CLASS({
     {
       name: 'loadingLevel',
       class: 'Enum',
-      of: 'foam.u2.borders.LoadingLevel'
+      of: 'foam.u2.borders.LoadingLevel',
+      documentation: `
+        Indicates the loading state the UI should present this wizardlet in.
+        This is used to control a LoadingBorder wraping the wizardlet.
+      `
     },
     {
       name: '__subSubContext__',

--- a/src/foam/u2/wizard/StepWizardConfig.js
+++ b/src/foam/u2/wizard/StepWizardConfig.js
@@ -15,22 +15,31 @@ foam.CLASS({
   properties: [
     {
       class: 'Boolean',
-      name: 'allowSkipping'
+      name: 'allowSkipping',
+      documentation: `
+        Allow skipping sections without completing them in incremental wizards.
+      `
     },
     {
       class: 'Boolean',
       name: 'allowBacktracking',
-      value: true
+      value: true,
+      documentation: `
+        Allow going back to previous sections in incremental wizards.
+      `
     },
     {
       class: 'Boolean',
-      name: 'requireAll'
+      name: 'requireAll',
+      documentation: `
+        Require all sections to be valid to invoke wizard completion (done button).
+      `
     },
     {
       class: 'Boolean',
       name: 'approvalMode',
       documentation: `
-        Set to true when ScrollingWizard is used to view UCJ data 
+        Set to true when ScrollingWizard is used to view UCJ data
         accociated to an Approval Request.
       `,
       value: false
@@ -39,6 +48,11 @@ foam.CLASS({
       class: 'foam.u2.ViewSpec',
       name: 'wizardView',
       flags: ['web'], // Temporary
+      documentation: `
+        Specify a view to use with this controller. This property isn't used by
+        StepWizardController, but it can be used where a wizard is launched so
+        that only providing this configuration object is necessary.
+      `,
       // value: { class: 'foam.u2.wizard.IncrementalStepWizardView' }
       value: { class: 'foam.u2.wizard.ScrollingStepWizardView' }
     }

--- a/src/foam/u2/wizard/StepWizardController.js
+++ b/src/foam/u2/wizard/StepWizardController.js
@@ -24,6 +24,10 @@ foam.CLASS({
       name: 'config',
       class: 'FObjectProperty',
       of: 'foam.u2.wizard.StepWizardConfig',
+      documentation: `
+        Configuration for the wizard. Some configurattion properties are not
+        applicable to all wizard views.
+      `,
       factory: function() {
         return this.StepWizardConfig.create();
       }
@@ -41,6 +45,10 @@ foam.CLASS({
       name: 'wizardlets',
       class: 'FObjectArray',
       of: 'foam.u2.wizard.Wizardlet',
+      documentation: `
+        An array containing all the wizardlets to use in this wizard. This may
+        include wizardlets with isAvailable initially set to false.
+      `,
       postSet: function (_, n) {
         this.setupWizardletListeners(n);
         this.determineWizardActions(n);
@@ -49,7 +57,10 @@ foam.CLASS({
     {
       name: 'wizardPosition',
       documentation: `
-        Wizardlet position
+        A WizardPosition instance specifying the index of the wizardlet and
+        section that is considered the "current" section. For the incremental
+        view, this is the current screen; for the scrolling view, this is the
+        first section that is below the top of the visible portion of the wizard.
       `,
       class: 'FObjectProperty',
       of: 'foam.u2.wizard.WizardPosition',

--- a/src/foam/u2/wizard/Wizardlet.js
+++ b/src/foam/u2/wizard/Wizardlet.js
@@ -11,22 +11,43 @@ foam.INTERFACE({
   properties: [
     {
       name: 'of',
-      class: 'Class'
+      class: 'Class',
+      documentation: `
+        Specifies a class for the wizardlet's 'data' property. This value can
+        be null to indicate that the wizardlet doesn't have any data.
+      `,
     },
     {
-      name: 'data'
+      name: 'data',
+      documentation: `
+        This is the data that will be saved by the wizardlet. If this is null,
+        the wizardlet may still provide a side-effect when save is called.
+      `
     },
     {
       name: 'title',
-      class: 'String'
+      class: 'String',
+      documentation: `
+        Specifies a human-friendly name for this wizardlet.
+      `
     },
     {
       name: 'isAvailable',
       class: 'Boolean',
       value: true,
       documentation: `
-        Specify the availability of this wizardlet. If true, wizardlet is
-        available iff at least one section is available. If false, wizardlet
+        Specify the availability of this wizardlet. Wizardlet availability
+        indicates that the wizardlet is allowed to be saved, or otherwise affect
+        the wizard. This is independent from visibility.
+      `
+    },
+    {
+      name: 'isVisible',
+      class: 'Boolean',
+      value: true,
+      documentation: `
+        Specify the visibility of this wizardlet. If true, wizardlet is
+        visible iff at least one section is available. If false, the wizardlet
         does not display even if some sections are available.
       `
     }
@@ -35,11 +56,44 @@ foam.INTERFACE({
   methods: [
     {
       flags: ['web'],
-      name: 'save'
+      name: 'save',
+      async: true,
+      args: [
+        { name: 'options', type: 'Object' }
+      ],
+      documentation: `
+        Convey an intent to save this wizardlet. The destination will depend on
+        the subclass of wizardlet, or a provided WAO.
+
+        This method takes arguments in the form of a plain object. The following
+        properties will affect how the wizardlet is saved:
+
+        - **disposable**: If true, this save should be ignored during an
+          ongoing operation. If false or unspecified, this save should be
+          enqueued during an ongoing operation.
+        - **reloadData**: If true, the wizardlet will reload data from the
+          server after saving. This should be used sparingly, as an expected
+          reload blocks user input to prevent data loss.
+      `
+    },
+    {
+      flags: ['web'],
+      name: 'cancel',
+      async: true,
+      documentation: `
+        This will be called when a wizardlet is no longer needed. For example,
+        if the wizardlet was related to a choice which the user de-selected.
+
+        This method is not to be disposable, and will not invoke a reload.
+      `
     },
     {
       flags: ['web'],
       name: 'createView',
+      documentation: `
+        This method is deprecated. Please use 'createView' in WizardletSection
+        instead.
+      `,
       args: [
         {
           name: 'data'

--- a/src/foam/u2/wizard/WizardletSection.js
+++ b/src/foam/u2/wizard/WizardletSection.js
@@ -23,10 +23,15 @@ foam.CLASS({
       name: 'section',
       class: 'FObjectProperty',
       of: 'foam.layout.Section',
+      documentation: `
+        An optional property for the original model section. This property must
+        be set if customView is null.
+      `
     },
     {
       name: 'title',
       class: 'String',
+      documentation: 'Full title of this section.',
       expression: function(section) {
         return section && section.title;
       }
@@ -34,7 +39,10 @@ foam.CLASS({
     {
       name: 'wizardlet',
       class: 'FObjectProperty',
-      of: 'foam.u2.wizard.Wizardlet'
+      of: 'foam.u2.wizard.Wizardlet',
+      documentation: `
+        This is a reference to the aggregating wizardlet.
+      `
     },
     {
       name: 'data',
@@ -47,11 +55,19 @@ foam.CLASS({
     },
     {
       name: 'isAvailable',
-      class: 'Boolean'
+      class: 'Boolean',
+      documentation: `
+        This section is visible only when this property is true.
+      `
     },
     {
       name: 'isValid',
       class: 'Boolean',
+      documentation: `
+        Indicates if this section in isolation is valid. If a model section is
+        specified, this is determined automatically. For a custom view, this
+        property should be overridden.
+      `,
       expression: function (wizardlet$of, data, data$errors_) {
         if ( ! wizardlet$of ) return true;
         if ( ! data ) return false;
@@ -67,11 +83,16 @@ foam.CLASS({
     },
     {
       name: 'customView',
-      class: 'foam.u2.ViewSpec'
+      class: 'foam.u2.ViewSpec',
+      documentation: `
+        A view to display for this section. If the 'section' property is set,
+        this property will override it.
+      `
     },
     {
       name: 'navTitle',
       class: 'String',
+      documentation: 'Short title used for navigation menu items',
       expression: function(section) {
         return section && section.navTitle;
       }
@@ -88,7 +109,7 @@ foam.CLASS({
           this.customView, null, this, ctx);
       }
 
-      
+
       ctx.register(
         this.VerticalDetailView,
         'foam.u2.detail.SectionedDetailView'

--- a/src/foam/u2/wizard/doc.flow
+++ b/src/foam/u2/wizard/doc.flow
@@ -1,0 +1,59 @@
+<title>Modular Wizard Documentation</title>
+
+<h1>Wizardlet Models</h1>
+
+<h2>Wizardlet</h2>
+
+A wizardlet is an independent portion of a wizard. It describes its data, views,
+and how it's saved and loaded. Wizardlets can be visible, allowing a user to
+fill in their data; or invisible, providing hidden functionality for saving or
+acting on wizard events.
+
+<foam class="foam.flow.widgets.TabbedModelDocumentation" defaultTab="methods" of="foam.u2.wizard.Wizardlet" />
+
+<h2>WizardletSection</h2>
+
+Wizardlets are sectioned. By default, a wizardlet will contain WizardletSection
+instances derived from 'of's section axioms. The abstraction of WizardletSection
+allows adding custom views to a wizardlet independently from the data model.
+
+The MinMaxCapabilityWizardlet is an example where a custom WizardletSection is
+used to display a selection of choices.
+
+<foam class="foam.flow.widgets.TabbedModelDocumentation" defaultTab="properties" of="foam.u2.wizard.WizardletSection" />
+
+<h1>Wizards</h1>
+
+Wizards are created by combining StepWizardController with a compatible view.
+An instance of StepWizardController should be the value of the view's data
+property.
+
+<h2>StepWizardController</h2>
+
+StepWizardController implements the behaviour for a wizard. It creates listeners
+on all wizardlets to provide status properties like 'allValid' and
+'visitedWizardlets'. It also contains logic for skippiing unavailable wizardlets
+and moving the position backwards if a previous wizardlet becomes available.
+
+The following properties are useful to initialize when creating the controller:
+<foam class="foam.flow.widgets.PropertyShortSummary" of="foam.u2.wizard.StepWizardController" whitelist="['wizardlets', 'config', 'wizardPosition']" />
+
+<h2>IncrementalStepWizardView</h2>
+
+This is a view for StepWizardController implementing a "page by page" approach
+wizard navigation. Each section will be seen on a separate screen, and the user
+must click "next" to reach the next screen. Requiring the user to click next
+allows control over how they proceed, as they must provide valid data before
+continuing.
+
+<h2>ScrollingStepWizardView</h2>
+
+This is a view for StepWizardController implementing a single scrolling view
+containing all sections. This allows a user to fill in sections in any order
+they choose, making it ideal for cases where a user might not have all the
+requirement information immediately.
+
+<h2>StepWizardConfig</h2>
+
+This is the model used for the 'config' property of StepWizardController.
+<foam class="foam.flow.widgets.PropertyShortSummary" of="foam.u2.wizard.StepWizardConfig" />


### PR DESCRIPTION
This is the first part of wizard documentation: documentation for the wizard itself, not considering its use in CRUNCH.

The next part will be a separate FLOW doc in `foam.u2.crunch` documenting CrunchController.