### PR TITLE
[NP-4240] Get input update mode from context

### DIFF
--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -885,13 +885,7 @@ foam.CLASS({
       class: 'Object',
       name: 'id',
       transient: true,
-      // factory: function() { return this.NEXT_ID(); }
-      factory: function() {
-        var id = this.NEXT_ID();
-        if ( ! window.idToE ) window.idToE = {};
-        window.idToE[id] = this;
-        return id;
-      }
+      factory: function() { return this.NEXT_ID(); }
     },
     {
       class: 'Enum',

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -76,6 +76,30 @@ foam.ENUM({
 });
 
 
+foam.ENUM({
+  package: 'foam.u2',
+  name: 'InputUpdateMode',
+
+  documentation: 'Different ways an input can update a property.',
+
+  values: [
+    {
+      name: 'ON_KEY',
+      label: 'Create',
+      modePropertyName: 'createVisibility'
+    },
+    {
+      name: 'ON_BLUR',
+      label: 'View',
+      modePropertyName: 'readVisibility',
+      restrictDisplayMode: function(mode) {
+        return mode == foam.u2.DisplayMode.RW ? foam.u2.DisplayMode.RO : mode;
+      }
+    }
+  ]
+});
+
+
 foam.CLASS({
   package: 'foam.u2',
   name: 'Entity',
@@ -861,7 +885,13 @@ foam.CLASS({
       class: 'Object',
       name: 'id',
       transient: true,
-      factory: function() { return this.NEXT_ID(); }
+      // factory: function() { return this.NEXT_ID(); }
+      factory: function() {
+        var id = this.NEXT_ID();
+        if ( ! window.idToE ) window.idToE = {};
+        window.idToE[id] = this;
+        return id;
+      }
     },
     {
       class: 'Enum',

--- a/src/foam/u2/tag/Input.js
+++ b/src/foam/u2/tag/Input.js
@@ -20,6 +20,10 @@ foam.CLASS({
   name: 'Input',
   extends: 'foam.u2.View',
 
+  imports: [
+    'inputUpdateMode?'
+  ],
+
   css: `
     /* Still show outline when focused as read-only to help accessibility *
     ^:read-only:focus { outline: 1px solid rgb(238, 238, 238); }
@@ -47,6 +51,10 @@ foam.CLASS({
       name: 'onKey',
       attribute: true,
       // documentation: 'When true, $$DOC{ref:".data"} is updated on every keystroke, rather than on blur.'
+      factory: function () {
+        if ( ! this.inputUpdateMode ) return false;
+        return this.inputUpdateMode == this.InputUpdateMode.ON_KEY;
+      }
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
Allow `onKey` to be passed via context so developers don't need to override views on properties using `foam.u2.tag.Input`, which can be done incorrectly.

For example, the following override might be done:
```
{
  class: 'String',
  name: 'myProperty',
  updateVisibility: 'RO',
  view: {
    class: 'foam.u2.tag.Input',
    onKey: true
  }
}
```

Since the view has an override, `ModeAltView` will not be used unless the developer included it in their ViewSpec. In this case it's clear this is unintentional, since `updateVisibility` is set to `RO`.