### PR TITLE
Fix Capability Transition Predicate

### DIFF
--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
@@ -46,8 +46,7 @@ foam.CLASS({
         UserCapabilityJunction old = (UserCapabilityJunction) x.get("OLD");
         UserCapabilityJunction ucj = (UserCapabilityJunction) x.get("NEW");
 
-        return old != null &&
-            old.getStatus() != ucj.getStatus() &&
+        return ( old == null || old != null && old.getStatus() != ucj.getStatus() ) &&
             ucj.getStatus() == getStatus() &&
             ucj.getTargetId() == getCapabilityId();
       `


### PR DESCRIPTION
CapabilityJunctionTransitionToStatus predicate no longer returns false on new user capability junction. Can now be applied to create rules extending its usability.