### PR TITLE
fixing rendering pages twice on count updated and on table_ set

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -196,8 +196,7 @@
   ],
 
   reactions: [
-    ['', 'propertyChange.currentTopPage_', 'updateRenderedPages_'],
-    ['', 'propertyChange.table_',          'updateRenderedPages_']
+    ['', 'propertyChange.currentTopPage_', 'updateRenderedPages_']
   ],
 
   methods: [
@@ -295,6 +294,8 @@
           window.removeEventListener('resize', this.updateTableHeight);
         });
       }
+
+      this.onDetach(this.table_$.sub(this.updateRenderedPages_));
     }
   ],
 


### PR DESCRIPTION
**so the bug cause was:**
we render pages on table_ being set
then refresh called on `updateCount` and all the pages got deleted and added again