### PR TITLE
Added a fancy and non-fancy enum view

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -181,11 +181,6 @@ foam.CLASS({
     function installInClass(cls) {
       var e = cls.create(this.definition);
       cls.installConstant(this.name, e);
-      if ( ! cls.getAxiomByName('FANCY') ) { cls.installAxiom(foam.core.Constant.create({ name: 'FANCY', value: false })); }
-      var a = cls.getAxiomByName('FANCY');
-      if ( ! a.value ) {
-        a.value = !! e.color || !! e.background;
-      }
       cls.VALUES.push(e);
     }
   ]

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -181,6 +181,11 @@ foam.CLASS({
     function installInClass(cls) {
       var e = cls.create(this.definition);
       cls.installConstant(this.name, e);
+      if ( ! cls.getAxiomByName('FANCY') ) { cls.installAxiom(foam.core.Constant.create({ name: 'FANCY', value: false })); }
+      var a = cls.getAxiomByName('FANCY');
+      if ( ! a.value ) {
+        a.value = !! e.color || !! e.background;
+      }
       cls.VALUES.push(e);
     }
   ]

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -366,11 +366,7 @@
       order: 90,
       gridColumns: 6,
       includeInDigest: true,
-      tableWidth: 450,
-      view: { class: 'foam.u2.EnumView' },
-      tableCellFormatter: function(value, obj) {
-        this.add(value.label);
-      }
+      tableWidth: 450
     },
     {
       class: 'DateTime',

--- a/src/foam/u2/view/ReadOnlyEnumView.js
+++ b/src/foam/u2/view/ReadOnlyEnumView.js
@@ -50,7 +50,8 @@ foam.CLASS({
       this.SUPER();
       var color = this.returnExpandedCSS(this.data.color);
       var background = this.returnExpandedCSS(this.data.background);
-      var isPill = this.data.FANCY;
+      debugger;
+      var isPill = this.isFancy(this.data.VALUES);
       this
         .enableClass(this.myClass('pill'), isPill)
         .addClass(this.myClass())
@@ -73,6 +74,14 @@ foam.CLASS({
           () => { this.start().add(data.label).end(); },
           () => { this.start('p').add(data.label).end(); }
         );
+    },
+    {
+      name: 'isFancy',
+      code: foam.Function.memoize1(function(values) {
+        for ( value of values ) {
+          if ( value.color || value.background ) { return true; }
+        }
+      })
     }
   ]
 });

--- a/src/foam/u2/view/ReadOnlyEnumView.js
+++ b/src/foam/u2/view/ReadOnlyEnumView.js
@@ -14,10 +14,9 @@ foam.CLASS({
   imports: ['returnExpandedCSS', 'theme'],
 
   css: `
-    ^{
+    ^pill{
       border-radius: 11.2px;
       border: 1px solid;
-      font-family: /*%FONT1%*/ Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
       font-size: 10px;
       font-weight: 500;
       letter-spacing: normal;
@@ -51,14 +50,16 @@ foam.CLASS({
       this.SUPER();
       var color = this.returnExpandedCSS(this.data.color);
       var background = this.returnExpandedCSS(this.data.background);
+      var isPill = this.data.FANCY;
       this
+        .enableClass(this.myClass('pill'), isPill)
         .addClass(this.myClass())
         .style({
           'background-color': background,
           'color': color,
           'border-color': background != '#FFFFFF' || background ? background : color
         })
-        .callIf(this.showGlyph && data.glyph, () =>{
+        .callIf(this.showGlyph && data.glyph, () => {
           var icon = {
             size: 14,
             backgroundColor: color,
@@ -68,9 +69,10 @@ foam.CLASS({
           };
           this.start(this.CircleIndicator, icon).addClass(this.myClass('icon')).end();
         })
-        .start()
-          .add(data.label)
-        .end();
+        .callIfElse(isPill,
+          () => { this.start().add(data.label).end(); },
+          () => { this.start('p').add(data.label).end(); }
+        );
     }
   ]
 });

--- a/src/foam/u2/view/ReadOnlyEnumView.js
+++ b/src/foam/u2/view/ReadOnlyEnumView.js
@@ -50,7 +50,6 @@ foam.CLASS({
       this.SUPER();
       var color = this.returnExpandedCSS(this.data.color);
       var background = this.returnExpandedCSS(this.data.background);
-      debugger;
       var isPill = this.isFancy(this.data.VALUES);
       this
         .enableClass(this.myClass('pill'), isPill)


### PR DESCRIPTION
- Any enums without a colour/background property for at least one of it's values now uses a non-pill view
- Removed custom enum view from Approval Request

New: 
<img width="287" alt="Screen Shot 2021-05-07 at 1 35 19 PM" src="https://user-images.githubusercontent.com/81172969/117487856-a28bce00-af39-11eb-9908-e5b6645fb785.png">

Old: 
<img width="165" alt="Screen Shot 2021-05-07 at 1 46 59 PM" src="https://user-images.githubusercontent.com/81172969/117488724-be43a400-af3a-11eb-8287-9891756a51c2.png">

Thanks Eric :)
