### PR TITLE
Updated Class/List usage to Class<?> & List<?>

### DIFF
--- a/src/foam/core/ClassInfo.java
+++ b/src/foam/core/ClassInfo.java
@@ -20,10 +20,10 @@ public interface ClassInfo extends java.lang.Comparable {
   boolean     isInstance(Object o);
   Object      newInstance() throws IllegalAccessException, InstantiationException;
 
-  ClassInfo   setObjClass(Class cls);
-  Class       getObjClass();
+  ClassInfo   setObjClass(Class<?> cls);
+  Class<?>    getObjClass();
 
-  List        getAxioms();
+  List<?>     getAxioms();
   Object      getAxiomByName(String name);
   <T> List<T> getAxiomsByClass(Class<T> cls);
 }


### PR DESCRIPTION
Using wildcards for the type lets you do things like 
```java
Business.getOwnClassInfo().getAxioms().stream()
  .map((o) -> (PropertyInfo) o)
  .filter(propMap::containsKey)
  .forEach((prop) -> f(prop, business, bdd));
```
without casting the axiom list to an `List<Object>` or some some other container with a concrete type.

Going forward, I think we should be using `List<?>` in _most_ cases instead of `List`

Also a Stackoverflow post about it https://stackoverflow.com/questions/14983489/difference-between-list-and-list where it's recommended to stop using `List` or other raw types