### PR TITLE
Fixed css bug for tables using custom DAOBrowserView

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -62,7 +62,7 @@ foam.CLASS({
 
     ^browse-view-container {
       box-sizing: border-box;
-      padding: 0 16px;
+      padding: 0 16px 20px 16px;
       overflow: hidden;
     }
 
@@ -87,10 +87,6 @@ foam.CLASS({
       height: 34px;
       border-radius: 0 5px 5px 0;
       border: 1px solid;
-    }
-
-    ^browse-view-container .foam-u2-view-ScrollTableView {
-      height: calc(100% - 20px);
     }
   `,
 


### PR DESCRIPTION
Moved padding to the DAOBrowserView rather than ScrollTableView to improve compatibility with custom DAOBrowserViews

![image](https://user-images.githubusercontent.com/81172969/118185397-7c1ed480-b40a-11eb-9472-f00a1c8775cf.png)
