### PR TITLE
Set Configurable: true when calling Object.defineProperty for Imports

### DIFF
--- a/src/foam/core/ImportsExports.js
+++ b/src/foam/core/ImportsExports.js
@@ -106,33 +106,37 @@ foam.CLASS({
       var slotName = this.slotName_;
       var required = this.required;
 
-      Object.defineProperty(proto, slotName, {
-        get: function importsSlotGetter() {
-          return this.__context__[key];
-        },
-        configurable: false,
-        enumerable: false
-      });
-
-      Object.defineProperty(proto, name, {
-        get: function importsGetter()  {
-          var slot = this[slotName];
-          if ( slot ) return slot.get();
-          if ( required ) {
-            console.warn('Access missing import:', name);
-          }
-          return undefined;
-        },
-        set: function importsSetter(v) {
-          var slot = this[slotName];
-          if ( slot )
-            slot.set(v);
-          else
-            console.warn('Attempt to set missing import:', name);
-        },
-        configurable: true,
-        enumerable: false
-      });
+      try{
+        Object.defineProperty(proto, slotName, {
+          get: function importsSlotGetter() {
+            return this.__context__[key];
+          },
+          configurable: false,
+          enumerable: false
+        });
+  
+        Object.defineProperty(proto, name, {
+          get: function importsGetter()  {
+            var slot = this[slotName];
+            if ( slot ) return slot.get();
+            if ( required ) {
+              console.warn('Access missing import:', name);
+            }
+            return undefined;
+          },
+          set: function importsSetter(v) {
+            var slot = this[slotName];
+            if ( slot )
+              slot.set(v);
+            else
+              console.warn('Attempt to set missing import:', name);
+          },
+          configurable: true,
+          enumerable: false
+        });
+      } catch (x){
+        console.warn(x);
+      }
     },
 
     function toSlot(obj) {

--- a/src/foam/core/ImportsExports.js
+++ b/src/foam/core/ImportsExports.js
@@ -134,8 +134,8 @@ foam.CLASS({
           configurable: true,
           enumerable: false
         });
-      } catch (x){
-        console.warn(x);
+      } catch (e){
+        console.warn(e);
       }
     },
 

--- a/src/foam/core/ImportsExports.js
+++ b/src/foam/core/ImportsExports.js
@@ -106,37 +106,33 @@ foam.CLASS({
       var slotName = this.slotName_;
       var required = this.required;
 
-      try{
-        Object.defineProperty(proto, slotName, {
-          get: function importsSlotGetter() {
-            return this.__context__[key];
-          },
-          configurable: false,
-          enumerable: false
-        });
-  
-        Object.defineProperty(proto, name, {
-          get: function importsGetter()  {
-            var slot = this[slotName];
-            if ( slot ) return slot.get();
-            if ( required ) {
-              console.warn('Access missing import:', name);
-            }
-            return undefined;
-          },
-          set: function importsSetter(v) {
-            var slot = this[slotName];
-            if ( slot )
-              slot.set(v);
-            else
-              console.warn('Attempt to set missing import:', name);
-          },
-          configurable: true,
-          enumerable: false
-        });
-      } catch (e){
-        console.warn(e);
-      }
+      Object.defineProperty(proto, slotName, {
+        get: function importsSlotGetter() {
+          return this.__context__[key];
+        },
+        configurable: true,
+        enumerable: false
+      });
+
+      Object.defineProperty(proto, name, {
+        get: function importsGetter()  {
+          var slot = this[slotName];
+          if ( slot ) return slot.get();
+          if ( required ) {
+            console.warn('Access missing import:', name);
+          }
+          return undefined;
+        },
+        set: function importsSetter(v) {
+          var slot = this[slotName];
+          if ( slot )
+            slot.set(v);
+          else
+            console.warn('Attempt to set missing import:', name);
+        },
+        configurable: true,
+        enumerable: false
+      });
     },
 
     function toSlot(obj) {


### PR DESCRIPTION
In the UCJ's case, the first call to `Object.defineProperty`  for **slotName** (https://github.com/kgrgreer/foam3/compare/development...tharmaman:NP-4493/HandleErrorsForImports?expand=1#diff-a538e25b7c753f2560a26b233b0c69ada59758c23dd8ff7043c0f5904f953c18L109) throws a TypeError (see 3 below). Setting Configurable: true when calling Object.defineProperty for Imports  fixes  this.

More Details:
1. For UCJ, the first axiom to get processed in `FObject.installAxioms` is the **CapabilityJunctionPayload MixIn**. Within the CapabilityJunctionPayload class, it **imports the capabilityDAO**. After processing the MixIn, the UCJ class has now has `capabilityDAO$` available as a property.
2. Shortly after the MixIn, the **direct capabilityDAO import** on UCJRefine gets processed in `FObject.installAxioms`. 
3. In `Import.instalInProto,` the first call to `Object.defineProperty` for the **slotName** will throw a TypeError.
4. This TypeError will propagate up to https://github.com/kgrgreer/foam3/blob/development/src/foam/core/FObject.js#L594 and  produce the following warning:
`Listener threw exception TypeError: Cannot redefine property: capabilityDAO$`
4. This is because `capabilityDAO$ `was already defined in 1.
5. However because the error was thrown and not caught within the UCJ axiom installation process but rather in an FObject listener. The remainder of the axioms for UCJ will not be installed.

This error is thrown because of `configurable: false`:
https://github.com/kgrgreer/foam3/blob/development/src/foam/core/ImportsExports.js#L133

TL;DR Setting Configurable: true when calling Object.defineProperty for Imports
