### PR TITLE
Move e to the  top

### DIFF
--- a/src/foam/nanos/crunch/UCJProperty.js
+++ b/src/foam/nanos/crunch/UCJProperty.js
@@ -33,6 +33,8 @@ foam.CLASS({
     {
       name: 'adapt',
       value: function (_, o) {
+        const e = foam.mlang.Expressions.create();
+
         const Predicate = foam.mlang.predicate.Predicate;
         if ( Predicate.isInstance(o) ) return o;
         if ( foam.String.isInstance(o) ) {
@@ -49,7 +51,6 @@ foam.CLASS({
         const UserCapabilityJunction = foam.nanos.crunch.UserCapabilityJunction;
         const AgentCapabilityJunction = foam.nanos.crunch.AgentCapabilityJunction;
 
-        const e = foam.mlang.Expressions.create();
         var predicate = e.AND(
           e.EQ(UserCapabilityJunction.SOURCE_ID, o.sourceId),
           e.EQ(UserCapabilityJunction.TARGET_ID, o.targetId)


### PR DESCRIPTION
So this is an error because the e is undefined in https://github.com/kgrgreer/foam3/compare/development...kgrgreer:NP-4517/FixUCJProperty?expand=1#diff-4d259c7ceedb70c5dc712f1e4b55088c80f5ad1d599571f5376881f669be51ffR41. 

For some reason this would break invoices when running medusa. Despite not being used. Investigating on the why.