### PR TITLE
[NP-4445] MedusaStorageTransientIsSet

### DIFF
--- a/src/foam/nanos/medusa/MedusaConsensusDAO.js
+++ b/src/foam/nanos/medusa/MedusaConsensusDAO.js
@@ -452,9 +452,9 @@ This is the heart of Medusa.`,
                 var i     = props.iterator();
                 while ( i.hasNext() ) {
                   foam.core.PropertyInfo prop = i.next();
-                  // Explicitly copy only storageTransient to avoid copying defaults
                   if ( prop.getStorageTransient() &&
-                       ! prop.getClusterTransient() ) {
+                       ! prop.getClusterTransient() &&
+                       prop.isSet(tran) ) {
                     prop.set(nu, prop.get(tran));
                   }
                 }


### PR DESCRIPTION
When copying storageTransient properties, test isSet so only updates are copied.

Previously was blindly copying so all storageTransient properties, including those with default values, were being copied, so values were being reset to default.