### PR TITLE
[NP-3799] ClientRuntimeException toast title/message and translation

### DIFF
--- a/src/foam/comics/v2/DAOCreateView.js
+++ b/src/foam/comics/v2/DAOCreateView.js
@@ -46,8 +46,7 @@ foam.CLASS({
     'foam.log.LogLevel',
     'foam.u2.layout.Cols',
     'foam.u2.layout.Rows',
-    'foam.u2.ControllerMode',
-    'foam.u2.dialog.NotificationMessage'
+    'foam.u2.ControllerMode'
   ],
   imports: [
     'ctrl',

--- a/src/foam/comics/v2/DAOUpdateView.js
+++ b/src/foam/comics/v2/DAOUpdateView.js
@@ -56,8 +56,7 @@ foam.CLASS({
     'foam.u2.layout.Cols',
     'foam.u2.layout.Rows',
     'foam.u2.layout.Grid',
-    'foam.u2.ControllerMode',
-    'foam.u2.dialog.NotificationMessage'
+    'foam.u2.ControllerMode'
   ],
 
   imports: [

--- a/src/foam/nanos/auth/RetrievePassword.js
+++ b/src/foam/nanos/auth/RetrievePassword.js
@@ -13,7 +13,8 @@ foam.CLASS({
   imports: [
     'ctrl',
     'resetPasswordToken',
-    'stack'
+    'stack',
+    'translationService',
   ],
 
   requires: [
@@ -98,10 +99,18 @@ foam.CLASS({
             transient: true
           }));
           this.stack.push({ class: 'foam.u2.view.LoginView', mode_: 'SignIn' }, this);
-        })
-        .catch((err) => {
+        }).catch((err) => {
+          let id = err.data && err.data.id && err.data.id;
+          var message = this.ERROR_MSG;
+          var description;
+          if ( id ) {
+            message = foam.String.labelize(id.split('.').pop());
+            message = this.translationService.getTranslation(foam.locale, id+'.notification.message', message);
+            description = this.translationService.getTranslation(foam.locale, id+'.notification.description', err.message);
+          }
           this.ctrl.add(this.NotificationMessage.create({
-            message: err.message || this.ERROR_MSG,
+            message: message,
+            description: description,
             type: this.LogLevel.ERROR,
             transient: true
           }));

--- a/src/foam/nanos/auth/RetrievePassword.js
+++ b/src/foam/nanos/auth/RetrievePassword.js
@@ -100,7 +100,7 @@ foam.CLASS({
           }));
           this.stack.push({ class: 'foam.u2.view.LoginView', mode_: 'SignIn' }, this);
         }).catch((err) => {
-          let id = err.data && err.data.id && err.data.id;
+          let id = err.data && err.data.id;
           var message = this.ERROR_MSG;
           var description;
           if ( id ) {

--- a/src/foam/nanos/notification/NotificationSettingsView.js
+++ b/src/foam/nanos/notification/NotificationSettingsView.js
@@ -27,8 +27,7 @@ foam.CLASS({
   exports: ['as data'],
 
   requires: [
-    'foam.nanos.notification.Notification',
-    'foam.u2.dialog.NotificationMessage'
+    'foam.nanos.notification.Notification'
   ],
 
   css: `

--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -143,8 +143,8 @@ foam.CLASS({
                       description = this.translationService.getTranslation(foam.locale, id+'.notification.description', err.message);
                     }
                     this.ctrl.add(this.NotificationMessage.create({
-                      message: title,
-                      description: message,
+                      message: message,
+                      description: description,
                       type: this.LogLevel.ERROR
                     }));
                   });

--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -15,15 +15,20 @@ foam.CLASS({
     'auth',
     'ctrl',
     'loginSuccess',
-    'stack',
-    'user',
     'menuDAO',
-    'memento'
+    'memento',
+    'notificationDAO',
+    'notify',
+    'stack',
+    'translationService',
+    'user',
   ],
 
   requires: [
     'foam.log.LogLevel',
-    'foam.u2.dialog.NotificationMessage'
+    'foam.u2.dialog.NotificationMessage',
+    'foam.nanos.notification.Notification',
+    'foam.nanos.notification.ToastState'
   ],
 
   messages: [
@@ -133,8 +138,18 @@ foam.CLASS({
                     this.user.copyFrom(updatedUser);
                     this.nextStep();
                   }).catch(err => {
+                    let id = err.data && err.data.id && err.data.id;
+                    var title = this.ERROR_MSG;
+                    var message;
+                    if ( id ) {
+                      title = foam.String.labelize(id.split('.').pop());
+                      title = this.translationService.getTranslation(foam.locale, id+'.title', title);
+                      message = this.translationService.getTranslation(foam.locale, id+'.message', err.message);
+                    }
+                    // this.notify(title, message, this.LogLevel.ERROR, true);
                     this.ctrl.add(this.NotificationMessage.create({
-                      message: err.message || this.ERROR_MSG,
+                      message: title,
+                      description: message,
                       type: this.LogLevel.ERROR
                     }));
                   });
@@ -145,8 +160,18 @@ foam.CLASS({
             }
           ).catch(
             err => {
+              let id = err.data && err.data.id && err.data.id;
+              var title = this.ERROR_MSG;
+              var message;
+              if ( id ) {
+                title = foam.String.labelize(id.split('.').pop());
+                title = this.translationService.getTranslation(foam.locale, id+'.title', title);
+                message = this.translationService.getTranslation(foam.locale, id+'.message', err.message);
+              }
+              // this.notify(title, message, this.LogLevel.ERROR, true);
               this.ctrl.add(this.NotificationMessage.create({
-                message: err.message || this.ERROR_MSG,
+                message: title,
+                description: message,
                 type: this.LogLevel.ERROR
               }));
           });

--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -17,8 +17,6 @@ foam.CLASS({
     'loginSuccess',
     'menuDAO',
     'memento',
-    'notificationDAO',
-    'notify',
     'stack',
     'translationService',
     'user',
@@ -26,9 +24,7 @@ foam.CLASS({
 
   requires: [
     'foam.log.LogLevel',
-    'foam.u2.dialog.NotificationMessage',
-    'foam.nanos.notification.Notification',
-    'foam.nanos.notification.ToastState'
+    'foam.u2.dialog.NotificationMessage'
   ],
 
   messages: [
@@ -139,14 +135,13 @@ foam.CLASS({
                     this.nextStep();
                   }).catch(err => {
                     let id = err.data && err.data.id && err.data.id;
-                    var title = this.ERROR_MSG;
-                    var message;
+                    var message = this.ERROR_MSG;
+                    var description;
                     if ( id ) {
-                      title = foam.String.labelize(id.split('.').pop());
-                      title = this.translationService.getTranslation(foam.locale, id+'.title', title);
-                      message = this.translationService.getTranslation(foam.locale, id+'.message', err.message);
+                      message = foam.String.labelize(id.split('.').pop());
+                      message = this.translationService.getTranslation(foam.locale, id+'.notification.message', message);
+                      description = this.translationService.getTranslation(foam.locale, id+'.notification.description', err.message);
                     }
-                    // this.notify(title, message, this.LogLevel.ERROR, true);
                     this.ctrl.add(this.NotificationMessage.create({
                       message: title,
                       description: message,
@@ -161,17 +156,16 @@ foam.CLASS({
           ).catch(
             err => {
               let id = err.data && err.data.id && err.data.id;
-              var title = this.ERROR_MSG;
-              var message;
+              var message = this.ERROR_MSG;
+              var description;
               if ( id ) {
-                title = foam.String.labelize(id.split('.').pop());
-                title = this.translationService.getTranslation(foam.locale, id+'.title', title);
-                message = this.translationService.getTranslation(foam.locale, id+'.message', err.message);
+                message = foam.String.labelize(id.split('.').pop());
+                message = this.translationService.getTranslation(foam.locale, id+'.notification.message', message);
+                description = this.translationService.getTranslation(foam.locale, id+'.notification.description', err.message);
               }
-              // this.notify(title, message, this.LogLevel.ERROR, true);
               this.ctrl.add(this.NotificationMessage.create({
-                message: title,
-                description: message,
+                message: message,
+                description: description,
                 type: this.LogLevel.ERROR
               }));
           });

--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -134,7 +134,7 @@ foam.CLASS({
                     this.user.copyFrom(updatedUser);
                     this.nextStep();
                   }).catch(err => {
-                    let id = err.data && err.data.id && err.data.id;
+                    let id = err.data && err.data.id;
                     var message = this.ERROR_MSG;
                     var description;
                     if ( id ) {
@@ -155,7 +155,7 @@ foam.CLASS({
             }
           ).catch(
             err => {
-              let id = err.data && err.data.id && err.data.id;
+              let id = err.data && err.data.id;
               var message = this.ERROR_MSG;
               var description;
               if ( id ) {

--- a/src/foam/nanos/u2/navigation/SignUp.js
+++ b/src/foam/nanos/u2/navigation/SignUp.js
@@ -20,8 +20,9 @@ foam.CLASS({
     'auth',
     'ctrl',
     'stack',
+    'translationService',
+    'theme',
     'user',
-    'theme'
   ],
 
   requires: [
@@ -223,8 +224,17 @@ foam.CLASS({
             this.user.copyFrom(user);
             await this.updateUser(x);
           }).catch((err) => {
+            let id = err.data && err.data.id && err.data.id;
+            var message = this.ERROR_MSG;
+            var description;
+            if ( id ) {
+              message = foam.String.labelize(id.split('.').pop());
+              message = this.translationService.getTranslation(foam.locale, id+'.notification.message', message);
+              description = this.translationService.getTranslation(foam.locale, id+'.notification.description', err.message);
+            }
             this.ctrl.add(this.NotificationMessage.create({
-              message: err.message || this.ERROR_MSG,
+              message: message,
+              description: description,
               type: this.LogLevel.ERROR
             }));
           })

--- a/src/foam/nanos/u2/navigation/SignUp.js
+++ b/src/foam/nanos/u2/navigation/SignUp.js
@@ -224,7 +224,7 @@ foam.CLASS({
             this.user.copyFrom(user);
             await this.updateUser(x);
           }).catch((err) => {
-            let id = err.data && err.data.id && err.data.id;
+            let id = err.data && err.data.id;
             var message = this.ERROR_MSG;
             var description;
             if ( id ) {


### PR DESCRIPTION
Presently directly calling 
this.ctrl.notify of  this.notify which generates a transient Notification is not working.  Have to use this NotificationMessage class which is very puzzling. 

* Wish to remove use of NotificationMessage, relying solely on Notifcation.transient for toast notifications.
* Parse/split service side exceptions into title and message for toast notifications.
* Provide translation via   exception-package.exception-name.title and exception-package.exception-name.message

<img width="1082" alt="Screen Shot 2021-05-25 at 8 58 16 AM" src="https://user-images.githubusercontent.com/684019/119501959-65944980-bd37-11eb-8af0-02e598275b62.png">
