### PR TITLE
 Spid auth updates

### DIFF
--- a/src/foam/nanos/auth/ServiceProvider.js
+++ b/src/foam/nanos/auth/ServiceProvider.js
@@ -55,11 +55,22 @@ foam.CLASS({
     },
     {
       name: 'inherentPermissions',
-      javaGetter: 'return new String[] { "serviceprovider.read." + getId() };',
+      javaGetter: `
+        return new String[] {
+          "serviceprovider.read." + getId(),
+          "serviceprovidercapability.read." + getId()
+        };
+      `,
       factory: function() {
-        return [ 'serviceprovider.read.' + this.id ];
+        return [
+          'serviceprovider.read.' + this.id,
+          'serviceprovidercapability.read.' + this.id
+        ];
       },
-      documentation: 'Service provider must have "serviceprovider.read.<SPID>" inherent permission.',
+      documentation: `Service provider must have inherent permissions
+        "serviceprovider.read.<SPID>" to allow users to read ServiceProviderAware objects under this spid, as well as
+        "serviceprovidercapability.read.<SPID> to allow user to read this ServiceProvider itself
+      `,
     }
   ],
 

--- a/src/foam/nanos/auth/test/ServiceProviderAuthorizerTest.js
+++ b/src/foam/nanos/auth/test/ServiceProviderAuthorizerTest.js
@@ -78,7 +78,12 @@ foam.CLASS({
         }
         test(threw, "Non admin user can't add serviceProvider");
 
-        test(serviceProviderDAO.inX(nonAdminUserContext).find(serviceProvider) == null, "Non admin user can't view serviceProvider");
+        try {
+          serviceProviderDAO.inX(nonAdminUserContext).find(serviceProvider);
+        } catch ( AuthorizationException e ) {
+          threw = true;
+        }
+        test(! threw, "Non admin user can view serviceProvider");
 
         threw = false;
         try {

--- a/src/foam/nanos/auth/test/ServiceProviderAuthorizerTest.js
+++ b/src/foam/nanos/auth/test/ServiceProviderAuthorizerTest.js
@@ -78,6 +78,7 @@ foam.CLASS({
         }
         test(threw, "Non admin user can't add serviceProvider");
 
+        threw = false;
         try {
           serviceProviderDAO.inX(nonAdminUserContext).find(serviceProvider);
         } catch ( AuthorizationException e ) {

--- a/src/services
+++ b/src/services
@@ -459,7 +459,7 @@ p({
   """
     return new foam.nanos.auth.AuthorizationDAO.Builder(x)
       .setDelegate((foam.dao.DAO) x.get("localServiceProviderDAO"))
-      .setAuthorizer(new foam.nanos.auth.StandardAuthorizer("serviceprovider"))
+      .setAuthorizer(new foam.nanos.auth.GlobalReadAuthorizer("serviceprovidercapability"))
       .build();
   """,
   "client":"{\"of\":\"foam.nanos.auth.ServiceProvider\"}"

--- a/src/services
+++ b/src/services
@@ -459,7 +459,7 @@ p({
   """
     return new foam.nanos.auth.AuthorizationDAO.Builder(x)
       .setDelegate((foam.dao.DAO) x.get("localServiceProviderDAO"))
-      .setAuthorizer(new foam.nanos.auth.GlobalReadAuthorizer("serviceprovidercapability"))
+      .setAuthorizer(new foam.nanos.auth.StandardAuthorizer("serviceprovidercapability"))
       .build();
   """,
   "client":"{\"of\":\"foam.nanos.auth.ServiceProvider\"}"


### PR DESCRIPTION
Update ServiceProviderAwareDAO permissioning to use the permissionPrefix "serviceprovidercapability" to distinguish between the permission strings of serviceprovidercapability and serviceprovideraware objects
and add inherentPermission serviceprovidercapability.read.id to ServiceProvider

Update ServiceProviderAuthorizerTest to reflect the changes in auth