### PR TITLE
CapabilityIsStatus

### DIFF
--- a/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
@@ -4,9 +4,9 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-foam.CLASS({
+ foam.CLASS({
   package: 'foam.nanos.crunch.predicate',
-  name: 'CapabilityGranted',
+  name: 'CapabilityIsStatus',
   extends: 'foam.mlang.predicate.AbstractPredicate',
   implements: ['foam.core.Serializable'],
 
@@ -31,6 +31,15 @@ foam.CLASS({
         When this property is true, CapabilityGranted expects a UCJ object in
         the context which it will use to determine the corresponding subject.
         Otherwise, the context is assumed to contain the appropriate subject.
+      `
+    },
+    {
+      name: 'status',
+      class: 'Enum',
+      of: 'foam.nanos.crunch.CapabilityJunctionStatus',
+      documentation: `Check status of the capabilities user capability junction status.`,
+      javaFactory: `
+        return foam.nanos.crunch.CapabilityJunctionStatus.GRANTED;
       `
     }
   ],
@@ -59,7 +68,7 @@ foam.CLASS({
 
         var ucj = crunchService.getJunction(x, getCapabilityId());
         if ( ucj == null ) return false;
-        return ucj.getStatus() == GRANTED;
+        return ucj.getStatus() == getStatus();
       `
     }
   ],

--- a/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
@@ -3,8 +3,7 @@
  * Copyright 2020 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-
- foam.CLASS({
+foam.CLASS({
   package: 'foam.nanos.crunch.predicate',
   name: 'CapabilityIsStatus',
   extends: 'foam.mlang.predicate.AbstractPredicate',
@@ -71,5 +70,5 @@
         return ucj.getStatus() == getStatus();
       `
     }
-  ],
+  ]
 });

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -494,7 +494,7 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/ClientCrunchService" },
   { name: "foam/nanos/crunch/ReputDependentUCJs" },
   //predicates
-  { name: 'foam/nanos/crunch/predicate/CapabilityGranted' },
+  { name: 'foam/nanos/crunch/predicate/CapabilityIsStatus' },
   { name: 'foam/nanos/crunch/predicate/CapabilityPrerequisitesGranted' },
   { name: 'foam/nanos/crunch/predicate/StatusChangedTo' },
   { name: 'foam/nanos/crunch/predicate/IsAgent' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -866,7 +866,7 @@ var classes = [
   'foam.nanos.crunch.extra.ImplyReviewedAction',
 
   //crunch predicates
-  'foam.nanos.crunch.predicate.CapabilityGranted',
+  'foam.nanos.crunch.predicate.CapabilityIsStatus',
   'foam.nanos.crunch.predicate.CapabilityPrerequisitesGranted',
   'foam.nanos.crunch.predicate.StatusChangedTo',
   'foam.nanos.crunch.predicate.IsAgent',


### PR DESCRIPTION
Addresses: https://nanopay.atlassian.net/browse/NP-4618

CapabilityGranted is a predicate used in a few capability predicate areas that grab the user's user capability junction in reference to the predicates capability Id. This is useful for checking if a user capability junction is status in a GRANTED state other than the user capability junction iterating through whatever process the predicate is being applied to. However the predicate is limited to the GRANTED Status. The status should be configurable.

Removed CapabilityGranted since it would have solely been used as a reference to existing journals. Updates on these journal entries can be made to avoid redundant classes.