### PR TITLE
NP-3799 LocaleSupport 

### DIFF
--- a/src/foam/core/FOAMException.js
+++ b/src/foam/core/FOAMException.js
@@ -75,12 +75,14 @@ foam.CLASS({
       class: 'String',
       value: '{{message_}}',
       externalTransient: true,
+      transient: true,
       visibility: 'RO'
     },
     {
       name: 'message_',
       class: 'String',
       externalTransient: true,
+      transient: true,
       visibility: 'RO'
     },
     {
@@ -172,24 +174,24 @@ foam.CLASS({
       name: 'toString',
       type: 'String',
       code: function() {
-        var s = '['+this.hostname+'],';
+        var s = this.getOwnClassInfo().getId()+',';
+        s += '['+this.hostname+'],';
         if ( this.errorCode ) {
           s += '('+this.errorCode+'),';
         }
-        s += this.getOwnClassInfo().getId()+',';
         s += getMessage();
         return s;
       },
       javaCode: `
       StringBuilder sb = new StringBuilder();
+      sb.append(getClass().getName());
+      sb.append(",");
       sb.append("["+getHostname()+"]");
       sb.append(",");
       if ( ! foam.util.SafetyUtil.isEmpty(getErrorCode()) ) {
         sb.append("("+getErrorCode()+")");
         sb.append(",");
       }
-      sb.append(getClass().getName());
-      sb.append(",");
       sb.append(getMessage());
       return sb.toString();
       `

--- a/src/foam/nanos/auth/LocaleSupport.js
+++ b/src/foam/nanos/auth/LocaleSupport.js
@@ -27,6 +27,8 @@ foam.CLASS({
       buildJavaClass: function(cls) {
         cls.extras.push(foam.java.Code.create({
           data: `
+  public final static String CONTEXT_KEY = "locale.language";
+
   private final static LocaleSupport instance__ = new LocaleSupport();
   public static LocaleSupport instance() { return instance__; }
           `

--- a/src/foam/nanos/auth/LocaleSupport.js
+++ b/src/foam/nanos/auth/LocaleSupport.js
@@ -60,9 +60,23 @@ foam.CLASS({
         }
       }
 
-      Theme theme = ((Themes) x.get("themes")).findTheme(x);
-      if ( theme != null ) {
+      Theme theme = (Theme) x.get("theme");
+      if ( theme == null ) {
+        theme = ((Themes) x.get("themes")).findTheme(x);
+      }
+      if ( theme != null &&
+           Theme.DEFAULT_LOCALE_LANGUAGE.isSet(theme) ) {
         return theme.getDefaultLocaleLanguage();
+      }
+
+      // HttpRequest Header
+      HttpServletRequest req = x.get(HttpServletRequest.class);
+      if ( req != null ) {
+        String acceptLanguage = req.getHeader("Accept-Language");
+        if ( ! SafetyUtil.isEmpty(acceptLanguage) ) {
+          String[] languages = acceptLanguage.split(",");
+          return languages[0];
+        }
       }
 
       return "en";

--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -367,7 +367,7 @@ foam.CLASS({
         self.setPrivate_('__subContext__', client.__subContext__);
 
         await self.fetchTheme();
-        foam.locale = localStorage.getItem('localeLanguage') || self.theme.defaultLocaleLanguage;
+        foam.locale = localStorage.getItem('localeLanguage') || self.theme.defaultLocaleLanguage || 'en';
 
         await client.translationService.initLatch;
         self.installLanguage();

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -302,7 +302,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           appConfig = appConfig.configure(x, null);
 
           rtn = rtn.put("appConfig", appConfig);
-          rtn = rtn.put("locale.language", foam.nanos.auth.LocaleSupport.instance().findLanguageLocale(x));
+          rtn = rtn.put(foam.nanos.auth.LocaleSupport.CONTEXT_KEY, foam.nanos.auth.LocaleSupport.instance().findLanguageLocale(rtn));
           return rtn;
         }
 
@@ -333,8 +333,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           .put("logger", new PrefixLogger(prefix, (Logger) x.get("logger")))
           .put("twoFactorSuccess", getContext().get("twoFactorSuccess"))
           .put(CachingAuthService.CACHE_KEY, getContext().get(CachingAuthService.CACHE_KEY))
-          .put(ServerCrunchService.CACHE_KEY, getContext().get(ServerCrunchService.CACHE_KEY))
-          .put("locale.language", foam.nanos.auth.LocaleSupport.instance().findLanguageLocale(rtn));
+          .put(ServerCrunchService.CACHE_KEY, getContext().get(ServerCrunchService.CACHE_KEY));
 
         // We need to do this after the user and agent have been put since
         // 'getCurrentGroup' depends on them being in the context.
@@ -346,6 +345,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
             .put("appConfig", group.getAppConfig(rtn));
         }
         rtn = rtn.put("theme", ((Themes) x.get("themes")).findTheme(rtn));
+        rtn = rtn.put(foam.nanos.auth.LocaleSupport.CONTEXT_KEY, foam.nanos.auth.LocaleSupport.instance().findLanguageLocale(rtn));
 
         return rtn;
       `

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -163,9 +163,9 @@ foam.CLASS({
       section: 'navigation'
     },
     {
+      documentation: 'See LocaleSupport for default fallback',
       class: 'String',
       name: 'defaultLocaleLanguage',
-      value: 'en'
     },
     {
       class: 'Map',


### PR DESCRIPTION
Remove default language from Theme, and fall back to default provided by LocalSupport.
LocaleSupport test for user, then Theme language if set, then HTTP headers for browser supplied language. 

Used for Server side Exception Translation.
Future work will attempt to translate client side. 
