### PR TITLE
Fix recursive warning scroll wizard

### DIFF
--- a/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
@@ -27,7 +27,7 @@ foam.CLASS({
       class: 'Boolean',
       value: true,
       documentation: `
-        When this property is true, CapabilityGranted expects a UCJ object in
+        When this property is true, CapabilityIsStatus expects a UCJ object in
         the context which it will use to determine the corresponding subject.
         Otherwise, the context is assumed to contain the appropriate subject.
       `

--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -110,7 +110,7 @@ foam.CLASS({
         var test_visible = el => {
           // Offset parent might be a wrapping element, but we want the element
           // who has the wizard scroller as its offsetParent
-          while ( el.offsetParent != null & el.offsetParent != this.scrollOffsetElement ) el = el.offsetParent;
+          while ( el.offsetParent != null && el.offsetParent != this.scrollOffsetElement ) el = el.offsetParent;
 
           var sectTop = el.offsetTop - offset;
           var sectBot = sectTop + el.clientHeight;

--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -110,7 +110,7 @@ foam.CLASS({
         var test_visible = el => {
           // Offset parent might be a wrapping element, but we want the element
           // who has the wizard scroller as its offsetParent
-          while ( el.offsetParent != this.scrollOffsetElement ) el = el.offsetParent;
+          while ( el.offsetParent != null & el.offsetParent != this.scrollOffsetElement ) el = el.offsetParent;
 
           var sectTop = el.offsetTop - offset;
           var sectBot = sectTop + el.clientHeight;


### PR DESCRIPTION
Fixes a recursion that leads to a freezing browser if scrolling wizard element offsetparent is null

Also updated typo in documentation on CapabilityIsStatus.