### PR TITLE
During copyFrom if PropertyInfo is FObject recursively call copyFrom.

### DIFF
--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -295,12 +295,26 @@ public interface FObject
     List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
     for ( PropertyInfo p : props ) {
       try {
-        if ( p.isSet(obj) ) p.set(this, p.get(obj));
+        if ( p.isSet(obj) ) {
+          Object value = p.get(this);
+          if ( value instanceof FObject ) {
+            p.set(this, ((FObject)value).copyFrom((FObject) p.get(obj)));
+          } else {
+            p.set(this, p.get(obj));
+          }
+        }
       } catch (ClassCastException e) {
         try {
           PropertyInfo p2 = (PropertyInfo) obj.getClassInfo().getAxiomByName(p.getName());
           if ( p2 != null ) {
-            if ( p2.isSet(obj) ) p.set(this, p2.get(obj));
+            if ( p2.isSet(obj) ) {
+              Object value = p.get(this);
+              if ( value instanceof FObject ) {
+                p.set(this, ((FObject)value).copyFrom((FObject) p2.get(obj)));
+              } else {
+                p.set(this, p2.get(obj));
+              }
+            }
           }
         } catch (ClassCastException ignore) {}
       }


### PR DESCRIPTION
Previously copyFrom of an FObject property would replace the to with the complete from FObject rather than just the isSet properties.