### PR TITLE
Fix PreventDuplicateUsernameAction

### DIFF
--- a/src/foam/core/ValidationException.js
+++ b/src/foam/core/ValidationException.js
@@ -31,8 +31,12 @@ foam.CLASS({
       super(message);
     }
 
-    public ValidationException(String message, java.lang.Exception cause) {
+    public ValidationException(String message, Throwable cause) {
       super(message, cause);
+    }
+
+    public ValidationException(Throwable cause) {
+      super(cause);
     }
             `
         }));

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -841,3 +841,7 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.BusinessValidati
 
 //TestExceptions
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.core.FOAMExceptionTestTestException.ExceptionMessage {{message}}, ErrorCode: {{errorCode}}",target:"MensagemDeExceção {{message}}, ErroDeCódigo: {{errorCode}}"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.DuplicateEmailException",target:"E-mail duplicado"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.DuplicateEmailException.Email already in use",target:"Email já em uso"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.DuplicateUserNameException",target:"Nome de usuário duplicado"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.DuplicateUserNameException.UserName already in use",target:"Nome de usuário já em uso"})

--- a/src/foam/nanos/auth/DuplicateEmailException.js
+++ b/src/foam/nanos/auth/DuplicateEmailException.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 

--- a/src/foam/nanos/auth/DuplicateEmailException.js
+++ b/src/foam/nanos/auth/DuplicateEmailException.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  name: 'DuplicateEmailException',
+  package: 'foam.nanos.auth',
+  extends: 'foam.core.ValidationException',
+  javaGenerateDefaultConstructor: false,
+  javaGenerateConvenienceConstructor: false,
+
+  properties: [
+    {
+      name: 'exceptionMessage',
+      value: 'Email already in use'
+    }
+  ],
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+  public DuplicateEmailException() {
+    super();
+  }
+
+  public DuplicateEmailException(String message) {
+    super(message);
+  }
+
+  public DuplicateEmailException(Throwable cause) {
+    super(cause);
+  }
+
+  public DuplicateEmailException(String message, Throwable cause) {
+    super(message, cause);
+  }
+        `);
+      }
+    }
+  ]
+});

--- a/src/foam/nanos/auth/DuplicateUserNameException.js
+++ b/src/foam/nanos/auth/DuplicateUserNameException.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  name: 'DuplicateUserNameException',
+  package: 'foam.nanos.auth',
+  extends: 'foam.core.ValidationException',
+  javaGenerateDefaultConstructor: false,
+  javaGenerateConvenienceConstructor: false,
+
+  properties: [
+    {
+      name: 'exceptionMessage',
+      value: 'UserName already in use'
+    }
+  ],
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+  public DuplicateUserNameException() {
+    super();
+  }
+
+  public DuplicateUserNameException(String message) {
+    super(message);
+  }
+
+  public DuplicateUserNameException(Throwable cause) {
+    super(cause);
+  }
+
+  public DuplicateUserNameException(String message, Throwable cause) {
+    super(message, cause);
+  }
+        `);
+      }
+    }
+  ]
+});

--- a/src/foam/nanos/auth/PreventDuplicateEmailTest.java
+++ b/src/foam/nanos/auth/PreventDuplicateEmailTest.java
@@ -43,8 +43,8 @@ public class PreventDuplicateEmailTest
     test(
       TestUtils.testThrows(
         () -> action.applyAction(x, userWithDuplicateEmail, null, null, null, null),
-        "User with same email already exists: " + userWithDuplicateEmail.getEmail(),
-        RuntimeException.class
+        "Email already in use",
+        foam.nanos.auth.DuplicateEmailException.class
       ),
       "Rule throws a RuntimeException with an appropriate message when a User is put with the same email as an existing user and a different id."
     );

--- a/src/foam/nanos/auth/ruler/PreventDuplicateEmailAction.js
+++ b/src/foam/nanos/auth/ruler/PreventDuplicateEmailAction.js
@@ -14,10 +14,10 @@ foam.CLASS({
 
   javaImports: [
     'foam.core.ContextAgent',
-    'foam.core.ValidationException',
     'foam.core.X',
     'foam.dao.DAO',
     'foam.mlang.sink.Count',
+    'foam.nanos.auth.DuplicateEmailException',
     'foam.nanos.auth.Subject',
     'foam.nanos.auth.User',
     'foam.util.Email',
@@ -26,7 +26,6 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'DUPLICATE_ERROR', message: 'User with same email already exists: ' },
     { name: 'EMPTY_ERROR', message: 'Email required' },
     { name: 'INVALID_ERROR', message: 'Invalid email' }
   ],
@@ -64,7 +63,7 @@ foam.CLASS({
             )).limit(1).select(count);
 
         if ( count.getValue() == 1 ) {
-          throw new ValidationException(DUPLICATE_ERROR + user.getEmail());
+          throw new DuplicateEmailException();
         }
       `
     }

--- a/src/foam/nanos/auth/ruler/PreventDuplicateEmailAction.js
+++ b/src/foam/nanos/auth/ruler/PreventDuplicateEmailAction.js
@@ -14,6 +14,7 @@ foam.CLASS({
 
   javaImports: [
     'foam.core.ContextAgent',
+    'foam.core.ValidationException',
     'foam.core.X',
     'foam.dao.DAO',
     'foam.mlang.sink.Count',
@@ -63,7 +64,7 @@ foam.CLASS({
             )).limit(1).select(count);
 
         if ( count.getValue() == 1 ) {
-          throw new RuntimeException(DUPLICATE_ERROR + user.getEmail());
+          throw new ValidationException(DUPLICATE_ERROR + user.getEmail());
         }
       `
     }

--- a/src/foam/nanos/auth/ruler/PreventDuplicateUsernameAction.js
+++ b/src/foam/nanos/auth/ruler/PreventDuplicateUsernameAction.js
@@ -14,10 +14,10 @@ foam.CLASS({
 
   javaImports: [
     'foam.core.ContextAgent',
-    'foam.core.ValidationException',
     'foam.core.X',
     'foam.dao.DAO',
     'foam.mlang.sink.Count',
+    'foam.nanos.auth.DuplicateUserNameException',
     'foam.nanos.auth.Subject',
     'foam.nanos.auth.User',
     'foam.util.SafetyUtil',
@@ -25,7 +25,6 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'DUPLICATE_ERROR', message: 'User with same username already exists: ' },
     { name: 'EMPTY_ERROR', message: 'Username required' }
   ],
 
@@ -60,7 +59,7 @@ foam.CLASS({
             )).limit(1).select(count);
 
         if ( count.getValue() == 1 ) {
-          throw new ValidationException(DUPLICATE_ERROR + user.getUserName());
+          throw new DuplicateUserNameException();
         }
       `
     }

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -62,6 +62,8 @@ FOAM_FILES([
   { name: "foam/nanos/auth/AgentJunctionStatus" },
   { name: "foam/nanos/auth/DeletedAware" },
   { name: "foam/nanos/auth/DeletedAwareDAOTest" },
+  { name: 'foam/nanos/auth/DuplicateEmailException' },
+  { name: 'foam/nanos/auth/DuplicateUserNameException' },
   { name: "foam/nanos/auth/PasswordPolicy" },
   { name: "foam/nanos/auth/Group" },
   { name: 'foam/nanos/auth/HumanNameTrait' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -265,6 +265,8 @@ var classes = [
   'foam.nanos.auth.AuthorizationDAO',
   'foam.nanos.auth.AuthenticationException',
   'foam.nanos.auth.AssignableAware',
+  'foam.nanos.auth.DuplicateEmailException',
+  'foam.nanos.auth.DuplicateUserNameException',
   'foam.nanos.auth.EnabledAware',
   'foam.nanos.auth.EnabledAwareDummy',
   'foam.nanos.auth.GroupPermissionJunction',


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-4686

## Changes
- Check against the spid of the user who is submitting the request in case the user.spid is not set. Eg. BePay send "Create User" request without providing user.spid data