### PR TITLE
add columnPermissionRequired for action

### DIFF
--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -306,6 +306,7 @@ foam.CLASS({
 
     async function initE() {
       var view = this;
+
       const asyncRes = await this.filterUnpermitted(view.of.getAxiomsByClass(foam.core.Property));
       this.allColumns = ! view.of ? [] : [].concat(
         asyncRes.map(a => a.name),
@@ -804,6 +805,7 @@ foam.CLASS({
     },
   ]
 });
+
 
 foam.CLASS({
   package: 'foam.u2.view',

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -306,13 +306,8 @@ foam.CLASS({
 
     async function initE() {
       var view = this;
-
-      const asyncRes = await this.filterUnpermitted(view.of.getAxiomsByClass(foam.core.Property));
-      this.allColumns = ! view.of ? [] : [].concat(
-        asyncRes.map(a => a.name),
-        view.of.getAxiomsByClass(foam.core.Action)
-        .map(a => a.name)
-      );
+      const asyncRes = await this.filterUnpermitted([].concat(view.of.getAxiomsByClass(foam.core.Property), view.of.getAxiomsByClass(foam.core.Action)));
+      this.allColumns = ! view.of ? [] : asyncRes.map(a => a.name);
 
       this.columns$.sub(this.updateColumns_);
       this.of$.sub(this.updateColumns_);
@@ -800,6 +795,27 @@ foam.CLASS({
         When set to true, the '<model>.column.<property>' permission is required for a
         user to be able to read this property. If false, any user can see the
         value of this property in a table column.
+      `,
+      name: 'columnPermissionRequired'
+    },
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'TableViewActionRefinement',
+  refines: 'foam.core.Action',
+  properties: [
+    {
+      class: 'Boolean',
+      name: 'columnHidden'
+    },
+    {
+      class: 'Boolean',
+      documentation: `
+        When set to true, the '<model>.column.<Action>' permission is required for a
+        user to be able to read this property. If false, any user can see the
+        value of this Action in a table column.
       `,
       name: 'columnPermissionRequired'
     },

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -306,8 +306,12 @@ foam.CLASS({
 
     async function initE() {
       var view = this;
-      const asyncRes = await this.filterUnpermitted([].concat(view.of.getAxiomsByClass(foam.core.Property), view.of.getAxiomsByClass(foam.core.Action)));
-      this.allColumns = ! view.of ? [] : asyncRes.map(a => a.name);
+      const asyncRes = await this.filterUnpermitted(view.of.getAxiomsByClass(foam.core.Property));
+      this.allColumns = ! view.of ? [] : [].concat(
+        asyncRes.map(a => a.name),
+        view.of.getAxiomsByClass(foam.core.Action)
+        .map(a => a.name).filter( a => view.of.getAxiomByName('tableColumns').columns.includes(a))
+      );
 
       this.columns$.sub(this.updateColumns_);
       this.of$.sub(this.updateColumns_);
@@ -800,28 +804,6 @@ foam.CLASS({
     },
   ]
 });
-
-foam.CLASS({
-  package: 'foam.u2.view',
-  name: 'TableViewActionRefinement',
-  refines: 'foam.core.Action',
-  properties: [
-    {
-      class: 'Boolean',
-      name: 'columnHidden'
-    },
-    {
-      class: 'Boolean',
-      documentation: `
-        When set to true, the '<model>.column.<Action>' permission is required for a
-        user to be able to read this property. If false, any user can see the
-        value of this Action in a table column.
-      `,
-      name: 'columnPermissionRequired'
-    },
-  ]
-});
-
 
 foam.CLASS({
   package: 'foam.u2.view',


### PR DESCRIPTION
Currently the columnPermission only filter out the property. this should also apply to Actions
nanoSide: https://github.com/nanoPayinc/NANOPAY/pull/12874