### PR TITLE
Added restoreFromPredicate methods

### DIFF
--- a/src/foam/u2/search/CurrencySearchView.js
+++ b/src/foam/u2/search/CurrencySearchView.js
@@ -38,5 +38,19 @@ foam.CLASS({
       documentation: `Required by SearchManager.`,
       value: 'currency search view'
     }
+  ],
+  
+  methods: [
+    /**
+     * Restores the view based on passed in predicate
+     */
+    function restoreFromPredicate(predicate) {
+      if ( predicate === this.TRUE ) return;
+
+      this.qualifier = predicate.cls_.name;
+      this.amount = typeof predicate.arg2.value === 'number' 
+        ? (predicate.arg2.value / 100)
+        : 0;
+    },
   ]
 });

--- a/src/foam/u2/search/IntegerSearchView.js
+++ b/src/foam/u2/search/IntegerSearchView.js
@@ -75,6 +75,16 @@ foam.CLASS({
   ],
 
   methods: [
+    /**
+     * Restores the view based on passed in predicate
+     */
+      function restoreFromPredicate(predicate) {
+      if ( predicate === this.TRUE ) return;
+
+      this.qualifier = predicate.cls_.name;
+      this.amount = predicate.arg2.value;
+    },
+    
     function initE() {
       this
         .addClass(this.myClass())


### PR DESCRIPTION
Would break when loading predicate from mementos specifically for Currency filters since the restoreFromPredicate method was not even implemented.