### PR TITLE
[DNM][NP-4600] Business Registration Bug Fix

### DIFF
--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -132,7 +132,6 @@ foam.CLASS({
           .add(this.StepWizardAgent)
           .add(this.DetachAgent)
           .add(this.SpinnerAgent)
-          .add(this.SaveAllAgent)
           .add(this.DetachSpinnerAgent)
           .add(this.CapabilityStoreAgent)
           // .add(this.TestAgent)
@@ -164,6 +163,7 @@ foam.CLASS({
           .remove('CheckPendingAgent')
           .remove('CheckNoDataAgent')
           .addBefore('RequirementsPreviewAgent',this.ShowPreexistingAgent)
+          .addBefore('DetachSpinnerAgent',this.SaveAllAgent)
           .add(this.MaybeDAOPutAgent)
           ;
       }


### PR DESCRIPTION
**address**: https://nanopay.atlassian.net/browse/NP-4600

**Issue**
When you submit business registration in the wizard, business registration ucj's source id gets updated, and exception is thrown 

**Source of error**
When you submit business registration in the wizard, save is called twice - one from 'refreshWizardlet', and the other one from 'SaveAllAgent'. We have a race condition where both saves put the same ucj to a dao, but since they are not synchronized properly, we get the exception. The following is the execution order of the two saves:

0. user fills in business info and submits in the wizard
1. save is called in 'refreshWizardlet
2. first save calls 'getJunction' to get the business registration ucj (source id = user, status = action required)
3. save is called in 'SaveAllAgent'
4. the second save calls 'getJunction' to get the same business registration ucj (source id = user, status = action required)
5. the ucj obtained from step 2 is put to the dao. the ucj gets granted, and its source id is updated to business and is saved to the dao
6. the ucj obtained from step 4 is put to the dao, but since the ucj source id was updated in step 5, the exception is thrown.

The issue is that the second 'getJunction' is called before the first 'put'.

**Fix**
Don't call save twice by moving 'SaveAllAgent' to capbleWizardSequence.