### PR TITLE
Comparison in transition to predicate status change

### DIFF
--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
@@ -47,7 +47,7 @@ foam.CLASS({
         UserCapabilityJunction ucj = (UserCapabilityJunction) x.get("NEW");
 
         return ( old == null || old != null && old.getStatus() != ucj.getStatus() ) &&
-            ucj.getStatus().equals(getStatus()) &&
+            ucj.getStatus() == getStatus() &&
             ucj.getTargetId().equals(getCapabilityId());
       `
     }

--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
@@ -47,8 +47,8 @@ foam.CLASS({
         UserCapabilityJunction ucj = (UserCapabilityJunction) x.get("NEW");
 
         return ( old == null || old != null && old.getStatus() != ucj.getStatus() ) &&
-            ucj.getStatus() == getStatus() &&
-            ucj.getTargetId() == getCapabilityId();
+            ucj.getStatus().equals(getStatus()) &&
+            ucj.getTargetId().equals(getCapabilityId());
       `
     }
   ]


### PR DESCRIPTION
reference comparison < content comparison in this scenario since the value references aren't located in the same memory address - predicate would always return false.