### PR TITLE
set authenticate to false on currencyDAO

### DIFF
--- a/src/services
+++ b/src/services
@@ -787,6 +787,7 @@ p({
   "class": "foam.nanos.boot.NSpec",
   "name": "currencyDAO",
   "serve": true,
+  "authenticate":false,
   "serviceScript":
   """
     return new foam.dao.EasyDAO.Builder(x)


### PR DESCRIPTION
need the currencydao to not be authenticated for ratediscovery model's currency selection 