### PR TITLE
Ucj expiry maintenance

### DIFF
--- a/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
@@ -40,6 +40,14 @@ foam.CLASS({
       javaFactory: `
         return foam.nanos.crunch.CapabilityJunctionStatus.GRANTED;
       `
+    },
+    {
+      class: 'Boolean',
+      name: 'includeGracePeriod',
+      documentation: `
+        If status is GRANTED, determine if ucjs that are GRANTED but in gracePeriod
+        should also be included.
+      `
     }
   ],
 
@@ -66,8 +74,10 @@ foam.CLASS({
         if ( cap == null ) return false;
 
         var ucj = crunchService.getJunction(x, getCapabilityId());
-        if ( ucj == null ) return false;
-        return ucj.getStatus() == getStatus();
+        if ( ucj == null || ucj.getStatus() != getStatus() ) return false;
+        // if status being checked is GRANTED, check if we should include those that are granted but in graceperiod
+        if ( getStatus() == GRANTED && ucj.getIsInGracePeriod() ) return getIncludeGracePeriod();
+        return true;
       `
     }
   ]


### PR DESCRIPTION
Not fully tested - but made fixes so that https://nanopay.atlassian.net/browse/NP-4792 can be started

1. logic for selecting ucjs to expire was wrong when it came to the graceperiod stuff, the first commit should fix that
2. second commit addresses the issue of signingofficer card not re-showing up in app store even though its in graceperiod.
NOTE the ui for renewable ucjs has changed to something I have not seen since last working on it, and the card does not open, errors in console relating to wizardlet, maybe this is still in the works?