### PR TITLE
Standardize secondary action styling in DAOController views

### DIFF
--- a/src/foam/comics/v2/DAOBrowseControllerView.js
+++ b/src/foam/comics/v2/DAOBrowseControllerView.js
@@ -32,7 +32,8 @@ foam.CLASS({
     'foam.u2.borders.CardBorder',
     'foam.u2.layout.Cols',
     'foam.u2.layout.Rows',
-    'foam.u2.view.IconChoiceView'
+    'foam.u2.view.IconChoiceView',
+    'foam.u2.view.OverlayActionListView'
   ],
 
   css: `
@@ -56,6 +57,10 @@ foam.CLASS({
       position: absolute;
       right: 0;
       padding: 12px 16px 0 0;
+    }
+
+    ^buttons{
+      margin-right: 8px;
     }
 
     ^ .foam-u2-borders-CardBorder {
@@ -155,7 +160,7 @@ foam.CLASS({
     var menuId = this.currentMenu ? this.currentMenu.id : this.config.of.id;
     this.addClass(this.myClass())
 
-      .add(this.slot(function(data, config, config$of, config$browseBorder, config$browseViews, config$browseTitle, config$browseSubtitle, config$primaryAction, config$createTitle, config$createControllerView) {
+      .add(this.slot(function(data, config, config$of, config$browseBorder, config$browseViews, config$browseTitle, config$browseSubtitle, config$primaryAction, config$createTitle, config$createControllerView, config$browseContext) {
         return self.E()
           .start(self.Rows)
             .addClass(self.myClass('container'))
@@ -163,28 +168,47 @@ foam.CLASS({
                 .addClass(self.myClass('header-container'))
                 .start(self.Cols)
                   .start()
-                    .addClasses(['h100',self.myClass('browse-title')])
+                    .addClasses(['h100', self.myClass('browse-title')])
                     .translate(menuId + ".browseTitle", config$browseTitle)
                   .end()
-                  .callIf( ! config.detailView, function() {
-                    this.startContext({ data: self })
-                      .tag(self.CREATE, {
-                           label: this.translationService.getTranslation(foam.locale, menuId + '.createTitle', config$createTitle),
-                           buttonStyle: foam.u2.ButtonStyle.PRIMARY
-                      })
-                    .endContext()
-                  })
-                  .callIf( config.createControllerView, function() {
-                    this.startContext({ data: self })
-                      .tag(self.CREATE, {
-                           label: this.translationService.getTranslation(foam.locale, menuId + '.handler.createControllerView.view.title', config$createControllerView.view.title),
-                           buttonStyle: foam.u2.ButtonStyle.PRIMARY
-                      })
-                    .endContext()
-                  })
-                  .callIf( config$primaryAction, function() {
-                    this.startContext({ data: self }).tag(config$primaryAction, { size: 'LARGE', buttonStyle: 'PRIMARY' }).endContext();
-                  })
+                  .start(self.Cols)
+                    .callIf( config.browseActions != [] && config.browseContext, function() {
+                      if ( config.browseActions.length > 2 ) {
+                        this.start(self.OverlayActionListView, {
+                          label: 'Actions',
+                          data: config.browseActions,
+                          obj: config$browseContext
+                        }).addClass(self.myClass('buttons')).end();
+                      } else {
+                        var actions = this.E().addClass(self.myClass('buttons')).startContext({ data: config.browseContext });
+                        for ( action of config.browseActions ) {
+                          actions.tag(action, { size: 'LARGE' });
+                        }
+                        this.add(actions.endContext());
+                      }
+                    })
+                    .callIf( ! config.detailView, function() {
+                      this.startContext({ data: self })
+                        .tag(self.CREATE, {
+                            label: this.translationService.getTranslation(foam.locale, menuId + '.createTitle', config$createTitle),
+                            buttonStyle: foam.u2.ButtonStyle.PRIMARY,
+                            size: 'LARGE'
+                        })
+                      .endContext()
+                    })
+                    .callIf( config.createControllerView, function() {
+                      this.startContext({ data: self })
+                        .tag(self.CREATE, {
+                            label: this.translationService.getTranslation(foam.locale, menuId + '.handler.createControllerView.view.title', config$createControllerView.view.title),
+                            buttonStyle: foam.u2.ButtonStyle.PRIMARY,
+                            size: 'LARGE'
+                        })
+                      .endContext();
+                    })
+                    .callIf( config$primaryAction, function() {
+                      this.startContext({ data: self }).tag(config$primaryAction, { size: 'LARGE', buttonStyle: 'PRIMARY' }).endContext();
+                    })
+                  .end()
                 .end()
                 .callIf(config$browseSubtitle.length > 0, function() {
                   this

--- a/src/foam/comics/v2/DAOBrowseControllerView.js
+++ b/src/foam/comics/v2/DAOBrowseControllerView.js
@@ -173,7 +173,7 @@ foam.CLASS({
                     .translate(menuId + ".browseTitle", config$browseTitle)
                   .end()
                   .start(self.Cols)
-                    .callIf( config.browseActions != [] && config.browseContext, function() {
+                    .callIf( config.browseActions.length && config.browseContext, function() {
                       if ( config.browseActions.length > 2 ) {
                         this.start(self.OverlayActionListView, {
                           label: this.ACTIONS,

--- a/src/foam/comics/v2/DAOBrowseControllerView.js
+++ b/src/foam/comics/v2/DAOBrowseControllerView.js
@@ -74,7 +74,8 @@ foam.CLASS({
   `,
 
   messages: [
-    { name: 'VIEW_ALL', message: 'View all ' }
+    { name: 'VIEW_ALL', message: 'View all ' },
+    { name: 'ACTIONS', message: 'Actions' }
   ],
 
   properties: [
@@ -175,7 +176,7 @@ foam.CLASS({
                     .callIf( config.browseActions != [] && config.browseContext, function() {
                       if ( config.browseActions.length > 2 ) {
                         this.start(self.OverlayActionListView, {
-                          label: 'Actions',
+                          label: this.ACTIONS,
                           data: config.browseActions,
                           obj: config$browseContext
                         }).addClass(self.myClass('buttons')).end();

--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -63,6 +63,8 @@ foam.CLASS({
 
     ^browse-view-container {
       box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
       height: 100%;
       margin-bottom: 20px;
       padding: 0 16px;

--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -286,7 +286,11 @@ foam.CLASS({
             data: self.predicatedDAO$proxy,
             config: self.config
           },  this, filterView.__subContext__.createSubContext());
-          
+
+          if ( ! self.config.browseContext ) {
+            self.config.browseContext = summaryView;
+          }
+
           return self.E()
             .start(self.Rows)
             .style({ height: '100%', 'justify-content': 'flex-start' })

--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -264,6 +264,23 @@ foam.CLASS({
       fromJSON: function fromJSON(value, ctx, prop, json) {
         return value;
       }
+    },
+    {
+      class: 'FObjectArray',
+      of: 'foam.core.Action',
+      name: 'browseActions',
+      documentation: 'An array of Actions valid for the summaryView',
+      adaptArrayElement: function(o) {
+        if ( foam.core.Action.isInstance(o) ) return;
+        var lastIndex = o.lastIndexOf('.');
+        var classObj = foam.lookup(o.substring(0, lastIndex));
+        return classObj[o.substring(lastIndex + 1)];
+      }
+    },
+    {
+      name: 'browseContext',
+      documentation: 'Used to relay context for summaryView/browserView back to the ControllerView',
+      value: null
     }
   ]
 });

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -542,6 +542,7 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.PropertyModal.OPTIONAL",
 
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOBrowseControllerView.CREATE.label",target:"Crio"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOBrowseControllerView.VIEW_ALL",target:"Ver tudo "})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOBrowseControllerView.ACTIONS",target:"Ações"})
 
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.User.SECTION_USER_INFORMATION.title",target:"Usuário Informação"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.User.SECTION_BUSINESS_INFORMATION.title",target:"Negócios Informação"})

--- a/src/foam/nanos/pm/PMTableView.js
+++ b/src/foam/nanos/pm/PMTableView.js
@@ -19,12 +19,6 @@ foam.CLASS({
 
   css: `
     ^ { overflow: auto; }
-    ^container > .foam-u2-ActionView-clearAll { 
-      margin: 0 10px 10px 0;
-      align-self: flex-start;
-    }
-    ^ .foam-u2-ActionView-create { display: none; }
-    ^ .foam-u2-ActionView-edit   { display: none; }
     ^container{
       display: flex;
       flex-direction: column;

--- a/src/foam/nanos/pm/PMTableView.js
+++ b/src/foam/nanos/pm/PMTableView.js
@@ -47,12 +47,7 @@ foam.CLASS({
 
   methods: [
     function initE() {
-      // Next line is a temporary hack to fix CSS loading, otherwise screen
-      // is broken if loaded before any tableviews
-      this.TableView.create();
-
       this.addClass(this.myClass('container'));
-      this.startContext({data: this}).add(this.CLEAR_ALL).endContext();
       // this.columns.push([this.CLEAR, null]);
 
       this.SUPER();

--- a/src/foam/nanos/pm/PMTableView.js
+++ b/src/foam/nanos/pm/PMTableView.js
@@ -7,7 +7,7 @@
 foam.CLASS({
   package: 'foam.nanos.pm',
   name: 'PMTableView',
-  extends: 'foam.u2.view.TableView',
+  extends: 'foam.u2.view.ScrollTableView',
 
   documentation: 'TableView for displaying PMInfos.',
 
@@ -17,14 +17,19 @@ foam.CLASS({
 
   exports: [ 'maxTotalTime', 'as tableView' ],
 
-  // Keep standard TableView styling
-  constants: { CSS_CLASS: 'foam-u2-view-TableView' },
-
   css: `
     ^ { overflow: auto; }
-    ^ .foam-u2-ActionView-clearAll { margin-bottom: 10px; }
+    ^container > .foam-u2-ActionView-clearAll { 
+      margin: 0 10px 10px 0;
+      align-self: flex-start;
+    }
     ^ .foam-u2-ActionView-create { display: none; }
     ^ .foam-u2-ActionView-edit   { display: none; }
+    ^container{
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
   `,
 
   properties: [
@@ -46,7 +51,7 @@ foam.CLASS({
       // is broken if loaded before any tableviews
       this.TableView.create();
 
-      this.addClass('foam-nanos-pm-PMTableView');
+      this.addClass(this.myClass('container'));
       this.startContext({data: this}).add(this.CLEAR_ALL).endContext();
       // this.columns.push([this.CLEAR, null]);
 

--- a/src/foam/nanos/test/TestBorder.js
+++ b/src/foam/nanos/test/TestBorder.js
@@ -14,7 +14,7 @@ foam.CLASS({
   requires: ['foam.nanos.test.Test'],
 
   css: `
-    ^upper > span, ^upper .buttons .foam-u2-ActionView {
+    ^upper > span{
       margin: 0 10px 10px 0;
     }
     ^container{
@@ -24,6 +24,7 @@ foam.CLASS({
     }
     ^upper{
       flex: 0 0 0;
+      margin-bottom: 10px;
     }
   `,
 
@@ -41,12 +42,6 @@ foam.CLASS({
         .addClass(this.myClass('container'))
         .start()
           .addClass(this.myClass('upper'))
-          .start('span')
-            .addClass('buttons')
-            .startContext({ data: this })
-              .add(this.RUN_ALL, this.RUN_FAILED_TESTS)
-            .endContext()
-          .end()
           .start('span').add('Total: ', this.total$).end()
           .start('span').add('Passed: ', this.passed$).end()
           .start('span').add('Failed: ', this.failed$).end()

--- a/src/foam/nanos/test/TestBorder.js
+++ b/src/foam/nanos/test/TestBorder.js
@@ -14,8 +14,16 @@ foam.CLASS({
   requires: ['foam.nanos.test.Test'],
 
   css: `
-    ^ > span, ^ .buttons .foam-u2-ActionView {
+    ^upper > span, ^upper .buttons .foam-u2-ActionView {
       margin: 0 10px 10px 0;
+    }
+    ^container{
+      display: flex;
+      flex-direction: column;
+      height: 100%
+    }
+    ^upper{
+      flex: 0 0 0;
     }
   `,
 
@@ -28,22 +36,24 @@ foam.CLASS({
 
   methods: [
     function initE() {
-      this
-        .addClass(this.myClass())
-        .start('span')
-          .addClass('buttons')
-          .startContext({ data: this })
-            .add(this.RUN_ALL, this.RUN_FAILED_TESTS)
-          .endContext()
-        .end()
-        .start('span').add('Total: ', this.total$).end()
-        .start('span').add('Passed: ', this.passed$).end()
-        .start('span').add('Failed: ', this.failed$).end()
-        .start('span').add('Status: ', this.status$).end();
-
-      this.SUPER();
-
       var self = this;
+      this
+        .addClass(this.myClass('container'))
+        .start()
+          .addClass(this.myClass('upper'))
+          .start('span')
+            .addClass('buttons')
+            .startContext({ data: this })
+              .add(this.RUN_ALL, this.RUN_FAILED_TESTS)
+            .endContext()
+          .end()
+          .start('span').add('Total: ', this.total$).end()
+          .start('span').add('Passed: ', this.passed$).end()
+          .start('span').add('Failed: ', this.failed$).end()
+          .start('span').add('Status: ', this.status$).end()
+        .end();
+        this.SUPER();
+
       this.data.select({
         put: function(t) {
           if ( t && t.enabled ) {

--- a/src/foam/u2/tag/Button.js
+++ b/src/foam/u2/tag/Button.js
@@ -251,7 +251,6 @@ foam.CLASS({
 
     ^large {
       padding: 12px 12px;
-      min-width: 100px;
     }
 
     ^iconOnly{

--- a/src/foam/u2/tag/Button.js
+++ b/src/foam/u2/tag/Button.js
@@ -251,6 +251,7 @@ foam.CLASS({
 
     ^large {
       padding: 12px 12px;
+      min-width: 100px;
     }
 
     ^iconOnly{

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -32,6 +32,7 @@
     ^ {
       overflow: auto;
       max-height: 100%;
+      flex: 1;
     }
     ^table {
       position: relative;

--- a/src/menus
+++ b/src/menus
@@ -74,7 +74,8 @@ p({
       "daoKey":"pmInfoDAO",
       "summaryView":{
         "class":"foam.nanos.pm.PMTableView"
-      }
+      },
+      "browseActions": [ "foam.nanos.pm.PMTableView.CLEAR_ALL" ]
     }
   },
   "parent":"admin"
@@ -159,7 +160,8 @@ p({
       "daoKey":"testDAO",
       "summaryView":{
         "class":"foam.nanos.test.TestBorder"
-      }
+      },
+      "browseActions":[ "foam.nanos.test.TestBorder.RUN_ALL", "foam.nanos.test.TestBorder.RUN_FAILED_TESTS" ]
     }
   },
   "parent":"admin"


### PR DESCRIPTION
- Actions can be added to the DAOControllerConfig and are added to the title bar instead creating new borders around the summary view
- Upto 2 actions are added in the view itself and any additional actions are added to a dropdown
- Adding secondary actions to inline tables will require this PR as well

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/81172969/122445771-dcf07e00-cf6f-11eb-9dbe-c1cdde353a27.png">
