### PR TITLE
Fixed scroll issue on DAOBrowserView

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -69,6 +69,17 @@ foam.CLASS({
       overflow: hidden;
     }
 
+    /*
+      Scroll is handled here to ensure summaryView always has a scroll 
+      even if it is not configured in the summaryView.
+      This is the generalised way to do this but should be removed 
+      if double scroll bars start appearing
+    */
+    ^browse-view-container > * {
+      height: 100%;
+      overflow: auto;
+    }
+
     ^canned-queries {
       padding: 0 16px;
     }


### PR DESCRIPTION
Notifications Screen was missing scroll as it did not use a scroll table view. This solution takes care of most cases where the view itself doesn't handle scroll. 