### PR TITLE
Wired up searchColumn config in DAOControllerConfig

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -120,6 +120,7 @@ foam.CLASS({
     'click',
     'config',
     'filteredTableColumns',
+    'searchColumns',
     'serviceName'
   ],
 
@@ -138,6 +139,14 @@ foam.CLASS({
       name: 'config',
       factory: function() {
         return this.DAOControllerConfig.create({ dao: this.data });
+      }
+    },
+    {
+      class: 'StringArray',
+      name: 'searchColumns',
+      factory: null,
+      expression: function(config$searchColumns){
+        return config$searchColumns;
       }
     },
     {

--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -138,6 +138,42 @@ foam.CLASS({
       }
     },
     {
+      class: 'StringArray',
+      name: 'searchColumns',
+      factory: null,
+      expression: function(of, defaultColumns) {
+        var tableSearchColumns = of.getAxiomByName('searchColumns');
+
+        var filteredDefaultColumns = defaultColumns.filter(c => {
+          //  to account for nested columns like approver.legalName
+          if ( c.split('.').length > 1 ) return false;
+
+          var a = of.getAxiomByName(c);
+
+          if ( ! a ) console.warn("Column does not exist for " + of.name + ": " + c);
+          
+          return a
+            && ! a.storageTransient 
+            && ! a.networkTransient
+            && a.searchView 
+            && ! a.hidden
+        });
+
+        var allProps = of.getAxiomsByClass(foam.core.Property).filter(p => {
+          return ! p.storageTransient 
+            && ! p.networkTransient
+            && p.searchView 
+            && ! p.hidden
+        })
+
+        return tableSearchColumns
+          ? tableSearchColumns.columns
+          : filteredDefaultColumns 
+            ? filteredDefaultColumns
+            : allProps
+      }
+    },
+    {
       class: 'Enum',
       of: 'foam.comics.SearchMode',
       name: 'searchMode',

--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -191,7 +191,7 @@ foam.CLASS({
 
         if ( ! of ) return [];
 
-        if ( searchColumns ) return searchColumns;
+        if ( searchColumns && searchColumns.length > 0 ) return searchColumns;
 
         var columns = of.getAxiomByName('searchColumns');
         columns = columns && columns.columns;
@@ -201,13 +201,28 @@ foam.CLASS({
         columns = columns && columns.columns;
         if ( columns ) {
           return columns.filter(function(c) {
-            var axiom = of.getAxiomByName(c);
-            return axiom && axiom.searchView;
+          //  to account for nested columns like approver.legalName
+          if ( c.split('.').length > 1 ) return false;
+
+          var a = of.getAxiomByName(c);
+
+          if ( ! a ) console.warn("Column does not exist for " + of.name + ": " + c);
+          
+          return a
+            && ! a.storageTransient
+            && ! a.networkTransient
+            && a.searchView
+            && ! a.hidden
           });
         }
 
         return of.getAxiomsByClass(foam.core.Property)
-          .filter((prop) => prop.searchView && ! prop.hidden)
+          .filter((p) => {
+            return ! p.storageTransient
+            && ! p.networkTransient
+            && p.searchView 
+            && ! p.hidden
+          })
           .map(foam.core.Property.NAME.f);
       }
     },


### PR DESCRIPTION
Able to know pass in searchColumns through DAOControllerConfig, previously could only define searchColumns on the model itself which would apply to all tables where that model is used. This allows for flexibility so that  you can pass in specific searchColumns through menus.