### PR TITLE
Np 4859/permission for agent ucj

### DIFF
--- a/src/permissions
+++ b/src/permissions
@@ -33,7 +33,7 @@ p({"class":"foam.nanos.auth.Permission","id":"user.rw.emailverified","descriptio
 p({"class":"foam.nanos.auth.Permission","id":"user.rw.onboarded","description":""})
 p({"class":"foam.nanos.auth.Permission","id":"service.userCapabilityJunctionDAO","description":""})
 p({"class":"foam.nanos.auth.Permission","id":"ucj.addPermission","description":"Permission to add a UCJ, if not UCJ owner."})
-p({"class":"foam.nanos.auth.Permission","id":"usercapabilityjunction.read.*","description":"Permission to read usercapabilityjunction"})
+p({"class":"foam.nanos.auth.Permission","id":"usercapabilityjunction.read.*","description":"used by backoffice agents - to view users/business ucj's. This grants bypass on ownership check for find or select on ucjDAO -other wise blocked in ucjDAO decorator"})
 p({"class":"foam.nanos.auth.Permission","id":"usercapabilityjunction.create","description":"Permission to create usercapabilityjunction"})
 p({"class":"foam.nanos.auth.Permission","id":"usercapabilityjunction.update.*","description":"Permission to update usercapabilityjunction"})
 p({"class":"foam.nanos.auth.Permission","id":"menu.read.admin.googleApiCredentials","description":""})


### PR DESCRIPTION
Removing permission 'service.userCapabilityJunctionDAO.admin' cause it does the same thing as 'usercapabilityjunction.read.*' but one was set on find and one on select. Makes sense that they are the same permission.

Also cleaning up decorator. - no need to throw exception - return null if access not allowed.