### PR TITLE
Switch construdtion of ValidationException to use the thrown Exception

### DIFF
--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -437,7 +437,7 @@ public interface FObject
       try {
         prop.validateObj(x, this);
       } catch (IllegalStateException e) {
-        var ve = new ValidationException(e.getMessage());
+        var ve = new ValidationException(e);
         ve.setPropertyInfo(prop);
         ve.setPropName(prop.getName());
         compoundException.add(ve);


### PR DESCRIPTION
This lets you see the stack trace and all other information from the original exception.

If it was intentional to hide the original exception, just close this PR. 