### PR TITLE
Removed  description from ApprovalRequest

### DIFF
--- a/src/foam/nanos/approval/ApprovableAwareDAO.js
+++ b/src/foam/nanos/approval/ApprovableAwareDAO.js
@@ -331,7 +331,6 @@ foam.CLASS({
           .setServerDaoKey(getDaoKey())
           .setObjId(String.valueOf(obj.getProperty("id")))
           .setClassificationEnum(ApprovalRequestClassificationEnum.APPROVABLE_REQUEST)
-          .setDescription(getOf().getObjClass().getSimpleName())
           .setOperation(operation)
           .setCreatedBy(user.getId())
           .setStatus(ApprovalStatus.REQUESTED).build();
@@ -373,7 +372,6 @@ foam.CLASS({
           .setDaoKey("approvableDAO")
           .setObjId(approvable.getId())
           .setClassificationEnum(ApprovalRequestClassificationEnum.APPROVABLE_REQUEST)
-          .setDescription(getOf().getObjClass().getSimpleName())
           .setOperation(operation)
           .setCreatedBy(user.getId())
           .setStatus(ApprovalStatus.REQUESTED).build();

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -233,16 +233,6 @@
       gridColumns: 6
     },
     {
-      class: 'String',
-      name: 'description',
-      documentation: `Approval request description.`,
-      includeInDigest: false,
-      tableWidth: 200,
-      section: 'approvalRequestInformation',
-      order: 40,
-      gridColumns: 6
-    },
-    {
       class: 'Reference',
       of: 'foam.nanos.auth.Group',
       name: 'group',

--- a/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
@@ -171,7 +171,6 @@ foam.CLASS({
                   .setGroup(getGroupToNotify())
                   .setAdditionalGroups(getAdditionalGroupsToNotify())
                   .setClassificationEnum(ApprovalRequestClassificationEnum.CAPABLE_CREATED_APPROVAL)
-                  .setDescription(capName + FOR + objName + " - id:" + String.valueOf(obj.getProperty("id")))
                   .setStatus(ApprovalStatus.REQUESTED).build();
 
                 approvalRequest = decorateApprovalRequest(x, approvalRequest, obj, capablePayload);


### PR DESCRIPTION
ApprovalRequest.Description is not used for processing anywhere and is primarily for the client UI. The information that would've been previously stored in description could be extracted by various properties such as the ReferenceSummary, Classification and CreatedFor.