### PR TITLE
Adding debug messages to CIDR whitelisting

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -384,6 +384,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           ((foam.nanos.logger.Logger) x.get("logger")).warning(this.getClass().getSimpleName(), "validateCidrWhiteList", remoteIp, e.getMessage());
         }
       }
+      ((foam.nanos.logger.Logger) x.get("logger")).debug(this.getClass().getSimpleName(), "validateCidrWhiteList", "Restricted IP address not allowed", remoteIp, getId());
       throw new foam.core.ValidationException("Restricted IP");
       `
     }

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -231,9 +231,11 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       // Do not allow IP to change if not in whitelist
       if ( ! SafetyUtil.isEmpty(getRemoteHost()) &&
            ! SafetyUtil.equals(getRemoteHost(), remoteIp) ) {
+        ((foam.nanos.logger.Logger) x.get("logger")).debug(this.getClass().getSimpleName(), "validateRemoteHost", "IP change detected", getRemoteHost(), remoteIp, getUserId());
         throw new foam.core.ValidationException("IP changed");
       }
 
+      ((foam.nanos.logger.Logger) x.get("logger")).debug(this.getClass().getSimpleName(), "validateRemoteHost", "Restricted IP address not allowed", getRemoteHost(), remoteIp, getUserId());
       throw new foam.core.ValidationException("Restricted IP");
       `
     },


### PR DESCRIPTION
I need more information when whitelisting fails, so adding debugging messages that can be turned on when there is a failure