### PR TITLE
sessionExpired pop up not closed at once

### DIFF
--- a/src/foam/box/SessionClientBox.js
+++ b/src/foam/box/SessionClientBox.js
@@ -58,7 +58,7 @@ foam.CLASS({
           if ( this.loginSuccess ) {
             if ( this.ctrl )  this.ctrl.remove();
             alert(this.REFRESH_MSG);
-            (this.window || window).location.reload(false);
+
             return;
           }
 


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-4866

fixed : 
<img width="495" alt="Screen Shot 2021-07-07 at 3 07 54 PM" src="https://user-images.githubusercontent.com/33228583/124815297-1bf16e00-df35-11eb-91bf-9fa7450646bd.png">
When session Expired pop up comes but even clicked 'ok' its not closed at once