### PR TITLE
DAG View Update

### DIFF
--- a/src/foam/u2/svg/graph/DAGView.js
+++ b/src/foam/u2/svg/graph/DAGView.js
@@ -364,7 +364,8 @@ foam.CLASS({
     function cellLaneRatio_(lane) {
       // f0 produces the series: [1 2 2 4 4 4 4....] as v increases from 0.
       //  Multiplying the output of f0 by 2 gives the denominator
-      // NOTE: Seems to center the exit lane without multiplying by 2
+      // TODO: Not multiplying by 2, seems to center the exit lane with leafs of length 1
+      // Needs to look into centering it for multi leaf nodes
       let f0 = v => Math.pow(2, Math.floor(Math.log2(v+1)));
 
       // f1 produces the series: [1 1 3 1 3 5 7....] as v increases from 0.

--- a/src/foam/u2/svg/graph/DAGView.js
+++ b/src/foam/u2/svg/graph/DAGView.js
@@ -364,13 +364,14 @@ foam.CLASS({
     function cellLaneRatio_(lane) {
       // f0 produces the series: [1 2 2 4 4 4 4....] as v increases from 0.
       //  Multiplying the output of f0 by 2 gives the denominator
+      // NOTE: Seems to center the exit lane without multiplying by 2
       let f0 = v => Math.pow(2, Math.floor(Math.log2(v+1)));
 
       // f1 produces the series: [1 1 3 1 3 5 7....] as v increases from 0.
       // ???: If this has a formal name please let me know
       let f1 = v => (v - f0(v) + 2) * 2 - 1;
 
-      return f1(lane) / (2*f0(lane));
+      return f1(lane) / f0(lane);
     }
   ]
 });


### PR DESCRIPTION
Will have to do more investigation, but by removing multiplying the denominator by 2, the exit line from leaf nodes render much more consistently. However, when leaving the 2, the exit line only seems to correctly be centered for a few nodes. At least in this case we can get consistent behaviour for single leaf nodes.

Not entirely sure the intent was on the math behind it.

OLD:
ChainView (Single leaf)
<img width="1680" alt="Screen Shot 2021-07-09 at 6 05 57 PM" src="https://user-images.githubusercontent.com/26717171/125140724-26e90180-e0e1-11eb-8e13-13694153beb0.png">

CrunchLab (multi leaf)
<img width="1680" alt="Screen Shot 2021-07-09 at 6 13 52 PM" src="https://user-images.githubusercontent.com/26717171/125140894-8d6e1f80-e0e1-11eb-9125-88c9a77458cc.png">

NEW:
ChainView  (Single leaf)
<img width="1680" alt="Screen Shot 2021-07-09 at 6 05 28 PM" src="https://user-images.githubusercontent.com/26717171/125140744-31a39680-e0e1-11eb-8075-76f2c0a0cec3.png">

CrunchLab (multi leaf)
<img width="1680" alt="Screen Shot 2021-07-09 at 6 14 25 PM" src="https://user-images.githubusercontent.com/26717171/125140917-9b23a500-e0e1-11eb-8ab4-39011411c892.png">