### PR TITLE
[NP-4811] Loggers

### DIFF
--- a/src/foam/nanos/logger/LogMessage.js
+++ b/src/foam/nanos/logger/LogMessage.js
@@ -155,7 +155,15 @@ foam.CLASS({
     {
       name: 'toString',
       javaCode: `
-      return timestamper_.get().createTimestamp(getCreated())+","+getThread()+","+getSeverity()+","+getMessage();
+      StringBuilder sb = new StringBuilder();
+      sb.append(timestamper_.get().createTimestamp(getCreated()));
+      sb.append(",");
+      sb.append(getThread());
+      sb.append(",");
+      sb.append(getSeverity());
+      sb.append(",");
+      sb.append(getMessage());
+      return sb.toString();
       `
     }
   ]

--- a/src/foam/nanos/logger/LoggerUserInfo.js
+++ b/src/foam/nanos/logger/LoggerUserInfo.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.logger',
+  name: 'LoggerUserInfo',
+  flags: [ 'java' ],
+
+  documentation: 'Holder of per call user info.',
+
+  javaImports: [
+    'foam.nanos.auth.Subject',
+    'foam.util.SafetyUtil'
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'spid'
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.nanos.auth.Subject',
+      name: 'subject'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'toString',
+      type: 'String',
+      javaCode: `
+      if ( getSubject() != null ) {
+        if ( SafetyUtil.isEmpty(getSpid()) ) {
+          setSpid(getSubject().getUser().getSpid());
+        }
+      }
+      StringBuilder sb = new StringBuilder();
+      sb.append("{spid:");
+      sb.append(getSpid());
+      if ( getSubject() != null ) {
+        sb.append(",user:");
+        sb.append(getSubject().getRealUser().getId());
+        if ( getSubject().isAgent() ) {
+          sb.append(",agent:");
+          sb.append(getSubject().getUser().getId());
+        }
+      }
+      sb.append("}");
+      return sb.toString();
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/logger/Loggers.java
+++ b/src/foam/nanos/logger/Loggers.java
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.nanos.logger;
+
+import foam.core.X;
+import foam.nanos.auth.ServiceProviderAware;
+import foam.nanos.auth.Subject;
+import foam.nanos.auth.User;
+import foam.nanos.logger.Logger;
+import foam.util.SafetyUtil;
+
+/**
+ * Support methods for Logger
+ */
+public class Loggers {
+
+  /**
+   * Return a PrefixLogger configured with spid, user, agent, and calling object class name
+   */
+  public static Logger logger(X x) {
+    return logger(x, null);
+  }
+
+  public static Logger logger(X x, Object caller) {
+    String spid = (String) x.get("spid");
+    if ( ! SafetyUtil.isEmpty(spid) ) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("{spid:");
+      sb.append(spid);
+      Subject subject = (Subject) x.get("subject");
+      if ( subject != null &&
+           subject.getRealUser() != null ) {
+        sb.append(",user:");
+        sb.append(subject.getRealUser().getId());
+        if ( subject.isAgent() ) {
+          sb.append(",agent:");
+          sb.append(subject.getUser().getId());
+        }
+      }
+      sb.append("}");
+      return new PrefixLogger(
+                              caller != null ?
+                              new Object[] {
+                                sb.toString(),
+                                caller.getClass().getSimpleName() } :
+                              new Object[] {
+                                sb.toString()
+                              },
+                              (Logger) x.get("logger")
+                              );
+    }
+    return (Logger) x.get("logger");
+  }
+}

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -387,6 +387,7 @@ var classes = [
   'foam.nanos.logger.AbstractLogger',
   'foam.nanos.logger.DAOLogger',
   'foam.nanos.logger.Logger',
+  'foam.nanos.logger.LoggerUserInfo',
   'foam.nanos.logger.NotificationLogMessageDAO',
   'foam.nanos.logger.RepeatLogMessageDAO',
   'foam.nanos.logger.ProxyLogger',


### PR DESCRIPTION
DRAFT
Loggers is a support class which provide 'logger's configured following some common patterns. 
In addition, Loggers.logger creates a PrefixLogger with spid, user, agent (when available).

Session.applyTo refactored to acquire logger from Loggers. 

Would like this setup when running Cron operations, but not sure where to get the spid from. 

I tried a number of other approaches such as LoggerFactory, Logger setup in NanoRouter, but without success. 