### PR TITLE
Removed absolute font sizing from vertical menu

### DIFF
--- a/src/foam/nanos/menu/VerticalMenu.js
+++ b/src/foam/nanos/menu/VerticalMenu.js
@@ -35,16 +35,13 @@ foam.CLASS({
   }
 
   ^ .side-nav-view {
-    font-size: medium;
-    font-weight: normal;
-    position: absolute;
+    background: /*%GREY5%*/ #f5f7fas;
+    border-right: 1px solid /*%GREY4%*/ #e7eaec;
+    color: /*%GREY2%*/ #9ba1a6;
     height: calc(100vh - 80px);
     overflow-x: hidden;
+    position: absolute;
     z-index: 100;
-    font-size: 26px;
-    color: /*%GREY2%*/ #9ba1a6;
-    border-right: 1px solid /*%GREY4%*/ #e7eaec;
-    background: /*%GREY5%*/ #f5f7fas;
   }
 
   ^search {


### PR DESCRIPTION
Removed absolute font sizing so that relative icon sizing is correct 

New: 
<img width="247" alt="image" src="https://user-images.githubusercontent.com/81172969/125813880-1c702dd9-3bc5-4231-b612-3647bd33f6b7.png">

Old: 
<img width="244" alt="Screen Shot 2021-07-15 at 11 21 10 AM" src="https://user-images.githubusercontent.com/81172969/125813920-78b4ed73-040e-40a3-bee2-af143f04718d.png">
