### PR TITLE
[NP-5038] Passed correct context to browseView in DAOBrowseControllerView

### DIFF
--- a/src/foam/comics/v2/DAOBrowseControllerView.js
+++ b/src/foam/comics/v2/DAOBrowseControllerView.js
@@ -228,9 +228,8 @@ foam.CLASS({
                     .end();
                 })
                 .call(function(){
-                  var e = this;
                   this.add(self.slot(function(browseView) {
-                    return self.E().tag(browseView, { config$: e.__subContext__.config$ });
+                    return self.E().tag(browseView, self.__subContext__);
                   }))
                 })
               .end()


### PR DESCRIPTION
This was changed recently where only a subset of the context was passed to the browse views. While DAOBrowserView could handle this any menu using a custom browserView was not rendering (ClusterConfigs). This fixes it by passing in the correct context