### PR TITLE
Only call p.get(obj) if the propertyIsSet to prevent the factory from invoking

### DIFF
--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -328,13 +328,17 @@ public interface FObject
     for ( PropertyInfo p : props ) {
       Object remote = null;
       try {
-        remote = p.get(obj);
+        if ( p.isSet(obj) ) {
+          remote = p.get(obj);
+        }
       } catch ( ClassCastException e ) {
         PropertyInfo p2 = (PropertyInfo) getClassInfo().getAxiomByName(p.getName());
         if ( p2 != null ) {
           p = p2;
           try {
-            remote = p.get(obj);
+            if ( p.isSet(obj) ) {
+              remote = p.get(obj);
+            }
           } catch ( ClassCastException ee ) {
             System.err.println("FObject.overlay "+p.getName()+" get "+ee);
           }


### PR DESCRIPTION
 Otherwise since factories are invoked from the getter, p.isSet will always be true by the time we get to FObject.java L339:

https://github.com/kgrgreer/foam3/compare/NP-5058/OverlayInvokeFactoryOnlyIfSet?expand=1#diff-11f1d52d0751398ab082ae845cfea0e006867c7a76b636d9c062e28a00e1f4e9R340

