### PR TITLE
Set default menu config for nested tables

### DIFF
--- a/src/foam/comics/v2/DAOBrowseControllerView.js
+++ b/src/foam/comics/v2/DAOBrowseControllerView.js
@@ -241,7 +241,7 @@ foam.CLASS({
                 })
                 .call(function() {
                   this.add(self.slot(function(browseView) {
-                    return self.E().tag(browseView, { data: data, config: config });
+                    return self.E().tag(browseView, { data: data, config: config } );
                   }));
                 })
               .end()

--- a/src/foam/u2/view/EmbeddedTableView.js
+++ b/src/foam/u2/view/EmbeddedTableView.js
@@ -60,6 +60,13 @@ foam.CLASS({
   methods: [
     async function render() {
       this.currentMemento_ = this.memento;
+
+      // Default controller config that would be used for nested tables if no menu config can be found.
+      // Update this  to be a fallback for menuKeys when we have menuKeys for references, DAOproperties and relationships
+      this.config.editPredicate =   foam.mlang.predicate.False.create();
+      this.config.createPredicate = foam.mlang.predicate.False.create();
+      this.config.deletePredicate = foam.mlang.predicate.False.create();
+
       if ( this.memento && this.memento.head == `&${this.data.of.name}` ) {
         this.openFullTable();
       } else {
@@ -88,7 +95,7 @@ foam.CLASS({
           class: this.DAOBrowseControllerView,
           data$: this.data$,
           config$: this.config$
-        }, parent: this }));
+        }, parent: this.__subContext__.createSubContext({ controllerMode: 'CREATE' }) }));
     }
   ],
   actions: [


### PR DESCRIPTION
This sets a watered down version of the DAOControllerConfig as default for nested tables. Create, edit and delete are all disabled. Export and Import actions have their own `isAvailable()` which is not controlled by the menu config. 

Currently, this applies to all nested tables but this would just be the default fallback for DAOProperties/Relationships that do not have menuKeys set