### PR TITLE
Changed rule group priority default to 10 and updated doc

### DIFF
--- a/src/foam/nanos/ruler/RuleGroup.js
+++ b/src/foam/nanos/ruler/RuleGroup.js
@@ -48,7 +48,12 @@
     {
       class: 'Int',
       name: 'priority',
-      documentation: 'Support prioritizing rule group execution in the rule engine.',
+      value: 10,
+      documentation: `
+        Support prioritizing rule group execution in the rule engine.
+        Priority is a multiple of 10 in the range of (lowest) 0 -> inf (highest).
+        Priority is defaulted to 10 so rule groups can ensure they go last by setting priority to 0
+      `,
       writePermissionRequired: true
     }
   ],


### PR DESCRIPTION
Only place in the system that uses rule group priority were two rules that set it to 100, this shouldn't have any side effects. 