### PR TITLE
Approval Request Table optimization

### DIFF
--- a/src/foam/nanos/approval/Approvable.js
+++ b/src/foam/nanos/approval/Approvable.js
@@ -134,19 +134,18 @@ foam.CLASS({
         sb.append(getObjId().toString());
         sb.append(") UPDATE");
 
-        modelString = sb.toString();
-
         foam.dao.DAO referenceDAO = (foam.dao.DAO) getX().get(getDaoKey());
 
-        if ( referenceDAO == null ) return modelString;
+        if ( referenceDAO == null ) return sb.toString();
 
         foam.core.FObject referenceObj = (foam.core.FObject) referenceDAO.find(getObjId());
 
         if ( referenceObj != null ){
-          modelString = modelString + ": " + referenceObj.toSummary();
+          sb.append(": ");
+          sb.append(referenceObj.toSummary());
         }
 
-        return modelString;
+        return sb.toString();
       `
     }
   ]

--- a/src/foam/nanos/approval/Approvable.js
+++ b/src/foam/nanos/approval/Approvable.js
@@ -120,7 +120,26 @@ foam.CLASS({
             ? `${modelString}: ${obj.toSummary()}`
             :  `(${modelString}:${this.objId}) UPDATE`
         });
-      }
+      },
+      javaCode: `
+        String modelString = getDaoKey();
+
+        modelString = modelString.replaceAll("local","");
+        modelString = modelString.replaceAll("DAO","");
+        modelString = '(' + modelString + ':' + getObjId().toString() + ") UPDATE";
+
+        foam.dao.DAO referenceDAO = (foam.dao.DAO) getX().get(getDaoKey());
+
+        if ( referenceDAO == null ) return modelString;
+
+        foam.core.FObject referenceObj = (foam.core.FObject) referenceDAO.find(getObjId());
+
+        if ( referenceObj != null ){
+          modelString = modelString + ": " + referenceObj.toSummary();
+        }
+
+        return modelString;
+      `
     }
   ]
 });

--- a/src/foam/nanos/approval/Approvable.js
+++ b/src/foam/nanos/approval/Approvable.js
@@ -126,7 +126,15 @@ foam.CLASS({
 
         modelString = modelString.replaceAll("local","");
         modelString = modelString.replaceAll("DAO","");
-        modelString = '(' + modelString + ':' + getObjId().toString() + ") UPDATE";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append('(');
+        sb.append(modelString);
+        sb.append(':');
+        sb.append(getObjId().toString());
+        sb.append(") UPDATE");
+
+        modelString = sb.toString();
 
         foam.dao.DAO referenceDAO = (foam.dao.DAO) getX().get(getDaoKey());
 

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -50,6 +50,7 @@
 
   imports: [
     'DAO approvalRequestDAO',
+    'tableViewApprovalRequestDAO',
     'ctrl',
     'currentMenu',
     'notify',
@@ -62,6 +63,7 @@
   searchColumns: [
     'id',
     'classificationEnum',
+    'createdFor',
     'status'
   ],
 
@@ -69,7 +71,7 @@
     'id',
     'referenceSummary',
     'classificationEnum',
-    'createdFor',
+    'createdForSummary',
     'assignedTo.legalName',
     'status',
     'memo'
@@ -151,57 +153,15 @@
 
   properties: [
     {
-      // TODO: True fix will be with ReferenceView
       class: 'String',
       name: 'referenceSummary',
       section: 'approvalRequestInformation',
       order: 21,
       gridColumns: 6,
-      transient: true,
+      storageTransient: true,
       tableWidth: 250,
       visibility: 'RO',
-      columnPermissionRequired: true,
-      tableCellFormatter: function(_,obj) {
-        let self = this;
-        try {
-          this.__subSubContext__[obj.daoKey].find(obj.objId).then(requestObj => {
-            let referenceSummaryString = `ID:${obj.objId}`;
-
-            if ( ! requestObj ) return self.add(referenceSummaryString);
-            
-            // need to use a  Promise resolve because toSummary doesn't always return a promise
-            Promise.resolve(requestObj.toSummary()).then(requestObjSummary => {
-              if ( requestObjSummary ) referenceSummaryString = requestObjSummary;
-
-              self.add(referenceSummaryString);
-            })
-          });
-        } catch (x) {}
-      },
-      view: function(_, X) {
-        let slot = foam.core.SimpleSlot.create();
-        let data = X.data;
-
-
-        X[data.daoKey] && X[data.daoKey].find(data.objId).then(requestObj => {
-          let referenceSummaryString = `ID:${data.objId}`;
-
-          if ( requestObj ){
-            Promise.resolve(requestObj.toSummary()).then(function(requestObjSummary) {
-              if ( requestObjSummary ){
-                referenceSummaryString = requestObjSummary;
-              }
-
-              slot.set(referenceSummaryString);
-            })
-          }
-        });
-
-        return {
-          class: 'foam.u2.view.ValueView',
-          data$: slot
-        };
-      },
+      columnPermissionRequired: true
     },
     {
       class: 'Long',
@@ -394,13 +354,16 @@
       section: 'approvalRequestInformation',
       order: 105,
       gridColumns: 6,
+      columnPermissionRequired: true
+    },
+    {
+      class: 'String',
+      name: 'createdForSummary',
+      section: 'approvalRequestInformation',
+      order: 107,
+      gridColumns: 6,
       columnPermissionRequired: true,
-      tableCellFormatter: function(value, obj, axiom) {
-        var defaultOutput = value ? `ID: ${value}`: "N/A";
-        this.__subSubContext__.userDAO
-          .find(value)
-          .then(user => this.add(user ? user.toSummary() : defaultOutput));
-      }
+      storageTransient: true
     },
     {
       class: 'Reference',
@@ -784,6 +747,7 @@
 
         this.approvalRequestDAO.put(approvedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_APPROVED_TITLE, this.SUCCESS_APPROVED, this.LogLevel.INFO, true);
 
@@ -867,6 +831,7 @@
 
         X.approvalRequestDAO.put(cancelledApprovalRequest).then(o => {
           X.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          X.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
 
           X.notify(this.SUCCESS_CANCELLED_TITLE, this.SUCCESS_CANCELLED, this.LogLevel.INFO, true);
@@ -1040,6 +1005,7 @@
 
         this.approvalRequestDAO.put(assignedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_ASSIGNED_TITLE, this.SUCCESS_ASSIGNED, this.LogLevel.INFO, true);
           if (
@@ -1066,6 +1032,7 @@
 
         this.approvalRequestDAO.put(unassignedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_UNASSIGNED_TITLE, this.SUCCESS_UNASSIGNED, this.LogLevel.INFO, true);
           if (
@@ -1092,6 +1059,7 @@
 
         this.approvalRequestDAO.put(approvedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_APPROVED_TITLE, this.SUCCESS_APPROVED, this.LogLevel.INFO, true);
 
@@ -1115,6 +1083,7 @@
 
         this.approvalRequestDAO.put(newMemoRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_MEMO_TITLE, this.SUCCESS_MEMO, this.LogLevel.INFO, true);
 
@@ -1139,6 +1108,7 @@
 
         this.approvalRequestDAO.put(rejectedApprovalRequest).then(o => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_REJECTED_TITLE, this.SUCCESS_REJECTED, this.LogLevel.INFO, true);
 
@@ -1161,6 +1131,7 @@
 
         this.approvalRequestDAO.put(assignedApprovalRequest).then(_ => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_ASSIGNED_TITLE, this.SUCCESS_ASSIGNED, this.LogLevel.INFO, true);
 

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -748,6 +748,9 @@
         this.approvalRequestDAO.put(approvedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+
           this.finished.pub();
           this.notify(this.SUCCESS_APPROVED_TITLE, this.SUCCESS_APPROVED, this.LogLevel.INFO, true);
 
@@ -832,6 +835,9 @@
         X.approvalRequestDAO.put(cancelledApprovalRequest).then(o => {
           X.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           X.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          X.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          X.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+
           this.finished.pub();
 
           X.notify(this.SUCCESS_CANCELLED_TITLE, this.SUCCESS_CANCELLED, this.LogLevel.INFO, true);
@@ -1006,6 +1012,9 @@
         this.approvalRequestDAO.put(assignedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+
           this.finished.pub();
           this.notify(this.SUCCESS_ASSIGNED_TITLE, this.SUCCESS_ASSIGNED, this.LogLevel.INFO, true);
           if (
@@ -1033,6 +1042,9 @@
         this.approvalRequestDAO.put(unassignedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+
           this.finished.pub();
           this.notify(this.SUCCESS_UNASSIGNED_TITLE, this.SUCCESS_UNASSIGNED, this.LogLevel.INFO, true);
           if (
@@ -1060,6 +1072,9 @@
         this.approvalRequestDAO.put(approvedApprovalRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          
           this.finished.pub();
           this.notify(this.SUCCESS_APPROVED_TITLE, this.SUCCESS_APPROVED, this.LogLevel.INFO, true);
 
@@ -1084,6 +1099,9 @@
         this.approvalRequestDAO.put(newMemoRequest).then(req => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+
           this.finished.pub();
           this.notify(this.SUCCESS_MEMO_TITLE, this.SUCCESS_MEMO, this.LogLevel.INFO, true);
 
@@ -1109,6 +1127,9 @@
         this.approvalRequestDAO.put(rejectedApprovalRequest).then(o => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          
           this.finished.pub();
           this.notify(this.SUCCESS_REJECTED_TITLE, this.SUCCESS_REJECTED, this.LogLevel.INFO, true);
 
@@ -1132,6 +1153,9 @@
         this.approvalRequestDAO.put(assignedApprovalRequest).then(_ => {
           this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+          this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+          this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+
           this.finished.pub();
           this.notify(this.SUCCESS_ASSIGNED_TITLE, this.SUCCESS_ASSIGNED, this.LogLevel.INFO, true);
 

--- a/src/foam/nanos/approval/CompositeApprovable.js
+++ b/src/foam/nanos/approval/CompositeApprovable.js
@@ -46,6 +46,7 @@
             :  `${this.id},...`
         });
       }
+      // TODO: implement javaCode not needed now
     }
   ]
 });

--- a/src/foam/nanos/approval/PopulateApprovalRequestSummariesDAO.js
+++ b/src/foam/nanos/approval/PopulateApprovalRequestSummariesDAO.js
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.CLASS({
+  package: 'foam.nanos.approval',
+  name: 'PopulateApprovalRequestSummariesDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  documentation: `
+    Adds referenceSummary and createdForSummary to ApprovalRequest 
+  `,
+
+  javaImports: [
+    'foam.core.Detachable',
+    'foam.core.FObject',
+    'foam.dao.AbstractSink',
+    'foam.dao.DAO',
+    'foam.dao.ProxySink',
+    'foam.nanos.approval.ApprovalRequest',
+    'foam.nanos.auth.User',
+    'foam.util.SafetyUtil'
+  ],
+
+  methods: [
+    {
+      name: 'find_',
+      javaCode: `
+        ApprovalRequest approval = (ApprovalRequest) getDelegate().find_(x, id);
+        if ( approval == null ) {
+          return approval;
+        }
+        
+        populateSummaries(x, approval);
+
+        return approval;
+      `
+    },
+    {
+      name: 'select_',
+      javaCode: `
+        if (sink != null) {
+          ProxySink refinedSink = new ProxySink(x, sink) {
+            @Override
+            public void put(Object obj, foam.core.Detachable sub) {
+              ApprovalRequest approval = (ApprovalRequest) obj;
+
+              populateSummaries(x, approval);
+
+              super.put(approval, sub);
+            }
+          };
+          return ((ProxySink) super.select_(x, refinedSink, skip, limit, order, predicate)).getDelegate();
+        }
+        return super.select_(x, sink, skip, limit, order, predicate);
+      `
+    },
+    {
+      name: 'populateSummaries',
+      args: [
+        { name: 'x', javaType: 'foam.core.X' },
+        { name: 'approval', javaType: 'foam.nanos.approval.ApprovalRequest' }
+      ],
+      type: 'Void',
+      javaCode:`
+        DAO userDAO = (DAO) x.get("userDAO");
+        DAO referenceDAO = (DAO) x.get(approval.getDaoKey());
+
+        // handle createdForSummary
+        String createdForSummaryString = approval.getCreatedFor() != 0 
+          ? "ID:" + Long.toString(approval.getCreatedFor())
+          : "N/A";
+        
+        User createdForUser = (User) userDAO.find(approval.getCreatedFor());
+
+        if ( createdForUser != null && ! SafetyUtil.isEmpty(createdForUser.toSummary()) ){
+          createdForSummaryString = createdForUser.toSummary();
+        }
+
+        // handle referenceSummaryString
+        String referenceSummaryString = "ID:" + approval.getObjId().toString();
+
+        FObject referenceObject = (FObject) referenceDAO.find(approval.getObjId());
+
+        String referenceObjectToSummary = referenceObject.toSummary();
+
+        if ( ! SafetyUtil.isEmpty(referenceObjectToSummary) ){
+          referenceSummaryString = referenceObjectToSummary;
+        }
+
+        approval.setCreatedForSummary(createdForSummaryString);
+        approval.setReferenceSummary(referenceSummaryString);
+
+        populateSummariesDecorator(x, approval);
+      `
+    },
+        {
+      name: 'populateSummariesDecorator',
+      documentation: `
+        An optional decorator to override in subclasses for more
+        customized summaries
+      `,
+      args: [
+        { name: 'x', javaType: 'foam.core.X' },
+        { name: 'approval', javaType: 'foam.nanos.approval.ApprovalRequest' }
+      ],
+      type: 'Void',
+      javaCode:`
+        // TODO: override in a subclass to add
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/approval/UCJApprovable.js
+++ b/src/foam/nanos/approval/UCJApprovable.js
@@ -78,7 +78,10 @@
       name: 'toSummary',
       code: function() {
         return this.ucj.id;
-      }
+      },
+      javaCode: `
+        return getUcj().getId();
+      `
     }
   ]
 });

--- a/src/foam/nanos/crunch/CapabilityJunctionPayload.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionPayload.js
@@ -21,7 +21,8 @@ foam.CLASS({
     'foam.core.FObject',
     'foam.core.Validatable',
     'foam.dao.DAO',
-    'foam.nanos.crunch.Capability'
+    'foam.nanos.crunch.Capability',
+    'foam.util.SafetyUtil'
   ],
 
   implements: [
@@ -92,11 +93,25 @@ foam.CLASS({
     },
     {
       name: 'toSummary',
+      type: 'String', //TODO: investigate why we need to define type String
       code: function(){
         return this.capability
           ? this.capabilityDAO.find(this.capability).then(capability => capability.name)
           : '';
-      }
+      },
+      javaCode: `
+        String toSummaryString = "";
+
+        if ( SafetyUtil.isEmpty(getCapability()) ){
+          return toSummaryString;
+        }
+
+        Capability capability = findCapability(getX());
+
+        toSummaryString = capability.getName();
+
+        return toSummaryString;
+      `
     }
   ],
 });

--- a/src/foam/nanos/crunch/ui/UCJView.js
+++ b/src/foam/nanos/crunch/ui/UCJView.js
@@ -125,6 +125,9 @@ foam.CLASS({
           this.approvalRequestDAO.put(rejectedApproval).then(o => {
             this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
             this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+            this.approvalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+            this.tableViewApprovalRequestDAO.cmd(foam.dao.CachingDAO.PURGE);
+            
             this.notify(this.SUCCESS_REMOVED, '', this.LogLevel.INFO, true);
             this.pushMenu('approvals', true);
           }, e => {

--- a/src/foam/nanos/crunch/ui/UCJView.js
+++ b/src/foam/nanos/crunch/ui/UCJView.js
@@ -15,6 +15,7 @@ foam.CLASS({
     'notify',
     'pushMenu',
     'stack',
+    'tableViewApprovalRequestDAO',
     'translationService',
     'userDAO'
   ],
@@ -123,6 +124,7 @@ foam.CLASS({
           rejectedApproval.memo = 'Outdated Approval.';
           this.approvalRequestDAO.put(rejectedApproval).then(o => {
             this.approvalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
+            this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD);
             this.notify(this.SUCCESS_REMOVED, '', this.LogLevel.INFO, true);
             this.pushMenu('approvals', true);
           }, e => {

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -578,6 +578,7 @@ FOAM_FILES([
   { name: 'foam/nanos/approval/CustomViewReferenceApprovable' },
   { name: 'foam/nanos/approval/FulfilledCompositeApprovableRule' },
   { name: 'foam/nanos/approval/RestrictedApprovableDAO' },
+  { name: 'foam/nanos/approval/PopulateApprovalRequestSummariesDAO' },
 
   //authservice
   { name: "foam/nanos/auth/CapabilityAuthService" },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -743,7 +743,9 @@ var classes = [
   // DAO decorators
   'foam.nanos.actioncommand.ActionCommandDAO',
   'foam.nanos.approval.ApprovalDAO',
+  'foam.nanos.approval.PopulateApprovalRequestSummariesDAO',
   'foam.nanos.approval.RestrictedApprovableDAO',
+  'foam.nanos.approval.SendGroupRequestApprovalDAO',
   'foam.nanos.audit.AuditDAO',
   'foam.nanos.auth.email.EmailVerificationDAO',
   'foam.nanos.auth.email.EmailVerificationWebAgent',
@@ -751,7 +753,6 @@ var classes = [
   'foam.nanos.geocode.GoogleMapsGeocodingDAO',
   'foam.dao.history.HistoryDAO',
   'foam.nanos.script.ScriptRunnerDAO',
-  'foam.nanos.approval.SendGroupRequestApprovalDAO',
   'foam.dao.UnreliableDAO',
   'foam.nanos.auth.UserPasswordHashingDAO',
   'foam.dao.ValidatingDAO',


### PR DESCRIPTION
- Migrated referenceSummary and createdFor custom view and table cell formatter client logic to a backend decorator: PopulateApprovalRequestSummariesDAO
- createdFor for the table column is now rendered through a storage transient property createdForSummary
- Add this.tableViewApprovalRequestDAO.cmd(this.AbstractDAO.RESET_CMD); to various approval methods
- toSummary java implementations for various models
- Added PopulateApprovalRequestSummariesDAO to handle setting of referenceSummary and createdForSummary when marshalling data over to the client
- Add createdFor to search and createdForSummary as the default column
- Made referenceSummary storageTransient