### PR TITLE
Pass context to stack where parent is not context v2

### DIFF
--- a/src/foam/u2/stack/Stack.js
+++ b/src/foam/u2/stack/Stack.js
@@ -184,8 +184,9 @@ foam.CLASS({
         }
       }
     },
-    function getContextFromParent(parent) {
-      if ( ! parent ) return this.__subSubContext__;
+    function getContextFromParent(parent, ctx) {
+      ctx = ctx || this;
+      if ( ! parent ) return ctx.__subSubContext__;
       if ( parent.isContext ) return parent;
       if ( parent.__subContext__ ) return parent.__subContext__;
 
@@ -194,7 +195,7 @@ foam.CLASS({
       // "parent" are available to "view"
       // TODO: revisit KGR's comment from earlier; this may not be needed
       console.warn('parent is neither an element nor a context');
-      return this.__subSubContext__.createSubContext(parent);
+      return ctx.__subSubContext__.createSubContext(parent);
     }
   ],
 

--- a/src/foam/u2/stack/StackView.js
+++ b/src/foam/u2/stack/StackView.js
@@ -76,19 +76,6 @@ foam.CLASS({
       return v;
     },
 
-    function getContextFromParent(parent) {
-      if ( ! parent ) return this.__subSubContext__;
-      if ( parent.isContext ) return parent;
-      if ( parent.__subContext__ ) return parent.__subContext__;
-
-
-      // Do a bit of a dance with the context, to ensure that exports from
-      // "parent" are available to "view"
-      // TODO: revisit KGR's comment from earlier; this may not be needed
-      console.warn('parent is neither an element nor a context');
-      return this.__subSubContext__.createSubContext(parent);
-    },
-
     function shouldMementoValueBeChanged(mementoValue, mementoHead) {
       if ( ! mementoValue )
         return false;

--- a/src/foam/u2/stack/StackView.js
+++ b/src/foam/u2/stack/StackView.js
@@ -64,7 +64,7 @@ foam.CLASS({
       var view   = s.view;
       var parent = s.parent;
 
-      var X = this.data.getContextFromParent(parent);
+      var X = this.data.getContextFromParent(parent, this);
 
       var v = foam.u2.ViewSpec.createView(view, null, this, X);
 


### PR DESCRIPTION
Going back after clicking into a readReferenceView would not handle the memento truncation resulting in the user having to click back multiple times. This fixes it for all views where the parent passed in is not the subContext