### PR TITLE
Np 5220/temp fix prevent parser error

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -491,7 +491,6 @@ FOAM_FILES([
   { name: "foam/swift/refines/Topic", flags: ['swift'] },
   { name: "foam/swift/refines/Remote", flags: ['swift'] },
 
-  { name: "foam/nanos/menu/DAOMenu2" },
   { name: "foam/nanos/menu/MenuToolBar" },
   { name: "foam/box/LogBox" },
   { name: "foam/box/MultiDelegateBox" },

--- a/src/foam/nanos/menu/Menu.js
+++ b/src/foam/nanos/menu/Menu.js
@@ -48,7 +48,9 @@
       tableWidth: 80
     },
     {
-      class: 'JSFObject',
+      // TODO: temporary fix until we figure out why JSFObject breaks when using Medusa
+      class: 'FObjectProperty',
+      of: 'foam.nanos.menu.AbstractMenu',
       name: 'handler',
       documentation: 'View initialized when menu is launched.',
       view: {


### PR DESCRIPTION
Will continue to investigate why JSFObject breaks the app on medusa build. Need this for production otherwise any update of a menu handler will corrupt the menu jrls.

Essentially something causes the UnknownFObject to be injected into the JSON server-side, which cannot be parsed by the client.

Also DAOMenu2.js already is in nanos.js