### PR TITLE
[DO_NOT_MERGE]set autocomplete off to avoid auto overwite postal code

### DIFF
--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -250,6 +250,10 @@ foam.CLASS({
         return newValue.toUpperCase();
       },
       gridColumns: 6,
+      view: {
+        class: 'foam.u2.TextField',
+        autocomplete: 'off'
+      },
       validationPredicates: [
         {
           args: ['postalCode'],
@@ -1072,7 +1076,7 @@ foam.CLASS({
         String regionCode = "";
         Region region = findRegionId(x);
         if ( region != null ) {
-          regionCode = region.getIsoCode();
+          regionCode = region.getRegionCode();
         }
 
         return ! SafetyUtil.isEmpty(regionCode) ?

--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -1076,7 +1076,7 @@ foam.CLASS({
         String regionCode = "";
         Region region = findRegionId(x);
         if ( region != null ) {
-          regionCode = region.getRegionCode();
+          regionCode = region.getIsoCode();
         }
 
         return ! SafetyUtil.isEmpty(regionCode) ?


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-4823
issue:
    autofill overwrite hidden signing officer postal code causing postal code validation failed. since signing officer address is hidden so there is no way for client to pass validation
this issue only happen when user auto populate the address during filling in BusinessOwnership section. no error throw If user type in address. If there is better solution for this please comment