### PR TITLE
[DO_NOT_MERGE][NP-5016] Provide "Save as PDF" button for business onboarding wizard to save the PDF to fileDAO

### DIFF
--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -34,6 +34,8 @@ foam.CLASS({
     'foam.blob.BlobService',
     'foam.blob.Blob',
     'foam.blob.InputStreamBlob',
+    'foam.core.X',
+    'foam.dao.DAO',
     'foam.nanos.auth.AuthService',
     'foam.nanos.auth.AuthorizationException',
     'foam.nanos.auth.LifecycleState',
@@ -42,7 +44,9 @@ foam.CLASS({
     'foam.nanos.auth.User',
     'foam.util.SafetyUtil',
     'java.io.*',
-    'java.util.Base64'
+    'java.util.Base64',
+    'net.nanopay.model.Business',
+    'static foam.mlang.MLang.*'
   ],
 
   tableColumns: [
@@ -279,8 +283,15 @@ foam.CLASS({
       name: 'authorizeOnDelete',
       javaCode: `
         AuthService auth = (AuthService) x.get("auth");
+        Boolean hasPermission = auth.check(x, "file.remove." + getId());
 
-        if ( ! auth.check(x, "file.remove.id") ) {
+        // find a file owner
+        // creating a file uses businessID for the file owner
+        DAO businessDAO = (DAO) x.get("businessDAO");
+        Business fileOwner = (Business) businessDAO
+          .find(EQ(Business.ID, getOwner()));
+
+        if ( ! hasPermission || fileOwner == null ) {
           throw new AuthorizationException();
         }
       `

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -280,7 +280,7 @@ foam.CLASS({
       javaCode: `
         AuthService auth = (AuthService) x.get("auth");
 
-        if ( ! auth.check(x, "file.remove.*") ) {
+        if ( ! auth.check(x, "file.remove.id") ) {
           throw new AuthorizationException();
         }
       `

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -17,8 +17,8 @@ foam.CLASS({
 
   implements: [
     'foam.nanos.auth.Authorizable',
-    'foam.nanos.auth.ServiceProviderAware',
-    'foam.nanos.auth.LifecycleAware'
+    'foam.nanos.auth.LifecycleAware',
+    'foam.nanos.auth.ServiceProviderAware'
   ],
 
   requires: [

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -17,7 +17,8 @@ foam.CLASS({
 
   implements: [
     'foam.nanos.auth.Authorizable',
-    'foam.nanos.auth.ServiceProviderAware'
+    'foam.nanos.auth.ServiceProviderAware',
+    'foam.nanos.auth.LifecycleAware'
   ],
 
   requires: [
@@ -35,6 +36,7 @@ foam.CLASS({
     'foam.blob.InputStreamBlob',
     'foam.nanos.auth.AuthService',
     'foam.nanos.auth.AuthorizationException',
+    'foam.nanos.auth.LifecycleState',
     'foam.nanos.auth.ServiceProviderAwareSupport',
     'foam.nanos.auth.Subject',
     'foam.nanos.auth.User',
@@ -151,7 +153,7 @@ foam.CLASS({
           selected$: selectSlot
         });
       },
-      comparePropertyValues: function(o1, o2) { return 0; } 
+      comparePropertyValues: function(o1, o2) { return 0; }
     },
     {
       class: 'Blob',
@@ -240,7 +242,17 @@ foam.CLASS({
           .findSpid(foam.core.XLocator.get(), map, this);
       `
     },
+    {
+      name: 'lifecycleState',
+      class: 'Enum',
+      of: 'foam.nanos.auth.LifecycleState',
+      documentation: 'Display a file state',
+      value: 'ACTIVE',
+      visibility: 'RO',
+      includeInDigest: true,
+    }
   ],
+
   methods: [
     {
       name: 'authorizeOnCreate',
@@ -267,7 +279,8 @@ foam.CLASS({
       name: 'authorizeOnDelete',
       javaCode: `
         AuthService auth = (AuthService) x.get("auth");
-        if ( ! auth.check(x, "file.remove." + getId()) ) {
+
+        if ( ! auth.check(x, "file.remove.*") ) {
           throw new AuthorizationException();
         }
       `

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -283,15 +283,11 @@ foam.CLASS({
       name: 'authorizeOnDelete',
       javaCode: `
         AuthService auth = (AuthService) x.get("auth");
-        Boolean hasPermission = auth.check(x, "file.remove." + getId());
+        Boolean hasPermission = auth.check(x, "file.remove." + this.getId());
+        Subject subject = (Subject) x.get("subject");
+        User user = subject.getRealUser();
 
-        // find a file owner
-        // creating a file uses businessID for the file owner
-        DAO businessDAO = (DAO) x.get("businessDAO");
-        Business fileOwner = (Business) businessDAO
-          .find(EQ(Business.ID, getOwner()));
-
-        if ( ! hasPermission || fileOwner == null ) {
+        if ( ! hasPermission && user.getId() != this.getCreatedBy() ) {
           throw new AuthorizationException();
         }
       `

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -271,7 +271,7 @@ foam.CLASS({
       javaCode: `
       `
     },
-    {
+   {
       name: 'authorizeOnUpdate',
       javaCode: `
         // KeyValueDAO will return the same object if it is update operation
@@ -284,9 +284,9 @@ foam.CLASS({
         AuthService auth = (AuthService) x.get("auth");
         Boolean hasPermission = auth.check(x, "file.remove." + this.getId());
         Subject subject = (Subject) x.get("subject");
-        User user = subject.getRealUser();
+        User user = subject.getUser();
 
-        if ( ! hasPermission && user.getId() != this.getCreatedBy() ) {
+        if ( ! hasPermission && user.getId() != this.getOwner() ) {
           throw new AuthorizationException();
         }
       `

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -35,7 +35,6 @@ foam.CLASS({
     'foam.blob.Blob',
     'foam.blob.InputStreamBlob',
     'foam.core.X',
-    'foam.dao.DAO',
     'foam.nanos.auth.AuthService',
     'foam.nanos.auth.AuthorizationException',
     'foam.nanos.auth.LifecycleState',

--- a/src/foam/nanos/fs/services.jrl
+++ b/src/foam/nanos/fs/services.jrl
@@ -53,6 +53,7 @@ p({
       .setJournalName("files")
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setPm(true)
+      .setLifecycleAware(true)
       .build()
   """,
   "client":"""


### PR DESCRIPTION
*Foam PR: https://github.com/kgrgreer/foam3/pull/780
*Nanopay PR : https://github.com/nanoPayinc/NANOPAY/pull/13219
*Ticket: https://nanopay.atlassian.net/browse/NP-5016

*Description: 
-  Added a button called “saveToPdf” in business onboarding wizard. 

> convert HTML page to PDF file 

> save the file to fileDAO

-  Added a permission to delete a file (mark a deleted file) to keep only the recent generated file in fileDAO. 

> only Fraud-ops can delete a file  

*Screenshots and pdf file example:
 1) PDF file example(Business Onboarding)
[businessOnboardingInfo.pdf](https://github.com/kgrgreer/foam3/files/6977494/businessOnboardingInfo.pdf)

 2) Permission to fraud - ops ( can delete a file)
<img width="1484" alt="can delete (mark) file with fraudops" src="https://user-images.githubusercontent.com/55885868/129244156-5ed7d485-9df0-42c3-9cba-419f4beb55bb.png">

 3) No permission to user (cannot delete a file)
<img width="1440" alt="cannot delete(mark) file with a user" src="https://user-images.githubusercontent.com/55885868/129244237-6523022e-e1d7-4108-b7ec-ea253033d3f3.png">

