### PR TITLE
[NP-5278] fix share holder selection view bug

### DIFF
--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -617,12 +617,7 @@ foam.CLASS({
     {
       name: 'onDataUpdate',
       code: function() {
-        if ( this.data ) {
-          this.sections[0].dao.find(this.data).then((result) => {
-            this.fullObject_ = result;
-          });
-        }
-        else this.clearSelection();
+        if ( this.data === undefined ) this.clearSelection();
       }
     },
     function clearSelection(evt) {


### PR DESCRIPTION
addresses https://nanopay.atlassian.net/browse/NP-5278

- Removed `if ( this.data ) {
          this.sections[0].dao.find(this.data).then((result) => {
            this.fullObject_ = result;
          });
        }`
  - Correct me if I am wrong, but this logic is already handled on line 570-573
  - the logic is wrong. What if you selected an option from section other than `sections[0]`?

- Updated condition for clearing section.
  - `data` is an ID property and it could be set to 0 which is falsy value, so we need to check against undefined.