### PR TITLE
updates to user login flow

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -164,7 +164,8 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'loginEnabled',
-      documentation: 'Determines whether the User can login to the platform.',
+      documentation: `Determines whether the User can login to the platform.
+      A user that tries to login with this false -- gets account disabled error msg.`,
       writePermissionRequired: true,
       includeInDigest: false,
       value: true,

--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -95,7 +95,7 @@ foam.CLASS({
     },
     {
       name: 'nextStep',
-      code: function(X) {
+      code: async function(X) {
         if ( this.user.twoFactorEnabled ) {
           this.loginSuccess = false;
           window.history.replaceState({}, document.title, '/');
@@ -104,6 +104,7 @@ foam.CLASS({
           }));
         } else {
           if ( ! this.user.emailVerified ) {
+            await this.auth.logout();
             this.stack.push(this.StackBlock.create({
               view: { class: 'foam.nanos.auth.ResendVerificationEmail' }
             }));

--- a/src/foam/nanos/u2/navigation/SignUp.js
+++ b/src/foam/nanos/u2/navigation/SignUp.js
@@ -183,7 +183,6 @@ foam.CLASS({
           window.history.replaceState(null, null, window.location.origin);
           location.reload();
         } else {
-          await this.auth.login(x, this.userName, this.desiredPassword);
           this.stack.push(this.StackBlock.create({
             view: { class: 'foam.nanos.auth.ResendVerificationEmail' }
           }));

--- a/src/services
+++ b/src/services
@@ -529,7 +529,15 @@ p({
 })
 
 p({"class":"foam.nanos.boot.NSpec", "name":"liveScriptBundler",                      "lazy":false,  "serve":false, "authenticate": false, "serviceClass":"foam.nanos.http.LiveScriptBundler"})
-p({"class":"foam.nanos.boot.NSpec", "name":"emailToken",                         "serve":true,  "serviceClass":"foam.nanos.auth.email.EmailTokenService","boxClass":"foam.nanos.auth.token.TokenServiceSkeleton","client":"{\"class\":\"foam.nanos.auth.token.ClientTokenService\"}"})
+p({
+  "class":"foam.nanos.boot.NSpec",
+  "name":"emailToken",
+  "serve":true,
+  "authenticate": false,
+  "serviceClass":"foam.nanos.auth.email.EmailTokenService",
+  "boxClass":"foam.nanos.auth.token.TokenServiceSkeleton",
+  "client":"{\"class\":\"foam.nanos.auth.token.ClientTokenService\"}"
+})
 
 p({
   "class": "foam.nanos.boot.NSpec",


### PR DESCRIPTION
User was never intended to be logged in on a signUp, but because the issue was needing access to the emailToken service, this was introduced.

So the fix, for NP-5310 is to not login the user and unauthenticated the service that is needed to login.

Bug was introduced with https://github.com/kgrgreer/foam3/commit/2a15f13fffc4f1bcc07b7dbe49cb0b7e267c22fe