### PR TITLE
Fix RO for richChoiceView

### DIFF
--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -617,10 +617,13 @@ foam.CLASS({
     {
       name: 'onDataUpdate',
       code: function() {
-        if ( this.data === undefined ) this.clearSelection();
+        if ( this.data === undefined ) {
+           this.clearSelection();
+           return;
+        }
         this.sections.forEach(section => {
           section.dao.find(this.data).then(result => {
-          this.fullObject_ = result;
+            this.fullObject_ = result;
           });
         });
       }

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -618,6 +618,11 @@ foam.CLASS({
       name: 'onDataUpdate',
       code: function() {
         if ( this.data === undefined ) this.clearSelection();
+        this.sections.forEach(section => {
+          section.dao.find(this.data).then(result => {
+          this.fullObject_ = result;
+          });
+        });
       }
     },
     function clearSelection(evt) {

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -618,12 +618,12 @@ foam.CLASS({
       name: 'onDataUpdate',
       code: function() {
         if ( this.data === undefined ) {
-           this.clearSelection();
-           return;
+          this.clearSelection();
+          return;
         }
         this.sections.forEach(section => {
           section.dao.find(this.data).then(result => {
-            this.fullObject_ = result;
+            if ( result ) this.fullObject_ = result;
           });
         });
       }


### PR DESCRIPTION
Added back `dao.find()` partially reverting https://github.com/kgrgreer/foam3/pull/804. The code was required to initially set the value for the `fullObject_` on view render. Added forEach to sections to ensure the value can be in any section and still be read.