### PR TITLE
Remove timestamp, used for network propagation PM, from protocol as i…

### DIFF
--- a/src/foam/box/socket/SocketConnectionBox.js
+++ b/src/foam/box/socket/SocketConnectionBox.js
@@ -155,7 +155,6 @@ foam.CLASS({
   methods: [
     {
       documentation: `Send format:
-timestamp: 4 bytes, // used to generate a PM when received. 
 length: 1 byte, // message byte length
 message
 NOTE: duplicated in SocketConnectionReplyBox
@@ -167,7 +166,7 @@ NOTE: duplicated in SocketConnectionReplyBox
       String replyBoxId = null;
       if ( replyBox != null ) {
         replyBoxId = java.util.UUID.randomUUID().toString();
-        getReplyBoxes().put(replyBoxId, new BoxHolder(replyBox, PM.create(getX(), this.getOwnClassInfo().getId(), getHost()+":"+getPort()+":roundtrip")));
+        getReplyBoxes().put(replyBoxId, new BoxHolder(replyBox, PM.create(getX(), this.getClass().getSimpleName(), getId()+":roundtrip")));
         SocketClientReplyBox box = new SocketClientReplyBox(replyBoxId);
         if ( replyBox instanceof ReplyBox ) {
           ((ReplyBox)replyBox).setDelegate(box);
@@ -193,7 +192,6 @@ NOTE: duplicated in SocketConnectionReplyBox
         synchronized (out_) {
           // NOTE: enable along with send debug call in SocketServerProcessor to monitor all messages.
           // getLogger().debug("send", message);
-          out_.writeLong(System.currentTimeMillis());
           out_.writeInt(messageBytes.length);
           out_.write(messageBytes);
           // TODO/REVIEW
@@ -227,19 +225,12 @@ NOTE: duplicated in SocketConnectionReplyBox
         }
       ],
       javaCode: `
-      String pmKey = this.getClass().getSimpleName()+":"+getHost()+":"+getPort();
-      String pmName = "receive"; 
       OMLogger omLogger = (OMLogger) x.get("OMLogger");
       try {
         while ( getValid() ) {
           PM pm = null;
           try {
-            long sent = in_.readLong();
-            PM p = PM.create(getX(), this.getClass().getSimpleName(), getHost()+":"+getPort()+":network");
-            p.setStartTime(sent);
-            p.log(x);
-
-            pm = PM.create(x, pmKey, pmName);
+            pm = PM.create(x, this.getClass().getSimpleName(), getId()+":receive");
 
             int length = in_.readInt();
             byte[] bytes = new byte[length];

--- a/src/foam/box/socket/SocketConnectionReplyBox.js
+++ b/src/foam/box/socket/SocketConnectionReplyBox.js
@@ -85,7 +85,6 @@ foam.CLASS({
   methods: [
     {
       documentation: `Send format:
-timestamp: 4 bytes, // used to generate a PM when received.
 length: 1 byte, // message byte length
 message
 NOTE: duplicated in SocketConnectionBox
@@ -102,7 +101,6 @@ NOTE: duplicated in SocketConnectionBox
         String message = formatter.builder().toString();
         byte[] messageBytes = message.getBytes(StandardCharsets.UTF_8);
         synchronized( out ) {
-          out.writeLong(System.currentTimeMillis());
           out.writeInt(messageBytes.length);
           out.write(messageBytes);
           out.flush();

--- a/src/foam/box/socket/SocketServerProcessor.java
+++ b/src/foam/box/socket/SocketServerProcessor.java
@@ -16,6 +16,7 @@ import foam.lib.json.JSONParser;
 import foam.nanos.logger.PrefixLogger;
 import foam.nanos.logger.Logger;
 import foam.nanos.pm.PM;
+import foam.nanos.om.OMLogger;
 
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -74,16 +75,13 @@ public class SocketServerProcessor
 
   public void execute(X x) {
     String pmKey = "SocketServerProcessor";
-    String pmName = String.valueOf(socket_.getRemoteSocketAddress());;
+    String pmName = String.valueOf(socket_.getRemoteSocketAddress());
+    OMLogger omLogger = (OMLogger) x.get("OMLogger");
     try {
       while ( true ) {
         PM pm = null;
         try {
-          long sent = in_.readLong();
-          PM p = PM.create(x, pmKey, pmName+":network");
-          p.setStartTime(sent);
-          p.log(x);
-
+          omLogger.log(pmKey, pmName);
           pm = PM.create(x, pmKey, pmName+":execute");
 
           int length = in_.readInt();
@@ -153,7 +151,6 @@ public class SocketServerProcessor
             String replyString = formatter.builder().toString();
             byte[] replyBytes = replyString.getBytes(java.nio.charset.StandardCharsets.UTF_8);
             synchronized ( out_ ) {
-              out_.writeLong(System.currentTimeMillis());
               out_.writeInt(replyBytes.length);
               out_.write(replyBytes);
               out_.flush();


### PR DESCRIPTION
…t's dependent on machines being in perfect time sync, else numbers are misleading. Additionally this time can be better tested with ping and roundtrip calculations