### PR TITLE
Saving CapabilityPayloads in CapabilityPayloadRecords

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -349,13 +349,7 @@ foam.CLASS({
       documentation: 'Personal phone number.',
       section: 'userInformation',
       order: 190,
-      gridColumns: 6,
-      javaPreSet: `
-        if ( ! SafetyUtil.isEmpty(val) ) {
-          val = val.trim();
-          val = val.startsWith("+") ? val.substring(1) : val;
-        }
-    `
+      gridColumns: 6
     },
     {
       class: 'Boolean',

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -349,7 +349,13 @@ foam.CLASS({
       documentation: 'Personal phone number.',
       section: 'userInformation',
       order: 190,
-      gridColumns: 6
+      gridColumns: 6,
+      javaPreSet: `
+        if ( ! SafetyUtil.isEmpty(val) ) {
+          val = val.trim();
+          val = val.startsWith("+") ? val.substring(1) : val;
+        }
+    `
     },
     {
       class: 'Boolean',

--- a/src/foam/nanos/crunch/connection/CapabilityPayloadDAO.js
+++ b/src/foam/nanos/crunch/connection/CapabilityPayloadDAO.js
@@ -259,6 +259,15 @@ foam.CLASS({
       var pm = PM.create(x, true, CapabilityPayloadDAO.getOwnClassInfo().getId(), "put");
 
       try {
+        CapabilityPayloadRecord record = new CapabilityPayloadRecord.Builder(x)
+          .setCapabilityPayload((CapabilityPayload) obj)
+          .build();
+        ((DAO) x.get("capabilityPayloadRecordDAO")).inX(x).put(record);
+      } catch ( Throwable t ) {
+        getLogger().warning("Failed to save record", obj, t);
+      }
+
+      try {
         CapabilityPayload receivingCapPayload = (CapabilityPayload) obj;
         Map<String,FObject> capabilityDataObjects = (Map<String,FObject>) receivingCapPayload.getCapabilityDataObjects();
 

--- a/src/foam/nanos/crunch/connection/CapabilityPayloadDAO.js
+++ b/src/foam/nanos/crunch/connection/CapabilityPayloadDAO.js
@@ -258,14 +258,7 @@ foam.CLASS({
       javaCode: `
       var pm = PM.create(x, true, CapabilityPayloadDAO.getOwnClassInfo().getId(), "put");
 
-      try {
-        CapabilityPayloadRecord record = new CapabilityPayloadRecord.Builder(x)
-          .setCapabilityPayload((CapabilityPayload) obj)
-          .build();
-        ((DAO) x.get("capabilityPayloadRecordDAO")).inX(x).put(record);
-      } catch ( Throwable t ) {
-        getLogger().warning("Failed to save record", obj, t);
-      }
+      recordCapabilityPayload(x, obj.fclone());
 
       try {
         CapabilityPayload receivingCapPayload = (CapabilityPayload) obj;
@@ -282,6 +275,22 @@ foam.CLASS({
       } finally {
         pm.log(x);
       }
+      `
+    },
+    {
+      name: 'recordCapabilityPayload',
+      args: 'Context outerX, FObject obj',
+      javaCode: `
+        ((Agency) getX().get("threadPool")).submit(outerX, x -> {
+          try {
+            CapabilityPayloadRecord record = new CapabilityPayloadRecord.Builder(x)
+              .setCapabilityPayload((CapabilityPayload) obj)
+              .build();
+            ((DAO) x.get("capabilityPayloadRecordDAO")).inX(x).put(record);
+          } catch ( Throwable t ) {
+            getLogger().warning("Failed to save record", obj, t);
+          }
+        }, "Save CapabilityPayloadRecord");
       `
     },
     {

--- a/src/foam/nanos/crunch/connection/CapabilityPayloadRecord.js
+++ b/src/foam/nanos/crunch/connection/CapabilityPayloadRecord.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch.connection',
+  name: 'CapabilityPayloadRecord',
+  documentation: `
+    Recording of CapabilityPayload requests.
+  `,
+
+  implements: [
+    'foam.nanos.auth.CreatedAware',
+    'foam.nanos.auth.CreatedByAware'
+  ],
+
+  properties: [
+    {
+      name: 'id',
+      class: 'String'
+    },
+    {
+      class: 'FObjectProperty',
+      name: 'capabilityPayload',
+      of: 'foam.nanos.crunch.connection.CapabilityPayload'
+    },
+    {
+      class: 'DateTime',
+      name: 'created'
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.User',
+      name: 'createdBy'
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.User',
+      name: 'createdByAgent'
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -253,6 +253,28 @@ p({
 
 p({
   class: "foam.nanos.boot.NSpec",
+  name: "capabilityPayloadRecordDAO",
+  lazy: true,
+  serve: true,
+  serviceScript: `
+    return new foam.dao.EasyDAO.Builder(x)
+      .setAuthorize(false)
+      .setGuid(true)
+      .setOf(foam.nanos.crunch.connection.CapabilityPayloadRecord.getOwnClassInfo())
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName("capabilityPayloadRecords")
+      .setFixedSize(new foam.dao.FixedSizeDAO.Builder(x)
+        .setComparator(foam.mlang.MLang.DESC(foam.nanos.crunch.connection.CapabilityPayloadRecord.CREATED) )
+        .setSize(10000)
+        .build())
+      .setIndex(new foam.core.PropertyInfo[] {foam.nanos.crunch.connection.CapabilityPayloadRecord.CREATED})
+      .build();
+  `,
+  client: "{\"of\":\"foam.nanos.crunch.connection.CapabilityPayloadRecord\"}"
+})
+
+p({
+  class: "foam.nanos.boot.NSpec",
   name: "wizardStateDAO",
   lazy: true,
   serve: true,

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -503,6 +503,7 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/UCJProperty" },
   { name: "foam/nanos/crunch/UCJUpdateApprovable" },
   { name: "foam/nanos/crunch/connection/CapabilityPayload" },
+  { name: "foam/nanos/crunch/connection/CapabilityPayloadRecord" },
   { name: "foam/nanos/crunch/connection/GrantPathNode" },
   { name: 'foam/nanos/crunch/document/Document' },
   //daos

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -850,6 +850,7 @@ var classes = [
   'foam.nanos.crunch.UCJUpdateApprovable',
 
   'foam.nanos.crunch.connection.CapabilityPayload',
+  'foam.nanos.crunch.connection.CapabilityPayloadRecord',
   'foam.nanos.crunch.connection.GrantPathNode',
 
   //daos


### PR DESCRIPTION
We need to keep a record of the calls to the capabilityPayloadDAO, but the CapabilityPayload model does not allow for proper saving to a DAO.

I have created a separate record with a separate DAO to allow us to save these records to help investigate operations issues as well to help with debugging.

The DAO has a fixed size so that the data doesn't get retained indefinitely.