### PR TITLE
scrollingstepwizardview set submit on submit

### DIFF
--- a/src/foam/u2/wizard/ScrollingStepWizardView.js
+++ b/src/foam/u2/wizard/ScrollingStepWizardView.js
@@ -354,6 +354,8 @@ foam.CLASS({
         for ( let w of this.data.wizardlets ) {
           if ( w.submit ) w.submit();
         }
+
+        this.data.submitted = true;
         this.onClose(x, true);
       }
     }


### PR DESCRIPTION
ScrollingStepWizardView dosn't use StepWizardController to navigate between screens, so submitted is never set
which effects the Capable wizard flow if it was to use the ScrollingStepWizardView