### PR TITLE
file upload error translation

### DIFF
--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -302,6 +302,7 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileD
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileDropZone.LABEL_SUPPORTED",target:"Tipos de arquivos suportados:"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileDropZone.ERROR_FILE_SIZE",target:"O tamanho do arquivo excede 15 MB"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileDropZone.ERROR_FILE_TYPE",target:"Tipo de arquivo inválido"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileDropZone.ERROR_FILE_TITLE",target:"Erro"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileDropZone.SUPPORTED_FORMATS.label",target:"formatos suportados"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.fs.fileDropZone.FileDropZone.TITLE.label",target:"título"})
 


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-5287

missing part of the ticket - added a missing PT translation when oversized file uploaded in payables

<img width="824" alt="Screen Shot 2021-09-10 at 9 51 40 AM" src="https://user-images.githubusercontent.com/33228583/132865118-967a5cf9-4b80-4242-ab2e-1545dfdb6ff8.png">
