### PR TITLE
spid changes

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -377,12 +377,11 @@ foam.CLASS({
         if ( PredicatedPrerequisiteCapabilityJunctionDAO.PERMISSION.equals(permission) ) return false;
 
         CrunchService crunchService = (CrunchService) x.get("crunchService");
-        var prereqs = crunchService.getPrereqs(x, getId(), null);
+        List<Capability> prereqs = crunchService.getCapabilityPath(x, getId(), false, false);
 
         if ( prereqs != null && prereqs.size() > 0 ) {
-          DAO capabilityDAO = (DAO) x.get("capabilityDAO");
-          for ( var capId : prereqs ) {
-            Capability capability = (Capability) capabilityDAO.find(capId);
+          for ( Capability capability : prereqs ) {
+            if ( getId().equals(capability.getId()) ) continue;
             if ( capability != null && capability.grantsPermission(permission) ) return true;
           }
         }

--- a/src/foam/nanos/crunch/rules.jrl
+++ b/src/foam/nanos/crunch/rules.jrl
@@ -19,9 +19,8 @@ p({
   "priority":100,
   "ruleGroup":"spidCapability",
   "documentation":"Re-assign user spid on CREATE of User-ServiceProvider junction",
-  "daoKey":"userCapabilityJunctionDAO",
+  "daoKey":"bareUserCapabilityJunctionDAO",
   "operation":0,
-  "after":true,
   "enabled":true,
   "action":{
     "class":"foam.nanos.auth.SetUserServiceProviderJunctionRuleAction"


### PR DESCRIPTION
Remove logic to create ucjs between user and the prerequisites of a serviceProvider capability when a new spid is set for the user, since permissions on the prerequisites will be implied by the serviceprovider capability

some documentation of serviceprovider capabilities
ServiceProvider overrides the following Capability logic
- `grantsPermission`
  - ServiceProvider.grantsPermission will return true for any permission in its permissionsGranted or inherentPermissions list, as well as any permissions granted by some capability in its capabilityPath
- `getPrereqsChainedStatus`
  - always return true, since prereqs are implicitly granted by the user-serviceprovider junction
  
  When a ucj is created between a user and serviceprovider sp
     - SetUserServiceProviderJunctionRuleAction is triggered, which
        - checks if user.spid is equal to sp.id, if so, simply return and do nothing
        - otherwise, remove any other spid capabilities the user has and update the user.spid to serviceprovider.id

  When user.spid changes
     - CreateUserCapabilityJunctionOnSpidSet is triggered, which
        - removes any old spid capabilities the user has 
        - adds a ucj with the new spid capability
           - this put to the ucjdao will trigger SetUserServiceProviderJunctionRuleAction, but since user.spid is equal to the targetid, the rule action will stop at this check