### PR TITLE
[NP-5449] Session OrX

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -156,11 +156,6 @@ public class SessionServerBox
         return;
       }
 
-      if ( session.getContext().get("localLocalSettingDAO") == null && session.getUserId() != 0 ) {
-        DAO localLocalSettingDAO = new foam.dao.MDAO(foam.nanos.session.LocalSetting.getOwnClassInfo());
-        session.setContext(session.getContext().put("localLocalSettingDAO", localLocalSettingDAO));
-      }
-
       X effectiveContext = session.applyTo(getX());
 
       // Make context available to thread-local XLocator

--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -183,6 +183,9 @@ public class SessionServerBox
       getDelegate().send(msg);
     } catch (Throwable t) {
       logger.warning(t.getMessage());
+      if ( t instanceof NullPointerException ) {
+        logger.error(t);
+      }
       msg.replyWithException(t);
 
       AppConfig appConfig = (AppConfig) getX().get("appConfig");

--- a/src/foam/core/OrX.java
+++ b/src/foam/core/OrX.java
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core;
+
+/** Simple Or X implementation. **/
+public class OrX
+  extends    ProxyX
+{
+  X localX_;
+  
+  public OrX() {
+    this(EmptyX.instance(), EmptyX.instance());
+  }
+
+  public OrX(X x, X delegate) {
+    localX_ = x;
+    setX(delegate);
+  }
+
+  public <T> T get(Class<T> key) {
+    T t = localX_.get(key);
+    if ( t == null ) return getX().get(key);
+    return t;
+  }
+
+  public Object get(Object name) {
+    Object o = localX_.get(name);
+    if ( o == null ) return get(this, name);
+    return o;
+  }
+
+  public Object get(X x, Object name) {
+    Object o = localX_.get(x, name);
+    if ( o == null ) return getX().get(x, name);
+    return o;
+  }
+
+  public int getInt(X x, Object key, int defaultValue) {
+    Object o = localX_.get(key);
+    if ( o == null ) return getX().getInt(x, key, defaultValue);
+    return (int) o;
+  }
+
+  public boolean getBoolean(X x, Object key, boolean defaultValue) {
+    Boolean b = (Boolean) localX_.get(key);
+    if ( b == null ) return getX().getBoolean(x, key, defaultValue);
+    return b;
+  }
+}

--- a/src/foam/core/OrX.java
+++ b/src/foam/core/OrX.java
@@ -53,4 +53,10 @@ public class OrX
     if ( o == null ) return defaultValue;
     return (boolean) o;
   }
+
+  public X cd(X x, String path) {
+    X o = getX().cd(x, path);
+    if ( o == null ) return localX_.cd(x, path);
+    return o;
+  }
 }

--- a/src/foam/core/OrX.java
+++ b/src/foam/core/OrX.java
@@ -6,7 +6,10 @@
 
 package foam.core;
 
-/** Simple Or X implementation. **/
+/** Simple Or X implementation.
+    get - first test local x, then delegate
+    put - put to delegate
+ **/
 public class OrX
   extends    ProxyX
 {
@@ -16,38 +19,36 @@ public class OrX
     this(EmptyX.instance(), EmptyX.instance());
   }
 
+  public OrX(X x) {
+    this(x, EmptyX.instance());
+  }
+
   public OrX(X x, X delegate) {
+    super(delegate);
     localX_ = x;
-    setX(delegate);
   }
 
   public <T> T get(Class<T> key) {
-    T t = localX_.get(key);
-    if ( t == null ) return getX().get(key);
+    T t = getX().get(key);
+    if ( t == null ) return localX_.get(key);
     return t;
   }
 
-  public Object get(Object name) {
-    Object o = localX_.get(name);
-    if ( o == null ) return get(this, name);
-    return o;
-  }
-
   public Object get(X x, Object name) {
-    Object o = localX_.get(x, name);
-    if ( o == null ) return getX().get(x, name);
+    Object o = getX().get(x, name);
+    if ( o == null ) return localX_.get(x, name);
     return o;
   }
 
   public int getInt(X x, Object key, int defaultValue) {
-    Object o = localX_.get(key);
-    if ( o == null ) return getX().getInt(x, key, defaultValue);
+    Object o = getX().getInt(x, key, defaultValue);
+    if ( o == null ) return (int) localX_.get(key);
     return (int) o;
   }
 
   public boolean getBoolean(X x, Object key, boolean defaultValue) {
-    Boolean b = (Boolean) localX_.get(key);
-    if ( b == null ) return getX().getBoolean(x, key, defaultValue);
+    Boolean b = (Boolean) getX().getBoolean(x, key, defaultValue);
+    if ( b == null ) return (boolean) localX_.get(key);
     return b;
   }
 }

--- a/src/foam/core/OrX.java
+++ b/src/foam/core/OrX.java
@@ -7,7 +7,7 @@
 package foam.core;
 
 /** Simple Or X implementation.
-    get - first test local x, then delegate
+    get - first test delegate, then local
     put - put to delegate
  **/
 public class OrX
@@ -30,25 +30,27 @@ public class OrX
 
   public <T> T get(Class<T> key) {
     T t = getX().get(key);
-    if ( t == null ) return localX_.get(key);
+    if ( t == null ) return (T) localX_.get(this, key);
     return t;
   }
 
-  public Object get(X x, Object name) {
-    Object o = getX().get(x, name);
-    if ( o == null ) return localX_.get(x, name);
+  public Object get(X x, Object key) {
+    Object o = getX().get(x, key);
+    if ( o == null ) return localX_.get(x, key);
     return o;
   }
 
   public int getInt(X x, Object key, int defaultValue) {
-    Object o = getX().getInt(x, key, defaultValue);
-    if ( o == null ) return (int) localX_.get(key);
+    Object o = getX().get(x, key); 
+    if ( o == null ) o = localX_.get(x, key);
+    if ( o == null ) return defaultValue;
     return (int) o;
   }
 
   public boolean getBoolean(X x, Object key, boolean defaultValue) {
-    Boolean b = (Boolean) getX().getBoolean(x, key, defaultValue);
-    if ( b == null ) return (boolean) localX_.get(key);
-    return b;
+    Object o = getX().get(x, key); 
+    if ( o == null ) o = localX_.get(x, key);
+    if ( o == null ) return defaultValue;
+    return (boolean) o;
   }
 }

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -225,9 +225,12 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         }
       ],
       javaCode: `
-        AppConfig appConfig = (AppConfig) ((AppConfig) x.get("appConfig")).fclone();
-        String url = ! foam.util.SafetyUtil.isEmpty(getUrl()) ? getUrl() : appConfig.getUrl();
-        appConfig.setUrl(url.replaceAll("/$", ""));
+        AppConfig appConfig = (AppConfig) x.get("appConfig");
+        String url = getUrl();
+        if ( ! foam.util.SafetyUtil.isEmpty(url) ) {
+          appConfig = (AppConfig) appConfig.fclone();
+          appConfig.setUrl(url.replaceAll("/$", ""));
+        }
         return appConfig;
         `
     },

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -340,7 +340,8 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       }
       if ( rtn == null ||
            user == null ||
-           ( subjectUser != null && subjectUser.getId() == user.getId() ) ||
+           ( subjectUser != null &&
+             subjectUser.getId() != user.getId() ) ||
            ( agent != null && subjectAgent != null &&
              subjectAgent.getId() != agent.getId() ) ) {
 

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -383,17 +383,14 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
 
         rtn = rtn.put("localLocalSettingDAO", new foam.dao.MDAO(foam.nanos.session.LocalSetting.getOwnClassInfo()));
 
-        rtn = rtn.put("logger", new foam.nanos.logger.PrefixLogger(
-          new Object[] {"session", getId().split("-")[0]},
-          foam.nanos.logger.Loggers.logger(rtn, true)
-        ));
+        rtn = rtn.put("logger", foam.nanos.logger.Loggers.logger(rtn, true));
 
+        // Cache the context changes of applyTo
         setApplyContext(apply);
         pm.log(x);
-foam.nanos.logger.Loggers.logger(x, this).info(getId().split("-")[0], "applyTo", "create", "subject", rtn.get("subject"));
       } else {
         rtn = new OrX(x, rtn);
-     }
+      }
       return rtn;
       `
     },


### PR DESCRIPTION
Each client call, on each request, whether DIG, HTTP, Socket,
performs session context setup via applyTo. applyTo is the most
expensive logic of context setup, but the results of applyTo do
not change between calls, so it makes sense to reuse the
context setup. Auth checks are independent of this.
Also, if the system were to reconfigure a theme, for example,
the existing sessions could be invalidated or the the 'context'
of each be reset to force applyTo to run on next client call.

This change in a medusa cluster provides a 20% performance gain
for 'ping' test on a 1Gbs network.

