### PR TITLE
Fix Desc.arg1 adapt

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -3230,7 +3230,14 @@ foam.CLASS({
       class: 'FObjectProperty',
       name: 'arg1',
       type: 'foam.mlang.order.Comparator',
-      adapt: function(_, c) { return foam.compare.toCompare(c); },
+      adapt: function(o, n, prop) {
+        var ret  = foam.compare.toCompare(n);
+        var type = foam.lookup(prop.type);
+        if ( type.isInstance(ret) ) {
+          return ret;
+        }
+        return foam.core.FObjectProperty.ADAPT.value.call(this, o, n, prop);
+      },
       javaJSONParser: 'foam.lib.json.ExprParser.instance()'
     }
   ],


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-5457

## Script to reproduce
```
var json = {
  "class": "foam.mlang.order.Desc",
  "arg1": {
    "class": "__Property__",
    "forClass_": "foam.nanos.auth.User",
    "name": "id"
  }
};
var desc = foam.mlang.order.Desc.create(json);
console.log(desc.arg1 == foam.nanos.auth.User.ID); // false
```

## Changes
- Fallback to FObjectProperty.adapt if could not convert to comparator