### PR TITLE
[NP-5493] proof of company address renewal bug fix

### DIFF
--- a/src/foam/nanos/crunch/ReputDependentUCJs.js
+++ b/src/foam/nanos/crunch/ReputDependentUCJs.js
@@ -79,11 +79,6 @@ foam.CLASS({
             }
 
             for ( UserCapabilityJunction ucjToReput : ucjsToReput ) {
-              if ( ucjToReput.getStatus() == CapabilityJunctionStatus.GRANTED ) {
-                var cap = (Capability) ucj.findTargetId(x);
-                if ( ucj.getIsInGracePeriod() && ! cap.getIsInternalCapability() ) ucjToReput.setIsInGracePeriod(true);
-                if ( ucj.getIsInRenewablePeriod() && ! cap.getIsInternalCapability() ) ucjToReput.setIsInRenewablePeriod(true);
-              }
               if ( effectiveUserId != null && effectiveX != null &&
                    ucjToReput.getSourceId() == effectiveUserId )
                 userCapabilityJunctionDAO.inX(effectiveX).put(ucjToReput);

--- a/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityIsStatus.js
@@ -76,7 +76,7 @@ foam.CLASS({
         var ucj = crunchService.getJunction(x, getCapabilityId());
         if ( ucj == null || ucj.getStatus() != getStatus() ) return false;
         // if status being checked is GRANTED, check if we should include ucjs that are renewable
-        if ( getStatus() == GRANTED && ucj.getIsRenewable() ) return getIncludeRenewable();
+        if ( getStatus() == GRANTED && crunchService.isRenewable(x, ucj.getTargetId()) ) return getIncludeRenewable();
         return true;
       `
     }


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-5493

In `ReputDependentUCJs`, updating `IsInGracePeriod` and `IsInRenewablePeriod` for each ucj in the capability chain can be removed as we can use `crunchService.isRenewable` to check if the top-level ucj is renewable. On top of that, setting the two properties to `nanopayBusinessRequirements` and `AFEX` prevented `international payment` from being granted when data was resubmitted. 