### PR TITLE
Add confirmation checkbox for ucj in grace period when renewing

### DIFF
--- a/src/foam/nanos/crunch/ExpireUserCapabilityJunctionsCron.java
+++ b/src/foam/nanos/crunch/ExpireUserCapabilityJunctionsCron.java
@@ -7,11 +7,13 @@
 package foam.nanos.crunch;
 
 import foam.core.ContextAgent;
+import foam.core.FObject;
 import foam.core.X;
 import foam.dao.ArraySink;
 import foam.dao.DAO;
 import foam.nanos.crunch.Capability;
 import foam.nanos.crunch.CapabilityJunctionStatus;
+import foam.nanos.crunch.RenewableData;
 import foam.nanos.crunch.UserCapabilityJunction;
 import foam.nanos.logger.Logger;
 import java.util.List;
@@ -27,7 +29,8 @@ public class ExpireUserCapabilityJunctionsCron implements ContextAgent {
   @Override
   public void execute(X x) {
     logger = (Logger) x.get("logger");
-    userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
+    DAO bareUserCapabilityJunctionDAO = (DAO) x.get("bareUserCapabilityJunctionDAO");
+    DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
     Date today = new Date();
 
     // Find all junctions that are past the expiration date and filter by the following
@@ -57,12 +60,21 @@ public class ExpireUserCapabilityJunctionsCron implements ContextAgent {
       if ( activeJunction.getIsInGracePeriod() || activeJunction.getGracePeriod() <= 0 ) {
         activeJunction.setStatus(CapabilityJunctionStatus.EXPIRED);
         activeJunction.setIsExpired(true);
+        userCapabilityJunctionDAO.put(activeJunction);
       } else {
         activeJunction.setIsInGracePeriod(true);
+
+        // update ucj data as renewable
+        FObject data = (FObject) activeJunction.getData();
+        if ( data != null || data instanceof RenewableData ) {
+          RenewableData renewableData = (RenewableData) data;
+          renewableData.setRenewable(true);
+          activeJunction.setData(renewableData);
+        }
+        bareUserCapabilityJunctionDAO.put(activeJunction);
       }
 
       logger.debug("Moved UserCapabilityJunction : " + activeJunction.getId() + " into status :" + activeJunction.getStatus());
-      userCapabilityJunctionDAO.put(activeJunction);
     }
   }
 }

--- a/src/foam/nanos/crunch/ExpireUserCapabilityJunctionsCron.java
+++ b/src/foam/nanos/crunch/ExpireUserCapabilityJunctionsCron.java
@@ -66,7 +66,7 @@ public class ExpireUserCapabilityJunctionsCron implements ContextAgent {
 
         // update ucj data as renewable
         FObject data = (FObject) activeJunction.getData();
-        if ( data != null || data instanceof RenewableData ) {
+        if ( data != null && data instanceof RenewableData ) {
           RenewableData renewableData = (RenewableData) data;
           renewableData.setRenewable(true);
           activeJunction.setData(renewableData);

--- a/src/foam/nanos/crunch/RenewableData.js
+++ b/src/foam/nanos/crunch/RenewableData.js
@@ -37,7 +37,6 @@ foam.CLASS({
       class: 'Boolean',
       label: '',
       section: 'reviewDataSection',
-      value: true,
       view: function(_, X) {
         return {
           class: 'foam.u2.CheckBox',

--- a/src/foam/nanos/crunch/RenewableData.js
+++ b/src/foam/nanos/crunch/RenewableData.js
@@ -37,6 +37,7 @@ foam.CLASS({
       class: 'Boolean',
       label: '',
       section: 'reviewDataSection',
+      value: true,
       view: function(_, X) {
         return {
           class: 'foam.u2.CheckBox',

--- a/src/foam/nanos/crunch/RenewableData.js
+++ b/src/foam/nanos/crunch/RenewableData.js
@@ -30,7 +30,15 @@ foam.CLASS({
       name: 'renewable',
       class: 'Boolean',
       section: 'reviewDataSection',
-      hidden: true
+      hidden: true,
+      javaSetter: `
+        // Reset reviwed when a ucj goes into renewable period
+        if ( ! getRenewable() && val ) {
+          setReviewed(false);
+        }
+        renewable_ = val;
+        renewableIsSet_ = true;
+      `
     },
     {
       name: 'reviewed',


### PR DESCRIPTION
- Set ucj.data.renewable to true so that the confirmation checkbox becomes visible when renewing ucjs in grace period
- Add ucjs in grace period to bareUCJ DAO as we don't want to trigger the UCJ rules (more specifically `configureUcjExpiryOnGranted` which undoes the change made on the ucjs). Putting them directly to the bareUCJ DAO will still do the job
