### PR TITLE
Fix missing context on FObjectProperty

### DIFF
--- a/src/foam/core/AbstractFObjectPropertyInfo.java
+++ b/src/foam/core/AbstractFObjectPropertyInfo.java
@@ -177,11 +177,4 @@ public abstract class AbstractFObjectPropertyInfo
   public int comparePropertyToValue(Object key, Object value) {
     return foam.util.SafetyUtil.compare(cast(key), cast(value));
   }
-
-  @Override
-  public Object f(Object o) {
-    var ret = (FObject) super.f(o);
-    ret.setX(((FObject) o).getX());
-    return ret;
-  }
 }

--- a/src/foam/core/AbstractFObjectPropertyInfo.java
+++ b/src/foam/core/AbstractFObjectPropertyInfo.java
@@ -177,4 +177,11 @@ public abstract class AbstractFObjectPropertyInfo
   public int comparePropertyToValue(Object key, Object value) {
     return foam.util.SafetyUtil.compare(cast(key), cast(value));
   }
+
+  @Override
+  public Object f(Object o) {
+    var ret = (FObject) super.f(o);
+    ret.setX(((FObject) o).getX());
+    return ret;
+  }
 }

--- a/src/foam/mlang/expr/Ref.js
+++ b/src/foam/mlang/expr/Ref.js
@@ -39,7 +39,7 @@ foam.CLASS({
         FObject refObj = null;
         try {
           refObj = (FObject)obj.getClass().getMethod("find" + StringUtil.capitalize(p1.getName()), foam.core.X.class)
-            .invoke(obj, ((FObject)obj).getX());
+            .invoke(obj, foam.core.XLocator.get());
         } catch ( Throwable t ) {
           Logger logger = (Logger) getX().get("logger");
           if ( logger == null ) {


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-5560

## Changes
- Use XLocator for REF instead of getting x from the object

## Stacktrace
```
2021-09-27T16:16:54.976-0400,nanos-398,ERROR,nulljava.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at foam.mlang.expr.Ref.f(Ref.java:132)
	at foam.mlang.expr.Dot.f(Dot.java:211)
	at foam.mlang.expr.Dot.f(Dot.java:209)
	at foam.nanos.column.NestedPropertiesExpression.f(NestedPropertiesExpression.java:342)
	at net.nanopay.meter.repo.ReportOutputter.outputFObjectAsList(ReportOutputter.java:84)
	at net.nanopay.meter.repo.ReportOutputter.output(ReportOutputter.java:109)
	at net.nanopay.meter.repo.ReportOutputter.outputArray(ReportOutputter.java:99)
	at net.nanopay.meter.repo.ReportOutputter.output(ReportOutputter.java:111)
	at net.nanopay.meter.repo.ReportOutputter.outputFObject(ReportOutputter.java:61)
	at foam.lib.html.Outputter.put(Outputter.java:194)
	at net.nanopay.meter.repo.UCJReportHandler.generate_(UCJReportHandler.java:190)
	at net.nanopay.meter.repo.UCJReportHandler.generate(UCJReportHandler.java:158)
	at net.nanopay.meter.repo.ReportHandler.lambda$generate$0(ReportHandler.java:119)
	at net.nanopay.meter.repo.ReportHandler$$Lambda$114/0000000000000000.execute(Unknown Source)
	at foam.nanos.pool.ThreadPoolAgency$ContextAgentRunnable.run(ThreadPoolAgency.java:676)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException
	at foam.nanos.auth.Address.findCountryId(Address.java:1698)
	... 24 more
```