### PR TITLE
Made ReferenceToSummaryCellFormatter implement Formatter

### DIFF
--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -259,6 +259,7 @@ foam.CLASS({
 foam.CLASS({
   package: 'foam.u2.view',
   name: 'ReferenceToSummaryCellFormatter',
+  implements: ['foam.u2.view.Formatter'],
 
   methods: [
     function format(e, value, obj, axiom) {


### PR DESCRIPTION
Would break the build if ReferenceToSummaryCellFormatter was used on a Property.TableCellFormatter without this change.