### PR TITLE
fix notification view not working - dao browser view

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -420,9 +420,10 @@ foam.CLASS({
               .add(filterView.slot( function(mementoUpdated, mementoToggle) {
                 // TEMPORARY
                 // wait for filterView to set momento before instantianting summaryView
-                if ( mementoUpdated ) return this.E()
-                .addClass(self.myClass('browse-view-container'))
-                .add(summaryView);
+                if ( mementoUpdated || config$hideQueryBar )
+                  return this.E()
+                  .addClass(self.myClass('browse-view-container'))
+                  .add(summaryView);
               }))
             .end();
         }));


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-5519



Notification view in top nav bar not fully loaded, due to its mementoUpdated is false.
mementoUpdated is set inside filterview but notification menu not going thru filterview
as its menu setting hideQueryBar = true.
Fixed by adding check hideQueryBar for this case.


<img width="787" alt="Screen Shot 2021-09-28 at 1 27 23 PM" src="https://user-images.githubusercontent.com/33228583/135136588-418d90dc-2a79-4f4d-8a7b-b31f6e78f3fa.png">


