### PR TITLE
Crunch defaults update

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -250,7 +250,6 @@ foam.CLASS({
       name: 'associatedEntity',
       class: 'Enum',
       of: 'foam.nanos.crunch.AssociatedEntity',
-      hidden: true,
       permissionRequired: true,
       includeInDigest: true,
       documentation: `

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -760,7 +760,7 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
           EQ(UserCapabilityJunction.SOURCE_ID, realUser.getId()),
           EQ(AgentCapabilityJunction.EFFECTIVE_USER, user.getId())
         );
-      }
+    }
     
     return result;
   }

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -506,6 +506,13 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
       ? subject.getUser()
       : subject.getRealUser()
       ;
+    // Setup default data
+    FObject dataa = null;
+    try {
+      dataa = cap.getOf() != null ? (FObject) cap.getOf().newInstance() : null;
+    } catch ( Exception ex ) {
+      throw new RuntimeException("Cannot adapt: " + ex.getMessage(), ex);
+    }
     var ucj = isAssociation
       ? new AgentCapabilityJunction.Builder(x)
         .setSourceId(associatedUser.getId())
@@ -518,6 +525,7 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
         .build()
       ;
     ucj.setStatus(CapabilityJunctionStatus.AVAILABLE);
+    ucj.setData(dataa);
     return ucj;
   }
 

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -509,7 +509,9 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
     // Setup default data
     FObject payload = null;
     try {
-      payload = cap.getOf() != null ? (FObject) cap.getOf().newInstance() : null;
+      if ( cap.getOf() != null ) {
+        payload = (FObject) cap.getOf().newInstance();
+      }
     } catch ( Exception ex ) {
       throw new RuntimeException("UCJ payload default setup ERROR: " + ex.getMessage(), ex);
     }

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -646,28 +646,9 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
 
   public WizardState getWizardState(X x, String capabilityId) {
     var subject = (Subject) x.get("subject");
-
-    DAO capabilityDAO = (DAO) x.get("capabilityDAO");
-    Capability capability = (Capability) capabilityDAO.find(capabilityId);
-
-    if ( ! subject.isAgent() ) {
-      return getWizardStateFor_(x, subject, capabilityId);
-    }
-
-    var realUser = new Subject();
-    realUser.setUser(subject.getRealUser());
-    realUser.setUser(subject.getRealUser());
-    var realUserWizardState = getWizardStateFor_(x, realUser, capabilityId);
-    var effectiveUser = new Subject();
-    effectiveUser.setUser(subject.getUser());
-    effectiveUser.setUser(subject.getUser());
-    var userWizardState = getWizardStateFor_(x, effectiveUser, capabilityId);
-
     var subjectWizardState = getWizardStateFor_(x, subject, capabilityId);
 
-    return capability.getAssociatedEntity() == AssociatedEntity.USER ? userWizardState :
-      capability.getAssociatedEntity() == AssociatedEntity.REAL_USER ? realUserWizardState :
-      subjectWizardState;
+    return subjectWizardState;
   }
 
   private WizardState getWizardStateFor_(X x, Subject s, String capabilityId) {

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -511,7 +511,7 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
     try {
       payload = cap.getOf() != null ? (FObject) cap.getOf().newInstance() : null;
     } catch ( Exception ex ) {
-      throw new RuntimeException("Cannot adapt: " + ex.getMessage(), ex);
+      throw new RuntimeException("UCJ payload default setup ERROR: " + ex.getMessage(), ex);
     }
     var ucj = isAssociation
       ? new AgentCapabilityJunction.Builder(x)

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -507,9 +507,9 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
       : subject.getRealUser()
       ;
     // Setup default data
-    FObject dataa = null;
+    FObject payload = null;
     try {
-      dataa = cap.getOf() != null ? (FObject) cap.getOf().newInstance() : null;
+      payload = cap.getOf() != null ? (FObject) cap.getOf().newInstance() : null;
     } catch ( Exception ex ) {
       throw new RuntimeException("Cannot adapt: " + ex.getMessage(), ex);
     }
@@ -525,7 +525,7 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
         .build()
       ;
     ucj.setStatus(CapabilityJunctionStatus.AVAILABLE);
-    ucj.setData(dataa);
+    ucj.setData(payload);
     return ucj;
   }
 

--- a/src/foam/nanos/crunch/UCJProperty.js
+++ b/src/foam/nanos/crunch/UCJProperty.js
@@ -43,19 +43,28 @@ foam.CLASS({
         if ( ! foam.Object.isInstance(o) && ! foam.Array.isInstance(o) ) {
           throw new Error('valid UCJProperty values are: Predicate, string, object');
         }
-        if ( ! o.hasOwnProperty('sourceId') || ! o.hasOwnProperty('targetId') ) {
+        if ( ! o.hasOwnProperty('sourceId') ) {
           throw new Error('an object value for UCJProperty must have ' +
-            'properties sourceId and targetId.');
+            'properties sourceId.');
         }
 
         const UserCapabilityJunction = foam.nanos.crunch.UserCapabilityJunction;
         const AgentCapabilityJunction = foam.nanos.crunch.AgentCapabilityJunction;
 
-        var predicate = e.AND(
+        var predicate = e.OR(
           e.EQ(UserCapabilityJunction.SOURCE_ID, o.sourceId),
-          e.EQ(UserCapabilityJunction.TARGET_ID, o.targetId)
-        );
+          e.AND(
+            e.INSTANCE_OF(AgentCapabilityJunction),
+            e.EQ(AgentCapabilityJunction.EFFECTIVE_USER, o.sourceId)
+            )
+          );
 
+        if ( o.hasOwnProperty('targetId') ) {
+          predicate = e.AND(
+            e.EQ(UserCapabilityJunction.SOURCE_ID, o.sourceId),
+            e.EQ(UserCapabilityJunction.TARGET_ID, o.targetId)
+          );
+        }
         if ( o.hasOwnProperty('effectiveUser') ) {
           predicate = e.AND(
             predicate,

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -132,6 +132,7 @@ foam.CLASS({
 
   requires: [
     'foam.core.ExpressionSlot',
+    'foam.u2.ControllerMode',
     'foam.u2.detail.AbstractSectionedDetailView',
     'foam.u2.tag.CircleIndicator',
     'foam.u2.wizard.WizardPosition',
@@ -163,13 +164,14 @@ foam.CLASS({
       });
       this
         .addClass(this.myClass())
-        .start()
+        .startContext({ controllerMode: this.ControllerMode.EDIT })
+        // despite visibility of wizard, always enable search
           .addClass(this.myClass('search'))
           .tag(foam.u2.SearchField, {
             data$: this.searchController.data$,
             onKey: true
           })
-        .end()
+        .endContext()
         .add(this.slot(function (
           data$wizardlets,
           data$wizardPosition,


### PR DESCRIPTION
- update **visibility on Capability.associatedEntity** -- no reason its should be set to hidden.

- **UCJPropery update to handle no targetId.** This enables a property to define sourceId, targertId, and EffectiveUser separately in a passed in object. Allowing one property to be used for various UCJ predications. 
note: This property does its work in the view: UCJReferenceView.

- **Crunch Wizard search usage** - updates in the _**StepWizardletStepsView**_ adding edit context wrapper around the search field means that it will always bee in edit mode....thus can search when in RO mode

- **update CrunchService.getAssociationPredicate_()**, previously could not handle a capability associated to a user and business, and now it can. 

- set default data on UCJ's created - **CrunchService.buildAssociatedUCJ() update**

_____new
- **updated crunchService.getWizardState()**