### PR TITLE
Move button svg sizing to CSS to make it less specific

### DIFF
--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -103,6 +103,7 @@ foam.CLASS({
       fill: initial;
       transform: rotate(0deg);
       transition: all 0.5s ease;
+      font-size: 6px;
     }
 
     ^filter-button-active{
@@ -294,7 +295,7 @@ foam.CLASS({
             .end()
             .start().addClass(self.myClass('container-handle'))
             .startContext({ data: self })
-              .start(self.TOGGLE_DRAWER, { label$: labelSlot, buttonStyle: 'SECONDARY', isIconAfter: true })
+              .start(self.TOGGLE_DRAWER, { label$: labelSlot, buttonStyle: 'SECONDARY', isIconAfter: true, themeIcon: 'dropdown' })
                 .enableClass(this.myClass('filter-button-active'), this.isOpen$)
                 .addClass(this.myClass('filter-button'))
               .end()

--- a/src/foam/u2/tag/Button.js
+++ b/src/foam/u2/tag/Button.js
@@ -290,6 +290,19 @@ foam.CLASS({
       height: 100%;
     }
 
+    ^small svg {
+      width: 1.15em;
+      height: 1.15em;
+    }
+    ^medium svg {
+      width: 1.71em;
+      height: 1.71em;
+    }
+    ^large svg {
+      width: 2.25em;
+      height: 2.25em;
+    }
+
     /* SVGs outside themeGlyphs may have their own heights and widths, 
     these ensure those are respected rather than imposing new dimensions */
     ^imgSVGIcon {
@@ -393,12 +406,10 @@ foam.CLASS({
     async function addContent() {
       /** Add text or icon to button. **/
       var self = this;
-      var size = this.buttonStyle == this.buttonStyle.LINK ? '1em' : this.size.iconSize;
-      var iconStyle = { width: size, height: size };
 
       if ( this.themeIcon && this.theme ) {
         var indicator = this.themeIcon.clone(this).expandSVG();
-        this.start(this.HTMLView, { data: indicator }).attrs({ role: 'presentation' }).addClass(this.myClass('SVGIcon')).style(iconStyle).end();
+        this.start(this.HTMLView, { data: indicator }).attrs({ role: 'presentation' }).addClass(this.myClass('SVGIcon')).end();
       } else if ( this.icon ) {
         if ( this.icon.endsWith('.svg') ) {
           var req  = this.HTTPRequest.create({
@@ -412,17 +423,15 @@ foam.CLASS({
             self.start(this.HTMLView, { data: x })
               .attrs({ role: 'presentation' })
               .addClasses([this.myClass('SVGIcon'), this.myClass('imgSVGIcon')])
-              .style(iconStyle)
             .end();
           });
         } else {
-          this.start('img').style(iconStyle).attrs({ src: this.icon$, role: 'presentation' }).end();
+          this.start('img').attrs({ src: this.icon$, role: 'presentation' }).end();
         }
       } else if ( this.iconFontName ) {
         this.nodeName = 'i';
         this.addClass(this.action.name);
         this.addClass(this.iconFontClass); // required by font package
-        this.style(iconStyle);
         this.attr(role, 'presentation')
         this.style({ 'font-family': this.iconFontFamily });
         this.add(this.iconFontName);

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -102,6 +102,10 @@ foam.CLASS({
     ^iconOnly{
       padding: 0px;
     }
+
+    ^dropdown svg {
+      font-size: 6px; 
+    }
   `,
 
   methods: [
@@ -124,14 +128,16 @@ foam.CLASS({
         this.add(this.shown$.map(function(shown) {
           var e = self.E();
           if ( shown ) {
-            e.start().callIfElse(self.theme,
+            e.callIfElse(self.theme,
               function() {
-                this.add(self.HTMLView.create({ data: self.theme.glyphs.dropdown.expandSVG() }));
+                this.start(self.HTMLView, { data: self.theme.glyphs.dropdown.expandSVG() })
+                  .addClasses([self.myClass('SVGIcon'), self.myClass('dropdown')])
+                .end();
               },
               function() {
                 this.start('img').attr('src', this.dropdownIcon$).end();
               }
-            ).end();
+            );
           }
           return e;
         }));


### PR DESCRIPTION
Allows for overriding where required using both width and height props as well as font-size. This is better for accessibility as icons will scale with font size even when the size is overridden 