### PR TITLE
dao update view message

### DIFF
--- a/src/foam/comics/v2/DAOUpdateView.js
+++ b/src/foam/comics/v2/DAOUpdateView.js
@@ -62,6 +62,7 @@ foam.CLASS({
   imports: [
     'ctrl',
     'memento',
+    'translationService',
     'stack'
   ],
 
@@ -77,7 +78,8 @@ foam.CLASS({
     { name: 'SECTIONED', message: 'Sectioned' },
     { name: 'MATERIAL', message: 'Material' },
     { name: 'WIZARD', message: 'Wizard' },
-    { name: 'VERTICAL', message: 'Vertical' }
+    { name: 'VERTICAL', message: 'Vertical' },
+    { name: 'UPDATED', message: 'Updated' }
   ],
 
   properties: [
@@ -131,7 +133,9 @@ foam.CLASS({
                 currentFeedback = currentFeedback.next;
               }
             } else {
-              this.ctrl.notify(`${this.data.model_.label} updated.`, '', this.LogLevel.INFO, true);
+              var title = this.translationService.getTranslation(foam.locale, this.config.browseTitle, this.data.model_.label);
+
+              this.ctrl.notify(title + " " + this.UPDATED, '', this.LogLevel.INFO, true);
             }
           }
           this.stack.back();

--- a/src/foam/comics/v2/DAOUpdateView.js
+++ b/src/foam/comics/v2/DAOUpdateView.js
@@ -61,6 +61,7 @@ foam.CLASS({
 
   imports: [
     'ctrl',
+    'currentMenu?',
     'memento',
     'translationService',
     'stack'
@@ -133,7 +134,8 @@ foam.CLASS({
                 currentFeedback = currentFeedback.next;
               }
             } else {
-              var title = this.translationService.getTranslation(foam.locale, this.config.browseTitle, this.data.model_.label);
+              var menuId = this.currentMenu ? this.currentMenu.id : this.config.of.id;
+              var title = this.translationService.getTranslation(foam.locale, menuId + '.browseTitle', this.config.browseTitle);
 
               this.ctrl.notify(title + " " + this.UPDATED, '', this.LogLevel.INFO, true);
             }

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -680,6 +680,7 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOUpdateView.MAT
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOUpdateView.WIZARD",target:"Mago"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOUpdateView.VERTICAL",target:"Vertical"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOUpdateView.BACK",target:"VOLTAR"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.comics.v2.DAOUpdateView.UPDATED",target:"Atualizado"})
 
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.boot.DAOConfigSummaryView.CONTROLLER1",target:"Controlador 1"})
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.boot.DAOConfigSummaryView.CONTROLLER2",target:"Controlador 2"})


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-5501
https://nanopay.atlassian.net/browse/NP-5505

Changed to use Dao config's browseTitle instead of model's name, label or summary when dao updated. As some model uses them for a special purpose and it just returned e.g. FacadeContact like this.

<img width="359" alt="Screen Shot 2021-10-04 at 5 08 00 PM" src="https://user-images.githubusercontent.com/33228583/136035923-c9cf3efc-03d4-43c1-9ad5-caf0f5f55bc8.png">
<img width="458" alt="Screen Shot 2021-10-04 at 5 07 36 PM" src="https://user-images.githubusercontent.com/33228583/136035926-a425c29c-bc68-4742-a0c5-7da92d34c18d.png">
<img width="497" alt="Screen Shot 2021-10-04 at 5 06 59 PM" src="https://user-images.githubusercontent.com/33228583/136035927-d29676a8-0de2-46dc-a94b-50f53f42a082.png">
<img width="667" alt="Screen Shot 2021-10-04 at 5 06 46 PM" src="https://user-images.githubusercontent.com/33228583/136035929-1b8275e1-5a33-4d50-9474-659024f5649e.png">


