### PR TITLE
To protect against shrc.custom not read at startup, fail 'up' if Syst…

### DIFF
--- a/src/foam/nanos/medusa/HealthCheckWebAgent.java
+++ b/src/foam/nanos/medusa/HealthCheckWebAgent.java
@@ -37,12 +37,14 @@ public class HealthCheckWebAgent
         response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         out.println("down");
       } else {
+        boolean cluster = "true".equals(System.getProperty("CLUSTER", "false"));
         if ( config.getType() == MedusaType.MEDIATOR ) {
           if ( config.getStatus() == Status.ONLINE &&
                config.getRegionStatus() == RegionStatus.ACTIVE &&
                ( config.getZone() > 0 ||
                  ( config.getZone() == 0 &&
-                   electoral.getState() == ElectoralServiceState.IN_SESSION ) ) ) {
+                   electoral.getState() == ElectoralServiceState.IN_SESSION  &&
+                   cluster ) ) ) {
             response.setStatus(HttpServletResponse.SC_OK);
             out.println("up");
           } else if ( config.getStatus() != Status.ONLINE &&


### PR DESCRIPTION
…em property 'CLUSTER' not found for mediator which would otherwise report 'up'