### PR TITLE
Remove Dependence On ObjectSummaryView and SummaryView

### DIFF
--- a/src/foam/comics/v2/DAOSummaryView.js
+++ b/src/foam/comics/v2/DAOSummaryView.js
@@ -65,7 +65,6 @@ foam.CLASS({
 
   exports: [
     'controllerMode',
-    'as objectSummaryView',
     'currentMemento_ as memento'
   ],
 

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -54,10 +54,8 @@ foam.CLASS({
     'ctrl',
     'currentMenu',
     'notify',
-    'objectSummaryView?',
     'stack',
     'subject',
-    'summaryView?',
     'translationService'
   ],
 
@@ -759,9 +757,7 @@ foam.CLASS({
         return ! isTrackingRequest;
       },
       code: function(X) {
-        var objToAdd = X.objectSummaryView ?
-          X.objectSummaryView : X.summaryView;
-        objToAdd.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
+        X.ctrl.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
           class: 'foam.u2.MemoModal',
           onExecute: this.approveWithMemoL.bind(this, X)
         }));
@@ -775,9 +771,7 @@ foam.CLASS({
         return ! isTrackingRequest;
       },
       code: function(X) {
-        var objToAdd = X.objectSummaryView ?
-          X.objectSummaryView : X.summaryView;
-        objToAdd.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
+        X.ctrl.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
           class: 'foam.u2.MemoModal',
           isMemoRequired: true,
           onExecute: this.addMemoL.bind(this, X)
@@ -793,10 +787,7 @@ foam.CLASS({
         return ! isTrackingRequest;
       },
       code: function(X) {
-        var objToAdd = X.objectSummaryView ?
-          X.objectSummaryView : X.summaryView;
-
-        objToAdd.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
+        X.ctrl.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
           class: 'foam.u2.MemoModal',
           onExecute: this.rejectWithMemo.bind(this, X),
           isMemoRequired: true
@@ -970,8 +961,7 @@ foam.CLASS({
         "approval.assign.*"
       ],
       code: function(X) {
-        var objToAdd = X.objectSummaryView ? X.objectSummaryView : X.summaryView;
-        objToAdd.tag({
+        X.ctrl.tag({
           class: "foam.u2.PropertyModal",
           property: this.ASSIGNED_TO.clone().copyFrom({ label: '' }),
           isModalRequired: true,

--- a/src/foam/nanos/notification/NotificationRowView.js
+++ b/src/foam/nanos/notification/NotificationRowView.js
@@ -10,6 +10,7 @@
     extends: 'foam.u2.View',
 
     requires: [
+      'foam.dao.AbstractDAO',
       'foam.log.LogLevel',
       'foam.nanos.auth.User',
       'foam.nanos.notification.NotificationCitationView',
@@ -18,7 +19,7 @@
     ],
 
     imports: [
-      'summaryView?',
+      'myNotificationDAO',
       'notificationDAO',
       'notify',
       'stack',
@@ -117,16 +118,10 @@
         name: 'removeNotification',
         code: function(X) {
           var self = X.rowView;
-          self.notificationDAO.remove(self.data).then(_ => {
+          X.notificationDAO.remove(self.data).then(_ => {
             self.finished.pub();
-            if ( self.summaryView && foam.u2.GroupingDAOList.isInstance(self.summaryView) ){
-              self.summaryView.update();
-            } else {
-              self.stack.push({
-                class: 'foam.nanos.notification.NotificationView'
-              });
-            }
-          })
+            X.myNotificationDAO.cmd(foam.dao.CachingDAO.PURGE);
+          });
         },
         confirmationRequired: function() {
           return true;
@@ -147,14 +142,8 @@
         self.userDAO.put(userClone).then(user => {
           self.finished.pub();
           self.user = user;
+          X.myNotificationDAO.cmd(foam.dao.CachingDAO.PURGE);
 
-          if ( self.summaryView && foam.u2.GroupingDAOList.isInstance(self.summaryView) ){
-            self.summaryView.update();
-          } else {
-            self.stack.push({
-              class: 'foam.nanos.notification.NotificationView'
-            });
-          }
         }).catch(e => {
           self.throwError.pub(e);
 
@@ -180,13 +169,7 @@
             self.data.read = true;
             self.notificationDAO.put(self.data).then(_ => {
               self.finished.pub();
-              if ( self.summaryView && foam.u2.GroupingDAOList.isInstance(self.summaryView) ){
-                self.summaryView.update();
-              } else {
-                self.stack.push({
-                  class: 'foam.nanos.notification.NotificationView'
-                });
-              }
+              X.myNotificationDAO.cmd(foam.dao.CachingDAO.PURGE);
             });
           }
         }
@@ -202,13 +185,7 @@
             self.data.read = false;
             self.notificationDAO.put(self.data).then(_ => {
               self.finished.pub();
-              if ( self.summaryView && foam.u2.GroupingDAOList.isInstance(self.summaryView) ){
-                self.summaryView.update();
-              } else {
-                self.stack.push({
-                  class: 'foam.nanos.notification.NotificationView'
-                });
-              }
+              X.myNotificationDAO.cmd(foam.dao.CachingDAO.PURGE);
             })
           }
         }

--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -48,10 +48,8 @@ foam.CLASS({
     'ctrl',
     'currentMenu',
     'notify',
-    'objectSummaryView?',
     'stack',
     'subject',
-    'summaryView?',
     'ticketDAO',
     'ticketStatusDAO',
     'userDAO'
@@ -539,8 +537,7 @@ foam.CLASS({
         "ticket.assign.*"
       ],
       code: function(X) {        
-        var objToAdd = X.objectSummaryView ? X.objectSummaryView : X.summaryView;
-        objToAdd.tag({
+        X.ctrl.tag({
           class: "foam.u2.PropertyModal",
           property: this.ASSIGNED_TO.clone().copyFrom({ label: '' }),
           isModalRequired: true,

--- a/src/foam/u2/layout/MDDAOCreateController.js
+++ b/src/foam/u2/layout/MDDAOCreateController.js
@@ -31,8 +31,7 @@ foam.CLASS({
   ],
 
   exports: [
-    'controllerMode',
-    'as objectSummaryView'
+    'controllerMode'
   ],
 
   properties: [

--- a/src/foam/u2/layout/MDDAOUpdateController.js
+++ b/src/foam/u2/layout/MDDAOUpdateController.js
@@ -34,8 +34,7 @@ foam.CLASS({
   ],
 
   exports: [
-    'controllerMode',
-    'as objectSummaryView'
+    'controllerMode'
   ],
 
   properties: [


### PR DESCRIPTION
- Previously we were relying on imports objectSummaryView and summaryView to add a modal
- Now we just add the modal on the controller to remove dependency on knowing what view it's instantiating the modal on
- Also Reworked the NotificationRowView to not have to explicitly call update on the view that renders it, just triggering the cache purge instead