### PR TITLE
Skip reput for action required ucj

### DIFF
--- a/src/foam/nanos/crunch/ReputDependentUCJs.js
+++ b/src/foam/nanos/crunch/ReputDependentUCJs.js
@@ -69,10 +69,11 @@ foam.CLASS({
               UserCapabilityJunction ucjToReput = (UserCapabilityJunction) filteredUserCapabilityJunctionDAO
                 .find(EQ(UserCapabilityJunction.TARGET_ID, dependentId));
 
-              // Skip null and AVAILABLE UCJs
+              // Skip null, AVAILABLE and ACTION_REQUIRED UCJs
               if (
                 ucjToReput == null
                 || ucjToReput.getStatus() == CapabilityJunctionStatus.AVAILABLE
+                || ucjToReput.getStatus() == CapabilityJunctionStatus.ACTION_REQUIRED
               ) continue;
 
               ucjsToReput.add((UserCapabilityJunction) ucjToReput.fclone());


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-5489

## Issues
- The same IdentityMind KYC rule was triggered multiple times during dependent ucjs reput since the ucj status is in action_required.

## Changes
- Skip reput for action required ucj