### PR TITLE
Login view fix

### DIFF
--- a/src/foam/core/Currency.js
+++ b/src/foam/core/Currency.js
@@ -12,6 +12,7 @@
   documentation: `The base model for storing, using and managing currency information.`,
 
   javaImports: [
+    'foam.core.XLocator',
     'foam.i18n.TranslationService',
     'foam.util.SafetyUtil'
   ],

--- a/src/foam/core/Currency.js
+++ b/src/foam/core/Currency.js
@@ -12,7 +12,6 @@
   documentation: `The base model for storing, using and managing currency information.`,
 
   javaImports: [
-    'foam.core.XLocator',
     'foam.i18n.TranslationService',
     'foam.util.SafetyUtil'
   ],

--- a/src/foam/nanos/auth/SignOutView.js
+++ b/src/foam/nanos/auth/SignOutView.js
@@ -34,6 +34,7 @@ foam.CLASS({
       this.SUPER();
       this.auth.logout().then(() => {
         localStorage.removeItem('defaultSession');
+        this.window.location.hash = '';
         this.window.location.reload();
       });
     }

--- a/src/foam/u2/view/LoginView.js
+++ b/src/foam/u2/view/LoginView.js
@@ -229,9 +229,6 @@ foam.CLASS({
     function render() {
       this.SUPER();
       var self = this;
-      // clearing any values that may linger in memento - such as SignOut
-      this.memento.value = '';
-      location.hash = '';
 
       this.document.addEventListener('keyup', this.onKeyPressed);
       this.onDetach(() => {


### PR DESCRIPTION
Fixes issues when directing a user to the sign up or sign in using location hash.

The loginview would change the memento value to an empty string which would trigger the memento value listener, which lead to pushing the first permitted menu to the stack. This makes it so any menu referencing the login view will no longer be misdirected. 