### PR TITLE
[NP-5617] Move KeyStoreManager to foam, add medusa dagger bootstrap hash into keystore.

### DIFF
--- a/src/foam/nanos/medusa/DefaultDaggerService.js
+++ b/src/foam/nanos/medusa/DefaultDaggerService.js
@@ -194,7 +194,7 @@ foam.CLASS({
       String alias = BOOTSTRAP_HASH.toLowerCase();
       try {
         KeyStoreManager manager = (KeyStoreManager) x.get("keyStoreManager");
-        return manager.getSecretKey(x, alias);
+        return manager.getSecret(x, alias, "PBEWithHmacSHA256AndAES_128");
       } catch (java.security.GeneralSecurityException | java.io.IOException e) {
         getLogger().warning("Keystore error", alias, e.getMessage());
       } catch (IllegalArgumentException e) {

--- a/src/foam/nanos/medusa/DefaultDaggerService.js
+++ b/src/foam/nanos/medusa/DefaultDaggerService.js
@@ -26,16 +26,10 @@ foam.CLASS({
     'foam.nanos.logger.PrefixLogger',
     'foam.nanos.logger.Logger',
     'foam.nanos.pm.PM',
+    'foam.nanos.security.KeyStoreManager',
     'foam.util.SafetyUtil',
     'java.nio.charset.StandardCharsets',
-    'net.nanopay.security.KeyStoreManager',
-    'java.security.KeyStore',
-    'static java.security.KeyStore.PasswordProtection',
-    'static java.security.KeyStore.SecretKeyEntry',
     'java.security.MessageDigest',
-    'java.security.spec.KeySpec',
-    'javax.crypto.spec.PBEKeySpec',
-    'javax.crypto.SecretKeyFactory',
     'java.util.ArrayList',
     'java.util.List'
   ],
@@ -200,12 +194,7 @@ foam.CLASS({
       String alias = BOOTSTRAP_HASH.toLowerCase();
       try {
         KeyStoreManager manager = (KeyStoreManager) x.get("keyStoreManager");
-        String key = manager.getSecretKey(x, alias);
-        if ( BOOTSTRAP_HASH_DEFAULT.equals(key) ) {
-getLogger().info("Alias found");
-          return key;
-        }
-        getLogger().warning("Invalid alias value", "expected", BOOTSTRAP_HASH_DEFAULT, "found", key);
+        return manager.getSecretKey(x, alias);
       } catch (java.security.GeneralSecurityException | java.io.IOException e) {
         getLogger().warning("Keystore error", alias, e.getMessage());
       } catch (IllegalArgumentException e) {

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -259,6 +259,7 @@ FOAM_FILES([
   { name: 'foam/nanos/medusa/benchmark/MedusaBenchmark' },
   { name: 'foam/nanos/medusa/benchmark/MedusaPingBenchmark' },
   { name: 'foam/nanos/medusa/test/MedusaTestObject' },
+  { name: 'foam/nanos/security/KeyStoreManager' },
   { name: 'foam/nanos/benchmark/UUIDBenchmark' },
   { name: "foam/nanos/u2/navigation/TopNavigation", flags: ['web'] },
   { name: "foam/nanos/u2/navigation/FooterView", flags: ['web'] },

--- a/src/foam/nanos/security/KeyStoreManager.js
+++ b/src/foam/nanos/security/KeyStoreManager.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -119,7 +119,7 @@ keytool -importpass \
  -storetype PKCS12 \
  <<<"$SECRET"
 `,
-      name: 'getSecretKey',
+      name: 'getSecret',
       type: 'String',
       javaThrows: [
         'java.lang.IllegalArgumentException',
@@ -133,6 +133,11 @@ keytool -importpass \
         },
         {
           name: 'alias',
+          type: 'String'
+        },
+        {
+          documentation: 'A PBE Algorithm. See https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#keystore-types',
+          name: 'algorithm',
           type: 'String'
         }
       ]

--- a/src/foam/nanos/security/KeyStoreManager.js
+++ b/src/foam/nanos/security/KeyStoreManager.js
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.nanos.security',
+  name: 'KeyStoreManager',
+
+  documentation: 'Simplified interface to work with File or Resource based Java KeyStore',
+
+  implements: [
+    'foam.nanos.NanoService'
+  ],
+
+  methods: [
+    {
+      name: 'getKeyStore',
+      documentation: 'Returns the KeyStore.',
+      javaType: 'java.security.KeyStore'
+    },
+    {
+      name: 'unlock',
+      documentation: 'Unlocks the KeyStore.',
+      type: 'Void',
+      javaThrows: [
+        'java.security.cert.CertificateException',
+        'java.security.NoSuchAlgorithmException',
+        'java.io.IOException'
+      ]
+    },
+    {
+      name: 'loadKey',
+      documentation: 'Loads a key from the KeyStore.',
+      javaType: 'java.security.KeyStore.Entry',
+      javaThrows: [
+        'java.security.UnrecoverableEntryException',
+        'java.security.NoSuchAlgorithmException',
+        'java.security.KeyStoreException'
+      ],
+      args: [
+        {
+          name: 'alias',
+          type: 'String'
+        }
+      ]
+    },
+    {
+      name: 'loadKey_',
+      documentation: 'Loads a key from the KeyStore using additional protection parameter.',
+      javaType: 'java.security.KeyStore.Entry',
+      javaThrows: [
+        'java.security.UnrecoverableEntryException',
+        'java.security.NoSuchAlgorithmException',
+        'java.security.KeyStoreException'
+      ],
+      args: [
+        {
+          name: 'alias',
+          type: 'String'
+        },
+        {
+          name: 'protParam',
+          javaType: 'java.security.KeyStore.ProtectionParameter'
+        }
+      ]
+    },
+    {
+      name: 'storeKey',
+      documentation: 'Stores a new key.',
+      type: 'Void',
+      javaThrows: [
+        'java.security.KeyStoreException'
+      ],
+      args: [
+        {
+          name: 'alias',
+          type: 'String'
+        },
+        {
+          name: 'entry',
+          javaType: 'java.security.KeyStore.Entry'
+        }
+      ]
+    },
+    {
+      name: 'storeKey_',
+      documentation: 'Stores a new key using additional protection parameter.',
+      type: 'Void',
+      javaThrows: [
+        'java.security.KeyStoreException'
+      ],
+      args: [
+        {
+          name: 'alias',
+          type: 'String'
+        },
+        {
+          name: 'entry',
+          javaType: 'java.security.KeyStore.Entry'
+        },
+        {
+          name: 'protParam',
+          javaType: 'java.security.KeyStore.ProtectionParameter'
+        }
+      ]
+    },
+    {
+      documentation: `Retrieve a password from the keystore imported via importpass.
+keytool -importpass \
+ -v \
+ -alias "$ALIAS" \
+ -keypass "$PASSWORD" \
+ -keyalg PBEWithHmacSHA256AndAES_128 \
+ -keysize 256 \
+ -keystore "$DOMAIN.jks" \
+ -storepass "$PASSWORD" \
+ -storetype PKCS12 \
+ <<<"$SECRET"
+`,
+      name: 'getSecretKey',
+      type: 'String',
+      javaThrows: [
+        'java.lang.IllegalArgumentException',
+        'java.io.IOException',
+        'java.security.GeneralSecurityException'
+      ],
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'alias',
+          type: 'String'
+        }
+      ]
+    }
+  ]
+});

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -485,6 +485,7 @@ var classes = [
   'foam.nanos.medusa.benchmark.MedusaBenchmark',
   'foam.nanos.medusa.benchmark.MedusaPingBenchmark',
   'foam.nanos.medusa.test.MedusaTestObject',
+  'foam.nanos.security.KeyStoreManager',
   'foam.nanos.benchmark.UUIDBenchmark',
   'foam.nanos.benchmark.AuthorizerBenchmark',
   'foam.comics.v2.EnabledActionsAuth',


### PR DESCRIPTION
Move KeyStoreManager interface from nanopay to foam.
Retrieve Medusa bootstrap hash from keystore.
Remainder of KeyStoreManager will be ported later.