### PR TITLE
Fix toastNotificationDAO decorator config bug

### DIFF
--- a/src/foam/nanos/notification/ToastNotificationDAO.js
+++ b/src/foam/nanos/notification/ToastNotificationDAO.js
@@ -17,7 +17,7 @@ foam.CLASS({
       name: 'put_',
       code: function(x, obj) {
         if ( obj.transient ) {
-          // Need to publish put so that toast messages are created in the notify method
+          // Need to publish put so that a toast message is still created in the onUserAgentAndGroupLoaded method in Application Controller
           this.on.put.pub(obj);
           return obj;
         }

--- a/src/foam/nanos/notification/ToastNotificationDAO.js
+++ b/src/foam/nanos/notification/ToastNotificationDAO.js
@@ -16,7 +16,11 @@ foam.CLASS({
     {
       name: 'put_',
       code: function(x, obj) {
-        if ( obj.transient ) return obj;
+        if ( obj.transient ) {
+          // Need to publish put so that toast messages are created in the notify method
+          this.on.put.pub(obj);
+          return obj;
+        }
 
         return this.delegate.put_(x, obj);
       }

--- a/src/foam/nanos/notification/ToastNotificationDAO.js
+++ b/src/foam/nanos/notification/ToastNotificationDAO.js
@@ -17,7 +17,8 @@ foam.CLASS({
       name: 'put_',
       code: function(x, obj) {
         if ( obj.transient ) {
-          // Need to publish put so that a toast message is still created in the onUserAgentAndGroupLoaded method in Application Controller
+          // Need to publish put so that a toast message is still created
+          // in the onUserAgentAndGroupLoaded method in Application Controller
           this.on.put.pub(obj);
           return obj;
         }


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-5682

The issue was that when you return in ToastNotificationDAO which is a client side decorator, you never get to the RequestResponseClientDAO decorator where you publish put. In application controller, we listen on put to the myNotificationDAO and create a toast message when the put is done, but since we didn't publish 'put', toast messages were not created.