### PR TITLE
break group loop if theme is found

### DIFF
--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -102,7 +102,10 @@ Later themes:
               theme = theme && theme.merge(groupTheme) || groupTheme;
               break;
             }
-            if ( !! theme ) break;
+            if ( groupTheme ) {
+              theme = groupTheme;
+              break;
+            }
             group = await group.parent$find;
           }
 

--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -98,11 +98,14 @@ Later themes:
           var defaultMenu = group && group.defaultMenu;
           while ( group ) {
             var groupTheme = await group.theme$find;
-            if ( ! theme && groupTheme && ! foam.util.equals(theme, groupTheme) ) {
-              theme = theme && theme.merge(groupTheme) || groupTheme;
+            if ( groupTheme ) {
+              if ( theme && ! foam.util.equals(theme, groupTheme) ) {
+                theme = theme.merge(groupTheme);
+              } else {
+                theme = groupTheme;
+              }
               break;
             }
-
             group = await group.parent$find;
           }
 

--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -98,14 +98,11 @@ Later themes:
           var defaultMenu = group && group.defaultMenu;
           while ( group ) {
             var groupTheme = await group.theme$find;
-            if ( groupTheme && ! foam.util.equals(theme, groupTheme) ) {
+            if ( ! theme && groupTheme && ! foam.util.equals(theme, groupTheme) ) {
               theme = theme && theme.merge(groupTheme) || groupTheme;
               break;
             }
-            if ( groupTheme ) {
-              theme = groupTheme;
-              break;
-            }
+
             group = await group.parent$find;
           }
 

--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -102,6 +102,7 @@ Later themes:
               theme = theme && theme.merge(groupTheme) || groupTheme;
               break;
             }
+            if ( !! theme ) break;
             group = await group.parent$find;
           }
 


### PR DESCRIPTION
Noticed my acting theme was associated to my acting groups parent theme.

Added a condition to break and use groupTheme if one was found - breaking the traversal up the parents.