### PR TITLE
add visibility to additionalGroups

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -538,17 +538,19 @@ foam.CLASS({
       section: 'approvalRequestInformation',
       columnPermissionRequired: true,
       gridColumns: 6,
-      order: 65
+      order: 70
     },
     {
       class: 'StringArray',
       name: 'additionalGroups',
       columnPermissionRequired: true,
+      section: 'approvalRequestInformation',
+      gridColumns: 6,
+      order: 65,
       documentation: `
         Optional field to specify the request to be sent to multiple  groups.
         Should remain non-transient to handle fulfilled requests being visible to different groups.
       `,
-      hidden: true
     }
   ],
 


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-10-22 at 10 52 37 AM" src="https://user-images.githubusercontent.com/10802216/138476556-e0624048-a1b1-441e-954c-1291a1d06c11.png">

fixes: https://nanopay.atlassian.net/browse/NP-5648
by giving visibility into who is getting this approval