### PR TITLE
add Reset_CMD to CapabilityStore.onChange()

### DIFF
--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -511,6 +511,7 @@ foam.CLASS({
         this.daoUpdate();
         // Attempting to reset menuDAO incase of menu permission grantings.
         this.menuDAO.cmd_(this, foam.dao.DAO.PURGE_CMD);
+        this.menuDAO.cmd_(this, foam.dao.DAO.RESET_CMD);
       }
     }
   ]


### PR DESCRIPTION
want a reset to set off the event on dao - to ensure menu permissions/visibility is updated.