### PR TITLE
Use SectionedDetailView for FObjectView in DAOCreateView

### DIFF
--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -98,7 +98,10 @@ foam.CLASS({
       class: 'foam.u2.ViewSpec',
       name: 'createView',
       factory: function() {
-        return { class: 'foam.u2.view.FObjectView' };
+        return {
+          class: 'foam.u2.view.FObjectView',
+          detailView: { class: 'foam.u2.detail.SectionedDetailView' }
+        };
       }
     },
     {

--- a/src/foam/comics/v2/DAOCreateView.js
+++ b/src/foam/comics/v2/DAOCreateView.js
@@ -160,7 +160,8 @@ foam.CLASS({
                 .startContext({ data: self.stack })
                     .tag(self.stack.BACK, {
                       buttonStyle: foam.u2.ButtonStyle.LINK,
-                      icon: 'images/back-icon.svg'
+                      icon: 'images/back-icon.svg',
+                      themeIcon: 'back'
                     })
                 .endContext()
                 .start(self.Cols).style({ 'align-items': 'center' })

--- a/src/foam/nanos/ticket/TicketDAOCreateView.js
+++ b/src/foam/nanos/ticket/TicketDAOCreateView.js
@@ -16,7 +16,8 @@ foam.CLASS({
       expression: function() {
         return {
           class: 'foam.u2.view.FObjectView',
-          of: 'foam.nanos.ticket.Ticket'
+          of: 'foam.nanos.ticket.Ticket',
+          detailView: { class: 'foam.u2.detail.SectionedDetailView' }
         };
       }
     }

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -83,10 +83,7 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
-      name: 'allowCustom',
-      expression: function(choices) {
-        return choices.length == 0;
-      }
+      name: 'allowCustom'
     },
     {
       class: 'Function',
@@ -158,6 +155,11 @@ foam.CLASS({
           }, X);
         }
       `
+    },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'detailView',
+      value: { class: 'foam.u2.detail.VerticalDetailView' }
     }
   ],
 
@@ -174,7 +176,7 @@ foam.CLASS({
       // populate the list of choices using models related to 'of' via the
       // implements and extends relations.
       if ( this.strategizer != null ) {
-        this.strategizer.query(null, this.of.id, null, this.predicate).then((strategyReferences) => {
+        this.strategizer.query(null, this.of.id, null, this.predicate).then(strategyReferences => {
           if ( ! Array.isArray(strategyReferences) || strategyReferences.length === 0 ) {
             this.choices = this.skipBaseClass ? [] : [[this.of.id, this.of.model_.label]];
             this.choicesLoaded.resolve();
@@ -244,15 +246,15 @@ foam.CLASS({
         start(this.OBJECT_CLASS).
           // If we were using a DetailView, this would be done for us, but since
           // we aren't, we need to connect the 'visibility' property ourself.
-          show(this.OBJECT_CLASS.createVisibilityFor(foam.core.SimpleSlot.create({value: this}), this.controllerMode$).map(function(m) {
+          show(this.OBJECT_CLASS.createVisibilityFor(foam.core.SimpleSlot.create({ value: this }), this.controllerMode$).map(function(m) {
             return m != foam.u2.DisplayMode.HIDDEN;
           })).
         end().
         start().
           show(this.objectClass$).
-          tag(foam.u2.detail.VerticalDetailView, {
+          tag(this.detailView, {
             data$: this.data$,
-            config: this.config
+            config$: this.config$
           }).
         end();
     },


### PR DESCRIPTION
- Move the detailView used by FObjectView to a ViewSpec property that is always set to sectionedDetailView in the DAOControllerConfig
- Only show choice selector when more than one choice is available. Choices will be displayed in a choice view if an `of` is provided and the strategizer can find sub classes. If the `allowCustom` property is set to `true`, a textField is used instead to allow the user to type in any class and the strategizer choices are added as a datalist to the input
