### PR TITLE
Suppress polling until login successful

### DIFF
--- a/src/foam/dao/CachingDAO.js
+++ b/src/foam/dao/CachingDAO.js
@@ -184,6 +184,8 @@ foam.CLASS({
     function poll() {
       var self = this;
 
+      if ( ! this.loginSuccess ) return;
+
       self.delegate
         .orderBy(this.DESC(self.pollingProperty)).limit(1)
         .select().then(function(data) {


### PR DESCRIPTION
The first poll causes a page refresh. 
If this occurs during login, then the login page is refreshed, causing a bit of confusion. 