### PR TITLE
Make EmailMessage clusterable allowing Medusa to report cluster/conse…

### DIFF
--- a/src/foam/nanos/medusa/ClusterableMixin.js
+++ b/src/foam/nanos/medusa/ClusterableMixin.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.medusa',
+  name: 'ClusterableMixin',
+
+  implements: [
+    'foam.nanos.medusa.Clusterable'
+  ],
+
+  properties: [
+    {
+      class: 'Boolean',
+      name: 'clusterable',
+      documentation: 'In a medusa cluster, when false, this entity remains local to the generating server.  Intended for entity such as Alarms, Notifications, Emails allowing a medusa server to report clustering issues.',
+      createVisibility: 'HIDDEN',
+      updateVisibility: 'RO'
+    }
+  ]
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -191,6 +191,7 @@ FOAM_FILES([
   { name: 'foam/nanos/medusa/AccessMode' },
   { name: 'foam/nanos/medusa/ClientElectoralService' },
   { name: 'foam/nanos/medusa/Clusterable' },
+  { name: 'foam/nanos/medusa/ClusterableMixin' },
   { name: 'foam/nanos/medusa/ClusterClientDAO' },
   { name: 'foam/nanos/medusa/ClusterCommand' },
   { name: 'foam/nanos/medusa/ClusterCommandHop' },

--- a/src/foam/nanos/notification/EmailSetting.js
+++ b/src/foam/nanos/notification/EmailSetting.js
@@ -79,6 +79,7 @@ foam.CLASS({
         EmailMessage message = new EmailMessage();
         message.setSpid(user.getSpid());
         message.setTo(new String[] { user.getEmail() });
+        message.setClusterable(notification.getClusterable());
         notification = (Notification) notification.fclone();
 
         if ( notification.getEmailArgs() != null ) {

--- a/src/foam/nanos/notification/email/EmailMessage.js
+++ b/src/foam/nanos/notification/email/EmailMessage.js
@@ -17,6 +17,10 @@ foam.CLASS({
     'foam.nanos.auth.ServiceProviderAware'
   ],
 
+  mixins: [
+    'foam.nanos.medusa.ClusterableMixin'
+  ],
+
   tableColumns: [
     'created',
     'subject',


### PR DESCRIPTION
…nsus issues.

Medusa generates Alarm (clusterable=false), which generate Notifications (clusterable=false) which generate Emails, which hitherto where not cluster aware. As a result a cluster may experience deadlock trying to report a cluster or consensus issue itself