### PR TITLE
Believe the RuntimeException of the caught Exception passing a nested…

### DIFF
--- a/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
@@ -175,8 +175,9 @@ foam.CLASS({
                 approvalRequest = decorateApprovalRequest(x, approvalRequest, obj, capablePayload);
 
                 approvalRequestDAO.put_(getX(), approvalRequest);
-              } catch (Exception e){
-                throw new RuntimeException(e);
+              } catch (Exception e) {
+                foam.nanos.logger.Loggers.logger(x, this).warning(e);
+                throw new RuntimeException(e.getMessage());
               }
             }
 


### PR DESCRIPTION
… Java exception with StackElements back to the client.

Refactoring to report locally and just pass message back to client.
Resulting in 
Could not initialize class java.lang.StackTraceElement$HashedModules