### PR TITLE
Fix button loading when using a glyph that is not found

### DIFF
--- a/src/foam/core/Glyph.js
+++ b/src/foam/core/Glyph.js
@@ -20,7 +20,7 @@ foam.CLASS({
       class: 'String',
       expression: function(themeName) {
         if ( ! this.theme ) return '';
-        return this.theme.glyphs[themeName].template;
+        return this.theme.glyphs[themeName] ? this.theme.glyphs[themeName].template : '';
       }
     },
     {
@@ -32,6 +32,7 @@ foam.CLASS({
   methods: [
     function expandSVG(values) {
       var val = this.template;
+      if ( ! val ) return;
       for ( k in values ) if ( values.hasOwnProperty(k) ) {
         let K = k.toUpperCase();
         val = val.replace(


### PR DESCRIPTION
Trying to load glyphs that did not exist would silently fail the button load. This ensures the rest of the render() function still works when the glyph loading fails
