### PR TITLE
Update Grid to not break on smaller screens

### DIFF
--- a/src/foam/u2/layout/DisplayWidth.js
+++ b/src/foam/u2/layout/DisplayWidth.js
@@ -28,7 +28,7 @@ foam.ENUM({
         Min-width @ 320px, max-width @ 576px, and an 8 column grid
       `,
       minWidth: 320,
-      cols: 8
+      cols: 6
     },
     {
       name: 'SM',
@@ -37,7 +37,7 @@ foam.ENUM({
         Min-width @ 576px, max-width @ 768px and a 12 column grid
       `,
       minWidth: 576,
-      cols: 8
+      cols: 12
     },
     {
       name: 'MD',

--- a/src/foam/u2/layout/Grid.js
+++ b/src/foam/u2/layout/Grid.js
@@ -34,11 +34,11 @@ foam.CLASS({
       code: function() {
         this.shown = false;
         var currentWidth = 0;
-        this.childNodes.forEach((ret) => {
+        this.childNodes.forEach(ret => {
           var cols = this.displayWidth ? this.displayWidth.cols : 12;
-          var width = this.GUnit.isInstance(ret) && ret.columns &&
+          var width = Math.min(this.GUnit.isInstance(ret) && ret.columns &&
             ret.columns[`${this.displayWidth.name.toLowerCase()}Columns`] ||
-            cols;
+            cols, cols);
 
           var startCol = currentWidth + 1;
           currentWidth += width;
@@ -51,8 +51,7 @@ foam.CLASS({
           var endCol = startCol + width;
 
           ret.style({
-            'grid-column-start': startCol,
-            'grid-column-end':   endCol
+            'grid-column': `${startCol} / ${endCol}`
           });
         });
         this.shown = true;


### PR DESCRIPTION
Foam grid would break on smaller screens with less than 12 columns as it would add columns for props that wanted to span more columns than the grid was configured for.