### PR TITLE
Shift FUID based on the checksum

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -186,7 +186,7 @@ FOAM_FILES([
   { name: "foam/util/SecurityUtilTest" },
   { name: "foam/util/async/Sequence" },
   { name: "foam/util/UIDGenerator" },
-  { name: "foam/util/UIDGeneratorTest" },
+  { name: "foam/util/test/UIDGeneratorTest" },
   { name: "foam/log/LogLevel" },
   { name: "foam/log/Logger" },
   { name: "foam/log/ConsoleLogger" },

--- a/src/foam/util/UIDGenerator.js
+++ b/src/foam/util/UIDGenerator.js
@@ -83,7 +83,7 @@ foam.CLASS({
       type: 'String',
       documentation: `
         Generate a Unique ID. The Unique ID consists of :
-        8 hexits timestamp(s) + at least 2 hexits sequence inside second + 3 hexits checksum.
+        8 hexits timestamp(s) + at least 2 hexits sequence inside second + 2 hexits machine ID + 3 hexits checksum.
 
         After the checksum is added, the ID is permutated based on the
         permutationSeq. In most cases, the generated ID should be 13 digits long.

--- a/src/foam/util/UIDGeneratorTest.js
+++ b/src/foam/util/UIDGeneratorTest.js
@@ -22,6 +22,12 @@ foam.CLASS({
         var hash   = mod("foobar");
         UIDGeneratorTest_GenerateVerifiableUniqueStringIDs(uidgen, hash);
         UIDGeneratorTest_GenerateVerifiableUniqueLongIDs(uidgen, hash);
+        // UIDs similarity tests
+        UIDGeneratorTest_CheckGeneratedUIDsSimilarity(uidgen, 0, 32);
+        UIDGeneratorTest_CheckGeneratedUIDsSimilarity(uidgen, 0x100, 32);
+        UIDGeneratorTest_CheckGeneratedUIDsSimilarity(uidgen, 0x1000, 32);
+        UIDGeneratorTest_CheckGeneratedUIDsSimilarity(uidgen, 0x10000, 32);
+        UIDGeneratorTest_CheckGeneratedUIDsSimilarity(uidgen, 0x100000, 32);
       `
     },
     {
@@ -64,6 +70,43 @@ foam.CLASS({
           verified = hash == UIDSupport.hash(id);
         }
         test(verified, "Should generated unique string ids be verifiable" + (verified ? "" : ", but " + id + " failed verification"));
+      `
+    },
+    {
+      name: 'calcSimilarityScore',
+      type: 'Integer',
+      args: [ 'String id1', 'String id2' ],
+      javaCode: `
+        var score = 0;
+        var id1Arr = id1.toCharArray();
+        var id2Arr = id2.toCharArray();
+        var l = Math.min(id1Arr.length, id2Arr.length);
+        var diff = 0;
+        for ( var i = 0; i < l; i++ ) {
+          if ( id1Arr[i] == id2Arr[i] ) {
+            diff++;
+          } else {
+            if ( diff > 0 ) score += Math.pow(2, diff - 1);
+            diff = 0;
+          }
+        }
+        if ( diff > 0 ) {
+          score += Math.pow(2, diff - 1);
+        }
+        return score;
+      `
+    },
+    {
+      name: 'UIDGeneratorTest_CheckGeneratedUIDsSimilarity',
+      args: [ 'UIDGenerator uidgen', 'int startSeqNo', 'int threshold' ],
+      javaCode: `
+        uidgen.setSeqNo(startSeqNo);
+        uidgen.setLastSecondCalled(System.currentTimeMillis() / 1000);
+
+        var id1 = uidgen.getNextString();
+        var id2 = uidgen.getNextString();
+        var score = calcSimilarityScore(id1, id2);
+        test(score <= threshold, "[startSeqNo: " + startSeqNo + "] Should not generated very similar unique ids [" + id1 + ", " + id2 + "].");
       `
     }
   ]

--- a/src/foam/util/UIDSupport.java
+++ b/src/foam/util/UIDSupport.java
@@ -76,7 +76,8 @@ public class UIDSupport {
    * @return Hash of the unique id
    */
   public static int hash(String uid) {
-    return hash(Long.parseLong(uid));
+    var hex = undoPermutate(uid);
+    return mod(Long.parseLong(hex, 16));
   }
 
   /**
@@ -86,12 +87,7 @@ public class UIDSupport {
    * @return Hash of the unique id
    */
   public static int hash(long uid) {
-    return hash_(Long.toHexString(uid));
-  }
-
-  private static int hash_(String hex) {
-    var id = undoPermutate(hex);
-    return mod(Long.parseLong(id, 16));
+    return hash(Long.toHexString(uid));
   }
 
   /**

--- a/src/foam/util/test/UIDGeneratorTest.js
+++ b/src/foam/util/test/UIDGeneratorTest.js
@@ -5,13 +5,15 @@
  */
 
 foam.CLASS({
-  package: 'foam.util',
+  package: 'foam.util.test',
   name: 'UIDGeneratorTest',
   extends: 'foam.nanos.test.Test',
 
   javaImports: [
-    'static foam.util.UIDSupport.*',
-    'java.util.HashSet'
+    'foam.util.UIDGenerator',
+    'foam.util.UIDSupport',
+    'java.util.HashSet',
+    'static foam.util.UIDSupport.*'
   ],
 
   methods: [

--- a/src/foam/util/tests.jrl
+++ b/src/foam/util/tests.jrl
@@ -1,5 +1,5 @@
 p({"class":"foam.util.EmailTest","id":"emailTest","description":"email tests"})
 p({"class":"foam.util.PasswordTest","id":"passwordTest","description":"password tests"})
 p({"class":"foam.util.SecurityUtilTest","id":"security util tests","description":"security util tests"})
-p({"class":"foam.util.UIDGeneratorTest","id":"UIDGeneratorTest","description":"UID generator tests"})
+p({"class":"foam.util.test.UIDGeneratorTest","id":"UIDGeneratorTest","description":"UID generator tests"})
 p({"class":"foam.parse.QueryParserUserTest","id":"QueryParserUserTest"})

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -689,7 +689,7 @@ var classes = [
   'foam.lib.parse.ActionParser',
   'foam.lib.parse.SymbolParser',
   'foam.util.UIDGenerator',
-  'foam.util.UIDGeneratorTest',
+  'foam.util.test.UIDGeneratorTest',
   'foam.util.EmailTest',
   'foam.util.PasswordTest',
   'foam.util.SecurityUtilTest',


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-5677

## Changes
- Shift fuid based the checksum after permutate to prevent generating very similar ids
- Fix string uid hashing