### PR TITLE
Helper DAO to simplify operations with non-default SessionID

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -301,6 +301,7 @@ FOAM_FILES([
   { name: "foam/dao/grid/ManyToManyGridRecord" },
   { name: "foam/dao/grid/ManyToManyGridDAO" },
   { name: "foam/dao/LazyCacheDAO" },
+  { name: "foam/dao/SessionClientDAO" },
   { name: "foam/dao/TTLCachingDAO"},
   { name: "foam/dao/TTLSelectCachingDAO"},
   { name: "foam/dao/CachingDAO" },

--- a/src/foam/box/SessionClientBox.js
+++ b/src/foam/box/SessionClientBox.js
@@ -129,7 +129,7 @@ foam.CLASS({
     {
       name: 'send',
       code: function send(msg) {
-        msg.attributes[this.SESSION_KEY] = this.jsSessionID;
+        msg.attributes[this.SESSION_KEY] = this.sessionID;
 
         msg.attributes.replyBox.localBox = this.SessionReplyBox.create({
           msg:       msg,

--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -188,6 +188,9 @@ public class SessionServerBox
       getDelegate().send(msg);
     } catch (Throwable t) {
       logger.warning(t.getMessage());
+      if ( t instanceof NullPointerException) {
+        logger.error(t);
+      }
       msg.replyWithException(t);
 
       AppConfig appConfig = (AppConfig) getX().get("appConfig");

--- a/src/foam/dao/SessionClientDAO.js
+++ b/src/foam/dao/SessionClientDAO.js
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'SessionClientDAO',
+  extends: 'foam.dao.ProxyDAO',
+  javaGenerateConvenienceConstructor: false,
+  javaGenerateDefaultConstructor: false,
+
+  documentation: `Support for calling DAO web services with explicit session id.
+use:
+c = foam.dao.SessionClientDAO.create({
+  serviceName: 'languageDAO',
+  sessionId: 'E7A01D59-E35C-47E1-A5A6-9EA81D5BCDAD'
+}, x);
+
+a = await c.select();
+console.log('a', a && a.array);
+// or
+c.select().then(function(a1) {
+  console.log('a1', a1 && a1.array);
+});
+`,
+
+  javaImports: [
+    'foam.core.X',
+    'foam.dao.ClientDAO',
+    'foam.dao.DAO',
+    'foam.dao.ProxyDAO',
+    'foam.box.HTTPAuthorizationType',
+    'foam.box.HTTPBox',
+    'foam.box.SessionClientBox',
+    'foam.nanos.logger.Logger',
+    'foam.nanos.logger.Loggers',
+    'foam.nanos.pm.PM',
+    'foam.nanos.session.Session',
+    'foam.util.SafetyUtil'
+  ],
+
+  imports: [
+    'sessionID as jsSessionID'
+  ],
+
+  exports: [
+    'sessionId as sessionID'
+  ],
+
+  requires: [
+    'foam.box.SessionClientBox',
+    'foam.box.HTTPBox',
+    'foam.box.HTTPAuthorizationType',
+    'foam.dao.ClientDAO'
+  ],
+
+  properties: [
+    {
+      name: 'serviceName',
+      class: 'String'
+    },
+    {
+      documentation: 'Session token / BEARER token',
+      name: 'sessionId',
+      class: 'String',
+      factory: function() { return this.jsSessionID || localStorage.defaultSession; }
+    }
+  ],
+
+  javaCode: `
+  public SessionClientDAO() {
+  }
+
+  public SessionClientDAO(X x, String serviceName) {
+    setX(x);
+    setServiceName(serviceName);
+    setSessionId(x.get(Session.class).getId());
+    init();
+  }
+  public SessionClientDAO(X x, String serviceName, String sessionId) {
+    setX(x);
+    setServiceName(serviceName);
+    setSessionId(sessionId);
+    init();
+  }
+  `,
+
+  methods: [
+    {
+      name: 'init',
+      code: function() {
+        this.SUPER();
+
+        var box = this.HTTPBox.create({
+          authorizationType: this.HTTPAuthorizationType.BEARER,
+          url: 'service/'+this.serviceName
+        });
+
+        box = this.SessionClientBox.create({
+          delegate: box
+        });
+
+        this.delegate = this.ClientDAO.create({
+          name: this.serviceName,
+          of: this.__subContext__[this.serviceName].of,
+          delegate: box
+        });
+      },
+      javaCode: `
+      X x = getX();
+      ProxyDAO proxy = (ProxyDAO) x.get(getServiceName());
+      setDelegate(new ClientDAO.Builder(x)
+        .setOf(proxy.getOf())
+        .setDelegate(new SessionClientBox.Builder(x)
+        .setSessionID(getSessionId())
+        .setDelegate(new HTTPBox.Builder(x)
+          .setAuthorizationType(HTTPAuthorizationType.BEARER)
+          .setSessionID(getSessionId())
+          .setUrl("service/"+getServiceName())
+          .build())
+        .build())
+        .build());
+      `
+    }
+  ]
+});

--- a/src/foam/dao/SessionClientDAO.js
+++ b/src/foam/dao/SessionClientDAO.js
@@ -45,9 +45,10 @@ c.select().then(function(a1) {
     'sessionID as jsSessionID'
   ],
 
-  exports: [
-    'sessionId as sessionID'
-  ],
+  // NOTE: Do not export, will invalidate the browser's current session
+  // exports: [
+  //   'sessionId as sessionID'
+  // ],
 
   requires: [
     'foam.box.SessionClientBox',
@@ -93,20 +94,22 @@ c.select().then(function(a1) {
       code: function() {
         this.SUPER();
 
+        // Create explicit sub context rather than an 'export'.
+        // 'export' will invalidate the browser's current session.
+        var x = this.__subContext__.createSubContext({
+          sessionID: this.sessionId
+        });
+
         var box = this.HTTPBox.create({
           authorizationType: this.HTTPAuthorizationType.BEARER,
           url: 'service/'+this.serviceName
-        });
-
-        box = this.SessionClientBox.create({
-          delegate: box
-        });
+        }, x);
 
         this.delegate = this.ClientDAO.create({
           name: this.serviceName,
           of: this.__subContext__[this.serviceName].of,
           delegate: box
-        });
+        }, x);
       },
       javaCode: `
       X x = getX();

--- a/src/foam/nanos/script/Script.js
+++ b/src/foam/nanos/script/Script.js
@@ -369,7 +369,7 @@ foam.CLASS({
         };
         try {
           with ({ log: log, print: log, x: this.__context__ })
-          return Promise.resolve(eval(this.code));
+            return Promise.resolve(eval('(async () => {' + this.code + '})()'));
         } catch (err) {
           this.output += err;
           return Promise.reject(err);

--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -95,7 +95,7 @@ foam.CLASS({
       type: 'Void',
       javaThrows: ['Throwable'],
       code: function(x) {
-        return eval(this.code);
+        return eval('(async () => {' + this.code + '})()');
       },
       args: [
         {
@@ -168,7 +168,7 @@ foam.CLASS({
             };
 
             with ( { log: log, print: log, x: this.__context__, test: test } ) {
-              Promise.resolve(eval(this.code)).then(() => {
+              Promise.resolve(eval('(async () => {' + this.code + '})()')).then(() => {
                 updateStats();
                 resolve();
               }, (err) => {

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -215,6 +215,7 @@ var classes = [
   'foam.dao.EnabledAwareDAO',
   'foam.dao.EnabledAwareDAOTest',
   'foam.dao.index.PersistedIndexTest',
+  'foam.dao.SessionClientDAO',
   'foam.dao.SequenceNumberDAO',
   'foam.dao.SequenceNumberDAOTest',
   'foam.dao.PipelinePMDAO',


### PR DESCRIPTION
Helper DAO to simplify operations with non-default SessionID.
Also support async/await in javascript scripts.

Intended for scripts which need to change between sessions - that of admin for provisioning, then a user session, for example. 