### PR TITLE
Maybe fix duplicate page loading in tables

### DIFF
--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -306,6 +306,8 @@
       code: function() {
         this.currGroup_ = undefined;
         this.rowObserver?.disconnect();
+        // Don't clear loadingPages_ here since they are being 
+        // loaded and will have latest data anyway
         Object.keys(this.renderedPages_).forEach(i => {
           this.clearPage(i, true);
         });


### PR DESCRIPTION
Believe the cause of the duplicate page loading was a refresh happening while the promise was still being returned causing the same page to be loaded twice. This should fix that. Also added some logging to get more information in case it does happen