### PR TITLE
Remove/Disable retry - when just a single node or mediator is offline…

### DIFF
--- a/src/foam/nanos/medusa/MediatorRouterDAO.js
+++ b/src/foam/nanos/medusa/MediatorRouterDAO.js
@@ -38,11 +38,11 @@ foam.CLASS({
           // forward on to next mediator
           ClusterConfig serverConfig = support.getNextServer();
           DAO dao = support.getClientDAO(x, getServiceName(), config, serverConfig);
-          dao = new RetryClientSinkDAO.Builder(x)
-                      .setDelegate(dao)
-                      .setMaxRetryAttempts(support.getMaxRetryAttempts())
-                      .setMaxRetryDelay(support.getMaxRetryDelay())
-                      .build();
+          // dao = new RetryClientSinkDAO.Builder(x)
+          //             .setDelegate(dao)
+          //             .setMaxRetryAttempts(support.getMaxRetryAttempts())
+          //             .setMaxRetryDelay(support.getMaxRetryDelay())
+          //             .build();
           Loggers.logger(x, this).debug("put", "request", "to", serverConfig.getId(), getServiceName());
           return dao.put_(x, obj);
         }

--- a/src/foam/nanos/medusa/MedusaBroadcast2NodesDAO.js
+++ b/src/foam/nanos/medusa/MedusaBroadcast2NodesDAO.js
@@ -78,11 +78,11 @@ foam.CLASS({
               DAO dao = (DAO) getClients().get(config.getId());
               if ( dao == null ) {
                 dao = support.getBroadcastClientDAO(x, getServiceName(), myConfig, config);
-                dao = new RetryClientSinkDAO.Builder(x)
-                          .setDelegate(dao)
-                          .setMaxRetryAttempts(support.getMaxRetryAttempts())
-                          .setMaxRetryDelay(support.getMaxRetryDelay())
-                          .build();
+                // dao = new RetryClientSinkDAO.Builder(x)
+                //           .setDelegate(dao)
+                //           .setMaxRetryAttempts(support.getMaxRetryAttempts())
+                //           .setMaxRetryDelay(support.getMaxRetryDelay())
+                //           .build();
                 getClients().put(config.getId(), dao);
               }
 

--- a/src/foam/nanos/medusa/MedusaBroadcastDAO.js
+++ b/src/foam/nanos/medusa/MedusaBroadcastDAO.js
@@ -135,12 +135,12 @@ foam.CLASS({
               DAO dao = (DAO) getClients().get(config.getId());
               if ( dao == null ) {
                   dao = support.getBroadcastClientDAO(x, getServiceName(), myConfig, config);
-                  dao = new RetryClientSinkDAO.Builder(x)
-                          .setName(getServiceName())
-                          .setDelegate(dao)
-                          .setMaxRetryAttempts(support.getMaxRetryAttempts())
-                          .setMaxRetryDelay(support.getMaxRetryDelay())
-                          .build();
+                  // dao = new RetryClientSinkDAO.Builder(x)
+                  //         .setName(getServiceName())
+                  //         .setDelegate(dao)
+                  //         .setMaxRetryAttempts(support.getMaxRetryAttempts())
+                  //         .setMaxRetryDelay(support.getMaxRetryDelay())
+                  //         .build();
                 getClients().put(config.getId(), dao);
               }
 


### PR DESCRIPTION
…, this will consume all thread resources and make things very slow.
Will be replaced with SAF. 