### PR TITLE
added missing notifications when mark as read/unread

### DIFF
--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -1064,3 +1064,8 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.auth.twofactor.TwoFac
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.table.TableView.MESSAGE_OF",target:"do"})
 
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.u2.table.UnstyledTableGroup.EMPTY_MSG",target:"Não"})
+
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.notification.NotificationRowView.MARK_AS_READ_MSG",target:"Marcado com sucesso como lido"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.notification.NotificationRowView.MARK_AS_UNREAD_MSG",target:"Marcado com sucesso como não lido"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.notification.NotificationRowView.FAILED_MARK_AS_READ_MSG",target:"Falha ao marcar como lida"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.notification.NotificationRowView.FAILED_MARK_AS_UNREAD_MSG",target:"Falha ao marcar como não lida"})

--- a/src/foam/nanos/notification/NotificationRowView.js
+++ b/src/foam/nanos/notification/NotificationRowView.js
@@ -79,6 +79,13 @@
       'optionPopup_'
     ],
 
+    messages: [
+      { name:'MARK_AS_READ_MSG', message: 'Successfully marked as read' },
+      { name:'FAILED_MARK_AS_READ_MSG', message: 'Failed to mark as read' },
+      { name:'MARK_AS_UNREAD_MSG', message: 'Successfully marked as unread' },
+      { name:'FAILED_MARK_AS_UNREAD_MSG', message: 'Failed to mark as unread' }
+    ],
+
     methods: [
       function render() {
         var self = this;
@@ -168,7 +175,11 @@
             self.data.read = true;
             self.notificationDAO.put(self.data).then(_ => {
               self.finished.pub();
+              self.ctrl.notify(self.MARK_AS_READ_MSG, '', this.LogLevel.INFO, true);
               X.myNotificationDAO.cmd(foam.dao.DAO.PURGE_CMD);
+            }).catch((e) => {
+              self.data.read = false;
+              self.ctrl.notify(self.FAILED_MARK_AS_READ_MSG, e.message, this.LogLevel.ERROR, true);
             });
           }
         }
@@ -184,8 +195,12 @@
             self.data.read = false;
             self.notificationDAO.put(self.data).then(_ => {
               self.finished.pub();
+              self.ctrl.notify(self.MARK_AS_UNREAD_MSG, '', this.LogLevel.INFO, true);
               X.myNotificationDAO.cmd(foam.dao.DAO.PURGE_CMD);
-            })
+            }).catch((e) => {
+             self.data.read = true;
+             self.ctrl.notify(self.FAILED_MARK_AS_UNREAD_MSG, e.message, this.LogLevel.ERROR, true);
+           });
           }
         }
       }


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-5875

added missing notifications when mark as read/unread
and tried to throw an error on purpose in order to test

<img width="272" alt="Screen Shot 2021-11-23 at 2 56 17 PM" src="https://user-images.githubusercontent.com/33228583/143095443-965d3059-b6d5-4aec-a88f-93dd4ec04d0b.png">
<img width="265" alt="Screen Shot 2021-11-23 at 2 55 50 PM" src="https://user-images.githubusercontent.com/33228583/143095444-511d4c34-27da-4ff2-ad1e-f69c19245dae.png">
<img width="259" alt="Screen Shot 2021-11-23 at 2 46 26 PM" src="https://user-images.githubusercontent.com/33228583/143095445-9872b6eb-571a-4d1b-b063-6074e8c89a85.png">
<img width="331" alt="Screen Shot 2021-11-23 at 2 46 18 PM" src="https://user-images.githubusercontent.com/33228583/143095447-1e616956-553a-47ae-a1c4-5bc09402995f.png">
<img width="252" alt="Screen Shot 2021-11-23 at 2 45 47 PM" src="https://user-images.githubusercontent.com/33228583/143095449-5176ea13-124d-4776-bc1a-72a9bb976f1d.png">
<img width="319" alt="Screen Shot 2021-11-23 at 2 45 36 PM" src="https://user-images.githubusercontent.com/33228583/143095451-f0f9ba1e-c827-4efa-8a29-0d2613432d97.png">
