### PR TITLE
Ucj prop view updat2

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -702,6 +702,7 @@ FOAM_FILES([
   { name: "foam/u2/crunch/wizardflow/GrantedEditAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/CheckNoDataAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/LoadCapabilitiesAgent", flags: ['web'] },
+  { name: "foam/u2/crunch/wizardflow/WAOSettingAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/CreateWizardletsAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/LoadWizardletsAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/FilterWizardletsAgent", flags: ['web'] },

--- a/src/foam/nanos/crunch/UCJProperty.js
+++ b/src/foam/nanos/crunch/UCJProperty.js
@@ -32,7 +32,7 @@ foam.CLASS({
     },
     {
       name: 'adapt',
-      value: function (_, o) {
+      value: function(_, o) {
         const e = foam.mlang.Expressions.create();
 
         const Predicate = foam.mlang.predicate.Predicate;
@@ -43,30 +43,20 @@ foam.CLASS({
         if ( ! foam.Object.isInstance(o) && ! foam.Array.isInstance(o) ) {
           throw new Error('valid UCJProperty values are: Predicate, string, object');
         }
-        if ( ! o.hasOwnProperty('sourceId') || ! o.hasOwnProperty('targetId') ) {
+        if ( ! o.hasOwnProperty('sourceId') ) {
           throw new Error('an object value for UCJProperty must have ' +
             'properties sourceId and targetId.');
         }
 
-        const UserCapabilityJunction = foam.nanos.crunch.UserCapabilityJunction;
+        const UserCapabilityJunction  = foam.nanos.crunch.UserCapabilityJunction;
         const AgentCapabilityJunction = foam.nanos.crunch.AgentCapabilityJunction;
 
-        var predicate = e.AND(
+        return e.OR(
           e.EQ(UserCapabilityJunction.SOURCE_ID, o.sourceId),
-          e.EQ(UserCapabilityJunction.TARGET_ID, o.targetId)
-        );
-
-        if ( o.hasOwnProperty('effectiveUser') ) {
-          predicate = e.AND(
-            predicate,
-            e.OR(
-              e.NOT(e.INSTANCE_OF(AgentCapabilityJunction)),
-              e.EQ(this.AgentCapabilityJunction.EFFECTIVE_USER, o.effectiveUser)
-            )
-          );
-        }
-
-        return predicate;
+          e.AND(
+            e.INSTANCE_OF(AgentCapabilityJunction),
+            e.EQ(AgentCapabilityJunction.EFFECTIVE_USER, o.sourceId)
+          ));
       }
     }
   ]

--- a/src/foam/nanos/crunch/ui/ReviewUCJView.js
+++ b/src/foam/nanos/crunch/ui/ReviewUCJView.js
@@ -30,6 +30,7 @@ foam.CLASS({
     'foam.u2.crunch.wizardflow.ConfigureFlowAgent',
     'foam.u2.crunch.wizardflow.CapabilityAdaptAgent',
     'foam.u2.crunch.wizardflow.LoadCapabilitiesAgent',
+    'foam.u2.crunch.wizardflow.WAOSettingAgent',
     'foam.u2.crunch.wizardflow.CreateWizardletsAgent',
     'foam.u2.crunch.wizardflow.LoadTopConfig',
     'foam.u2.crunch.wizardflow.StepWizardAgent',
@@ -87,6 +88,7 @@ foam.CLASS({
       });
       // Invoke custom wizard flow which excludes pending check and preview
       this.Sequence.create(null, crunchContext)
+        .add(this.WAOSettingAgent)
         .add(this.ConfigureFlowAgent)
         .add(this.CapabilityAdaptAgent)
         .add(this.LoadCapabilitiesAgent)

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -61,6 +61,7 @@ foam.CLASS({
     'foam.u2.crunch.wizardflow.SpinnerAgent',
     'foam.u2.crunch.wizardflow.DetachSpinnerAgent',
     'foam.u2.crunch.wizardflow.DebugAgent',
+    'foam.u2.crunch.wizardflow.WAOSettingAgent',
     'foam.util.async.Sequence',
     'foam.u2.borders.MarginBorder',
     'foam.u2.crunch.CapabilityInterceptView',
@@ -119,6 +120,7 @@ foam.CLASS({
           .add(this.LoadTopConfig)
           .add(this.GrantedEditAgent)
           .add(this.LoadCapabilitiesAgent)
+          .add(this.WAOSettingAgent)
           // TODO: remove CheckRootIdAgent after phase 2 fix on PENDING
           .add(this.CheckRootIdAgent)
           .add(this.CheckPendingAgent)
@@ -162,8 +164,8 @@ foam.CLASS({
           capable: capable
         });
         return this.createWizardSequence(capable && capable.capabilityIds[0], x)
-          .reconfigure('LoadCapabilitiesAgent', {
-            waoSetting: this.LoadCapabilitiesAgent.WAOSetting.CAPABLE })
+          .reconfigure('WAOSettingAgent', {
+            waoSetting: this.WAOSettingAgent.WAOSetting.CAPABLE })
           .remove('SkipGrantedAgent')
           .remove('CheckRootIdAgent')
           .remove('CheckPendingAgent')

--- a/src/foam/u2/crunch/UCJReferenceView.js
+++ b/src/foam/u2/crunch/UCJReferenceView.js
@@ -14,13 +14,21 @@ foam.CLASS({
     instead of updating UCJs directly.
   `,
 
+  implements: [
+    'foam.mlang.Expressions'
+  ],
+
   imports: [
+    'capabilityDAO',
     'crunchController',
     'userCapabilityJunctionDAO'
   ],
 
   requires: [
     'foam.nanos.crunch.ui.UCJView',
+    'foam.nanos.crunch.Capability',
+    'foam.nanos.crunch.UserCapabilityJunction',
+    'foam.nanos.crunch.AgentCapabilityJunction',
     'foam.u2.crunch.wizardflow.ApprovalRequestAgent',
     'foam.u2.crunch.wizardflow.LoadCapabilitiesAgent',
     'foam.u2.stack.Stack',
@@ -36,30 +44,53 @@ foam.CLASS({
   properties: [
     {
       name: 'localStack',
-      factory: function () {
+      factory: function() {
         return this.Stack.create();
       }
     },
     {
       name: 'ucj',
       transient: true
+    },
+    {
+      name: 'ucjPropertyList',
+      class: 'FObjectArray',
+      of: 'foam.nanos.crunch.UserCapabilityJunction',
+      transient: true,
+      documentation: 'Stores the property predicate search results from ucjDAO.'
+    },
+    {
+      name: 'capabilitiesList',
+      class: 'FObjectArray',
+      of: 'foam.nanos.crunch.Capability',
+      transient: true,
+      documentation: 'Set this property to display these ucj\'s in wizard'
     }
   ],
 
   methods: [
     async function render() {
+      // the variable ucj in this function acts as the root capaiblity.
+      // Also takes the subject from ucj and sets it through the wizard.
+      // TODO this only works for ONE signing officer
       this
-        .add(this.slot(function (ucj) {
-          if ( ! ucj ) return this.E();
+        .add(this.slot(async function(ucjPropertyList) {
+          var ucj = await ucjPropertyList.filter(u => this.AgentCapabilityJunction.isInstance(u) );
+          this.capabilitiesList = (
+            await this.capabilityDAO.where(this.AND(
+              this.IN(this.Capability.ID, this.ucjPropertyList.map(u => u.targetId)),
+              this.NEQ(this.Capability.OF, null))).select()
+          ).array;
           return this.UCJView.create({
-            data: ucj,
-            mode: this.mode
+            isSettingCapabilities: true,
+            data: ucj.length > 0 ? ucj[0] : ucjPropertyList[0],
+            mode: this.mode,
+            capabilitiesList: this.capabilitiesList
           });
-        }))
-
-      this.ucj = (
+        }));
+      this.ucjPropertyList = (
         await this.userCapabilityJunctionDAO.where(this.data).select()
-      ).array[0];
+      ).array;
     }
   ]
 });

--- a/src/foam/u2/crunch/wizardflow/CreateWizardletsAgent.js
+++ b/src/foam/u2/crunch/wizardflow/CreateWizardletsAgent.js
@@ -18,7 +18,7 @@ foam.CLASS({
 
   imports: [
     'capabilities',
-    'getWAO' // Provided  by LoadCapabilitiesAgent
+    'getWAO' // Provided by WAOSettingAgent
   ],
 
   exports: [

--- a/src/foam/u2/crunch/wizardflow/GrantedEditAgent.js
+++ b/src/foam/u2/crunch/wizardflow/GrantedEditAgent.js
@@ -24,6 +24,7 @@ foam.CLASS({
     'foam.nanos.crunch.CapabilityJunctionStatus',
     'foam.u2.crunch.wizardflow.ApprovalRequestAgent',
     'foam.u2.crunch.wizardflow.LoadCapabilitiesAgent',
+    'foam.u2.crunch.wizardflow.WAOSettingAgent',
     'foam.u2.crunch.wizardflow.SkipMode'
   ],
 
@@ -42,8 +43,8 @@ foam.CLASS({
           return;
         }
         this.sequence
-          .reconfigure('LoadCapabilitiesAgent', {
-            waoSetting: this.LoadCapabilitiesAgent.WAOSetting.APPROVAL
+          .reconfigure('WAOSettingAgent', {
+            waoSetting: this.WAOSettingAgent.WAOSetting.APPROVAL
           })
           .remove('LoadTopConfig')
           .remove('CheckPendingAgent')

--- a/src/foam/u2/crunch/wizardflow/LoadCapabilitiesAgent.js
+++ b/src/foam/u2/crunch/wizardflow/LoadCapabilitiesAgent.js
@@ -19,33 +19,15 @@ foam.CLASS({
   ],
   exports: [
     'capabilities',
-    'getWAO',
     'subject as wizardSubject'
-  ],
-
-  requires: [
-    'foam.nanos.crunch.ui.ApprovableUserCapabilityJunctionWAO',
-    'foam.nanos.crunch.ui.UserCapabilityJunctionWAO',
-    'foam.nanos.crunch.ui.CapableWAO',
-  ],
-
-  enums: [
-    {
-      name: 'WAOSetting',
-      values: ['UCJ','CAPABLE','APPROVAL']
-    }
   ],
 
   properties: [
     {
       name: 'capabilities',
-      class: 'Array'
-    },
-    {
-      name: 'waoSetting',
-      factory: function () {
-        return this.WAOSetting.UCJ;
-      }
+      class: 'Array',
+      documentation: `This array can consist of capabilities
+      and arrays of capabilities.`
     },
     {
       name: 'subject',
@@ -63,22 +45,10 @@ foam.CLASS({
     function execute() {
       if ( this.subject ) {
         return this.crunchService.getCapabilityPathFor(null, this.rootCapability.id, false, this.subject.user, this.subject.realUser)
-          .then(capabilities => { this.capabilities = capabilities });
+          .then(capabilities => this.capabilities = capabilities);
       }
       return this.crunchService.getCapabilityPath(null, this.rootCapability.id, false, true)
-        .then(capabilities => { this.capabilities = capabilities });
-    },
-    function getWAO() {
-      switch ( this.waoSetting ) {
-        case this.WAOSetting.UCJ:
-          return this.UserCapabilityJunctionWAO.create({ subject: this.subject }, this.__context__);
-        case this.WAOSetting.CAPABLE:
-          return this.CapableWAO.create({}, this.__context__);
-        case this.WAOSetting.APPROVAL:
-          return this.ApprovableUserCapabilityJunctionWAO.create({ subject: this.subject });
-        default:
-          throw new Error('WAOSetting is unrecognized: ' + this.waoSetting);
-      }
+        .then(capabilities => this.capabilities = capabilities);
     }
   ]
 });

--- a/src/foam/u2/crunch/wizardflow/WAOSettingAgent.js
+++ b/src/foam/u2/crunch/wizardflow/WAOSettingAgent.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.CLASS({
+  package: 'foam.u2.crunch.wizardflow',
+  name: 'WAOSettingAgent',
+  implements: [ 'foam.core.ContextAgent' ],
+
+  documentation: `
+    basic WAO setting.
+  `,
+
+  imports: [
+    'subject'
+  ],
+
+  exports: [
+    'getWAO',
+    'subject as wizardSubject'
+  ],
+
+  requires: [
+    'foam.nanos.crunch.ui.ApprovableUserCapabilityJunctionWAO',
+    'foam.nanos.crunch.ui.UserCapabilityJunctionWAO',
+    'foam.nanos.crunch.ui.CapableWAO',
+  ],
+
+  enums: [
+    {
+      name: 'WAOSetting',
+      values: ['UCJ', 'CAPABLE', 'APPROVAL']
+    }
+  ],
+
+  properties: [
+    {
+      name: 'waoSetting',
+      factory: function() {
+        return this.WAOSetting.UCJ;
+      }
+    }
+  ],
+
+  methods: [
+    function execute() {
+      return Promise.resolve();
+    },
+    function getWAO() {
+      switch ( this.waoSetting ) {
+        case this.WAOSetting.UCJ:
+          return this.UserCapabilityJunctionWAO.create({ subject: this.subject }, this.__context__);
+        case this.WAOSetting.CAPABLE:
+          return this.CapableWAO.create({}, this.__context__);
+        case this.WAOSetting.APPROVAL:
+          return this.ApprovableUserCapabilityJunctionWAO.create({ subject: this.subject });
+        default:
+          throw new Error('WAOSetting is unrecognized: ' + this.waoSetting);
+      }
+    }
+  ]
+});

--- a/src/permissions
+++ b/src/permissions
@@ -44,7 +44,7 @@ p({"class":"foam.nanos.auth.Permission","id":"serviceprovider.remove.*","descrip
 p({"class":"foam.nanos.auth.Permission","id":"serviceproviderdao.read.*","description":"Permits reading service provider objects within the serviceProviderDAO. Differs from serviceprovider.action.id which is applied to an authorization layer for objects implementing the ServiceProviderAware interface."})
 p({"class":"foam.nanos.auth.Permission","id":"serviceproviderdao.update.*","description":"Permits updates service provider objects within the serviceProviderDAO. Differences between serviceproviderdao.action.* and serviceprovider.action.id. documented on serviceproviderdao.read.*"})
 p({"class":"foam.nanos.auth.Permission","id":"serviceproviderdao.remove.*","description":"Permits removing service provider objects within the serviceProviderDAO. Differences between serviceproviderdao.action.* and serviceprovider.action.id. documented on serviceproviderdao.read.*"})
-p({"class":"foam.nanos.auth.Permission","id":"usercapabilityjunction.warn.update","description":"Log when a user with this permission updates a user capability junction."})
+p({"class":"foam.nanos.auth.Permission","id":"usercapabilityjunction.warn.update","description":"This permission enables a log output when subject.getRealUser() != subject.getUser() and an update is occuring. Log when a user with this permission updates a user capability junction."})
 p({"class":"foam.nanos.auth.Permission","id":"exportdriverregistry.read.CSV"})
 p({"class":"foam.nanos.auth.Permission","id":"exportdriverregistry.read.GoogleSheets"})
 p({"class":"foam.nanos.auth.Permission","id":"exportdriverregistry.read.JSON"})


### PR DESCRIPTION
This PR injects a bypass Sequence into the Crunch Wizard Generation for the purpose of passing in a custom list of capabilities.
WAOSettingAgent.js extracted from LoadCapabilitiesAgent.js - and set into each relavent Sequence call.
Issue: Did not want to use LoadCapabilitiesAgent.js in new Sequence. Wanted to pass in my own Capability list.
UCJReferenceView.js updated to handle a list of capabilities.
Previously UCJReferenceView worked on passing in the top level ucj into the Wizard Sequence.
Current UCJReferenceView works on passing in a query to the used in generating the Wizard Sequence.
UCJView.js updated to generate a different wizard Sequence if UcjView.isSettingCapabilities = true
UCJProperty.js updated
previously: query was to a specific UCJ - predicate = sourceId && targetId, also if specifying an acj - set this userId into the query.
Current: return any related ucj to the passed in sourceId.
TODO - the modifications to UCJProperty should be more generic. We want the previous method set up as well. However note UCJProperty is setup in 2 places. ONE on user which my linking pr is addressing. TWO the UCJUpdateApprovable.js which does want to pass in a topLevel ucj, however, instead of relying on the UCJProperty defaults - it has its value set explicitly from the CrunchService and then has its own method to launch the wizard. Thus leaving this as a todo is acceptable.