### PR TITLE
Only allow primitive types for theme replacement

### DIFF
--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -596,7 +596,7 @@ foam.CLASS({
       // then we don't want this method to expand the commented portion of that
       // CSS because it's already in long form. By checking if */ follows the
       // macro, we can tell if it's already in long form and skip it.
-      return val ? css.replace(
+      return val && foam.util.isPrimitive(val) ? css.replace(
         new RegExp('%' + M + '%(?!\\*/)', 'g'),
         '/*%' + M + '%*/ ' + val) : css;
     },
@@ -606,7 +606,7 @@ foam.CLASS({
       const M = m.toUpperCase(); 
       var prop = m.startsWith('DisplayWidth') ? m + '.minWidthString' : m
       var val = foam.util.path(this.theme, prop, false);
-      return val ? css.replace(
+      return val && foam.util.isPrimitive(val)  ? css.replace(
         new RegExp('/\\*%' + M + '%\\*/[^);!]*', 'g'),
         '/*%' + M + '%*/ ' + val) : css;
     },


### PR DESCRIPTION
Block any empty objects from being used in theme replacement (cause default values to be ignored).
<img width="474" alt="Screen Shot 2021-11-29 at 2 28 58 PM" src="https://user-images.githubusercontent.com/81172969/143931113-63e1c88d-f52f-4eb7-9eee-e63477e1b8bf.png">
