### PR TITLE
Fix AUID generating duplicate ids

### DIFF
--- a/src/foam/util/AUIDGenerator.js
+++ b/src/foam/util/AUIDGenerator.js
@@ -61,13 +61,11 @@ foam.CLASS({
         In most cases, the generated AUID should be 15 hex digits long.
       `,
       javaCode: `
-        // 8 bits timestamp
-        long curSec = (System.currentTimeMillis() - EPOCH) / 1000;
-        id.append(toHexString(curSec, 8));
+        long curSec = 0;
+        int seqNo   = 0;
 
-        // At least 2 bits sequence
-        int seqNo = 0;
         synchronized (this) {
+          curSec = (System.currentTimeMillis() - EPOCH) / 1000;
           if ( curSec != getLastSecondCalled() ) {
             setSeqNo(0);
             setLastSecondCalled(curSec);
@@ -75,6 +73,10 @@ foam.CLASS({
           seqNo = getSeqNo();
           setSeqNo(seqNo + 1);
         }
+
+        // 8 bits timestamp
+        id.append(toHexString(curSec, 8));
+        // At least 2 bits sequence
         id.append(toHexString(seqNo, 2));
       `
     }

--- a/src/foam/util/test/UIDUniquenessTest.js
+++ b/src/foam/util/test/UIDUniquenessTest.js
@@ -46,7 +46,7 @@ foam.CLASS({
           threads[i] = new Thread(() -> {
             try {
               for ( var j = 0; j < getSize(); j++ ) {
-                if ( duplicateFound.get() ) return;
+                if ( duplicateFound.get() || error.get() ) return;
                 var uid = uidgen.getNextString();
                 if ( ! uids.containsKey(uid) ) {
                   uids.put(uid, uid);
@@ -65,10 +65,12 @@ foam.CLASS({
         for ( var t : threads ) {
           try { t.join(); } catch ( InterruptedException e ) { /* Ignored */ }
         }
+
+        var extraInfo = " Total threads: " + uidGenerators.length + "; Ids generated: " + uids.size() + ".";
         if ( error.get() ) {
-          test(false, "Failed to generate UID");
+          test(false, "Failed to generate UID. " + extraInfo);
         } else {
-          test(duplicateFound.get() == expected, message);
+          test(duplicateFound.get() == expected, message + extraInfo);
         }
       `
     },
@@ -77,7 +79,12 @@ foam.CLASS({
       args: [ 'Context x' ],
       javaCode: `
         var uidgen = new AUIDGenerator.Builder(x).setMachineId(1).build();
-        testDuplicateFound(false, "Should not generate duplicate uid on the same instance.", uidgen, uidgen, uidgen, uidgen);
+        testDuplicateFound(false, "Should not generate duplicate uid on the same instance.",
+          uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen,
+          uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen,
+          uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen,
+          uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen, uidgen
+        );
       `
     },
     {


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-5677

## Issues
- While waiting for other threads the `curSec` passed the `lastSecondCalled` but the it was already appended to the id thus re-generating the id of the old curSec with seqNo=0

## Changes
- Synchronize curSec
- Update unit test threads to 32