### PR TITLE
[NP-5773] - Execute conditions on subject user

### DIFF
--- a/src/foam/nanos/approval/AuthenticatedApprovalDAOAuthorizer.js
+++ b/src/foam/nanos/approval/AuthenticatedApprovalDAOAuthorizer.js
@@ -31,7 +31,7 @@ foam.CLASS({
     {
       name: 'authorizeOnRead',
       javaCode: `
-        User user = ((Subject) x.get("subject")).getRealUser();
+        User user = ((Subject) x.get("subject")).getUser();
         if ( user == null || ! SafetyUtil.equals(user.getId(), ((ApprovalRequest)obj).getApprover()) ) {
           throw new AuthorizationException();
         }
@@ -41,7 +41,7 @@ foam.CLASS({
       name: 'authorizeOnUpdate',
       javaCode: `
         ApprovalRequest approvalRequest = (ApprovalRequest) oldObj;
-        User user = ((Subject) x.get("subject")).getRealUser();
+        User user = ((Subject) x.get("subject")).getUser();
         AuthService authService = (AuthService) x.get("auth");
         if ( user == null || ! SafetyUtil.equals(approvalRequest.getApprover(), user.getId()) && ! ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system"))) {
           throw new AuthorizationException();
@@ -51,7 +51,7 @@ foam.CLASS({
     {
       name: 'authorizeOnDelete',
       javaCode: `
-        User user = ((Subject) x.get("subject")).getRealUser();
+        User user = ((Subject) x.get("subject")).getUser();
         if ( user == null  || ! ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system")) ) {
           throw new AuthorizationException("Approval can only be deleted by system");
         }


### PR DESCRIPTION
Allows for approvals to be authorized correctly when user and realUser are different entities.

Ref: https://nanopay.atlassian.net/browse/NP-5773