### PR TITLE
Save object if modified in async rules

### DIFF
--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -197,11 +197,12 @@ public class RuleEngine extends ContextAwareSupport {
       if ( ! rule.f(x, nu, oldObj) ) return;
 
       PM pm = PM.create(getX(), RulerDAO.getOwnClassInfo(), "ASYNC", rule.getDaoKey(), rule.getId());
-      var before = nu.fclone();
+      FObject before = null;
+      if ( rule.getOperation() != Operation.REMOVE ) {
+        before = nu.fclone();
+      }
       rule.asyncApply(x, nu, oldObj, RuleEngine.this, rule);
-      if ( rule.getOperation() != Operation.REMOVE
-        && before.diff(nu).size() > 0
-      ) {
+      if ( before != null && ! before.equals(nu) ) {
         getDelegate().put_(userX_, nu);
       }
       pm.log(getX());

--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -9,6 +9,7 @@ package foam.nanos.ruler;
 import foam.core.*;
 import foam.dao.DAO;
 import foam.nanos.auth.*;
+import foam.nanos.dao.Operation;
 import foam.nanos.logger.Logger;
 import foam.nanos.pm.PM;
 
@@ -196,7 +197,13 @@ public class RuleEngine extends ContextAwareSupport {
       if ( ! rule.f(x, nu, oldObj) ) return;
 
       PM pm = PM.create(getX(), RulerDAO.getOwnClassInfo(), "ASYNC", rule.getDaoKey(), rule.getId());
+      var before = nu.fclone();
       rule.asyncApply(x, nu, oldObj, RuleEngine.this, rule);
+      if ( rule.getOperation() != Operation.REMOVE
+        && before.diff(nu).size() > 0
+      ) {
+        getDelegate().put_(userX_, nu);
+      }
       pm.log(getX());
     }, "Async apply rule id: " + rule.getId()));
   }

--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -199,7 +199,7 @@ public class RuleEngine extends ContextAwareSupport {
       PM pm = PM.create(getX(), RulerDAO.getOwnClassInfo(), "ASYNC", rule.getDaoKey(), rule.getId());
       var before = rule.getOperation() != Operation.REMOVE ? nu.fclone() : obj;
       rule.asyncApply(x, nu, oldObj, RuleEngine.this, rule);
-      if ( ! before.equals(nu) ) {
+      if ( rule.getOperation() != Operation.REMOVE && ! before.equals(nu) ) {
         getDelegate().put_(userX_, nu);
       }
       pm.log(getX());

--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -199,9 +199,7 @@ public class RuleEngine extends ContextAwareSupport {
       PM pm = PM.create(getX(), RulerDAO.getOwnClassInfo(), "ASYNC", rule.getDaoKey(), rule.getId());
       rule.asyncApply(x, nu, oldObj, RuleEngine.this, rule);
       var before = reloadObject(obj, rule.getOperation());
-      if ( rule.getOperation() != Operation.REMOVE
-        && ! before.equals(nu)
-      ) {
+      if ( rule.getOperation() != Operation.REMOVE && ! before.equals(nu) ) {
         getDelegate().put_(userX_, nu);
       }
       pm.log(getX());
@@ -232,7 +230,7 @@ public class RuleEngine extends ContextAwareSupport {
   private FObject reloadObject(FObject obj, Operation operation) {
     // For REMOVE operation, the object was removed from the DAO thus
     // returning the original object.
-    if ( operation == Operation.REMOVE) {
+    if ( operation == Operation.REMOVE ) {
       return obj;
     }
 


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-6128

## Issues
- Unlike sync rules where the object would be automatically saved if modified, the async rules require explicit dao.put() call to save the object.

## Changes
- Handle saving the object if it was modified in async rules