### PR TITLE
Used wizardSubject for the getWAO method

### DIFF
--- a/src/foam/u2/crunch/wizardflow/WAOSettingAgent.js
+++ b/src/foam/u2/crunch/wizardflow/WAOSettingAgent.js
@@ -14,12 +14,11 @@
   `,
 
   imports: [
-    'subject'
+    'wizardSubject'
   ],
 
   exports: [
-    'getWAO',
-    'subject as wizardSubject'
+    'getWAO'
   ],
 
   requires: [
@@ -51,11 +50,11 @@
     function getWAO() {
       switch ( this.waoSetting ) {
         case this.WAOSetting.UCJ:
-          return this.UserCapabilityJunctionWAO.create({ subject: this.subject }, this.__context__);
+          return this.UserCapabilityJunctionWAO.create({ subject: this.wizardSubject }, this.__context__);
         case this.WAOSetting.CAPABLE:
           return this.CapableWAO.create({}, this.__context__);
         case this.WAOSetting.APPROVAL:
-          return this.ApprovableUserCapabilityJunctionWAO.create({ subject: this.subject });
+          return this.ApprovableUserCapabilityJunctionWAO.create({ subject: this.wizardSubject });
         default:
           throw new Error('WAOSetting is unrecognized: ' + this.waoSetting);
       }


### PR DESCRIPTION
wizardSubject was not getting passed in, and there was an export to wizardSubject happening which was taken from loadCapabilitiesAgent which has subject as a property.