### PR TITLE
Fix copyFrom sub-class object

### DIFF
--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -299,16 +299,16 @@ public interface FObject
     List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
     for ( PropertyInfo p : props ) {
       try {
-        if ( p.isSet(obj) ) p.set(this, p.get(obj));
-      } catch (ClassCastException e) {
-        try {
+        if ( getClass().equals(obj.getClass()) ) {
+          if ( p.isSet(obj) ) p.set(this, p.get(obj));
+        } else {
           PropertyInfo p2 = (PropertyInfo) obj.getClassInfo().getAxiomByName(p.getName());
           if ( p2 != null ) {
             if ( p2.isSet(obj) ) p.set(this, p2.get(obj));
           }
-        } catch (ClassCastException ignore) {
-          System.err.println("FObject.copyFrom "+p.getName()+" "+ignore.getMessage());
         }
+      } catch (ClassCastException ignore) {
+        System.err.println("FObject.copyFrom "+p.getName()+" "+ignore.getMessage());
       }
     }
     return this;

--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -299,7 +299,7 @@ public interface FObject
     List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
     for ( PropertyInfo p : props ) {
       try {
-        if ( getClass().equals(obj.getClass()) ) {
+        if ( getClass() == obj.getClass() ) {
           if ( p.isSet(obj) ) p.set(this, p.get(obj));
         } else {
           PropertyInfo p2 = (PropertyInfo) obj.getClassInfo().getAxiomByName(p.getName());


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-6179

## Issue
- PropertyInfo.isSet() is checking `<propName>IsSet_` private local variable on the class itself, when copying from a sub-class object which has it own `<propName>IsSet_` was not being checked.

## Changes
- Check if the obj to copy is the same class as `this` and act accordingly