### PR TITLE
Added the ability to pass in a [value, label] to CardSelectionView

### DIFF
--- a/src/foam/u2/view/CardSelectionView.js
+++ b/src/foam/u2/view/CardSelectionView.js
@@ -43,7 +43,12 @@
       documentation: `
         Used to control the number of cards shown in a row if isVertical is false
       `
-    }
+    },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'choiceView',
+      value: { class: 'foam.u2.view.CardSelectView' }
+    },
   ],
 
   methods: [
@@ -55,21 +60,32 @@
           .add(
             self.slot(function(choices) {
               var toRender = choices.sort().map((choice, index) => {
-                var valueSimpSlot = self.mustSlot(choice);
                 var isSelectedSlot = self.slot(function(choices, data) {
                   return self.choiceIsSelected(data, choices[index]);
                 });
+
+                var cardSelectViewConfig = {
+                  isSelected$: isSelectedSlot
+                }
+
+                var valueSimpSlot;
+
+                if ( choice instanceof Array ){
+                  valueSimpSlot = self.mustSlot(choice[0]);
+                  cardSelectViewConfig.label = choice[1];
+                } else {
+                  valueSimpSlot = self.mustSlot(choice);
+                  cardSelectViewConfig.of = choice.cls_.id;
+                }
+
+                cardSelectViewConfig.data$ = valueSimpSlot;
 
                 return self.E()
                   .addClass(self.myClass('innerFlexer'))
                   .style({
                     'width': self.isVertical ? '100%' : `${100 / self.numCols}%`
                   })
-                  .start(self.CardSelectView, {
-                    data$: valueSimpSlot,
-                    isSelected$: isSelectedSlot,
-                    of: choice.cls_.id
-                  })
+                  .start(this.choiceView, cardSelectViewConfig)
                     .call(function () {
                       self.E().onDetach(
                         this.clicked.sub(() => {
@@ -94,7 +110,7 @@
     },
 
     function choiceIsSelected(data, choice) {
-      return foam.util.equals(data, choice);
+      return foam.util.equals(data, choice instanceof Array ? choice[0] : choice);
     },
 
     function mustSlot(v) {


### PR DESCRIPTION
This way anyone that wants to use a CardSelectionView can now easily set it up by overriding the view for any property and passing the choices in thru an array of choices in the format of [value, label]. For example, if I have a property called isScheduled which is a boolean, I can override the view to pass in an array of [[false, now], [true, later]] by overriding the property view.