### PR TITLE
[NP-6321] Add IsolatedDAO

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -288,6 +288,7 @@ FOAM_FILES([
   { name: "foam/dao/KeyValueDAO", flags: [ "java" ] },
   { name: "foam/dao/ReadOnlyDAO", flags: [ "java" ] },
   { name: "foam/dao/StoreAndForwardDAO" },
+  { name: "foam/dao/IsolatedDAO" },
   { name: "foam/dao/Journal", flags: [ "java" ] },
   { name: "foam/dao/CompositeJournal", flags: [ "java" ] },
   { name: "foam/dao/AbstractFileJournal", flags: [ "java" ] },

--- a/src/foam/dao/IsolatedDAO.js
+++ b/src/foam/dao/IsolatedDAO.js
@@ -21,12 +21,12 @@ foam.CLASS({
       properties: [
         {
           class: 'String',
-          documentation: 'DAO method name associated with operation.',
           name: 'methodName',
+          documentation: 'DAO method name associated with operation.'
         },
         {
-          documentation: 'Arguments object associated with operation.',
           name: 'args',
+          documentation: 'Arguments object associated with operation.'
         }
       ]
     }
@@ -36,9 +36,8 @@ foam.CLASS({
     {
       class: 'FObjectArray',
       of: 'FObject',
-      // of: 'DAOOperation',
-      documentation: 'Queue for pending DAO operations.',
       name: 'q_',
+      documentation: 'Queue for pending DAO operations.'
     }
   ],
 
@@ -51,7 +50,7 @@ foam.CLASS({
       // Store DAO operations in order.
       var op = this.DAOOperation.create({
         methodName: methodName,
-        args: args,
+        args: args
       });
       this.q_.push(op);
 

--- a/src/foam/dao/IsolatedDAO.js
+++ b/src/foam/dao/IsolatedDAO.js
@@ -60,6 +60,7 @@ foam.CLASS({
     // This is similar to StoreAndForwardDAO, but we only want to override put and remove.
     function put_() { return this.store_(foam.dao.DOP.PUT_, arguments); },
     function remove_() { return this.store_(foam.dao.DOP.REMOVE_, arguments); },
+    function removeAll_() { return this.store_(foam.dao.DOP.REMOVE_ALL_.label, arguments); },
 
     async function store_(dop, args) {
       // Store DAO operations in order.

--- a/src/foam/dao/IsolatedDAO.js
+++ b/src/foam/dao/IsolatedDAO.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2022 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'IsolatedDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  documentation: `
+    Stores a DAO operation but does not call the delegate until
+    commit() is called.
+  `,
+
+  classes: [
+    {
+      name: 'DAOOperation',
+
+      properties: [
+        {
+          class: 'String',
+          documentation: 'DAO method name associated with operation.',
+          name: 'methodName',
+        },
+        {
+          documentation: 'Arguments object associated with operation.',
+          name: 'args',
+        },
+      ]
+    }
+  ],
+
+  properties: [
+    {
+      class: 'FObjectArray',
+      of: 'FObject',
+      // of: 'DAOOperation',
+      documentation: 'Queue for pending DAO operations.',
+      name: 'q_',
+    },
+  ],
+
+  methods: [
+    // This is similar to StoreAndForwardDAO, but we only want to override put and remove.
+    function put_() { return this.store_(foam.dao.DOP.PUT_.label, arguments); },
+    function remove_() { return this.store_(foam.dao.DOP.REMOVE_.label, arguments); },
+
+    async function store_(methodName, args) {
+      // Store DAO operations in order.
+      var op = this.DAOOperation.create({
+        methodName: methodName,
+        args: args,
+      });
+      this.q_.push(op);
+
+      // Always succeed
+      return args[0];
+    },
+    async function commit() {
+      for ( let op of this.q_ ) {
+        await this.delegate[op.methodName].apply(this.delegate, op.args);
+      }
+    }
+  ]
+});

--- a/src/foam/dao/IsolatedDAO.js
+++ b/src/foam/dao/IsolatedDAO.js
@@ -61,16 +61,16 @@ foam.CLASS({
     function put_() { return this.store_(foam.dao.DOP.PUT_, arguments); },
     function remove_() { return this.store_(foam.dao.DOP.REMOVE_, arguments); },
 
-    async function store_(methodName, args) {
+    async function store_(dop, args) {
       // Store DAO operations in order.
       var op = this.DAOOperation.create({
-        methodName: methodName,
+        dop: dop,
         args: args
       });
       this.q_.push(op);
 
       // Always succeed
-      return args[0];
+      return args[args.length - 1];
     },
     async function commit() {
       for ( let op of this.q_ ) {

--- a/src/foam/dao/IsolatedDAO.js
+++ b/src/foam/dao/IsolatedDAO.js
@@ -27,7 +27,7 @@ foam.CLASS({
         {
           documentation: 'Arguments object associated with operation.',
           name: 'args',
-        },
+        }
       ]
     }
   ],
@@ -39,7 +39,7 @@ foam.CLASS({
       // of: 'DAOOperation',
       documentation: 'Queue for pending DAO operations.',
       name: 'q_',
-    },
+    }
   ],
 
   methods: [

--- a/src/foam/dao/tests.jrl
+++ b/src/foam/dao/tests.jrl
@@ -21,7 +21,7 @@ p({
         const dao = ArrayDAO.create({ of: 'foam.nanos.cron.TimeHMS' });
         isolatedDao = IsolatedDAO.create({
             of: 'foam.nanos.cron.TimeHMS',
-            delegate: dao,
+            delegate: dao
         });
 
         isolatedDao.put(TimeHMS.create({ hour: 1 }));

--- a/src/foam/dao/tests.jrl
+++ b/src/foam/dao/tests.jrl
@@ -16,17 +16,34 @@ p({
     code: `
         const ArrayDAO = foam.dao.ArrayDAO;
         const IsolatedDAO = foam.dao.IsolatedDAO;
-        const TimeHMS = foam.nanos.cron.TimeHMS;
+        const Model = foam.core.Model;
+        const e = foam.mlang.Expressions.create();
 
-        let arrayDAO = ArrayDAO.create({ of: 'foam.nanos.cron.TimeHMS' });
+        // Test put only
+        let arrayDAO = ArrayDAO.create({ of: 'foam.core.Model' });
         dao = IsolatedDAO.create({
-            of: 'foam.nanos.cron.TimeHMS',
+            of: 'foam.core.Model',
             delegate: arrayDAO
         });
 
-        dao.put(TimeHMS.create({ hour: 1 }));
+        dao.put(Model.create({ id: 'TestA' }));
         test(arrayDAO.array.length == 0, "delegate put not called immediately");
         await dao.cmd(IsolatedDAO.COMMIT);
         test(arrayDAO.array.length != 0, "delegate put called after commit");
+
+        // Test put and remove
+        arrayDAO = ArrayDAO.create({ of: 'foam.core.Model' });
+        dao = IsolatedDAO.create({
+            of: 'foam.core.Model',
+            delegate: arrayDAO
+        });
+
+        dao.put(Model.create({ name: 'test_1' }));
+        dao.put(Model.create({ name: 'test_2' }));
+        dao.put(Model.create({ name: 'test_3' }));
+        dao.remove(Model.create({ name: 'test_1' }));
+        test(arrayDAO.array.length == 0, "delegate put/remove not called immediately");
+        await dao.cmd(IsolatedDAO.COMMIT);
+        test(arrayDAO.array.length == 2, "state after commit matches mixed DAO operations");
     `
 })

--- a/src/foam/dao/tests.jrl
+++ b/src/foam/dao/tests.jrl
@@ -7,3 +7,26 @@ p({"class":"foam.dao.EnabledAwareDAOTest","id":"EnabledAwareDAOTest"})
 p({"class":"foam.nanos.test.Test","id":"FixedSizeDAOTest","status":2,"code":"of = foam.nanos.auth.User.getOwnClassInfo();\n\ndao = new foam.dao.FixedSizeDAO.Builder(x)\n  .setDelegate(new foam.dao.MDAO(of))\n  .setComparator(foam.mlang.MLang.DESC(of.getAxiomByName(\"lastModified\")))\n  .setSize(10)\n  .build();\n\nlong startTime = new java.util.Date().getTime();\nfor ( int i = 100 ; i <= 200 ; i++ ) {\n    dao.put(new foam.nanos.auth.User.Builder(x)\n      .setId(i)\n      .setFirstName(\"Test \" + i)\n      .setLastModified(new java.util.Date(startTime + i))\n      .build());\n}\n\nprint(dao.select(new foam.mlang.sink.Count()).getValue());\n\nprint(dao.select(foam.mlang.MLang.MIN(of.getAxiomByName(\"firstName\"))));\nprint(dao.select(foam.mlang.MLang.MAX(of.getAxiomByName(\"firstName\"))));","output":""})
 p({"class":"foam.nanos.test.Test","id":"FixedSizeDAOTest","status":2,"code":"of = foam.nanos.auth.User.getOwnClassInfo();\n\ndao = new foam.dao.FixedSizeDAO.Builder(x)\n  .setDelegate(new foam.dao.MDAO(of))\n  .setComparator(foam.mlang.MLang.DESC(of.getAxiomByName(\"lastModified\")))\n  .setPredicate(foam.mlang.MLang.TRUE)\n  .setSize(10)\n  .build();\n\nlong startTime = new java.util.Date().getTime();\nfor ( int i = 100 ; i <= 200 ; i++ ) {\n    dao.put(new foam.nanos.auth.User.Builder(x)\n      .setId(i)\n      .setFirstName(\"Test \" + i)\n      .setLastModified(new java.util.Date(startTime + i))\n      .build());\n}\n\nprint(dao.select(new foam.mlang.sink.Count()).getValue());\n\nprint(dao.select(foam.mlang.MLang.MIN(of.getAxiomByName(\"firstName\"))));\nprint(dao.select(foam.mlang.MLang.MAX(of.getAxiomByName(\"firstName\"))));","output":""})
 p({"class":"foam.nanos.test.Test","id":"FixedSizeDAOTest","failed":0,"lastRun":"2019-09-11T18:35:15.399Z","lastDuration":138,"status":1,"output":"10\nvalue: Test 191, arg1: foam.nanos.auth.User.firstName\nvalue: Test 200, arg1: foam.nanos.auth.User.firstName\n"})
+p({
+    class: 'foam.nanos.test.Test',
+    id: 'IsolatedDAOTest',
+    enabled: true,
+    description: "Tests for CachingDAO",
+    server: false,
+    code: `
+        const ArrayDAO = foam.dao.ArrayDAO;
+        const IsolatedDAO = foam.dao.IsolatedDAO;
+        const TimeHMS = foam.nanos.cron.TimeHMS;
+
+        const dao = ArrayDAO.create({ of: 'foam.nanos.cron.TimeHMS' });
+        isolatedDao = IsolatedDAO.create({
+            of: 'foam.nanos.cron.TimeHMS',
+            delegate: dao,
+        });
+
+        isolatedDao.put(TimeHMS.create({ hour: 1 }));
+        test(dao.array.length == 0, "delegate put not called immediately");
+        await isolatedDao.commit();
+        test(dao.array.length != 0, "delegate put called after commit");
+    `
+})

--- a/src/foam/dao/tests.jrl
+++ b/src/foam/dao/tests.jrl
@@ -18,15 +18,15 @@ p({
         const IsolatedDAO = foam.dao.IsolatedDAO;
         const TimeHMS = foam.nanos.cron.TimeHMS;
 
-        const dao = ArrayDAO.create({ of: 'foam.nanos.cron.TimeHMS' });
-        isolatedDao = IsolatedDAO.create({
+        let arrayDAO = ArrayDAO.create({ of: 'foam.nanos.cron.TimeHMS' });
+        dao = IsolatedDAO.create({
             of: 'foam.nanos.cron.TimeHMS',
-            delegate: dao
+            delegate: arrayDAO
         });
 
-        isolatedDao.put(TimeHMS.create({ hour: 1 }));
-        test(dao.array.length == 0, "delegate put not called immediately");
-        await isolatedDao.commit();
-        test(dao.array.length != 0, "delegate put called after commit");
+        dao.put(TimeHMS.create({ hour: 1 }));
+        test(arrayDAO.array.length == 0, "delegate put not called immediately");
+        await dao.cmd(IsolatedDAO.COMMIT);
+        test(arrayDAO.array.length != 0, "delegate put called after commit");
     `
 })


### PR DESCRIPTION
This DAO decorator implements the concept of **Isolation** as seen in [ACID](https://en.wikipedia.org/wiki/ACID) transactions. Objects can be `put` into or `remove`d from this DAO, but the changes won't go into the _real_ DAO until `.commit()` is called.