### PR TITLE
[NP-6321] Allow context return in sequence

### DIFF
--- a/src/foam/u2/crunch/wizardflow/LoadCapabilitiesAgent.js
+++ b/src/foam/u2/crunch/wizardflow/LoadCapabilitiesAgent.js
@@ -42,12 +42,13 @@ foam.CLASS({
 
   methods: [
     // If Property expressions ever unwrap promises this method can be blank.
-    function execute() {
+    async function execute() {
       if ( this.subject ) {
-        return this.crunchService.getCapabilityPathFor(null, this.rootCapability.id, false, this.subject.user, this.subject.realUser)
+        await this.crunchService.getCapabilityPathFor(null, this.rootCapability.id, false, this.subject.user, this.subject.realUser)
           .then(capabilities => this.capabilities = capabilities);
+        return;
       }
-      return this.crunchService.getCapabilityPath(null, this.rootCapability.id, false, true)
+      await this.crunchService.getCapabilityPath(null, this.rootCapability.id, false, true)
         .then(capabilities => this.capabilities = capabilities);
     }
   ]

--- a/src/foam/util/async/Sequence.js
+++ b/src/foam/util/async/Sequence.js
@@ -9,6 +9,13 @@ foam.CLASS({
   name: 'Sequence',
   extends: 'foam.core.Fluent',
 
+  documentation: `
+    Sequence creates and executes ContextAgents in the order specified, passing
+    each ContextAgent's export context to the subsequent ContextAgent.
+    If method execute() of the ContextAgent returns a context explicitly, then
+    this will be used instead of the export context.
+  `,
+
   implements: [
     'foam.core.ContextAgent',
     'foam.mlang.Expressions'

--- a/src/foam/util/async/Sequence.js
+++ b/src/foam/util/async/Sequence.js
@@ -152,7 +152,9 @@ foam.CLASS({
         }
         // Call the context agent and pass its exports to the next one
         return contextAgent.execute().then(
-          () => nextStep(contextAgent.__subContext__));
+          newX => {
+            return nextStep(newX || contextAgent.__subContext__);
+          });
       };
       return nextStep(this.__subContext__)
     },


### PR DESCRIPTION
Currently `Sequence` uses the export context (`__subContext__`) of each ContextAgent as the context of the subsequent ContextAgent. However, if a ContextAgent's `execute()` method explicitly returns a context, this context is not being used instead. This PR makes `Sequence` use explicitly returned contexts before export contexts.