### PR TITLE
set memento on detailPropertyView

### DIFF
--- a/src/foam/u2/DetailPropertyView.js
+++ b/src/foam/u2/DetailPropertyView.js
@@ -18,6 +18,7 @@
 foam.CLASS({
   package: 'foam.u2',
   name: 'DetailPropertyView',
+  mixins: ['foam.nanos.controller.MementoMixin'],
   extends: 'foam.u2.Element',
 
   documentation: 'View for one row/property of a DetailView.',
@@ -55,6 +56,7 @@ foam.CLASS({
 
   methods: [
     function render() {
+      this.initMemento();
       var prop = this.prop;
 
       this.show(


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-6271

fixed the bug that Memento isn't set up  and exported properly in DetailPropertyView.js


<img width="642" alt="Screen Shot 2022-01-25 at 4 49 21 PM" src="https://user-images.githubusercontent.com/33228583/151065475-d7d63db5-dd67-41d2-8cfa-eafe3115c720.png">

<img width="681" alt="Screen Shot 2022-01-25 at 4 49 01 PM" src="https://user-images.githubusercontent.com/33228583/151065425-fd73dc42-f1f1-4923-b34b-fcad9545bb3f.png">

