### PR TITLE
check associatedEntity matches the part of subject being checked in CapabilityAuthService

### DIFF
--- a/src/foam/mlang/predicate/CapabilityAuthServicePredicate.js
+++ b/src/foam/mlang/predicate/CapabilityAuthServicePredicate.js
@@ -30,6 +30,11 @@ foam.CLASS({
     {
       name: 'permission',
       class: 'String'
+    },
+    {
+      name: 'entity',
+      class: 'Enum',
+      of: 'foam.nanos.crunch.AssociatedEntity'
     }
   ],
 
@@ -47,7 +52,7 @@ foam.CLASS({
           UserCapabilityJunction ucj = (UserCapabilityJunction) obj;
           if ( ucj.getStatus() == CapabilityJunctionStatus.GRANTED ) {
             Capability c = (Capability) getCapabilityDAO().find(ucj.getTargetId());
-            if ( c != null && ! c.isDeprecated(x) ) {
+            if ( c != null && c.getAssociatedEntity().equals(getEntity()) && ! c.isDeprecated(x) ) {
               c.setX(x);
               if ( c.grantsPermission(getPermission()) ) {
                return true;

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -29,6 +29,7 @@ foam.CLASS({
     'foam.mlang.predicate.CapabilityAuthServicePredicate',
     'foam.nanos.auth.Subject',
     'foam.nanos.crunch.AgentCapabilityJunction',
+    'foam.nanos.crunch.AssociatedEntity',
     'foam.nanos.crunch.Capability',
     'foam.nanos.crunch.CapabilityIntercept',
     'foam.nanos.crunch.CapabilityJunctionStatus',
@@ -127,13 +128,14 @@ foam.CLASS({
               NOT(HAS(UserCapabilityJunction.EXPIRY)),
               NOT(EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.EXPIRED))
           );
-          Predicate predicate = new CapabilityAuthServicePredicate(x, capabilityDAO, permission);
+          CapabilityAuthServicePredicate predicate = new CapabilityAuthServicePredicate(x, capabilityDAO, permission, null);
 
           // Check if a ucj implies the subject.user(business) has this permission
           Predicate userPredicate = AND(
             EQ(UserCapabilityJunction.SOURCE_ID, user.getId()),
             NOT(INSTANCE_OF(AgentCapabilityJunction.class))
           );
+          predicate.setEntity(AssociatedEntity.USER);
           if ( userCapabilityJunctionDAO.find(AND(userPredicate, capabilityScope, predicate)) != null ) {
             return true;
           }
@@ -144,6 +146,7 @@ foam.CLASS({
               EQ(UserCapabilityJunction.SOURCE_ID, realUser.getId()),
               NOT(INSTANCE_OF(AgentCapabilityJunction.class))
             );
+            predicate.setEntity(AssociatedEntity.REAL_USER);
             if ( userCapabilityJunctionDAO.find(AND(userPredicate, capabilityScope, predicate)) != null ) {
               return true;
             }
@@ -156,6 +159,7 @@ foam.CLASS({
               EQ(AgentCapabilityJunction.EFFECTIVE_USER, user.getId()),
               INSTANCE_OF(AgentCapabilityJunction.class)
             );
+            predicate.setEntity(AssociatedEntity.ACTING_USER);
             if ( userCapabilityJunctionDAO.find(AND(userPredicate, capabilityScope, predicate)) != null ) {
               return true;
             }


### PR DESCRIPTION
in the current menus cleanup there is an issue where when a user switches to a business, they still have access to the menus they have obtained permission for via crunch as a user.
with the old menu setup, there is no issue since user and business have their own navigation root menus which have no overlap in the child menus.

fix - currently Capability.associatedEntity is only being used in assigning the sourceUsers of an ucj, however they should also be used when checking permissions granted via ucj.
i.e., if entity E has capability C which has an AssociatedEntity=USER, the permissions granted by C should only have an effect when subject.USER is E

