### PR TITLE
[NP-6301] Add transient wizard support

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -944,6 +944,7 @@ FOAM_FILES([
   { name: "foam/u2/dialog/SimpleActionDialog" },
   { name: "foam/u2/tag/CircleIndicator" },
   { name: "foam/u2/wizard/agents/ConfigureFlowAgent", flags: ['web'] },
+  { name: "foam/u2/wizard/agents/RootCapabilityAgent", flags: ['web'] },
   { name: "foam/u2/wizard/agents/StepWizardAgent", flags: ['web'] },
   { name: "foam/u2/wizard/agents/SpinnerAgent", flags: ['web'] },
   { name: "foam/u2/wizard/agents/DetachAgent", flags: ['web'] },

--- a/src/foam/nanos/menu/SequenceMenu.js
+++ b/src/foam/nanos/menu/SequenceMenu.js
@@ -19,13 +19,21 @@ foam.CLASS({
       // of: 'foam.util.FluentSpec',
       of: 'foam.core.FObject',
       name: 'sequence'
+    },
+    {
+      class: 'StringArray',
+      name: 'parentMethod'
     }
   ],
 
   methods: [
     function launch(X, menu) {
       // Rebase sequence onto new context first
-      const sequence = this.Sequence.create({}, X);
+      let sequence = this.Sequence.create({}, X);
+      if ( this.parentMethod.length > 0 ) {
+        sequence = X[this.parentMethod[0]]
+          [this.parentMethod[1]](X);
+      }
       for (let fluentSpec of this.sequence) {
         fluentSpec.apply(sequence);
       }

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -180,7 +180,7 @@ foam.CLASS({
       documentation: `
         A transient wizard has disposable CRUNCH payloads and is used for it's side effects.
         To use this sequence, a context agent exporting rootCapabilityId should be inserted
-        before CapabilityAdaptAgent. This capability will be set as the requirement for a
+        before CapabilityAdaptAgent; this capability will be set as the requirement for a
         new BaseCapable object that will be discarded at the end of the sequence.
       `,
       code: function createTransientWizardSequence(x) {

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -175,6 +175,30 @@ foam.CLASS({
           ;
       }
     },
+    {
+      name: 'createTransientWizardSequence',
+      documentation: `
+        A transient wizard has disposable CRUNCH payloads and is used for it's side effects.
+        To use this sequence, a context agent exporting rootCapabilityId should be inserted
+        before CapabilityAdaptAgent. This capability will be set as the requirement for a
+        new BaseCapable object that will be discarded at the end of the sequence.
+      `,
+      code: function createTransientWizardSequence(x) {
+        const capable = foam.nanos.crunch.lite.BaseCapable.create();
+        x = x || this.__subContext__;
+        x = x.createSubContext({ capable });
+        return this.createWizardSequence('no-capability-id', x)
+          .reconfigure('WAOSettingAgent', {
+            waoSetting: this.WAOSettingAgent.WAOSetting.CAPABLE })
+          .remove('SkipGrantedAgent')
+          .remove('CheckRootIdAgent')
+          .remove('CheckPendingAgent')
+          .remove('CheckNoDataAgent')
+          .addBefore('RequirementsPreviewAgent',this.ShowPreexistingAgent)
+          .add(this.MaybeDAOPutAgent)
+          ;
+      }
+    },
 
     function wizardSequenceToViewSequence_(sequence) {
       return sequence

--- a/src/foam/u2/wizard/agents/RootCapabilityAgent.js
+++ b/src/foam/u2/wizard/agents/RootCapabilityAgent.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.wizard.agents',
+  name: 'RootCapabilityAgent',
+  implements: [ 'foam.core.ContextAgent' ],
+
+  documentation: `
+    Set the root capability ID in context to a specific value.
+  `,
+
+  exports: [
+    'rootCapability'
+  ],
+
+  properties: [
+    {
+      name: 'rootCapability',
+      class: 'String'
+    }
+  ],
+
+  methods: [
+    async function execute() {
+    }
+  ]
+});


### PR DESCRIPTION
- Allow SequenceMenu to specify `['crunchController', 'someMethod']` as a sequence to start from
- Add `createTransientWizardSequence` for transient CRUNCH wizards
- Add `RootCapabilityAgent` to allow setting root capability ID from a SequenceMenu