### PR TITLE
Fix bug causing browser to crash when viewing detailView from menuDAO

### DIFF
--- a/src/foam/nanos/menu/Menu.js
+++ b/src/foam/nanos/menu/Menu.js
@@ -133,7 +133,9 @@
     {
       class: 'foam.u2.ViewSpec',
       name: 'view',
-      factory: function() { return { class: 'foam.u2.view.MenuView' }; }
+      value: function(args, X) {
+        return { class: 'foam.u2.view.MenuView', data: this };
+      }
     }
   ],
 

--- a/src/foam/nanos/menu/Menu.js
+++ b/src/foam/nanos/menu/Menu.js
@@ -133,7 +133,7 @@
     {
       class: 'foam.u2.ViewSpec',
       name: 'view',
-      factory: function() { return { class: 'foam.u2.view.MenuView', menu: this }; }
+      factory: function() { return { class: 'foam.u2.view.MenuView' }; }
     }
   ],
 

--- a/src/foam/u2/view/MenuView.js
+++ b/src/foam/u2/view/MenuView.js
@@ -15,25 +15,24 @@ foam.CLASS({
   ],
 
   properties: [
-    'menu',
     {
       name: 'label',
-      factory: function() { return this.menu.label || ''; }
+      factory: function() { return this.data.label || ''; }
     },
     {
       name: 'icon',
-      factory: function() { return this.menu.icon; }
+      factory: function() { return this.data.icon; }
     },
     {
       name: 'themeIcon',
-      factory: function() { return this.menu.themeIcon; }
+      factory: function() { return this.data.themeIcon; }
     }
   ],
 
   listeners: [
     function click(evt) {
       this.SUPER(evt);
-      this.menu.launch_(this.__subContext__, this);
+      this.data.launch_(this.__subContext__, this);
       if ( this.parentMenuDropdown ) this.parentMenuDropdown.close();
       return;
     }


### PR DESCRIPTION
Problem was not with the `menu: this` but rather with the fact that it was a factory for ViewSpec instead of value. We need to explicitly add `data:this` as the context is the parent u2 element not the menu since most menus(like actions) are added to an element as direct objects instead of views ie `this.tag(this.users)` where users is the menuObject itself