### PR TITLE
Fix web build when script has no hashbang

### DIFF
--- a/src/foam/nanos/http/LiveScriptBundler.java
+++ b/src/foam/nanos/http/LiveScriptBundler.java
@@ -153,7 +153,7 @@ public class LiveScriptBundler
     try {
       log_("START", "Building javascript... (JS)");
 
-      Process        p  = new ProcessBuilder(JS_BUILD_PATH).start();
+      Process        p  = new ProcessBuilder("node", JS_BUILD_PATH).start();
       BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
       String         line;
       while ( (line = br.readLine()) != null ) {


### PR DESCRIPTION
Changes `liveScriptBundler` service to call `node` instead of the script directly, so that the script can work even if it has no
```
#!/usr/bin/env node
```
at the top