### PR TITLE
[NP-6563] Fix FObjectSpec view

### DIFF
--- a/src/foam/util/FluentSpec.js
+++ b/src/foam/util/FluentSpec.js
@@ -26,7 +26,8 @@ foam.CLASS({
       return foam.String.isInstance(spec) ? { class: spec } : spec ;
     } ],
     [ 'javaJSONParser', 'foam.lib.json.UnknownFObjectParser.instance()' ],
-    [ 'displayWidth', 80 ]
+    [ 'displayWidth', 80 ],
+    [ 'view', 'foam.u2.view.MapView' ]
   ]
 });
 


### PR DESCRIPTION
FluentSpec, currently used for defining a Sequence in a journal, uses FObjectSpec. FObjectSpec was not using MapView, so the detail view (intended for FObjects) was overwriting FObjectSpec values with actual instances in cached objects as a result of slot feedback.