### PR TITLE
Add IdentifiedStringHolder

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -849,6 +849,7 @@ FOAM_FILES([
   { name: "foam/test/AllSerializableProperties", flags: [ "java" ] },
   { name: "foam/test/TestEnum", flags: [ "java" ] },
   { name: "foam/test/TestObj", flags: [ "java" ] },
+  { name: "foam/test/IdentifiedStringHolder", flags: [ "java" ] },
   { name: "foam/core/FObjectTest", flags: [ "java" ] },
   { name: "foam/flow/Document", flags: [ "java" ] },
   { name: "foam/flow/DocumentMenu", flags: [ "java" ] },

--- a/src/foam/core/holders.js
+++ b/src/foam/core/holders.js
@@ -30,27 +30,6 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.core',
-  name: 'IdentifiedStringHolder',
-
-  documentation: `
-    Like StringHolder but can be put into a DAO. This is useful for convenient
-    testing by creating a stringHolderDAO in development deployment journals.
-  `,
-
-  properties: [
-    {
-      name: 'id',
-      class: 'String'
-    },
-    {
-      name: 'value',
-      class: 'String'
-    }
-  ]
-});
-
-foam.CLASS({
-  package: 'foam.core',
   name: 'BooleanHolder',
 
   properties: [

--- a/src/foam/core/holders.js
+++ b/src/foam/core/holders.js
@@ -32,6 +32,11 @@ foam.CLASS({
   package: 'foam.core',
   name: 'IdentifiedStringHolder',
 
+  documentation: `
+    Like StringHolder but can be put into a DAO. This is useful for convenient
+    testing by creating a stringHolderDAO in development deployment journals.
+  `,
+
   properties: [
     {
       name: 'id',

--- a/src/foam/core/holders.js
+++ b/src/foam/core/holders.js
@@ -30,6 +30,22 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.core',
+  name: 'IdentifiedStringHolder',
+
+  properties: [
+    {
+      name: 'id',
+      class: 'String'
+    },
+    {
+      name: 'value',
+      class: 'String'
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.core',
   name: 'BooleanHolder',
 
   properties: [

--- a/src/foam/test/IdentifiedStringHolder.js
+++ b/src/foam/test/IdentifiedStringHolder.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.test',
+  name: 'IdentifiedStringHolder',
+
+  documentation: `
+    Like StringHolder but can be put into a DAO. This is useful for convenient
+    testing by creating a stringHolderDAO in development deployment journals.
+
+    If this is ever deemed useful outside of testing it could be moved to exist
+    in the same package as StringHolder.
+  `,
+
+  properties: [
+    {
+      name: 'id',
+      class: 'String'
+    },
+    {
+      name: 'value',
+      class: 'String'
+    }
+  ]
+});


### PR DESCRIPTION
This is so the `wizard-testing` deployment journals can create a `stringHolderDAO` service for convenient testing