### PR TITLE
[NP-6341] Add wizard fixes for custom views

### DIFF
--- a/src/foam/u2/wizard/WizardletSection.js
+++ b/src/foam/u2/wizard/WizardletSection.js
@@ -42,7 +42,10 @@ foam.CLASS({
       of: 'foam.u2.wizard.Wizardlet',
       documentation: `
         This is a reference to the aggregating wizardlet.
-      `
+      `,
+      cloneProperty: function (v, m) {
+        m[this.name] = v;
+      }
     },
     {
       name: 'data',
@@ -114,7 +117,7 @@ foam.CLASS({
 
       if ( this.customView ) {
         return this.ViewSpec.createView(
-          this.customView, null, this, ctx);
+          this.customView, { data$: this.wizardlet.data$ }, this, ctx);
       }
 
 


### PR DESCRIPTION
- Provides `data` to custom wizardlet views 
  - This previously wasn't an issue because subclassing wizardlets do this slotting in their sections factories, but journal-configured sections require this slotting to happen here
- Prevents deep cloning of `WizardletSection.wizardlet` (recursive property)