### PR TITLE
Added in opt-in for FObjectHolder

### DIFF
--- a/src/foam/u2/wizard/PrerequisiteWAO.js
+++ b/src/foam/u2/wizard/PrerequisiteWAO.js
@@ -33,6 +33,10 @@
         OPTIONAL: For grabbing only a specific property from the CapabilityJunction's data
       `,
       name: 'propertyName'
+    },
+    {
+      class: 'Boolean',
+      name: 'isWrappedInFObjectHolder'
     }
   ],
 
@@ -75,13 +79,20 @@
         clonedPrereqWizardletData = prereqWizardletData.clone();
       }
 
-      const fObjectHolder = this.FObjectHolder.create({ fobject: clonedPrereqWizardletData });
+      if ( this.isWrappedInFObjectHolder ){
+        const fObjectHolder = this.FObjectHolder.create({ fobject: clonedPrereqWizardletData });
 
-      wizardlet.data = fObjectHolder;
+        wizardlet.data = fObjectHolder;
 
+        wizardlet.isLoaded = true;
+
+        return fObjectHolder;
+      }
+
+      wizardlet.data = clonedPrereqWizardletData;
       wizardlet.isLoaded = true;
 
-      return fObjectHolder;
+      return clonedPrereqWizardletData;
     }
   ]
 });

--- a/src/foam/u2/wizard/XORMinMaxWAO.js
+++ b/src/foam/u2/wizard/XORMinMaxWAO.js
@@ -25,6 +25,10 @@
     {
       class: 'String',
       name: 'minMaxCapabilityId',
+    },
+    {
+      class: 'Boolean',
+      name: 'isWrappedInFObjectHolder'
     }
   ],
 
@@ -67,13 +71,20 @@
 
       const clonedWizardletData = selectedCapabilityWizardlet.data.clone();
 
-      const fObjectHolder = this.FObjectHolder.create({ fobject: clonedWizardletData });
+      if ( this.isWrappedInFObjectHolder ){
+        const fObjectHolder = this.FObjectHolder.create({ fobject: clonedWizardletData });
 
-      wizardlet.data = fObjectHolder;
+        wizardlet.data = fObjectHolder;
+  
+        wizardlet.isLoaded = true;
+  
+        return fObjectHolder;
+      }
 
+      wizardlet.data = clonedWizardletData;
       wizardlet.isLoaded = true;
 
-      return fObjectHolder
+      return clonedWizardletData;
     }
   ]
 });


### PR DESCRIPTION
Allows us to specify a specific 'of' on capabilities which use the prereqWAO and xorminmaxWAO in the case that there can only be one specific class type thats loaded from prereqs.