### PR TITLE
Np 6617/fix anonymous flow

### DIFF
--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -437,10 +437,9 @@ foam.CLASS({
 
         Session session = x.get(Session.class);
         ServiceProvider serviceProvider = (ServiceProvider) dao.find((String) x.get("spid"));
-        if ( serviceProvider == null ) {
-          throw new AuthorizationException("Service Provider doesn't exist.");
-        }
-        if ( serviceProvider.getAnonymousUser() == 0 || 
+
+        if ( serviceProvider == null ||
+             serviceProvider.getAnonymousUser() == 0 || 
              session == null || session.getUserId() == 0 ||
              session.getUserId() != serviceProvider.getAnonymousUser() )
              return false;

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -431,8 +431,12 @@ foam.CLASS({
         Returns true if session user matches the anonymus user of the current spid.
       `,
       javaCode: `
+        DAO dao = x.get("localServiceProviderDAO") == null ? (DAO) getX().get("localServiceProviderDAO") : (DAO) x.get("localServiceProviderDAO");
+        if ( dao == null )
+          throw new NullPointerException("Cannot find localServiceProviderDAO");
+
         Session session = x.get(Session.class);
-        ServiceProvider serviceProvider = (ServiceProvider) ((DAO) x.get("localServiceProviderDAO")).find((String) x.get("spid"));
+        ServiceProvider serviceProvider = (ServiceProvider) dao.find((String) x.get("spid"));
         if ( serviceProvider == null ) {
           throw new AuthorizationException("Service Provider doesn't exist.");
         }

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -247,7 +247,7 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
 
     Session session = x.get(Session.class);
     if ( cache && session != null ) {
-      session.setContext(session.getContext().put(CACHE_KEY, map));
+      session.setApplyContext(session.getContext().put(CACHE_KEY, map));
     }
 
     return map;
@@ -279,14 +279,14 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
     Map<String, List<String>> cache = (Map) session.getContext().get(CACHE_KEY);
     cache.put(ccj.getSourceId(), getPrereqs_(x.put("subject", subject), ccj.getSourceId()));
 
-    session.setContext(session.getContext().put(CACHE_KEY, cache));
+    session.setApplyContext(session.getContext().put(CACHE_KEY, cache));
   }
 
   // sets the prerequisite cache to null, is used when session info changes
   public static void purgeCache(X x) {
     Session session = x.get(Session.class);
     if ( session != null ){
-      session.setContext(session.getContext().put(CACHE_KEY, null));
+      session.setApplyContext(session.getContext().put(CACHE_KEY, null));
     }
   }
 

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -356,8 +356,8 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         // and set the wasAnonymous boolean accordingly
         boolean wasAnonymous = false;
         if ( subjectUser != null ) {
-          X oldX = (X) foam.util.Auth.sudo(x, subjectUser, subjectAgent);
-          wasAnonymous = auth.isAnonymous(oldX);
+          ServiceProvider sp = (ServiceProvider) subjectUser.findSpid(x);
+          wasAnonymous = sp != null && sp.getAnonymousUser() == subjectUser.getId();
         }
 
         rtn = new OrX(reset(x));

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -383,7 +383,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         rtn = ! wasAnonymous ? rtn
           .put("twoFactorSuccess", getContext().get("twoFactorSuccess"))
           .put(ServerCrunchService.CACHE_KEY, getContext().get(ServerCrunchService.CACHE_KEY))
-          : rtn;
+          : rtn.put(ServerCrunchService.CACHE_KEY, null);
 
         // We need to do this after the user and agent have been put since
         // 'getCurrentGroup' depends on them being in the context.


### PR DESCRIPTION
fixes:
- anonymous rateshoppping flow: upon logging in the user, we still use the prerequisitejunction cache initialized for the anonymous user
- when setting prerequisitecache, use session.applycontext instead of session.context since the session will use applycontext to set the session context in later calls to the server