### PR TITLE
remove rasterLogo

### DIFF
--- a/src/foam/nanos/notification/email/ApplyBaseArgumentsEmailPropertyService.js
+++ b/src/foam/nanos/notification/email/ApplyBaseArgumentsEmailPropertyService.js
@@ -92,9 +92,7 @@
 
         String url = appConfig.getUrl().replaceAll("/$", "");
         templateArgs.put("logo", url + "/" + theme.getLogo());
-        templateArgs.put("rasterLogo", url + "/" + theme.getRasterLogo());
         templateArgs.put("largeLogo", url + "/" + theme.getLargeLogo());
-        templateArgs.put("largeRasterLogo", url + "/" + theme.getLargeRasterLogo());
         templateArgs.put("appLink", url);
         templateArgs.put("appName", theme.getAppName());
         templateArgs.put("locale", user.getLanguage().getCode().toString());

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -220,44 +220,8 @@ foam.CLASS({
     },
     {
       class: 'Image',
-      name: 'rasterLogo',
-      documentation: 'A raster logo to display in the application. Use when svg is not supported',
-      displayWidth: 60,
-      view: {
-        class: 'foam.u2.MultiView',
-        views: [
-          {
-            class: 'foam.u2.tag.TextArea',
-            rows: 4, cols: 80
-          },
-          { class: 'foam.u2.view.ImageView' },
-        ]
-      },
-      section: 'images',
-      writePermissionRequired: true
-    },
-    {
-      class: 'Image',
       name: 'largeLogo',
       documentation: 'A large logo to display in the application.',
-      displayWidth: 60,
-      view: {
-        class: 'foam.u2.MultiView',
-        views: [
-          {
-            class: 'foam.u2.tag.TextArea',
-            rows: 4, cols: 80
-          },
-          { class: 'foam.u2.view.ImageView' },
-        ]
-      },
-      section: 'images',
-      writePermissionRequired: true
-    },
-    {
-      class: 'Image',
-      name: 'largeRasterLogo',
-      documentation: 'A large raster logo to display in the application. Use when svg is not supported.',
       displayWidth: 60,
       view: {
         class: 'foam.u2.MultiView',

--- a/src/foam/nanos/theme/themes.jrl
+++ b/src/foam/nanos/theme/themes.jrl
@@ -6,7 +6,6 @@ p({
   "description":"The default FOAM theme.",
   "defaultMenu":"admin.nspec",
   "logo":"images/foam_red.png",
-  "rasterLogo":"images/foam_red.png",
   "font1":"Arial",
   "primaryColor":"#1e1f21",
   "secondaryColor":"#406dea",


### PR DESCRIPTION
nanopay : https://github.com/nanoPayinc/NANOPAY/pull/14281

https://nanopay.atlassian.net/browse/NP-6536

Removed unnecessary rasterLogo, largeRasterLogo being used only for non .svg images as the converter in imageServlet supported.


<img width="840" alt="Screen Shot 2022-03-01 at 2 51 57 PM" src="https://user-images.githubusercontent.com/33228583/156249736-e64546a0-20a2-4abe-8605-d7f89ed44f49.png">

