### PR TITLE
Remove id check from AuthorizeOnCreate in Notification

### DIFF
--- a/src/foam/nanos/notification/Notification.js
+++ b/src/foam/nanos/notification/Notification.js
@@ -263,14 +263,14 @@ foam.CLASS({
       name: 'authorizeOnCreate',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("create")) && ! getTransient() ) throw new AuthorizationException("You don't have permission to create this notification.");
+      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("create", true)) && ! getTransient() ) throw new AuthorizationException("You don't have permission to create this notification.");
       `
     },
     {
       name: 'authorizeOnUpdate',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("update")) && ! getTransient() ) throw new AuthorizationException("You don't have permission to update notifications you do not own.");
+      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("update", false)) && ! getTransient() ) throw new AuthorizationException("You don't have permission to update notifications you do not own.");
       `
     },
     {
@@ -284,17 +284,18 @@ foam.CLASS({
       name: 'authorizeOnRead',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("read")) ) throw new AuthorizationException("You don't have permission to read notifications you do not own.");
+      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("read", false)) ) throw new AuthorizationException("You don't have permission to read notifications you do not own.");
       `
     },
     {
       name: 'createPermission',
       args: [
-        { name: 'operation', type: 'String' }
+        { name: 'operation', type: 'String' },
+        { name: 'skipId', type: 'Boolean' }
       ],
       type: 'String',
       javaCode: `
-        return "notification." + operation + "." + getId();
+        return skipId ? "notification." + operation : "notification." + operation + "." + getId();
       `
     }
   ],


### PR DESCRIPTION
Proper implementation for https://github.com/kgrgreer/foam3/pull/1480

Brings Notification Authorizer in line with standardAuthorizer and adds ability for users to create their own notification