### PR TITLE
[NP-6341] Add Slot.or

### DIFF
--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -20,7 +20,7 @@ foam.CLASS({
   name: 'Slot', // ???: Rename AbstractSlot or make an Interface
 
   requires: [
-    'foam.core.internal.AOrB',
+    'foam.core.internal.Or',
     'foam.core.internal.SubSlot'
   ],
 
@@ -165,7 +165,7 @@ foam.CLASS({
     },
 
     function or(other) {
-      return this.AOrB.create({ a$: this, b$: other }).output$;
+      return this.Or.create({ a$: this, b$: other }).output$;
     },
 
     /**
@@ -367,7 +367,7 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.core.internal',
-  name: 'AOrB',
+  name: 'Or',
 
   properties: [
     'a',

--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -20,6 +20,7 @@ foam.CLASS({
   name: 'Slot', // ???: Rename AbstractSlot or make an Interface
 
   requires: [
+    'foam.core.internal.AOrB',
     'foam.core.internal.SubSlot'
   ],
 
@@ -161,6 +162,10 @@ foam.CLASS({
       };
       l();
       return other.sub(l);
+    },
+
+    function or(other) {
+      return this.AOrB.create({ a$: this, b$: other }).output$;
     },
 
     /**
@@ -355,6 +360,23 @@ foam.CLASS({
     function valueChange() {
       var parentValue = this.parent.get();
       this.value = parentValue ? parentValue[this.name] : undefined;
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.internal',
+  name: 'AOrB',
+
+  properties: [
+    'a',
+    'b',
+    {
+      name: 'output',
+      expression: function (a, b) {
+        return a || b;
+      }
     }
   ]
 });


### PR DESCRIPTION
Slot.or allows following a number of slots to get the first truthy value.

```javascript
test = foam.nanos.cron.TimeHMS.create();
test.hour$.or(test.minute$).sub(s => console.log(s.src.get()))

test.minute = 3; // outputs '3'
test.hour = 2; // outputs '2'
test.hour = 0; // outputs '3'
```