### PR TITLE
[NP-6341] Fix lifted data selection

### DIFF
--- a/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
@@ -225,16 +225,6 @@ foam.CLASS({
       };
       this.choiceWizardlets.push(wizardlet);
 
-      // Auto-select lifted capabilities if they're available to start with
-      if ( meta.lifted && wizardlet.isAvailable ) {
-        this.selectedData = [...( this.selectedData || [] ), wizardlet.capability];
-
-        // Hide choice selection if maximum is reached by capability lifting
-        if ( this.selectedData.length >= this.max ) {
-          this.isVisible = false;
-        }
-      }
-
       // isAvailable defaults to false if this MinMax is in control of the
       //   prerequisite wizardlet
       if ( ! meta.lifted ) wizardlet.isAvailable = false;
@@ -243,10 +233,20 @@ foam.CLASS({
     },
     function handleLifting(liftedWizardlets) {
       const updated = () => {
+        // Hide choice selection if lifted choices reach maximum
         const countLifted = liftedWizardlets
           .map(w => w.isAvailable ? 1 : 0)
           .reduce((count, val) => count + val);
         this.isVisible = countLifted < this.max && this.isAvailable;
+      
+
+        // Update lifted choices based on their availability
+        let newSelectedData = [...this.selectedData];
+        for ( const w of liftedWizardlets ) {
+          if ( w.isAvailable ) newSelectedData.push(w.capability);
+          else foam.Array.remove(newSelectedData, w.capability);
+        }
+        this.selectedData = foam.Array.unique(newSelectedData);
       }
       const slots = liftedWizardlets.map(w => w.isAvailable$);
       this.ArraySlot.create({ slots }).sub(updated);


### PR DESCRIPTION
Fixes population of MinMax's `selectedData` property so that lifted selections work with prerequisite-fetching WAOs (XORMinMaxWAO)