### PR TITLE
[NP-6740] Cleanup Popup and add showActions

### DIFF
--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -20,6 +20,7 @@ foam.CLASS({
   name: 'Slot', // ???: Rename AbstractSlot or make an Interface
 
   requires: [
+    'foam.core.internal.And',
     'foam.core.internal.Or',
     'foam.core.internal.SubSlot'
   ],
@@ -162,6 +163,10 @@ foam.CLASS({
       };
       l();
       return other.sub(l);
+    },
+
+    function and(other) {
+      return this.And.create({ a$: this, b$: other }).output$;
     },
 
     function or(other) {
@@ -376,6 +381,23 @@ foam.CLASS({
       name: 'output',
       expression: function (a, b) {
         return a || b;
+      }
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.internal',
+  name: 'And',
+
+  properties: [
+    'a',
+    'b',
+    {
+      name: 'output',
+      expression: function (a, b) {
+        return a && b;
       }
     }
   ]

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -2089,9 +2089,6 @@ foam.CLASS({
 
     function addEventListener_(topic, listener, opt_args) {
       var el = this.el_();
-      if ( topic == 'keydown' ) {
-        console.log('KEYDOWN LIST', { el, listener, opt_args })
-      }
       el && el.addEventListener(topic, listener, opt_args || false);
     },
 

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -2089,6 +2089,9 @@ foam.CLASS({
 
     function addEventListener_(topic, listener, opt_args) {
       var el = this.el_();
+      if ( topic == 'keydown' ) {
+        console.log('KEYDOWN LIST', { el, listener, opt_args })
+      }
       el && el.addEventListener(topic, listener, opt_args || false);
     },
 

--- a/src/foam/u2/dialog/Popup.js
+++ b/src/foam/u2/dialog/Popup.js
@@ -99,19 +99,35 @@ foam.CLASS({
   properties: [
     [ 'backgroundColor', '#fff' ],
     {
-      name: 'closeable',
       class: 'Boolean',
+      name: 'closeable',
       value: true
     },
-    'onClose',
     {
+      name: 'onClose',
+      deprecated: true,
+      documentation: `
+        Sets a listener for when the popup is closed.
+        This property is deprecated. Subscribe to 'action.closeModal' instead.
+      `,
+      setter: function (_, n) {
+        this.onDetach(this.sub('action', 'closeModal', n));
+      }
+    },
+    {
+      class: 'Boolean',
       name: 'isStyled',
       value: true,
       documentation: 'Can be used to turn off all styling for modal container'
     },
     {
-      name: 'fullscreen',
       class: 'Boolean',
+      name: 'fullscreen',
+      value: true
+    },
+    {
+      class: 'Boolean',
+      name: 'showActions',
       value: true
     }
   ],
@@ -123,7 +139,6 @@ foam.CLASS({
 
       this.addClass()
         .enableClass(this.myClass('fullscreen'), this.fullscreen$)
-        .on('keydown', this.onKeyDown)
         .start()
           .addClass(this.myClass('background'))
           .on('click', this.closeable ? this.close : null)
@@ -133,7 +148,8 @@ foam.CLASS({
           .enableClass(this.myClass('inner'), this.isStyled$)
           .style({ 'background-color': this.isStyled ? this.backgroundColor : ''})
           .startContext({ data: this })
-            .start(this.CLOSE_MODAL, { buttonStyle: 'TERTIARY' }).show(this.closeable$)
+            .start(this.CLOSE_MODAL, { buttonStyle: 'TERTIARY', label: '' })
+              .show(this.closeable$.and(this.showActions$))
               .addClass(this.myClass('X'))
             .end()
           .endContext()
@@ -150,13 +166,7 @@ foam.CLASS({
 
   listeners: [
     function close() {
-      if ( this.onClose ) this.onClose();
       this.remove();
-    },
-
-    function onKeyDown(e) {
-      var isEsc = (e.key === 'Escape' || e.keyCode === 27); // 27 is the keyCode for escape keys, keyCode is mainly for older browser support
-      if ( isEsc ) { this.close(); }
     }
   ],
 
@@ -164,10 +174,13 @@ foam.CLASS({
     {
       name: 'closeModal',
       icon: 'images/ic-cancelblack.svg',
-      label: '',
-      code: function(X) {
-        this.close();
-      }
+      label: 'X',
+      keyboardShortcuts: [ 27 /* Escape */ ],
+      code: () => {}
     }
+  ],
+
+  reactions: [
+    ['', 'action.closeModal', 'close']
   ]
 });


### PR DESCRIPTION
This PR makes the following changes

- Add `showActions` property to Popup
- Mark `onClose` property as deprecated, preferring a topic listener
- Replace manual implementation of a reaction with a reaction axiom
- Replace manual implementation of a keyboard shortcut with the proper configuration on an Action