### PR TITLE
[NP-6782] Fix next button inconsistency

### DIFF
--- a/src/foam/u2/wizard/StepWizardController.js
+++ b/src/foam/u2/wizard/StepWizardController.js
@@ -287,8 +287,9 @@ foam.CLASS({
       // If it exists, load the next wizardlet
       // TODO: Just load next wizardlet instead of loading all in the beginning
       var start = this.wizardPosition.wizardletIndex;
-      var end = this.nextScreen ?
-        this.nextScreen.wizardletIndex : this.wizardlets.length;
+      const nextScreen = this.nextAvailable(this.wizardPosition, this.positionAfter.bind(this));
+      var end = nextScreen ?
+        nextScreen.wizardletIndex : this.wizardlets.length;
       var p = Promise.resolve();
       for ( let i = start ; i < end ; i++ ) {
         if ( ! this.wizardlets[i].isAvailable ) continue;
@@ -300,7 +301,7 @@ foam.CLASS({
           this.submitted = true;
           return true;
         }
-        this.wizardPosition = this.nextScreen;
+        this.wizardPosition = nextScreen;
         return false;
       });
     },


### PR DESCRIPTION
We managed to create a situation where the wizard's next button lands on a wizardlet that shouldn't. This was caused by a deep tree of MinMax wizardlets and `isVisible` having the wrong value for a choice at just the right time.

This PR fixes the issue by always re-calculating the next screen when you click next, instead of trusting the expression that gets invalidated on wizard position.

Future work on migrating incremental-wizard-specific logic from StepWizardController into a separate controller will help simplify this logic.