### PR TITLE
Restrict file update unless lifecycleState changed

### DIFF
--- a/src/foam/nanos/fs/FileUpdateDecorator.js
+++ b/src/foam/nanos/fs/FileUpdateDecorator.js
@@ -10,7 +10,8 @@ foam.CLASS({
   extends: 'foam.dao.ProxyDAO',
 
   javaImports: [
-    'foam.core.FObject'
+    'foam.core.FObject',
+    'foam.nanos.fs.File'
   ],
 
   methods: [
@@ -19,9 +20,11 @@ foam.CLASS({
       javaCode: `
         Object id = obj.getProperty("id");
         FObject oldObj = getDelegate().find(id);
-        boolean isCreate = id == null || oldObj == null;
-
-        if ( ! isCreate ) return obj;
+        
+        // Restrict file update unless lifecycleState changed
+        if ( oldObj != null && File.LIFECYCLE_STATE.compare(obj, oldObj) == 0 ) {
+          return obj;
+        }
 
         return getDelegate().put_(x, obj);
       `

--- a/src/foam/nanos/fs/FileUpdateDecorator.js
+++ b/src/foam/nanos/fs/FileUpdateDecorator.js
@@ -18,15 +18,18 @@ foam.CLASS({
     {
       name: 'put_',
       javaCode: `
-        Object id = obj.getProperty("id");
-        FObject oldObj = getDelegate().find(id);
-        
-        // Restrict file update unless lifecycleState changed
-        if ( oldObj != null && File.LIFECYCLE_STATE.compare(obj, oldObj) == 0 ) {
-          return obj;
+        var oldObj = getDelegate().find_(x, obj);
+        if ( null == oldObj )
+          return getDelegate().put_(x, obj);
         }
 
-        return getDelegate().put_(x, obj);
+        // Restrict file update unless for lifecycleState change
+        if ( File.LIFECYCLE_STATE.compare(obj, oldObj) == 0 ) return obj;
+
+        // Only update file lifecycleState
+        var file = (File) oldObj.fclone();
+        file.setLifecycleState((LifecycleState) File.LIFECYCLE_STATE.get(obj));
+        return getDelegate().put_(x, file);
       `
     }
   ]


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-6834

## Issues
- FileUpdateDecorator.js:24 is blocking file delete, LifecycleAwareDAO turns remove_ into put_ but FileUpdateDecorator prevents updating - https://github.com/kgrgreer/foam3/pull/1067/files

## Changes
- Restrict file update unless lifecycleState changed