### PR TITLE
[NP-6891] Fix Eq.toString (but I wonder why it does this)

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -774,8 +774,8 @@ foam.CLASS({
       name: 'toString',
       code: function() {
         return foam.String.constantize(this.cls_.name) + '(' +
-            this.arg1 && this.arg1.toString() || 'NA' + ', ' +
-            this.arg2 && this.arg2.toString() || 'NA' + ')';
+            (this.arg1 && this.arg1.toString() || 'NA') + ', ' +
+            (this.arg2 && this.arg2.toString() || 'NA') + ')';
       },
       javaCode: `
         String arg1 = getArg1() != null ? getArg1().toString() : "NA";


### PR DESCRIPTION
Previous expression was printing `arg1` but not `arg2`. For some reason, having the same output for `toString()` on two different mlangs prevents the next DAO call from reaching the server.