### PR TITLE
add Expired as ticket status, show created for id

### DIFF
--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -67,7 +67,9 @@ foam.CLASS({
     'lastModified',
     'status',
     'title',
-    'comment'
+    'comment',
+    'dateCommented',
+    'createdFor'
   ],
 
   messages: [
@@ -237,6 +239,26 @@ foam.CLASS({
           }.bind(this));
       },
       order: 9
+    },
+    {
+      class: 'String',
+      name: 'dateCommented',
+      value: '',
+      storageTransient: true,
+      section: 'infoSection',
+      tableCellFormatter: function(_, obj) {
+        obj.ticketCommentDAO
+          .where(obj.EQ(foam.nanos.ticket.TicketComment.TICKET, obj.id))
+          .orderBy(obj.DESC(foam.nanos.ticket.TicketComment.CREATED))
+          .limit(1)
+          .select(obj.PROJECTION(foam.nanos.ticket.TicketComment.CREATED))
+          .then(function(comment) {
+            if ( comment ) {
+              this.add(comment.projection);
+            }
+          }.bind(this));
+      },
+      order: 10
     },
     {
       class: 'DateTime',

--- a/src/foam/nanos/ticket/ticketStatuses.jrl
+++ b/src/foam/nanos/ticket/ticketStatuses.jrl
@@ -7,6 +7,13 @@ p({
 
 p({
   "class":"foam.nanos.ticket.TicketStatus",
+  "id":"EXPIRED",
+  "label":"Expired",
+  "ordinal":95
+})
+
+p({
+  "class":"foam.nanos.ticket.TicketStatus",
   "id":"CLOSED",
   "label":"Closed",
   "ordinal":99


### PR DESCRIPTION
Should go to `Release-v3.17`
* add `dateCommented` property to show the time of ticket's last comment 
* add `EXPIRED` as a ticket status
* show `createdFor` user id in table view, note that we cannot filter by created for id, because `createdFor` is a reference to `User`