### PR TITLE
NP-6731 medusa replay bug

### DIFF
--- a/src/foam/nanos/medusa/RetryClientSinkDAO.js
+++ b/src/foam/nanos/medusa/RetryClientSinkDAO.js
@@ -163,7 +163,8 @@ foam.CLASS({
           } catch ( Throwable t ) {
             getLogger().warning("submit", t.getMessage());
             ReplayingInfo replaying = (ReplayingInfo) x.get("replayingInfo");
-            if ( replaying != null &&
+            if ( isMediator(x) &&
+                 replaying != null &&
                  replaying.getIndex() > ((MedusaEntry) obj).getIndex() ) {
               // This entry has been saved quorum times, no need to retry.
               return obj;
@@ -238,6 +239,18 @@ foam.CLASS({
     {
       name: 'reset',
       javaCode: `//nop`
+    },
+    {
+      name: 'isMediator',
+      args: 'Context x',
+      type: 'boolean',
+      javaCode:`
+        ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+        if ( support == null ) return false;
+        ClusterConfig myConfig = support.getConfig(x, support.getConfigId());
+        if ( myConfig == null ) return false;
+        return myConfig.getType() == MedusaType.MEDIATOR ? true : false;
+      `
     }
   ]
 });


### PR DESCRIPTION
There are two factors which can cause this issue:
1. the largest index in the node is transient entry
2. tcp connection fails during the replaying, which cause a medusaEntry not send.
Solve:
1. always send entries in the cache during the replay process.
2. set maximumRetryAttempts in SetNodeSink to 2, which allow node to be able to send entry once after connection re-establish.