### PR TITLE
EasyDAO - nSpec javaPostSet

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -119,7 +119,8 @@ foam.CLASS({
     {
       name: 'nSpec',
       class: 'FObjectProperty',
-      type: 'foam.nanos.boot.NSpec'
+      type: 'foam.nanos.boot.NSpec',
+      javaPostSet: 'setName(val.getName());'
     },
     {
       documentation: 'Hold Last usuable dao in decorator chain. For example, an MDAO wrapped in FixedSizeDAO should always go through the FixedSizeDAO and not update the MDAO directly.',


### PR DESCRIPTION
On set of nspec, update the 'name' property. The name property accessor
may have been called before nspec is set, resulting in name defaulting
to model 'of' rather than the intended nspec name.
Occurs during test cases.