### PR TITLE
Fix MinMax.isAvailable slotting to MultiChoiceView

### DIFF
--- a/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardletSection.js
+++ b/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardletSection.js
@@ -44,7 +44,7 @@ foam.CLASS({
           );
     
           this.choiceWizardlets.forEach((choiceWizardlet) => {
-            choiceWizardlet.isAvailable$ = vs.getSelectedSlot(choiceWizardlet.capability);
+            vs.getSelectedSlot(choiceWizardlet.capability).linkFrom(choiceWizardlet.isAvailable$);
           })
     
           return vs;

--- a/src/foam/u2/crunch/wizardflow/GraphWizardletsAgent.js
+++ b/src/foam/u2/crunch/wizardflow/GraphWizardletsAgent.js
@@ -139,11 +139,11 @@ foam.CLASS({
       if ( ! entry.parentControlled ) {
         if ( ! entry.availabilitySlot ) {
           entry.availabilitySlot = source.primaryWizardlet.isAvailable$;
-          entry.availabilityDetach = entry.primaryWizardlet.isAvailable$.linkFrom(entry.availabilitySlot);
+          entry.availabilityDetach = entry.primaryWizardlet.isAvailable$.follow(entry.availabilitySlot);
         } else {
           entry.availabilityDetach.detach();
           entry.availabilitySlot = entry.availabilitySlot.or(source.primaryWizardlet.isAvailable$)
-          entry.availabilityDetach = entry.primaryWizardlet.isAvailable$.linkFrom(entry.availabilitySlot);
+          entry.availabilityDetach = entry.primaryWizardlet.isAvailable$.follow(entry.availabilitySlot);
         }
       }
     },


### PR DESCRIPTION
After MinMaxWizardletSection initializes its delegate view (MultiChoiceView), each choice wizardlet’s isAvailable slot is replaced. This reverses any previous initialization, which also prevents lifted prerequisites of MinMax wizardlets from working as expected.

```javascript
this.choiceWizardlets.forEach((choiceWizardlet) => {
  choiceWizardlet.isAvailable$ = vs.getSelectedSlot(choiceWizardlet.capability);
})
```

This PR reverses the link, initializing the MultiChoiceView's slot with the existing wizardlet state.
```javascript
this.choiceWizardlets.forEach((choiceWizardlet) => {
  vs.getSelectedSlot(choiceWizardlet.capability).linkFrom(choiceWizardlet.isAvailable$);
})
```

For user capabilities loaded from existing UserCapabilityJunction payloads, isAvailable should be set correctly on all wizardlets when the wizard is open. Since this code doesn’t run until the choice view is reached, the effect of applying isAvailable values from loaded data should be redundant.