### PR TITLE
Fix group default Menus not replacing theme defaults

### DIFF
--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -109,7 +109,7 @@ Later themes:
             group = await group.parent$find;
           }
 
-          if ( !! defaultMenu && theme && ! theme.defaultMenu) {
+          if ( !! defaultMenu ) {
             theme.defaultMenu = defaultMenu;
             theme.logoRedirect = defaultMenu;
           }


### PR DESCRIPTION
Fixes groups not overriding theme default menus

Breaks the issue described in https://github.com/kgrgreer/foam3/pull/1270 but it was only a fix for one specific case anyway so we should reopen that ticket and discuss a better solution if required