### PR TITLE
check user props availability when key up

### DIFF
--- a/src/foam/u2/view/UserPropertyAvailabilityView.js
+++ b/src/foam/u2/view/UserPropertyAvailabilityView.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'UserPropertyAvailabilityView',
   extends: 'foam.u2.View',
 
-  documentation: 
+  documentation:
     'A TextField view that supports availability checks on specified User model property values (ie. Username/Email).',
 
   implements: [
@@ -103,12 +103,11 @@ foam.CLASS({
           .addClass(this.myClass('input'))
           .attr('name', this.fromPropertyName + 'Input')
           .on('blur', this.checkAvailability )
-          .on('keypress', (e) => {
+          .on('keyup', (e) => {
             if ( this.restrictedCharacters && ! this.restrictedCharacters.test(e.key) ) {
               e.preventDefault();
             }
-            this.isAvailable = true;
-            this.showIcon = false;
+            this.checkAvailability();
           })
         .end()
       .end();


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-6892


There was a bug that even invalid email/password when sign up 'get started' button enabled then finally error message thrown when it clicked moment. Because email/password availability checked when only no keyboard focused.
Updated to do availability checked when key is released and this.checkAvailability() will handle showIcon, isAvailable there.


<img width="458" alt="Screen Shot 2022-04-26 at 10 59 29 AM" src="https://user-images.githubusercontent.com/33228583/165333819-213d3e5e-7c08-417b-812a-4ebd62d8c1ed.png">
<img width="387" alt="Screen Shot 2022-04-26 at 10 59 12 AM" src="https://user-images.githubusercontent.com/33228583/165333821-ffc38cb6-7fef-4c6f-a0fe-ef1d191084ab.png">
<img width="433" alt="Screen Shot 2022-04-26 at 10 59 04 AM" src="https://user-images.githubusercontent.com/33228583/165333822-e7ef10b3-d8d3-4a91-9816-77c75b1f009f.png">

