### PR TITLE
Avoid duplicate calls to installInProto

### DIFF
--- a/src/foam/core/Property.js
+++ b/src/foam/core/Property.js
@@ -405,7 +405,7 @@ foam.CLASS({
       // since installInClass() may have created a modified version
       // to inherit Property Properties from a super-Property.
       var prop = proto.cls_.getAxiomByName(this.name);
-      if ( prop !== this ) {
+      if ( prop.installInProto !== this.installInProto ) {
         // Delegate to the installInProto found in the class in case it
         // has custom behaviour it wants to do.  See Class property for
         // and example.

--- a/src/foam/core/Property.js
+++ b/src/foam/core/Property.js
@@ -405,7 +405,7 @@ foam.CLASS({
       // since installInClass() may have created a modified version
       // to inherit Property Properties from a super-Property.
       var prop = proto.cls_.getAxiomByName(this.name);
-      if ( prop.installInProto !== this.installInProto ) {
+      if ( prop !== this ) {
         // Delegate to the installInProto found in the class in case it
         // has custom behaviour it wants to do.  See Class property for
         // and example.

--- a/src/foam/u2/wizard/PathProperty.js
+++ b/src/foam/u2/wizard/PathProperty.js
@@ -55,6 +55,7 @@ foam.CLASS({
 
       const prop = this;
       Object.defineProperty(proto, this.name + '$get', {
+        configurable: true,
         get: function pathGetter() {
           return function (target) {
             return this[prop.name].f(target);
@@ -63,6 +64,7 @@ foam.CLASS({
       });
 
       Object.defineProperty(proto, this.name + '$set', {
+        configurable: true,
         get: function pathSetter() {
           return function (target, value) {
             const expr = this[prop.name];


### PR DESCRIPTION
Avoid of calling `installInProto` of the property in `proto.cls_` when `this` and `proto.cls_` are different objects but share the same `installInProto`.