### PR TITLE
[NP-6979] Make SplitWAO easier to config

### DIFF
--- a/src/foam/u2/wizard/data/PrerequisiteLoader.js
+++ b/src/foam/u2/wizard/data/PrerequisiteLoader.js
@@ -16,6 +16,7 @@ foam.CLASS({
   imports: [
     'capabilityToPrerequisite',
     'wizardletId',
+    'wizardletOf',
     'wizardlets'
   ],
 
@@ -44,7 +45,10 @@ foam.CLASS({
     },
     {
       class: 'Class',
-      name: 'of'
+      name: 'of',
+      expression: function (wizardletOf) {
+        return wizardletOf;
+      }
     }
   ],
   

--- a/src/foam/u2/wizard/wao/SplitWAO.js
+++ b/src/foam/u2/wizard/wao/SplitWAO.js
@@ -12,7 +12,10 @@ foam.CLASS({
   requires: [
     'foam.u2.wizard.data.NullCanceler',
     'foam.u2.wizard.data.NullLoader',
-    'foam.u2.wizard.data.NullSaver'
+    'foam.u2.wizard.data.NullSaver',
+    'foam.u2.wizard.data.ProxyCanceler',
+    'foam.u2.wizard.data.ProxyLoader',
+    'foam.u2.wizard.data.ProxySaver'
   ],
 
   properties: [
@@ -40,10 +43,12 @@ foam.CLASS({
   methods: [
     async function cancel (wizardlet) {
       const canceler = foam.json.parse(this.canceler, undefined, wizardlet.__subContext__);
+      this.ensure_terminal(canceler, this.ProxyCanceler, this.NullCanceler);
       await canceler.cancel();
     },
     async function load (wizardlet) {
       const loader = foam.json.parse(this.loader, undefined, wizardlet.__subContext__);
+      this.ensure_terminal(loader, this.ProxyLoader, this.NullLoader);
       if ( wizardlet.loading ) return;
       wizardlet.loading = true;
       wizardlet.data = await loader.load();
@@ -51,6 +56,7 @@ foam.CLASS({
     },
     async function save (wizardlet) {
       const saver = foam.json.parse(this.saver, undefined, wizardlet.__subContext__);
+      this.ensure_terminal(saver, this.ProxySaver, this.NullSaver);
       // temp workaround until daosaver is implemented
       if ( this.NullSaver.isInstance(saver) ) {
         await this.delegate.save(wizardlet);
@@ -61,6 +67,15 @@ foam.CLASS({
         await saver.save(wizardlet.data);
       }
       wizardlet.loading = false;
+    },
+    // ensure that the last delegate is the null implementation
+    function ensure_terminal (obj, proxyCls, nullCls) {
+      while ( proxyCls.isInstance(obj) ) {
+        if ( ! obj.delegate ) {
+          obj.delegate = nullCls.create();
+        }
+        obj = obj.delegate;
+      }
     }
   ]
 });

--- a/src/foam/u2/wizard/wizardlet/BaseWizardlet.js
+++ b/src/foam/u2/wizard/wizardlet/BaseWizardlet.js
@@ -24,7 +24,8 @@ foam.CLASS({
   ],
 
   exports: [
-    'id as wizardletId'
+    'id as wizardletId',
+    'of as wizardletOf'
   ],
 
   requires: [


### PR DESCRIPTION
This PR allows SplitWAO in journals to not have redundant configuration
- SplitWAO and delegates can get wizardlet `of` from context
- Loader,Saver,Canceler gets terminating Null implementation automatically