### PR TITLE
Handle array comparison

### DIFF
--- a/src/foam/nanos/ruler/predicate/PropertyChangePredicate.js
+++ b/src/foam/nanos/ruler/predicate/PropertyChangePredicate.js
@@ -15,7 +15,9 @@ foam.CLASS({
 
   javaImports: [
     'foam.core.FObject',
-    'static foam.mlang.MLang.*'
+    'foam.core.PropertyInfo',
+    'static foam.mlang.MLang.NEW_OBJ',
+    'static foam.mlang.MLang.OLD_OBJ'
   ],
   properties: [
     {
@@ -28,12 +30,12 @@ foam.CLASS({
     {
       name: 'f',
       javaCode: `
-        FObject nu  = (FObject) NEW_OBJ.f(obj);
-        FObject old = (FObject) OLD_OBJ.f(obj);
-        return old != null && nu != null &&
-          ! foam.util.SafetyUtil.equals(
-            nu.getProperty(getPropName()),
-            old.getProperty(getPropName()));
+        var nu  = NEW_OBJ.f(obj);
+        var old = OLD_OBJ.f(obj);
+        var prop = (PropertyInfo) ((FObject) nu)
+          .getClassInfo().getAxiomByName(getPropName());
+
+        return old != null && nu != null && prop.compare(nu, old) != 0;
       `
     }
   ]

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -835,13 +835,13 @@ foam.CLASS({
         var name = prop.name;
 
         if ( ! t1.hasOwnProperty(name) ) t1[name] = t2[name];
-        else if ( ! foam.util.equals(t1[name], t2[name]) ) {
+        else if ( prop.compare(t1, t2) != 0 ) {
           t1[name].push(...t2[name]);
         }
       },
       javaCode: `
         if ( ! prop.isSet(t1) ) prop.set(t1, prop.get(t2));
-        else if ( ! SafetyUtil.equals(prop.get(t1), prop.get(t2)) ) {
+        else if ( prop.compare(t1, t2) != 0 ) {
           var value1 = (Object[]) prop.get(t1);
           var value2 = (Object[]) prop.get(t2);
 
@@ -865,14 +865,14 @@ foam.CLASS({
         var name = prop.name;
 
         if ( ! t1.hasOwnProperty(name) ) t1[name] = t2[name];
-        else if ( ! foam.util.equals(t1[name], t2[name]) ) {
+        else if ( prop.compare(t1, t2) != 0 ) {
           Object.assign(t1[name], t2[name]);
         }
       },
       javaCode: `
         if ( ! prop.isSet(t1) ) {
           prop.set(t1, prop.get(t2));
-        } else if ( ! SafetyUtil.equals(prop.get(t1), prop.get(t2)) ) {
+        } else if ( prop.compare(t1, t2) != 0 ) {
           var m1 = (Map) prop.get(t1);
           var m2 = (Map) prop.get(t2);
 
@@ -895,14 +895,14 @@ foam.CLASS({
         var name = prop.name;
 
         if ( ! t1.hasOwnProperty(name) ) t1[name] = t2[name];
-        else if ( ! foam.util.equals(t1[name], t2[name]) ) {
+        else if ( prop.compare(t1, t2) != 0 ) {
           t1[name].copyFrom(t2[name]);
         }
       },
       javaCode: `
         if ( ! prop.isSet(t1) ) {
           prop.set(t1, prop.get(t2));
-        } else if ( ! SafetyUtil.equals(prop.get(t1), prop.get(t2)) ) {
+        } else if ( prop.compare(t1, t2) != 0 ) {
           var value1 = (FObject) prop.get(t1);
           var value2 = (FObject) prop.get(t2);
 

--- a/src/foam/util/Arrays.java
+++ b/src/foam/util/Arrays.java
@@ -7,11 +7,9 @@
 package foam.util;
 
 import java.lang.reflect.Array;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
+import static org.apache.commons.lang3.ArrayUtils.toObject;
 
 public class Arrays {
 
@@ -172,4 +170,18 @@ public class Arrays {
     sortRange(a, c, skip, limit, p2 + 1, end);
   }
 
+  public static Object[] toArray(Object o) {
+    if ( o.getClass().isArray() ) {
+      if ( o.getClass() == boolean[].class ) return toObject((boolean[]) o);
+      if ( o.getClass() == byte[].class    ) return toObject((byte[]) o);
+      if ( o.getClass() == char[].class    ) return toObject((char[]) o);
+      if ( o.getClass() == double[].class  ) return toObject((double[]) o);
+      if ( o.getClass() == float[].class   ) return toObject((float[]) o);
+      if ( o.getClass() == int[].class     ) return toObject((int[]) o);
+      if ( o.getClass() == long[].class    ) return toObject((long[]) o);
+      if ( o.getClass() == short[].class   ) return toObject((short[]) o);
+      return (Object[]) o;
+    }
+    return null;
+  }
 }

--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -63,7 +63,7 @@ public class SafetyUtil {
 
     // Handle array comparison
     if ( o1.getClass().isArray() && o2.getClass().isArray() ) {
-      return compare(Arrays.toArray(o1), Arrays.toArray(o2));
+      return compare((Object[]) o1, (Object[]) o2);
     }
 
     if ( o1.equals(o2) ||

--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -62,7 +62,17 @@ public class SafetyUtil {
     }
 
     // Handle array comparison
-    if ( o1.getClass().isArray() && o2.getClass().isArray() ) {
+    if ( o1.getClass().isArray() && o2.getClass().isArray()
+      && o1.getClass() == o2.getClass()
+    ) {
+      if ( o1.getClass() == boolean[].class ) return compare((boolean[]) o1, (boolean[]) o2);
+      if ( o1.getClass() == byte[].class    ) return compare((byte[])    o1, (byte[]) o2);
+      if ( o1.getClass() == char[].class    ) return compare((char[])    o1, (char[]) o2);
+      if ( o1.getClass() == double[].class  ) return compare((double[])  o1, (double[]) o2);
+      if ( o1.getClass() == float[].class   ) return compare((float[])   o1, (float[]) o2);
+      if ( o1.getClass() == int[].class     ) return compare((int[])     o1, (int[]) o2);
+      if ( o1.getClass() == long[].class    ) return compare((long[])    o1, (long[]) o2);
+      if ( o1.getClass() == short[].class   ) return compare((short[])   o1, (short[]) o2);
       return compare((Object[]) o1, (Object[]) o2);
     }
 
@@ -75,6 +85,134 @@ public class SafetyUtil {
   }
 
   public static int compare(Object[] o1, Object[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(boolean[] o1, boolean[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(byte[] o1, byte[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(char[] o1, char[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(double[] o1, double[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(float[] o1, float[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(int[] o1, int[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(long[] o1, long[] o2) {
+    if ( o1 == o2   ) return  0;
+    if ( o2 == null ) return  1;
+    if ( o1 == null ) return -1;
+
+    int d = compare(o1.length, o2.length);
+    if ( d != 0 ) return d;
+
+    for ( int i = 0 ; i < o1.length ; i++ ) {
+      d = compare(o1[i], o2[i]);
+      if ( d != 0 ) return d;
+    }
+
+    return 0;
+  }
+
+  public static int compare(short[] o1, short[] o2) {
     if ( o1 == o2   ) return  0;
     if ( o2 == null ) return  1;
     if ( o1 == null ) return -1;

--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -61,6 +61,11 @@ public class SafetyUtil {
       return -1;
     }
 
+    // Handle array comparison
+    if ( o1.getClass().isArray() && o2.getClass().isArray() ) {
+      return compare(Arrays.toArray(o1), Arrays.toArray(o2));
+    }
+
     if ( o1.equals(o2) ||
       ! ( o1 instanceof Comparable || o2 instanceof Comparable ) ) return 0;
     if ( ! (o2 instanceof Comparable) ) return 1;

--- a/src/foam/util/test/SafetyUtilTest.js
+++ b/src/foam/util/test/SafetyUtilTest.js
@@ -10,6 +10,7 @@ foam.CLASS({
   extends: 'foam.nanos.test.Test',
 
   javaImports: [
+    'foam.nanos.auth.User',
     'foam.util.SafetyUtil',
   ],
   documentation: 'test utility functions',
@@ -17,36 +18,85 @@ foam.CLASS({
   methods: [
     {
     name: 'runTest',
-    javaCode: ` 
-      String message = "Strings are euqal -- ignores case";
-      String s1 = "abc";
-      String s2 = "aBc";
-      String s3 = "AbCdEfGh";
-      String s4 = "abcdEFGH";
-      String s5 = "123456aabb";
-      String s6 = "123456AABB";
-      String s7 = "12AbCdEfGh34";
-      String s8 = "12abcdEFGH34";
-      String s9 = "AbCd1122EfGh";
-      String s10 = "abcd1122EFGH";
-      String s11 = "notEqual";
-      String s12 = "NOT_EQUAL";
-      String empty = "";
-      String nptr = null;
-      test( SafetyUtil.equalsIgnoreCase( s1, s2 ), message );
-      test( SafetyUtil.equalsIgnoreCase( s3, s4 ), message );
-      test( SafetyUtil.equalsIgnoreCase( s5, s6 ), message );
-      test( SafetyUtil.equalsIgnoreCase( s7, s8 ), message );
-      test( SafetyUtil.equalsIgnoreCase( s9, s10 ), message );
-      test( !SafetyUtil.equalsIgnoreCase( s11, s12 ), "Not equal -- different string" );
-      test( !SafetyUtil.equalsIgnoreCase( empty, s11 ), "Not equal -- empty string" );
-      test( !SafetyUtil.equalsIgnoreCase( s1, empty ), "Not equal -- empty string" );
-      test( SafetyUtil.equalsIgnoreCase( empty, empty ), "Equal -- both empty string" );
-      test( SafetyUtil.equalsIgnoreCase( nptr, nptr ), "Equal -- both null" );
-      test( !SafetyUtil.equalsIgnoreCase( empty, nptr ), "Not equal -- empty string and null" );
-      test( !SafetyUtil.equalsIgnoreCase( nptr, empty ), "Not equal -- empty string and null" );
-      test( !SafetyUtil.equalsIgnoreCase( nptr, s8 ), "Not equal -- empty string and string" );
+    javaCode: `
+      SafetyUtilTest_equalsIgnoreCase();
+      SafetyUtilTest_compare_primitive_array();
+      SafetyUtilTest_compare_object_array();
+      SafetyUtilTest_compare_fobject_array();
     `,
     },
+    {
+      name: 'SafetyUtilTest_equalsIgnoreCase',
+      javaCode: `
+        String message = "Strings are euqal -- ignores case";
+        String s1 = "abc";
+        String s2 = "aBc";
+        String s3 = "AbCdEfGh";
+        String s4 = "abcdEFGH";
+        String s5 = "123456aabb";
+        String s6 = "123456AABB";
+        String s7 = "12AbCdEfGh34";
+        String s8 = "12abcdEFGH34";
+        String s9 = "AbCd1122EfGh";
+        String s10 = "abcd1122EFGH";
+        String s11 = "notEqual";
+        String s12 = "NOT_EQUAL";
+        String empty = "";
+        String nptr = null;
+        test( SafetyUtil.equalsIgnoreCase( s1, s2 ), message );
+        test( SafetyUtil.equalsIgnoreCase( s3, s4 ), message );
+        test( SafetyUtil.equalsIgnoreCase( s5, s6 ), message );
+        test( SafetyUtil.equalsIgnoreCase( s7, s8 ), message );
+        test( SafetyUtil.equalsIgnoreCase( s9, s10 ), message );
+        test( !SafetyUtil.equalsIgnoreCase( s11, s12 ), "Not equal -- different string" );
+        test( !SafetyUtil.equalsIgnoreCase( empty, s11 ), "Not equal -- empty string" );
+        test( !SafetyUtil.equalsIgnoreCase( s1, empty ), "Not equal -- empty string" );
+        test( SafetyUtil.equalsIgnoreCase( empty, empty ), "Equal -- both empty string" );
+        test( SafetyUtil.equalsIgnoreCase( nptr, nptr ), "Equal -- both null" );
+        test( !SafetyUtil.equalsIgnoreCase( empty, nptr ), "Not equal -- empty string and null" );
+        test( !SafetyUtil.equalsIgnoreCase( nptr, empty ), "Not equal -- empty string and null" );
+        test( !SafetyUtil.equalsIgnoreCase( nptr, s8 ), "Not equal -- empty string and string" );
+      `
+    },
+    {
+      name: 'SafetyUtilTest_compare_primitive_array',
+      javaCode: `
+        Object arr1 = new int[] { 1,2,3,4,5 };
+        Object arr2 = new int[] { 1,2,3,4,5 };
+        Object arr3 = new int[] { 1,2,3,4,5,6 };
+
+        test(SafetyUtil.compare(arr1, arr2) ==  0, "Compare primitive array, arr1 == arr2");
+        test(SafetyUtil.compare(arr1, arr3) == -1, "Compare primitive array, arr1 < arr3");
+        test(SafetyUtil.compare(arr3, arr2) ==  1, "Compare primitive array, arr3 > arr2");
+      `
+    },
+    {
+      name: 'SafetyUtilTest_compare_object_array',
+      javaCode: `
+        Object arr1 = new Integer[] { 1,2,3,4,5 };
+        Object arr2 = new Integer[] { 1,2,3,4,5 };
+        Object arr3 = new Integer[] { 1,2,3,4,5,6 };
+
+        test(SafetyUtil.compare(arr1, arr2) ==  0, "Compare object array, arr1 == arr2");
+        test(SafetyUtil.compare(arr1, arr3) == -1, "Compare object array, arr1 < arr3");
+        test(SafetyUtil.compare(arr3, arr2) ==  1, "Compare object array, arr3 > arr2");
+      `
+    },
+    {
+      name: 'SafetyUtilTest_compare_fobject_array',
+      javaCode: `
+        var u1 = new User(); u1.setId(1);
+        var u2 = new User(); u2.setId(2);
+        var u3 = new User(); u3.setId(3);
+
+        Object arr1 = new Object[] { u1, u2 };
+        Object arr2 = new Object[] { u1, u2 };
+        Object arr3 = new Object[] { u1, u2, u3 };
+
+        test(SafetyUtil.compare(arr1, arr2) ==  0, "Compare fobject array, arr1 == arr2");
+        test(SafetyUtil.compare(arr1, arr3) == -1, "Compare fobject array, arr1 < arr3");
+        test(SafetyUtil.compare(arr3, arr2) ==  1, "Compare fobject array, arr3 > arr2");
+      `
+    }
   ]
 });

--- a/src/pom.js
+++ b/src/pom.js
@@ -170,7 +170,7 @@ foam.POM({
     { name: "foam/util/test/DummyNuid",                               flags: "js|java" },
     { name: "foam/util/test/UIDGeneratorTest",                        flags: "js|java" },
     { name: "foam/util/test/UIDUniquenessTest",                       flags: "js|java" },
-    { name: "foam/util/test/SafetyUtilTest",                          flags: "js|java" },
+    { name: "foam/util/test/SafetyUtilTest",                          flags: "java" },
     { name: "foam/util/uid/GlobalSearchService",                      flags: "js|java" },
     { name: "foam/util/uid/FuidSearchService",                        flags: "js|java" },
     { name: "foam/util/uid/ClientGlobalSearchService",                flags: "js|java" },


### PR DESCRIPTION
## Issue
- `SafetyUtil.compare(object, object)` is the default entry point for property comparison but for array it should delegate to `SafetyUtil.compare(object[], object[])`

## Changes
- Delegate array comparison to the overloaded method
- Add unit tests