### PR TITLE
Load Null For Unavailable Wizardlets

### DIFF
--- a/src/foam/u2/wizard/data/PrerequisiteLoader.js
+++ b/src/foam/u2/wizard/data/PrerequisiteLoader.js
@@ -67,6 +67,20 @@ foam.CLASS({
 
       const prereqWizardlet = this.wizardlets.filter( wizardlet => wizardlet.id === this.prerequisiteCapabilityId )[0];
 
+      if ( ! prereqWizardlet.isAvailable ){
+        if ( this.loadIntoPath ) {
+
+          if ( ! initialData ) {
+            initialData = this.of.create({}, this);
+          }
+  
+          this.loadIntoPath$set(initialData, null);
+  
+          return initialData;
+        }
+
+        return null;
+      }
 
       if ( ! prereqWizardlet.of ) {
         console.error(


### PR DESCRIPTION
- For wizardlets that are unavailable, PrerequisiteLoader will load null for either the entire data or a specific property path.