### PR TITLE
[NP-7099] Fix populateApprovalRequestSummariesDAO

### DIFF
--- a/src/foam/nanos/approval/PopulateApprovalRequestSummariesDAO.js
+++ b/src/foam/nanos/approval/PopulateApprovalRequestSummariesDAO.js
@@ -4,7 +4,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
- foam.CLASS({
+foam.CLASS({
   package: 'foam.nanos.approval',
   name: 'PopulateApprovalRequestSummariesDAO',
   extends: 'foam.dao.ProxyDAO',
@@ -46,7 +46,7 @@
           ProxySink refinedSink = new ProxySink(x, sink) {
             @Override
             public void put(Object obj, foam.core.Detachable sub) {
-              ApprovalRequest approval = (ApprovalRequest) obj;
+              ApprovalRequest approval = (ApprovalRequest) ((FObject) obj).fclone();
 
               populateSummaries(x, approval);
 
@@ -68,7 +68,6 @@
       javaCode:`
         DAO userDAO = (DAO) x.get("userDAO");
         DAO referenceDAO = (DAO) x.get(approval.getDaoKey());
-        approval = (ApprovalRequest) approval.fclone();
 
         // handle createdForSummary
         String createdForSummaryString = approval.getCreatedFor() != 0


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-7099

This needs to go into Release-v3.18

**Summary:**
shouldn't be fcloning approval requests inside the populate method since the changes made in the method won't be applied to the approval requests outside the scope of the method

**After the fix**

<img width="1920" alt="Screen Shot 2022-05-16 at 10 17 29 PM" src="https://user-images.githubusercontent.com/58435071/168717115-a18ccacd-3191-4231-a8bc-96262c48606c.png">
<img width="1920" alt="Screen Shot 2022-05-16 at 10 17 24 PM" src="https://user-images.githubusercontent.com/58435071/168717106-bb703d93-965c-4f45-a3d5-d480673e6f91.png">**
