### PR TITLE
GraphBuilder.fromJunction() + Weighted Graph Traversal Support

### DIFF
--- a/src/foam/graph/Graph.js
+++ b/src/foam/graph/Graph.js
@@ -22,8 +22,7 @@ foam.CLASS({
   methods: [
     function getDirectChildren(parentId, order) {
       var parentNode = this.data[parentId];
-      var childNodes = parentNode.forwardLinks.map(id => this.data[id]);
-      
+      var childNodes = parentNode.forwardLinks.map(link => this.data[link.id]);
       if ( order ) {
         let i = 0;
         let idsBehind = {};
@@ -36,8 +35,8 @@ foam.CLASS({
           let needToSwap = false;
           for ( let j = 0 ; j < node.forwardLinks.length ; j ++ ) {
             let link = node.forwardLinks[j];
-            if ( link == parentNode.data.id ) continue;
-            if ( ! idsBehind[link] ) {
+            if ( link.id == parentNode.data.id ) continue;
+            if ( ! idsBehind[link.id] ) {
               needToSwap = link;
               break;
             }

--- a/src/foam/graph/GraphBuilder.js
+++ b/src/foam/graph/GraphBuilder.js
@@ -8,6 +8,10 @@ foam.CLASS({
   package: 'foam.graph',
   name: 'GraphBuilder',
 
+  implements: [
+    'foam.mlang.Expressions'
+  ],
+
   requires: [
     'foam.graph.Graph',
     'foam.graph.GraphNode'
@@ -74,7 +78,7 @@ foam.CLASS({
 
       return relationshipDAO
         .select().then(r => Promise.all(r.array.map(o => {
-          parent.forwardLinks = [...parent.forwardLinks, o.id];
+          parent.forwardLinks = [...parent.forwardLinks, { id: o.id } ];
 
           // Add secondary relationship link but don't create actual nodes for them
           if ( compositeRelationship && compositeRelationship.getSecondaryForwardNames().length > 0 ){
@@ -95,10 +99,85 @@ foam.CLASS({
           return fromPromise.then(() => {
             // Add inverse links before resolving the promise
             this.data[o.id].inverseLinks =
-              [...this.data[o.id].inverseLinks, rootObject.id];
+              [...this.data[o.id].inverseLinks, { id: rootObject.id }];
           });
         })));
     },
+    async function fromJunction(
+      rootObject,
+      objectDaoKey,
+      junctionDaoKey,
+      weightPropertyName,
+      noRootAdd
+    ){
+      // Add graph node (with no relations yet)
+      if ( ! this.data[rootObject.id] ) {
+        this.data[rootObject.id] = this.GraphNode.create({
+          data: rootObject,
+          id: rootObject.id
+        });
+        if ( ! noRootAdd ) this.roots.push(this.data[rootObject.id]);
+      }
+
+      var isRoot;
+      this.roots.forEach(root => {
+        if ( root.id === rootObject.id ) isRoot = true;
+      })
+
+      // Iterate over rootObject's children
+      var junctionDAO = this.__subContext__[junctionDaoKey];
+      var objectDAO = this.__subContext__[objectDaoKey];
+
+      // assumption is that any junction will consist of AT LEAST:
+      // 1. sourceId
+      // 2. targetId
+      // although this is not enforced anywhere with a common abstract class
+      var currentJunctions = await junctionDAO.where(
+          this.EQ(junctionDAO.of["SOURCE_ID"], rootObject.id)
+        )
+        .select();
+      
+      var targetObjectsPromises = currentJunctions.array.map(junc => {
+        
+
+        this.data[junc.sourceId].forwardLinks = [
+          ...this.data[junc.sourceId].forwardLinks, 
+          { 
+            id: junc.targetId,
+            weight: junc[weightPropertyName]
+          }
+        ];
+
+         return objectDAO.find(junc.targetId);
+      });
+
+      var targetObjectsResolved = await Promise.all(targetObjectsPromises);
+
+      var childJunctionPromises = targetObjectsResolved.map(res => {
+        return this.fromJunction(
+          res,
+          'capabilityDAO',
+          'prerequisiteCapabilityJunctionDAO',
+          'priority',
+          true
+        );
+      })
+
+      await Promise.all(childJunctionPromises)
+
+      // the target graphNode is created in the recursive call so after it is done
+      // we can just go ahead and update all junctions to have proper inverse links
+      currentJunctions.array.forEach(junc => {
+        this.data[junc.targetId].inverseLinks = [
+          ...this.data[junc.targetId].inverseLinks,
+          {
+            id: rootObject.id,
+            weight: junc[weightPropertyName]
+          }
+        ];
+      })
+    },
+
     function build() {
       let graph = this.Graph.create({ data: this.data });
       graph.roots = this.roots;

--- a/src/foam/graph/GraphNode.js
+++ b/src/foam/graph/GraphNode.js
@@ -22,18 +22,41 @@ foam.CLASS({
       }
     },
     {
+      /**
+
+       */
       name: 'forwardLinks',
-      class: 'StringArray',
+      class: 'Array',
+      documentation: `
+        {
+          id: String
+          weight?: Integer
+        }
+      `,
       adapt: function (_, n) {
         // Remove duplicate entries
-        const tmp = {};
-        for ( const v of n ) tmp[v] = true;
-        return Object.keys(tmp);
+        var ids = new Set();
+        var newArray = [];
+
+        for ( const v of n ) {
+          if (! ids.has(v.id) ){
+            ids.add(v.id);
+            newArray.push(v);
+          }
+        }
+
+        return newArray;
       }
     },
     {
       name: 'inverseLinks',
-      class: 'StringArray'
+      class: 'Array',
+      documentation: `
+        {
+          id: String
+          weight?: Integer
+        }
+      `,
     },
     {
       name: 'data'

--- a/src/foam/graph/GraphTraverser.js
+++ b/src/foam/graph/GraphTraverser.js
@@ -22,6 +22,12 @@ foam.CLASS({
       value: 'PRE_ORDER'
     },
     {
+      class: 'Enum',
+      of: 'foam.graph.WeightPriorityStrategy',
+      name: 'weightPriorityStrategy',
+      value: 'NONE'
+    },
+    {
       class: 'FObjectProperty',
       of: 'foam.graph.Graph',
       name: 'graph'
@@ -72,7 +78,18 @@ foam.CLASS({
     function traverse() {
       this.memo_ = {};
       const RECUR = x => {
-        const childNodes = x.current.forwardLinks.map(id => this.graph.data[id]);
+        const forwardLinks = x.current.forwardLinks;
+
+        if ( this.weightPriorityStrategy == this.weightPriorityStrategy.MIN ){
+          forwardLinks.sort((l1,l2) => l1.weight - l2.weight);
+        }
+
+        if ( this.weightPriorityStrategy == this.weightPriorityStrategy.MAX ){
+          forwardLinks.sort((l1,l2) => l2.weight - l1.weight)
+        }
+
+        const childNodes = forwardLinks.map(link => this.graph.data[link.id]);
+
         for ( const current of childNodes ) {
           this.updateNodeToDescendants(current.id);
 

--- a/src/foam/graph/WeightPriorityStrategy.js
+++ b/src/foam/graph/WeightPriorityStrategy.js
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2022 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.graph',
+  name: 'WeightPriorityStrategy',
+
+  values: [ 
+    'NONE',
+    'MIN',
+    'MAX'
+  ]
+});

--- a/src/foam/u2/crunch/wizardflow/GraphWizardletsAgent.js
+++ b/src/foam/u2/crunch/wizardflow/GraphWizardletsAgent.js
@@ -23,6 +23,7 @@ foam.CLASS({
   requires: [
     'foam.graph.GraphTraverser',
     'foam.graph.TraversalOrder',
+    'foam.graph.WeightPriorityStrategy',
     'foam.nanos.crunch.ui.CapabilityWizardlet',
     'foam.nanos.crunch.ui.LiftingAwareWizardlet',
     'foam.nanos.crunch.ui.PrerequisiteAwareWizardlet',
@@ -54,7 +55,8 @@ foam.CLASS({
       // Step 1: Traverse capability graph to create wizardlets
       const traverser = this.GraphTraverser.create({
         graph: this.capabilityGraph,
-        order: this.TraversalOrder.POST_ORDER
+        order: this.TraversalOrder.POST_ORDER,
+        weightPriorityStrategy: this.WeightPriorityStrategy.MIN
       });
 
       this.capabilityToPrerequisite = traverser.nodeToDescendants;

--- a/src/foam/u2/crunch/wizardflow/LoadCapabilityGraphAgent.js
+++ b/src/foam/u2/crunch/wizardflow/LoadCapabilityGraphAgent.js
@@ -36,7 +36,13 @@ foam.CLASS({
   methods: [
     async function execute() {
       let graphBuilder = this.GraphBuilder.create();
-      await graphBuilder.fromRelationship(this.rootCapability, 'prerequisites');
+      await graphBuilder.fromJunction(
+        this.rootCapability,
+        'capabilityDAO',
+        'prerequisiteCapabilityJunctionDAO',
+        'priority'
+      );
+
       this.capabilityGraph = graphBuilder.build();
     }
   ]

--- a/src/pom.js
+++ b/src/pom.js
@@ -507,6 +507,7 @@ foam.POM({
     { name: "foam/graph/GraphNode",                                   flags: "js" },
     { name: "foam/graph/GraphBuilder",                                flags: "js" },
     { name: "foam/graph/TraversalOrder",                              flags: "js" },
+    { name: "foam/graph/WeightPriorityStrategy",                      flags: "js" },
     { name: "foam/graph/GraphTraverser",                              flags: "js" },
     { name: "foam/u2/svg/Position",                                   flags: "web" },
     { name: "foam/u2/svg/RelativePosition",                           flags: "web" },


### PR DESCRIPTION
- Refactored **GraphNode.inverseLink**s and **GraphNode.forwardLinks** to both be of type Array instead of StringArray. This is so that links can be an Array of Maps, where each Map at least has an id key, but can optionally have a weight key and more.
- Added `fromJunction` support to **GraphBuilder**, this is so we can build the graph from junctions instead of relying on the relationship property. Building from Junctions is what also enables us to store info on the weight of the junction when creating links. Whereas before relying on the relationship would skip information on the junction itself which stores priority, only caring about source and target.
- Added a **WeightPriorityStrategy** enum consisting of defining a MIN, MAX or NONE priority.
- Wired **GraphTraverser** to be able to use the **WeightPriorityStrategy** when creating and storing its childNodes to data. Choosing NONE meaning what was on the system before, would mean that it would be sort by alphabetical order of ids.
- Made **LoadCapabilityGraphAgent** use GraphBuilder.fromJunction instead of fromRelationship so we can have access to **CapabilityCapabilityJunction.Priority**
- Made **GraphWizardletsAgent** use **WeightPriorityStrategy.MIN** it's **GraphTraverser**. This is so the traversal algorithm can prioritize lower priority nodes first which is how ServerCrunchService works.