### PR TITLE
JDAO - default to synchronous replay, to avoid deadlock

### DIFF
--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -28,6 +28,11 @@ foam.CLASS({
     {
       class: 'foam.dao.DAOProperty',
       name: 'dao'
+    },
+    {
+      documentation: 'Perform replay synchronously. Manual workaround for deadlock with AsyncAssemblyLine',
+      class: 'Boolean',
+      name: 'syncReplay'
     }
   ],
 
@@ -46,9 +51,11 @@ foam.CLASS({
         // NOTE: explicitly calling PM constructor as create only creates
         // a percentage of PMs, but we want all replay statistics
         PM pm = new PM(dao.getOf(), "replay." + getFilename());
-        AssemblyLine assemblyLine = x.get("threadPool") == null ?
-          new foam.util.concurrent.SyncAssemblyLine()   :
-          new foam.util.concurrent.AsyncAssemblyLine(x, "replay") ;
+        AssemblyLine assemblyLine =
+          ( getSyncReplay() ||
+            x.get("threadPool") == null ) ?
+          new foam.util.concurrent.SyncAssemblyLine() :
+          new foam.util.concurrent.AsyncAssemblyLine(x, "replay");
 
         try ( BufferedReader reader = getReader() ) {
           if ( reader == null ) {

--- a/src/foam/dao/java/JDAO.js
+++ b/src/foam/dao/java/JDAO.js
@@ -62,6 +62,12 @@ In this current implementation setDelegate must be called last.`,
       name: 'journal'
     },
     {
+      documentation: 'Perform replay synchronously. Manual workaround for deadlock with AsyncAssemblyLine',
+      class: 'Boolean',
+      name: 'syncReplay',
+      value: true
+    },
+    {
       name: 'delegate',
       class: 'foam.dao.DAOProperty',
       javaFactory: 'return new MDAO(getOf());',
@@ -82,6 +88,7 @@ In this current implementation setDelegate must be called last.`,
                   .setDao(delegate)
                   .setFilename(getFilename())
                   .setCreateFile(false)
+                  .setSyncReplay(getSyncReplay())
                   .build());
               }
             }


### PR DESCRIPTION
Change JDAO to synchronous replay to avoid deadlock. 