### PR TITLE
Update AlternateFlow to have selectedData

### DIFF
--- a/src/foam/u2/wizard/AlternateFlow.js
+++ b/src/foam/u2/wizard/AlternateFlow.js
@@ -42,6 +42,10 @@ foam.CLASS({
     {
       class: 'StringArray',
       name: 'removals'
+    },
+    {
+      class: 'Array',
+      name: 'select'
     }
   ],
 
@@ -58,6 +62,17 @@ foam.CLASS({
           w[propToChange] = newValue;
         }
       })
+
+      if ( this.select.length != 0 ) {
+        for ( let item of this.select ) {
+          foam.assert(item.length == 2, "'select' entries in AlternateFlow must have two elements")
+
+          let minMaxId = item[0];
+          let choices = item[1];
+          let w = x.wizardlets.find(w => w.id === minMaxId);
+          w.data.selectedData = choices;
+        }
+      }
     }
   ]
 })


### PR DESCRIPTION
nanopay: https://github.com/nanoPayinc/NANOPAY/pull/14695

https://nanopay.atlassian.net/browse/NP-7102
https://nanopay.atlassian.net/browse/NP-7148
https://nanopay.atlassian.net/browse/NP-7103


For Anonymous transfer tranferType is set to invisible in shop-rates menu by using AlternateFlow.
But with AlternateFlow a choiceView's selectedData was not being set.
So now AlternateFlow handling this to set a wizardlet data properly. Confirmed by @KernelDeimos 


Anonymous transfer 
<img width="768" alt="Screen Shot 2022-05-26 at 1 28 42 PM" src="https://user-images.githubusercontent.com/33228583/170544301-f084113b-0844-44fe-95c7-82017108508d.png">
<img width="730" alt="Screen Shot 2022-05-26 at 1 28 49 PM" src="https://user-images.githubusercontent.com/33228583/170544319-b37e4442-eb0d-4f1b-9998-b17a154b92c8.png">

<img width="1062" alt="Screen Shot 2022-05-26 at 1 37 59 PM" src="https://user-images.githubusercontent.com/33228583/170544338-eb09aa7b-3958-4fef-867d-f8a606424c32.png">

<img width="1216" alt="Screen Shot 2022-05-26 at 1 38 29 PM" src="https://user-images.githubusercontent.com/33228583/170544413-bcfd21b7-a9b5-4555-b075-95c081664b9e.png">




connect

<img width="694" alt="Screen Shot 2022-05-26 at 1 29 38 PM" src="https://user-images.githubusercontent.com/33228583/170544460-4dc58496-f2eb-4c1c-a9d3-7366cd022f8b.png">

