### PR TITLE
Schedulable and XORMinMaxWAO Fixes

### DIFF
--- a/src/foam/nanos/cron/Schedulable.js
+++ b/src/foam/nanos/cron/Schedulable.js
@@ -43,11 +43,18 @@
       value: 'schedulableEventDAO'
     },
     {
-      name: 'schedule',
+      class: 'FObjectProperty',
       of: 'foam.nanos.cron.Schedule',
-      view: {
-        class: 'foam.u2.view.FObjectView',
-        of: 'foam.nanos.cron.SimpleIntervalSchedule'
+      name: 'schedule',
+      label: '',
+      factory: function(){
+        return foam.nanos.cron.SimpleIntervalSchedule.create();
+      },
+      view: function (_, X){
+        return {
+          class: 'foam.u2.view.SimpleIntervalScheduleView',
+          data$: X.data.schedule$
+        }
       }
     },
     {

--- a/src/foam/nanos/cron/Schedulable.js
+++ b/src/foam/nanos/cron/Schedulable.js
@@ -52,7 +52,7 @@
       },
       view: function (_, X){
         return {
-          class: 'foam.u2.view.SimpleIntervalScheduleView',
+          class: 'foam.nanos.cron.SimpleIntervalScheduleView',
           data$: X.data.schedule$
         }
       }

--- a/src/foam/nanos/cron/SimpleIntervalScheduleView.js
+++ b/src/foam/nanos/cron/SimpleIntervalScheduleView.js
@@ -5,7 +5,7 @@
   */
 
 foam.CLASS({
-  package: 'foam.u2.view',
+  package: 'foam.nanos.cron',
   name: 'SimpleIntervalScheduleView',
   extends: 'foam.u2.View',
 

--- a/src/foam/nanos/cron/capabilities.jrl
+++ b/src/foam/nanos/cron/capabilities.jrl
@@ -68,7 +68,8 @@ p({
           color: '#406dea'
         },
         view: {
-          class: 'foam.u2.detail.TabbedDetailView'
+          class: 'foam.u2.detail.VerticalDetailView',
+          showTitle: false
         }
       },
       {
@@ -79,8 +80,9 @@ p({
           backgroundColor: '#DADDE2'
         },
         view: {
-          class: 'foam.u2.view.SimpleIntervalScheduleView'
-        }
+          class: 'foam.u2.detail.VerticalDetailView'
+        },
+        title: 'Schedule Details'
       }
     ],
     wao: {
@@ -98,7 +100,7 @@ p({
           class: 'foam.u2.wizard.wao.XORMinMaxWAO',
           of: 'foam.core.MapHolder',
           minMaxCapabilityId: 'schedulable-xorminmax',
-          loadFromPath: 'objectToSchedule',
+          loadFromPath: 'schedule',
           loadIntoPath: 'value.schedule'
         }
       ]

--- a/src/foam/nanos/cron/capabilities.jrl
+++ b/src/foam/nanos/cron/capabilities.jrl
@@ -38,10 +38,9 @@ p({
     saveOnAvailable: false,
     saveOnCurrent: true,
     wao:{
-      class: "foam.u2.wizard.wao.PrerequisiteWAO",
-      of:  "foam.nanos.cron.Schedulable",
-      prerequisiteCapabilityId: "schedulable-review",
+      class: 'foam.u2.wizard.wao.XORMinMaxWAO',
       of: "foam.nanos.cron.Schedulable",
+      minMaxCapabilityId: 'schedulable-xorminmax',
       delegate: {
         class: "foam.u2.wizard.wao.DAOWAO",
         daoKey: "schedulableDAO",
@@ -54,23 +53,62 @@ p({
 p({
   id: 'schedulable-review',
   name: 'Schedulable Review',
-  of: 'foam.nanos.cron.Schedulable',
+  of: 'foam.core.MapHolder',
   wizardlet: {
-    class: 'foam.nanos.crunch.ui.CapabilityWizardlet',
-    of: 'foam.nanos.cron.Schedulable',
-    combinedSection: true,
+    class: 'foam.u2.wizard.wizardlet.ReviewWizardlet',
+    title: "Review Your Schedule",
+    showTitle: false,
+    of: 'foam.core.MapHolder',
+    items: [
+      {
+        class: 'foam.u2.wizard.wizardlet.ReviewItem',
+        name: 'objectToSchedule',
+        border: {
+          class: 'foam.u2.borders.TopBorderCard',
+          color: '#406dea'
+        },
+        view: {
+          class: 'foam.u2.detail.TabbedDetailView'
+        }
+      },
+      {
+        class: 'foam.u2.wizard.wizardlet.ReviewItem',
+        name: 'schedule',
+        border: {
+          class: 'foam.u2.borders.BackgroundCard',
+          backgroundColor: '#DADDE2'
+        },
+        view: {
+          class: 'foam.u2.view.SimpleIntervalScheduleView'
+        }
+      }
+    ],
     wao: {
-      class: "foam.u2.wizard.wao.XORMinMaxWAO",
-      minMaxCapabilityId: "schedulable-xorminxmax",
-      of: "foam.nanos.cron.Schedulable",
-      delegate: { class: 'foam.u2.wizard.wao.NullWAO' }
+      class: 'foam.u2.wizard.wao.CompositeWAO',
+      of: 'foam.core.MapHolder',
+      delegates: [
+        {
+          class: 'foam.u2.wizard.wao.XORMinMaxWAO',
+          of: 'foam.core.MapHolder',
+          minMaxCapabilityId: 'schedulable-xorminmax',
+          loadFromPath: 'objectToSchedule',
+          loadIntoPath: 'value.objectToSchedule'
+        },
+        {
+          class: 'foam.u2.wizard.wao.XORMinMaxWAO',
+          of: 'foam.core.MapHolder',
+          minMaxCapabilityId: 'schedulable-xorminmax',
+          loadFromPath: 'objectToSchedule',
+          loadIntoPath: 'value.schedule'
+        }
+      ]
     }
   }
 })
 
 p({
   class: 'foam.nanos.crunch.MinMaxCapability',
-  id: "schedulable-xorminxmax",
+  id: "schedulable-xorminmax",
   name: "Schedulable MinMax",
   min: 1,
   max: 1

--- a/src/foam/nanos/cron/prerequisiteCapabilityJunctions.jrl
+++ b/src/foam/nanos/cron/prerequisiteCapabilityJunctions.jrl
@@ -12,9 +12,9 @@ p({
 })
 p({
   sourceId: 'schedulable-review',
-  targetId: 'schedulable-xorminxmax'
+  targetId: 'schedulable-xorminmax'
 })
 p({
-  sourceId: 'schedulable-xorminxmax',
+  sourceId: 'schedulable-xorminmax',
   targetId: 'generic-schedulable'
 })

--- a/src/foam/u2/wizard/wao/XORMinMaxWAO.js
+++ b/src/foam/u2/wizard/wao/XORMinMaxWAO.js
@@ -69,21 +69,38 @@
 
       const prereqMinMaxWizardlet = this.wizardlets.filter( wizardlet => wizardlet.id === this.minMaxCapabilityId )[0];
 
-      const minMaxSelectedData = prereqMinMaxWizardlet.data.selectedData;
+      let selectedCapabilityId;
 
-      if ( minMaxSelectedData.length != 1 ){
-        console.error(
-          `Cannot apply XOR to MinMaxCapabilityId: ${this.minMaxCapabilityId}`
-        );
+      if ( ! prereqMinMaxWizardlet.isVisible ){
+        // check if any of its children are available as this implies selection
+        var impliedChoiceArray = prereqMinMaxWizardlet.choiceWizardlets.filter(cw => cw.isAvailable);
 
-        if ( this.of ) {
-          wizardlet.data = this.of.create({}, this);
+        if ( impliedChoiceArray.length != 1 ){
+          console.error(
+            `Cannot apply XOR to MinMaxCapabilityId: ${this.minMaxCapabilityId}`
+          );
+          return;
         }
-        
-        return;
-      }
 
-      const selectedCapabilityId = minMaxSelectedData[0];
+        selectedCapabilityId = impliedChoiceArray[0].id;
+
+      } else {
+        const minMaxSelectedData = prereqMinMaxWizardlet.data.selectedData;
+
+        if ( minMaxSelectedData.length != 1 ){
+          console.error(
+            `Cannot apply XOR to MinMaxCapabilityId: ${this.minMaxCapabilityId}`
+          );
+  
+          if ( this.of ) {
+            wizardlet.data = this.of.create({}, this);
+          }
+          
+          return;
+        }
+  
+        selectedCapabilityId = minMaxSelectedData[0];
+      }
 
       const selectedCapabilityWizardlet = prereqMinMaxWizardlet.prerequisiteWizardlets.find(w =>
         w.capability && w.capability.id == selectedCapabilityId

--- a/src/pom.js
+++ b/src/pom.js
@@ -1165,6 +1165,6 @@ foam.POM({
     { name: "foam/u2/view/GlobalFuidSearch",                          flags: "web" },
     { name: "foam/u2/FUIDAutocompleter",                              flags: "web" },
     { name: "foam/u2/view/FUIDSearch",                                flags: "web" },
-    { name: "foam/u2/view/SimpleIntervalScheduleView",                flags: "web" }
+    { name: "foam/nanos/cron/SimpleIntervalScheduleView",             flags: "web" }
  ]
 });


### PR DESCRIPTION
- Adds SimpleIntervalScheduleView layout view to Schedulable.schedule
- Fix typo in schedulable-xorxminmax => schedulable-xorminmax
- @KernelDeimos  the change i implemented in XORMinMaxWAO was so that if you had made a min max capability invisible, but a choice of that min max available, then because selectedData isn't filled out on the min max since it was not don't officially through the GUI will be an empty array. This way XORMinMaxWAO knows if its searching for a min max choice and data is empty, it will check to see if any of it's children are available (thereby implying granted) and grab the data from the granted capability. I am assuming AlternateFlow.select already solves this issue though by setting selectedData on a min max?