### PR TITLE
Fix adaptBoolean

### DIFF
--- a/src/foam/core/Boolean.js
+++ b/src/foam/core/Boolean.js
@@ -25,6 +25,12 @@ foam.CLASS({
   properties: [
     [ 'type', 'Boolean' ],
     [ 'value', false ],
-    [ 'adapt', function adaptBoolean(_, v) { return !! v; } ]
+    [ 'adapt', function adaptBoolean(_, v) {
+      if ( typeof v === 'string' ) {
+        v = v.trim().toLowerCase();
+        return v != 'false' && v != '0' & v != 'no' && v != 'off';
+      }
+      return !! v;
+    } ]
   ]
 });


### PR DESCRIPTION
Return false for strings "false", "0", "no" and "off" since the double NOT operator (!!) doesn't handle string value to boolean conversion.