### PR TITLE
fix timestamp not showing on reports

### DIFF
--- a/src/foam/nanos/column/TableColumnOutputter.js
+++ b/src/foam/nanos/column/TableColumnOutputter.js
@@ -43,11 +43,11 @@ foam.CLASS({
             }
             return ( val / 100 ).toString();
           }
-          if ( foam.core.Date.isInstance(prop) ) {
-            return val.toLocaleDateString(foam.locale);
-          }
           if ( foam.core.DateTime.isInstance(prop) ) {
             return val.toString().substring(0, 24);
+          }
+          if ( foam.core.Date.isInstance(prop) ) {
+            return val.toLocaleDateString(foam.locale);
           }
           if ( foam.core.Time.isInstance(prop) ) {
             return val.toString().substring(0, 8);


### PR DESCRIPTION
**Please attach to Release-v3.19**
This PR fixes the issue where timestamps not showing for exported reports such as Reconciliation Reports, Reduced Reconciliation Reports, User Onboarding Reports and Transactions.

<img width="1332" alt="Screen Shot 2022-06-07 at 1 30 06 PM" src="https://user-images.githubusercontent.com/97463241/172476979-9d616c66-167f-47a9-b301-deaaf116b25e.png">

fixed: 
<img width="1359" alt="Screen Shot 2022-06-07 at 1 29 07 PM" src="https://user-images.githubusercontent.com/97463241/172476968-b0b434a4-2e7c-4af8-bca3-0b2b6728b64f.png">

