### PR TITLE
ClusterConfigSupport - adjust node redundancy: cluster size 2 - redun…

### DIFF
--- a/src/foam/nanos/medusa/ClusterConfigSupport.js
+++ b/src/foam/nanos/medusa/ClusterConfigSupport.js
@@ -428,8 +428,7 @@ configuration for contacting the primary node.`,
       type: 'Integer',
       javaCode: `
       int c = getNodeCount();
-      // maximize groups for small test/staging clusters - sacrifice HA
-      if ( c < 4 ) return 0;
+      if ( c < 3 ) return 0; // size 2 test cluster - sacrifice HA
       if ( c < 9 ) return 1;
       return 2;
       `


### PR DESCRIPTION
…dancy 0, cluster size < 9 - redundancy 1, else 2.  This provides redundancy in minimal production cluster of 2 mediators and 3 nodes