### PR TITLE
Added CSS Mlangs to auto generate token values

### DIFF
--- a/src/foam/color/colorlib.js
+++ b/src/foam/color/colorlib.js
@@ -208,7 +208,6 @@ foam.LIB({
       let l = foam.Color.rgbToGrey([r, g, b])*1000;
       let scale = l + (l*(value/100));
       var [r, g, b] = foam.Color.adjustRGBBrightness([r, g, b], scale/1000);
-      console.log(r,g,b);
       return `rgb(${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)})`;
     },
     function rgbToGrey(rgb /*[0..255,0.255,0.255]*/) /* -> 0..1 */ {

--- a/src/foam/color/colorlib.js
+++ b/src/foam/color/colorlib.js
@@ -208,6 +208,7 @@ foam.LIB({
       let l = foam.Color.rgbToGrey([r, g, b])*1000;
       let scale = l + (l*(value/100));
       var [r, g, b] = foam.Color.adjustRGBBrightness([r, g, b], scale/1000);
+      console.log(r,g,b);
       return `rgb(${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)})`;
     },
     function rgbToGrey(rgb /*[0..255,0.255,0.255]*/) /* -> 0..1 */ {
@@ -218,7 +219,7 @@ foam.LIB({
     function adjustRGBBrightness(rgb /*[0..255,0.255,0.255]*/, desired/*0..1*/) {
       var [r, g, b] = rgb;
       var gr = foam.Color.rgbToGrey(rgb);
-      if ( desired > gr ) {
+      if ( desired >= gr ) {
         var mix = (desired - gr) / ( 1 - gr);
         return [ 255 * mix + (1-mix) * r, 255 * mix + (1-mix) * g, 255 * mix + (1-mix) * b];
       }

--- a/src/foam/color/colorlib.js
+++ b/src/foam/color/colorlib.js
@@ -207,7 +207,6 @@ foam.LIB({
       var [r, g, b] = [colorObj.red, colorObj.green, colorObj.blue];
       let l = foam.Color.rgbToGrey([r, g, b])*1000;
       let scale = l + (l*(value/100));
-      console.log(l, scale);
       var [r, g, b] = foam.Color.adjustRGBBrightness([r, g, b], scale/1000);
       return `rgb(${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)})`;
     },

--- a/src/foam/color/colorlib.js
+++ b/src/foam/color/colorlib.js
@@ -185,7 +185,7 @@ foam.LIB({
         foam.assert( str.length == 6 || str.length == 8 );
         components = str.match(/../g).map(v => parseInt(v, 16));
       } else if ( str.startsWith('rgb') ) {
-        components = str.splice(str.startsWith('rgba') ? 5 : 4, -1).split(',');
+        components = str.substring(str.startsWith('rgba') ? 5 : 4, str.length-1).split(',');
       }
 
       return {
@@ -196,10 +196,35 @@ foam.LIB({
       };
     },
     
-    function getBestForeground (str, black, white) {
+    function getBestForeground(str, black, white) {
       with ( foam.Color.parse(str) ) {
         return red*0.3 + green*0.6 + blue*0.1 > 170 ? black : white;
       }
-    }
+    },
+
+    function lighten(str, value) {
+      colorObj = foam.Color.parse(str);
+      var [r, g, b] = [colorObj.red, colorObj.green, colorObj.blue];
+      let l = foam.Color.rgbToGrey([r, g, b])*1000;
+      let scale = l + (l*(value/100));
+      console.log(l, scale);
+      var [r, g, b] = foam.Color.adjustRGBBrightness([r, g, b], scale/1000);
+      return `rgb(${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)})`;
+    },
+    function rgbToGrey(rgb /*[0..255,0.255,0.255]*/) /* -> 0..1 */ {
+      var [r, g, b] = rgb;
+      return 0.299 * r/255 + 0.587 * g/255 + 0.114 * b/255;
+    },
+
+    function adjustRGBBrightness(rgb /*[0..255,0.255,0.255]*/, desired/*0..1*/) {
+      var [r, g, b] = rgb;
+      var gr = foam.Color.rgbToGrey(rgb);
+      if ( desired > gr ) {
+        var mix = (desired - gr) / ( 1 - gr);
+        return [ 255 * mix + (1-mix) * r, 255 * mix + (1-mix) * g, 255 * mix + (1-mix) * b];
+      }
+      var scale = desired/gr;
+      return [ scale * r, scale * g, scale * b ];
+    },
   ]
 });

--- a/src/foam/color/colorlib.js
+++ b/src/foam/color/colorlib.js
@@ -198,7 +198,7 @@ foam.LIB({
     
     function getBestForeground(str, black, white) {
       with ( foam.Color.parse(str) ) {
-        return red*0.3 + green*0.6 + blue*0.1 > 170 ? black : white;
+        return red*0.299 + green*0.587 + blue*0.114 > 186 ? black : white;
       }
     },
 

--- a/src/foam/core/Window.js
+++ b/src/foam/core/Window.js
@@ -223,23 +223,7 @@ foam.CLASS({
       this.window.cancelAnimationFrame(id);
     },
 
-    function installCSS(text,  /* optional */ owner, /* optional */ id) {
-      /* Create a new <style> tag containing the given CSS code. */
-      if ( text instanceof Promise ) {
-        var id = id ?? 'style' + foam.next$UID();
-        this.installCSS_('', owner, id);
-        text.then(t => {
-          const el = this.getElementById(id);
-          if ( t !== el?.textContent ) {
-            el.textContent = t;
-          }
-        })
-      } else {
-        this.installCSS_(text, owner, id);
-      }
-    },
-
-    function installCSS_(text, owner, id) {
+    function installCSS(text, /* optional */ owner, /* optional */ id) {
       this.document && this.document.head && this.document.head.insertAdjacentHTML(
         'beforeend',
         '<style' +

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -1319,7 +1319,7 @@ foam.LIB({
 foam.LIB({
   name: 'foam.CSS',
   methods: [
-    async function getTokenValue(tokenString, cls, ctx) {
+    function getTokenValue(tokenString, cls, ctx) {
       if ( ! tokenString?.startsWith('$') ) return tokenString;
       var [ tokenName, cls ] = foam.CSS.returnTokenAndClass(tokenString, cls);
       var result = cls && cls[foam.String.constantize(tokenName)];
@@ -1330,15 +1330,15 @@ foam.LIB({
         result = defaultsCls[foam.String.constantize(tokenName)];
       }
       if ( foam.Function.isInstance(result?.value) ) {
-        const expr = foam.css.ColorExprBuilder.create();
+        const expr = foam.css.TokenUtilsBuilder.create();
         // Fake an fobject to get token value in current ctx from mlang
-        var ret = await result.value(expr).f({cls_: cls, __subContext__: ctx});
-        ret = await foam.CSS.returnTokenValue(ret, cls, ctx);
+        var ret = result.value(expr).f({cls_: cls, __subContext__: ctx});
+        ret = foam.CSS.returnTokenValue(ret, cls, ctx);
         return ret || result.fallback || `/* failed mlang token replacement ${tokenString}, ${cls}*/`
       }
       if ( result?.value?.startsWith('$') ) {
         // Using await as this method may be overriden with one that returns a promise
-        var ret = await this.getTokenValue(result.value, cls, ctx);
+        var ret = this.getTokenValue(result.value, cls, ctx);
         return ret || result.fallback || `/* failed token replacement ${tokenString}, ${cls}*/`;
       }
       return result?.value ||
@@ -1357,12 +1357,12 @@ foam.LIB({
       }
       return [ tokenName, cls, fullString ]
     },
-    async function returnTokenValue(token, cls, ctx) {
+    function returnTokenValue(token, cls, ctx) {
       // Safe method to always call the right getTokenValue() depending on ctx
       let tokenFinder = ctx?.cssTokenOverrideService?.getTokenValue || foam.CSS.getTokenValue;
-      return await tokenFinder(token, cls, ctx);
+      return tokenFinder(token, cls, ctx);
     },
-    async function replaceTokens(text, cls, ctx, opt_tokenPattern) {
+    function replaceTokens(text, cls, ctx, opt_tokenPattern) {
       let foundTokens = [];
       //TODO: This reg exp breaks when tokens have function values like rgb()/hsl()
       // Need the ) for media queries. Fix before using tokens for media queries
@@ -1371,7 +1371,7 @@ foam.LIB({
       if ( ! tokensToFind?.length ) return text;
       for ( var i = 0 ; i < tokensToFind.length ; i++ ) {
         let sanitizedToken = opt_tokenPattern ? tokensToFind[i].match(/\$[^\*\s]*/)[0] : tokensToFind[i] //if using a non-standard token pattern
-        let replacement = await foam.CSS.returnTokenValue(sanitizedToken, cls, ctx);
+        let replacement = foam.CSS.returnTokenValue(sanitizedToken, cls, ctx);
         foundTokens[tokensToFind[i]] = { sanitizedToken: sanitizedToken, value: replacement}
       }
       return text.replace(tokenPattern, function(match) {

--- a/src/foam/css/TokenUtils.js
+++ b/src/foam/css/TokenUtils.js
@@ -30,7 +30,7 @@ foam.CLASS({
     {
       name: 'arg1',
       adapt: function(_, n) {
-        if ( typeof n === 'string' ) {
+        if ( foam.String.isInstance(n) ) {
           return this.Constant.create({ value: n });
         }
         return n;
@@ -39,7 +39,7 @@ foam.CLASS({
     {
       name: 'arg2',
       adapt: function(_, n) {
-        if ( typeof n === 'number' ) {
+        if ( foam.Number.isInstance(n) ) {
           return this.Constant.create({ value: n });
         }
         return n;
@@ -64,7 +64,7 @@ foam.CLASS({
     {
       name: 'baseColor',
       adapt: function(_, n) {
-        if ( typeof n === 'string' ) {
+        if ( foam.String.isInstance(n) ) {
           return this.Constant.create({ value: n });
         }
         return n;
@@ -73,7 +73,7 @@ foam.CLASS({
     {
       name: 'darkColor',
       adapt: function(_, n) {
-        if ( typeof n === 'string' ) {
+        if ( foam.String.isInstance(n) ) {
           return this.Constant.create({ value: n });
         }
         return n;
@@ -82,7 +82,7 @@ foam.CLASS({
     {
       name: 'lightColor',
       adapt: function(_, n) {
-        if ( typeof n === 'string' ) {
+        if ( foam.String.isInstance(n) ) {
           return this.Constant.create({ value: n });
         }
         return n;
@@ -104,9 +104,9 @@ foam.CLASS({
   package: 'foam.css',
   name: 'TokenUtilsBuilder',
   requires: [
+    'foam.css.FindForegroundExpr',
     'foam.css.LightenExpr',
-    'foam.css.TokenExpr',
-    'foam.css.FindForegroundExpr'
+    'foam.css.TokenExpr'
   ],
   methods: [
     function TOKEN(name) { return this.TokenExpr.create({ arg1: name }); },

--- a/src/foam/css/TokenUtils.js
+++ b/src/foam/css/TokenUtils.js
@@ -9,16 +9,15 @@ foam.CLASS({
   name: 'TokenExpr',
 
   documentation: `
-    Mlang expr for getting the value of the token from current context
-    WARNING: Unlike most Mlang exprs, this expr is async and can only be used with other exprs that support async
+    Expr for getting the value of the token from current context
   `,
 
   properties: [
     { name: 'arg1' }
   ],
   methods: [
-    async function f(o) {
-      return await foam.CSS.returnTokenValue(this.arg1, o.cls_, o.__subContext__);
+    function f(o) {
+      return foam.CSS.returnTokenValue(this.arg1, o.cls_, o.__subContext__);
     }
   ]
 });
@@ -48,9 +47,9 @@ foam.CLASS({
     }
   ],
   methods: [
-    async function f(o) {
-      const color = await this.arg1.f(o);
-      const amount = await this.arg2.f(o);
+    function f(o) {
+      const color = this.arg1.f(o);
+      const amount = this.arg2.f(o);
       return foam.Color.lighten(color, amount);
     }
   ]
@@ -91,10 +90,10 @@ foam.CLASS({
     }
   ],
   methods: [
-    async function f(o) {
-      const color = await this.baseColor.f(o);
-      const dark = await this.darkColor.f(o);
-      const light = await this.lightColor.f(o);
+    function f(o) {
+      const color = this.baseColor.f(o);
+      const dark = this.darkColor.f(o);
+      const light = this.lightColor.f(o);
       return foam.Color.getBestForeground(color, dark, light);
     }
   ]
@@ -103,7 +102,7 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.css',
-  name: 'ColorExprBuilder',
+  name: 'TokenUtilsBuilder',
   requires: [
     'foam.css.LightenExpr',
     'foam.css.TokenExpr',

--- a/src/foam/css/mlang.js
+++ b/src/foam/css/mlang.js
@@ -1,0 +1,117 @@
+/**
+* @license
+* Copyright 2022 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  package: 'foam.css',
+  name: 'TokenExpr',
+
+  documentation: `
+    Mlang expr for getting the value of the token from current context
+    WARNING: Unlike most Mlang exprs, this expr is async and can only be used with other exprs that support async
+  `,
+
+  properties: [
+    { name: 'arg1' }
+  ],
+  methods: [
+    async function f(o) {
+      return await foam.CSS.returnTokenValue(this.arg1, o.cls_, o.__subContext__);
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.css',
+  name: 'LightenExpr',
+  requires: [ 'foam.mlang.Constant'],
+  properties: [
+    {
+      name: 'arg1',
+      adapt: function(_, n) {
+        if ( typeof n === 'string' ) {
+          return this.Constant.create({ value: n });
+        }
+        return n;
+      }
+    },
+    {
+      name: 'arg2',
+      adapt: function(_, n) {
+        if ( typeof n === 'number' ) {
+          return this.Constant.create({ value: n });
+        }
+        return n;
+      }
+    }
+  ],
+  methods: [
+    async function f(o) {
+      const color = await this.arg1.f(o);
+      const amount = await this.arg2.f(o);
+      return foam.Color.lighten(color, amount);
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.css',
+  name: 'FindForegroundExpr',
+
+  requires: [ 'foam.mlang.Constant'],
+  properties: [
+    {
+      name: 'baseColor',
+      adapt: function(_, n) {
+        if ( typeof n === 'string' ) {
+          return this.Constant.create({ value: n });
+        }
+        return n;
+      }
+    },
+    {
+      name: 'darkColor',
+      adapt: function(_, n) {
+        if ( typeof n === 'string' ) {
+          return this.Constant.create({ value: n });
+        }
+        return n;
+      }
+    },
+    {
+      name: 'lightColor',
+      adapt: function(_, n) {
+        if ( typeof n === 'string' ) {
+          return this.Constant.create({ value: n });
+        }
+        return n;
+      }
+    }
+  ],
+  methods: [
+    async function f(o) {
+      const color = await this.baseColor.f(o);
+      const dark = await this.darkColor.f(o);
+      const light = await this.lightColor.f(o);
+      return foam.Color.getBestForeground(color, dark, light);
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.css',
+  name: 'ColorExprBuilder',
+  requires: [
+    'foam.css.LightenExpr',
+    'foam.css.TokenExpr',
+    'foam.css.FindForegroundExpr'
+  ],
+  methods: [
+    function TOKEN(name) { return this.TokenExpr.create({ arg1: name }); },
+    function LIGHTEN(a, b) { return this.LightenExpr.create({ arg1: a, arg2: b }); },
+    function FOREGROUND(a, b, c) { return this.FindForegroundExpr.create({ baseColor: a, darkColor: b, lightColor: c }); },
+  ]
+});

--- a/src/foam/demos/u2/TokenPom.js
+++ b/src/foam/demos/u2/TokenPom.js
@@ -1,0 +1,8 @@
+foam.POM({
+  name: 'tokenPom',
+  version: 22,
+  projects: [
+    { name: '../../../pom' },
+    { name: '../../../foam/nanos/pom' }
+  ]
+});

--- a/src/foam/demos/u2/TokenTest.html
+++ b/src/foam/demos/u2/TokenTest.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <script language="javascript" src="../../../foam.js" project="foam/demos/u2/TokenPom"></script>
+  </head>
+  <body>
+    <script src="Border.js"></script>
+    <script src="TokenTest.js"></script>
+    <foam id="demo" class="TokenTest"></foam>
+  </body>
+</html>

--- a/src/foam/demos/u2/TokenTest.js
+++ b/src/foam/demos/u2/TokenTest.js
@@ -110,7 +110,6 @@ foam.CLASS({
         X.cssTokenOverrideDAO.put(foam.nanos.theme.customisation.CSSTokenOverride.create({ theme: '', source: 'test1', target: this.color }, this))
           .then(() => {
             if ( this.ctrl ) {
-              this.ctrl.themeChange.pub();
               return;
             }
             // Trying to imitate ApplicationController's fancy CSS live update

--- a/src/foam/demos/u2/TokenTest.js
+++ b/src/foam/demos/u2/TokenTest.js
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2022 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  name: 'TokenTest',
+  extends: 'foam.u2.View',
+
+  imports: ['ctrl?'],
+
+  exports: [
+    'tokenDAO as cssTokenOverrideDAO',
+    'tokenService as cssTokenOverrideService'
+  ],
+  css: `
+    ^test1 {
+      background: $test1;
+      color: $foreground1;
+    }
+    ^test2 {
+      background: $test2;
+      color: $foreground2;
+    }
+    ^myButton.foam-u2-ActionView {
+      background: $test1;
+      color: $foreground1;
+    }
+    ^myButton.foam-u2-ActionView:hover:not(:disabled) {
+      background: $test2;
+      color: $foreground2;
+    }
+    ^myButton.foam-u2-ActionView:focus {
+      background: $test3;
+      color: $foreground2;
+      border-color: $test1;
+    }
+  `,
+  cssTokens: [
+    {
+      name: 'test1',
+      value: 'red'
+    },
+    {
+      name: 'test2',
+      value: function(e) { return e.LIGHTEN(e.TOKEN('$test1'), -20); }
+    },
+    {
+      name: 'test3',
+      value: function(e) { return e.LIGHTEN(e.TOKEN('$test2'), -20); }
+    },
+    {
+      name: 'foreground1',
+      value: function(e) { return e.FOREGROUND(e.TOKEN('$test1'), 'black', 'white'); }
+    },
+    {
+      name: 'foreground2',
+      value: function(e) { return e.FOREGROUND(e.TOKEN('$test2'), 'black', 'white'); }
+    }
+  ],
+
+  properties: [
+    'color',
+    {
+      name: 'tokenDAO',
+      factory: function() {
+        return foam.dao.EasyDAO.create({
+          of: foam.nanos.theme.customisation.CSSTokenOverride,
+          daoType: 'MDAO'
+        }, this);
+      }
+    },
+    {
+      name: 'tokenService',
+      factory: function() {
+        return foam.nanos.theme.customisation.CSSTokenOverrideService.create({}, this);
+      }
+    }
+  ],
+  methods: [
+    function render() {
+      this
+      .start()
+        .addClass(this.myClass('test1'))
+        .add('Token test1 as background, auto-generated foreground')
+      .end()
+      .start()
+        .addClass(this.myClass('test2'))
+        .add('Token test2 as background (auto generated as 20% darker version of test1, also generates foreground based on current background)')
+      .end()
+      .br().br()
+      .startContext({ data: this })
+      .tag(this.COLOR.__, { config: { label: 'Color for test1 token' } })
+      .tag(this.SAVE)
+      .endContext()
+      .br().br()
+      .start()
+        .add('Interact with this action to see auto generated hover and clicked states')
+        .br()
+        .start(this.TEST_ACTION, { buttonStyle: 'PRIMARY' }).addClass(this.myClass('myButton')).end()
+      .end();
+    }
+  ],
+  actions: [
+    { name: 'testAction', code: () => {} },
+    {
+      name: 'save',
+      code: function(X) {
+        X.cssTokenOverrideDAO.put(foam.nanos.theme.customisation.CSSTokenOverride.create({ theme: '', source: 'test1', target: this.color }, this))
+          .then(() => {
+            if ( this.ctrl ) {
+              this.ctrl.themeChange.pub();
+              return;
+            }
+            // Trying to imitate ApplicationController's fancy CSS live update
+            let a = foam.u2.CSS.create({ code: this.cls_.model_.css }, this);
+            X.installCSS(a.expandCSS(this.cls_, a.code, X));
+          });
+      }
+    }
+  ]
+});

--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -421,6 +421,7 @@ foam.CLASS({
         await client.translationService.initLatch;
         self.installLanguage();
 
+        self.onDetach(self.__subContext__.cssTokenOverrideService?.sub('cacheUpdated', this.reloadStyles));
         // TODO Interim solution to pushing unauthenticated menu while applicationcontroller refactor is still WIP
         if ( self.route ) {
           var menu = await self.__subContext__.menuDAO.find(self.route);
@@ -472,18 +473,7 @@ foam.CLASS({
       });
 
       // Reload styling on theme change
-      // TODO BEFORE MERGE: Refactor this to work with new theme system
-      this.onDetach(this.sub('themeChange', () => {
-        for ( const eid in this.styles ) {
-          const style = this.styles[eid];
-          // If cssTokens are still being installed then no need to reinstall
-          if ( ! foam.String.isInstance(style.text) ) continue;
-          text = foam.CSS.replaceTokens(style.text, style.cls, this.__subContext__, this.THEME_OVERRIDE_REGEXP);
-          Promise.resolve(text).then( t => {
-            this.replaceStyleTag(t, eid)
-          });
-        }
-      }));
+      this.onDetach(this.sub('themeChange', this.reloadStyles));
     },
 
     function render() {
@@ -553,6 +543,8 @@ foam.CLASS({
       var newClient = await this.ClientBuilder.create({}, this).promise;
       this.client = newClient.create(null, this);
       this.setPrivate_('__subContext__', this.client.__subContext__);
+      // TODO: find a better way to resub on client reloads
+      this.onDetach(this.__subContext__.cssTokenOverrideService.sub('cacheUpdated', this.reloadStyles));
       this.subject = await this.client.auth.getCurrentSubject(null);
     },
 
@@ -671,19 +663,11 @@ foam.CLASS({
       if ( ! text ) return;
       var eid = 'style' + foam.next$UID();
       this.styles[eid] = { text: text, cls: id };
-      if ( foam.String.isInstance(text) ) {
-        for ( var i = 0 ; i < this.MACROS.length ; i++ ) {
-          const m = this.MACROS[i];
-          text = this.expandShortFormMacro(this.expandLongFormMacro(text, m), m);
-        }
-        this.installCSS(text, id, eid);
-      } else {
-        // If css is a promise add the style tag but add the css only when returned from promise
-        this.installCSS('', id, eid);
-        Promise.resolve(text).then(t => {
-          this.replaceStyleTag(t, eid)
-        });
+      for ( var i = 0 ; i < this.MACROS.length ; i++ ) {
+        const m = this.MACROS[i];
+        text = this.expandShortFormMacro(this.expandLongFormMacro(text, m), m);
       }
+      this.installCSS(text, id, eid);
     },
 
     function returnExpandedCSS(text) {
@@ -919,6 +903,18 @@ foam.CLASS({
       const el = this.getElementById(eid);
       if ( text !== el?.textContent ) {
         el.textContent = text;
+      }
+    },
+    {
+      name: 'reloadStyles',
+      isMerged: true,
+      mergeDelay: 500,
+      code: function() {
+        for ( const eid in this.styles ) {
+          const style = this.styles[eid];
+          text = foam.CSS.replaceTokens(style.text, style.cls, this.__subContext__, this.THEME_OVERRIDE_REGEXP);
+          this.replaceStyleTag(text, eid);
+        }
       }
     }
   ]

--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -158,7 +158,7 @@ foam.CLASS({
     },
     {
       name: 'THEME_OVERRIDE_REGEXP',
-      factory: function() { return new RegExp(/\/\*\$(.*)\*\/[^);!]*/, 'g'); }
+      factory: function() { return new RegExp(/\/\*\$(.*)\*\/[^;!]*/, 'g'); }
     }
   ],
 

--- a/src/foam/nanos/theme/customisation/CSSTokenOverrideService.js
+++ b/src/foam/nanos/theme/customisation/CSSTokenOverrideService.js
@@ -7,31 +7,89 @@
 foam.CLASS({
   package: 'foam.nanos.theme.customisation',
   name: 'CSSTokenOverrideService',
+  mixins: ['foam.util.DeFeedback'],
 
-  imports: ['cssTokenOverrideDAO? as tokenOverrideDAO', 'theme?'],
+  imports: [
+    'cssTokenOverrideDAO? as tokenOverrideDAO',
+    'theme?'
+  ],
 
   implements: ['foam.mlang.Expressions'],
 
-  requires: ['foam.nanos.theme.customisation.CSSTokenOverride'],
+  requires: [
+    'foam.nanos.theme.customisation.CSSTokenOverride',
+    'foam.core.Latch'
+  ],
+
+  topics: ['cacheUpdated'], 
+
+  properties: [
+    {
+      name: 'tokenCache',
+      // class: 'Map'
+      class: 'Array'
+    },
+    {
+      name: 'initLatch',
+      documentation: 'Latch to denote cache has been loaded and service is ready',
+      factory: function() { 
+        return this.Latch.create(); 
+      }
+    },
+    {
+      name: 'cached_',
+      class: 'Boolean'
+    }
+  ],
+
+  methods: [
+    function init() {
+      // TODO: Add responsive theme based token caching, TBD when
+      this.loadTokenCache().then(() => {
+        this.onDetach(this.tokenOverrideDAO.on.sub(this.maybeReload));
+      });
+    },
+    function loadTokenCache() {
+      this.initLatch.then(() => {
+        this.cached_ = true;
+        this.cacheUpdated.pub();
+      })
+      return this.tokenOverrideDAO.select(token => {
+        this.tokenCache.push(token);
+      }).then(() => { this.initLatch.resolve(); });
+    }
+  ],
 
   listeners: [
-    async function getTokenValue(tokenString, cls, ctx) {
+    function maybeReload() {
+      this.initLatch = this.Latch.create();
+      this.clearProperty('tokenCache');
+      this.clearProperty('cached_');
+      this.loadTokenCache();
+      return this.initLatch;
+    },
+    function getTokenValue(tokenString, cls, ctx) {
       var self = this;
-      let themeID = ctx?.theme?.id || this.theme?.id || '';
-      let result = null;
-      var [ tokenName, cls, fullString ] = foam.CSS.returnTokenAndClass(tokenString, cls);
-      if ( this.tokenOverrideDAO ) {
+      if ( this.cached_ ) {
+        let themeID = ctx?.theme?.id || this.theme?.id || '';
+        let result = null;
+        var [ tokenName, cls, fullString ] = foam.CSS.returnTokenAndClass(tokenString, cls);
         var args = [
-          //[theme, name]
+          /**
+           * Wildcarding:
+           * ThemeID = current theme
+           * tokenName = tokenString with $ removed, eg. "token1"
+           * fullString = cls.id + tokenString eg. "foam.somePackage.someClass.token1"
+           */
           [themeID, fullString],
           [themeID, tokenName],
           ['',fullString],
           ['',tokenName]
         ];
         for ( var i = 0 ; i < args.length && ! result ; i ++) {
-          result = await this.tokenValueHelper.apply(self, args[i]);
+          result = this.tokenValueHelper.apply(self, args[i]);
           if ( result ) {
-            if ( result.startsWith('$') )
+            if ( result.startsWith?.('$') )
               return this.getTokenValue.call(this, result, cls, ctx);
             return result;
           }
@@ -40,16 +98,13 @@ foam.CLASS({
       //TODO: Put to default theme in override dao
       return foam.CSS.getTokenValue.call(this, tokenString, cls, ctx);
     },
-    async function tokenValueHelper(theme, name) {
+    function tokenValueHelper(theme, name) {
       var pred = this.AND(
         this.EQ(this.CSSTokenOverride.ENABLED, true),
         this.EQ(this.CSSTokenOverride.THEME, theme),
         this.EQ(this.CSSTokenOverride.SOURCE, name)
       );
-      // TODO: why does this not work?
-      // let r = await this.tokenOverrideDAO.find(pred);
-      let r = await this.tokenOverrideDAO.select();
-      r = r?.array.filter(obj => pred.f(obj))
+      r = this.tokenCache.filter(obj => pred.f(obj))
       return r.length ? r[0]?.target : undefined;
     }
   ]

--- a/src/foam/nanos/theme/customisation/CSSTokenOverrideService.js
+++ b/src/foam/nanos/theme/customisation/CSSTokenOverrideService.js
@@ -38,7 +38,7 @@ foam.CLASS({
         }
       }
       //TODO: Put to default theme in override dao
-      return foam.CSS.getTokenValue.call(this, tokenName, cls, ctx, true);
+      return foam.CSS.getTokenValue.call(this, tokenString, cls, ctx);
     },
     async function tokenValueHelper(theme, name) {
       var pred = this.AND(

--- a/src/foam/u2/CSSToken.js
+++ b/src/foam/u2/CSSToken.js
@@ -20,9 +20,9 @@ foam.CLASS({
     {
       name: 'value',
       preSet: function(o, d) {
-        var f = ! d || foam.util.isPrimitive(d);
+        var f = ! d || foam.util.isPrimitive(d) || foam.Function.isInstance(d);
         if ( ! f ) {
-          this.__context__.warn('Set Token value to non-primitive or Token:' + d);
+          this.__context__.warn('Trying to set invalid token value:' + d);
           return o;
         }
         return d;
@@ -39,12 +39,12 @@ foam.CLASS({
         return d;
       }
     },
-    'sourceCls_',
+    'sourceCls_'
   ],
 
   methods: [
     function toSummary() {
-      return `name: ${this.name}, value: ${this.value}, fallback: ${this.fallback}`
+      return `name: ${this.name}, value: ${this.value}, fallback: ${this.fallback}`;
     },
     function installInClass(cls) {
       var axiom = this;
@@ -53,7 +53,7 @@ foam.CLASS({
         cls,
         foam.String.constantize(this.name),
         {
-          get: function() { return axiom },
+          get: function() { return axiom; }
         }
       );
     },

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -194,7 +194,7 @@ foam.CLASS({
       };
     },
 
-    async function expandCSS(cls, text, ctx) {
+    function expandCSS(cls, text, ctx) {
       if ( ! this.expands_ ) return text;
 
       /* Performs expansion of the ^ shorthand on the CSS. */
@@ -213,7 +213,7 @@ foam.CLASS({
 
         return base + next;
       });
-      return await foam.CSS.replaceTokens(text, cls, ctx);
+      return foam.CSS.replaceTokens(text, cls, ctx);
     }
   ]
 });

--- a/src/pom.js
+++ b/src/pom.js
@@ -1170,6 +1170,6 @@ foam.POM({
     { name: "foam/u2/view/FUIDSearch",                                flags: "web" },
     { name: "foam/nanos/cron/SimpleIntervalScheduleView",             flags: "web" },
     { name: "foam/u2/view/ClassCompleterView",                        flags: "web" },
-    { name: "foam/css/mlang",                                         flags: "web" }
+    { name: "foam/css/TokenUtils",                                    flags: "web" }
  ]
 });

--- a/src/pom.js
+++ b/src/pom.js
@@ -1169,6 +1169,7 @@ foam.POM({
     { name: "foam/u2/FUIDAutocompleter",                              flags: "web" },
     { name: "foam/u2/view/FUIDSearch",                                flags: "web" },
     { name: "foam/nanos/cron/SimpleIntervalScheduleView",             flags: "web" },
-    { name: "foam/u2/view/ClassCompleterView",                        flags: "web" }
+    { name: "foam/u2/view/ClassCompleterView",                        flags: "web" },
+    { name: "foam/css/mlang",                                         flags: "web" }
  ]
 });


### PR DESCRIPTION
Adds mlangs for cssTokens that allows us to generate hover states and best foreground colours from a single token value. See demo for implementation. 

- Remove promises from the expandCSS flow making it synchronous again
- Add caching to cssTokenOverrideService
- Add style reloading on the tokenOverrideService cache update
- Add TokenUtils to generate multiple tokens from a single token value