### PR TITLE
Np 7093/add time stamp not date

### DIFF
--- a/src/foam/nanos/column/TableColumnOutputter.js
+++ b/src/foam/nanos/column/TableColumnOutputter.js
@@ -44,7 +44,7 @@ foam.CLASS({
             return ( val / 100 ).toString();
           }
           if ( foam.core.DateTime.isInstance(prop) ) {
-            return val.toString().substring(0, 24);
+            return val.toString();
           }
           if ( foam.core.Date.isInstance(prop) ) {
             return val.toLocaleDateString(foam.locale);

--- a/src/foam/nanos/column/TableColumnOutputter.js
+++ b/src/foam/nanos/column/TableColumnOutputter.js
@@ -43,11 +43,11 @@ foam.CLASS({
             }
             return ( val / 100 ).toString();
           }
-          if ( foam.core.Date.isInstance(prop) ) {
-            return val.toLocaleDateString(foam.locale);
-          }
           if ( foam.core.DateTime.isInstance(prop) ) {
             return val.toString().substring(0, 24);
+          }
+          if ( foam.core.Date.isInstance(prop) ) {
+            return val.toLocaleDateString(foam.locale);
           }
           if ( foam.core.Time.isInstance(prop) ) {
             return val.toString().substring(0, 8);


### PR DESCRIPTION
**Please peg to 3.19**
We should keep the time zone in the timestamps for downloaded reports.

Before:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/97463241/173149749-3afb0f3e-dce5-4234-9385-0ca0aa3eb4ce.png">

After
<img width="875" alt="Screen Shot 2022-06-10 at 1 54 27 PM" src="https://user-images.githubusercontent.com/97463241/173149615-17c6d8b5-84a6-435a-8929-d73d32253f6b.png">
: