### PR TITLE
[NP-7280] Allow edit and save of incomplete Capables

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -783,7 +783,11 @@ model from which to test ServiceProvider ID (spid)`,
     },
     {
       name: 'allowActionRequiredPuts',
-      class: 'Boolean'
+      class: 'Boolean',
+      documentation: `
+        For Capable objects, setting this to true disables CapabilityIntercepts
+        and instead allows putting objects with ACTION_REQUIRED payloads.
+      `
     },
     {
       name: 'fixedSize',

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -313,7 +313,11 @@ foam.CLASS({
           delegate = new foam.nanos.auth.LastModifiedByAwareDAO.Builder(getX()).setDelegate(delegate).build();
 
         if ( getCapable() )
-          delegate = new foam.nanos.crunch.lite.CapableDAO.Builder(getX()).setDaoKey(getName()).setDelegate(delegate).build();
+          delegate = new foam.nanos.crunch.lite.CapableDAO.Builder(getX())
+            .setDaoKey(getName())
+            .setDelegate(delegate)
+            .setAllowActionRequiredPuts(getAllowActionRequiredPuts())
+            .build();
 
         if ( getContextualize() ) {
           delegate = new foam.dao.ContextualizingDAO.Builder(getX()).
@@ -776,6 +780,10 @@ model from which to test ServiceProvider ID (spid)`,
       name: 'capable',
       class: 'Boolean',
       javaFactory: 'return getEnableInterfaceDecorators() && foam.nanos.crunch.lite.Capable.class.isAssignableFrom(getOf().getObjClass());'
+    },
+    {
+      name: 'allowActionRequiredPuts',
+      class: 'Boolean'
     },
     {
       name: 'fixedSize',

--- a/src/foam/nanos/crunch/lite/CapableDAO.js
+++ b/src/foam/nanos/crunch/lite/CapableDAO.js
@@ -33,6 +33,10 @@ foam.CLASS({
       name: 'defaultStatus',
       of: 'foam.nanos.crunch.CapabilityJunctionStatus',
       value: foam.nanos.crunch.CapabilityJunctionStatus.ACTION_REQUIRED
+    },
+    {
+      class: 'Boolean',
+      name: 'allowActionRequiredPuts'
     }
   ],
 
@@ -103,7 +107,8 @@ foam.CLASS({
         if ( 
           ! toPutCapableObj.checkRequirementsStatusNoThrow(x, toPutCapableObj.getCapabilityIds(), CapabilityJunctionStatus.GRANTED) &&
           ! toPutCapableObj.checkRequirementsStatusNoThrow(x, toPutCapableObj.getCapabilityIds(), CapabilityJunctionStatus.PENDING) &&
-          ! toPutCapableObj.checkRequirementsStatusNoThrow(x, toPutCapableObj.getCapabilityIds(), CapabilityJunctionStatus.REJECTED)
+          ! toPutCapableObj.checkRequirementsStatusNoThrow(x, toPutCapableObj.getCapabilityIds(), CapabilityJunctionStatus.REJECTED) &&
+          ! getAllowActionRequiredPuts()
         ) {
           CapabilityIntercept cre = new CapabilityIntercept();
           cre.setDaoKey(getDaoKey());

--- a/src/foam/nanos/crunch/lite/CapableObjectData.js
+++ b/src/foam/nanos/crunch/lite/CapableObjectData.js
@@ -8,6 +8,10 @@ foam.CLASS({
   package: 'foam.nanos.crunch.lite',
   name: 'CapableObjectData',
 
+  imports: [
+    'crunchController?'
+  ],
+
   properties: [
     {
       name: 'capablePayloads',
@@ -37,8 +41,7 @@ foam.CLASS({
       class: 'StringArray',
       name: 'capabilityIds',
       columnPermissionRequired: true,
-      section: 'capabilityInformation',
-      visibility: 'HIDDEN'
+      section: 'capabilityInformation'
     },
     {
       class: 'String',
@@ -70,6 +73,21 @@ foam.CLASS({
         return this.CapableAdapterDAO.create({
           capable: this
         });
+      }
+    }
+  ],
+
+  actions: [
+    {
+      name: 'openCapableWizard',
+      code: async function () {
+        if ( ! this.crunchController ) return;
+        for ( const capabilityId of this.capabilityIds ) {
+          const seq = this.crunchController.createCapableWizardSequence(
+            undefined, this, capabilityId
+          );
+          await seq.execute();
+        }
       }
     }
   ]


### PR DESCRIPTION
Adds a parameter for `CapableDAO` to optionally allow ACTION_REQUIRED Capable objects to be saved. These Capable objects will not induce an intercept.