### PR TITLE
ScriptRunnerDAO - do not return clone to caller, only pass clone to r…

### DIFF
--- a/src/foam/nanos/script/Script.js
+++ b/src/foam/nanos/script/Script.js
@@ -405,7 +405,7 @@ foam.CLASS({
 
         try {
           Thread.currentThread().setPriority(getPriority());
-
+          setLastRun(new Date());
           if ( l == foam.nanos.script.Language.BEANSHELL ) {
             Interpreter shell = (Interpreter) createInterpreter(x, ps);
             setOutput("");
@@ -427,7 +427,6 @@ foam.CLASS({
           logger.error(this.getClass().getSimpleName(), "runScript", getId(), t);
           throw thrown;
         } finally {
-          setLastRun(new Date());
           setLastDuration(pm.getTime());
           ps.flush();
           setOutput(baos.toString());

--- a/src/foam/nanos/script/ScriptRunnerDAO.js
+++ b/src/foam/nanos/script/ScriptRunnerDAO.js
@@ -31,8 +31,8 @@ foam.CLASS({
         if ( script.getStatus() == ScriptStatus.SCHEDULED ) {
           if ( script.canRun(x) ) {
             script.setStatus(ScriptStatus.RUNNING);
-            script = (Script) getDelegate().put_(x, script).fclone();
-            runScript(x, script);
+            script = (Script) getDelegate().put_(x, script);
+            runScript(x, (Script) script.fclone());
           } else {
             script.setStatus(ScriptStatus.UNSCHEDULED);
             script = (Script) getDelegate().put_(x, script);

--- a/src/foam/nanos/script/TestRunnerScript.js
+++ b/src/foam/nanos/script/TestRunnerScript.js
@@ -77,8 +77,8 @@ foam.CLASS({
         // turn off logging to get rid of clutter.
         LogLevelFilterLogger loggerFilter = (LogLevelFilterLogger) x.get("logger");
         loggerFilter.setLogDebug(false);
-        loggerFilter.setLogInfo(true);
-        loggerFilter.setLogWarning(true);
+        loggerFilter.setLogInfo(false);
+        loggerFilter.setLogWarning(false);
 
         TestRunnerConfig config = (TestRunnerConfig) x.get("testRunnerConfig");
         String testSuite = config != null ? config.getTestSuite() : null;

--- a/src/foam/nanos/script/TestRunnerScript.js
+++ b/src/foam/nanos/script/TestRunnerScript.js
@@ -77,8 +77,8 @@ foam.CLASS({
         // turn off logging to get rid of clutter.
         LogLevelFilterLogger loggerFilter = (LogLevelFilterLogger) x.get("logger");
         loggerFilter.setLogDebug(false);
-        loggerFilter.setLogInfo(false);
-        loggerFilter.setLogWarning(false);
+        loggerFilter.setLogInfo(true);
+        loggerFilter.setLogWarning(true);
 
         TestRunnerConfig config = (TestRunnerConfig) x.get("testRunnerConfig");
         String testSuite = config != null ? config.getTestSuite() : null;


### PR DESCRIPTION
…unScript. This addresses the issue where status is not always set correctly at completion of the script, and also for extends of Script, no child object parameters are saved.