### PR TITLE
Add foam.DEF_MACRO and foam.APPLY_MACRO

### DIFF
--- a/src/foam/core/Macro.js
+++ b/src/foam/core/Macro.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2022 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+    package: 'foam.core',
+    name: 'MacroModel',
+    extends: 'foam.core.Model',
+
+    imports: [
+        // Import the methods exported by foam.APPLY_MACRO
+        'CLASS'
+    ],
+
+    documentation: 'Metaprogramming construct to create FOAM models from data',
+
+    properties: [
+        {
+            class: 'Function',
+            name: 'code'
+        }
+    ]
+});
+
+foam.LIB({
+    name: 'foam',
+
+    methods: [
+        function DEF_MACRO(m) {
+            m.class = m.class || 'foam.core.MacroModel';
+            foam.CLASS(m);
+        },
+        function APPLY_MACRO(macroCls, data) {
+            let macro = foam.lookup(macroCls).model_;
+
+            // Future-proofing in case .model_ returns the raw object
+            if ( ! macro.cls_ ) {
+                // macro = foam.json.parse(macro);
+                throw new Error('APPLY_MACRO expects model_ to be an FObject');
+            }
+            
+            // Because macros are synchronous we can reaplce foam.CLASS for
+            // convenience. Note that this means methods like foam.INTERFACE
+            // will also use this implementation while the macro is applied.
+            const realFoamDotClass = foam.CLASS;
+            foam.CLASS = function (m) {
+                m.genTransient = true;
+                realFoamDotClass.call(foam, m);
+            };
+
+            if ( foam.Array.isInstance(data) ) {
+                for ( const datum of data ) {
+                    macro.code.call(macro, datum);
+                }
+            } else {
+                macro.code.call(macro, data);
+            }
+
+            foam.CLASS = realFoamDotClass;
+        }
+    ]
+});
+
+foam.LIB({
+    name: 'foam.Function',
+
+    methods: [
+        // This library function is specifically useful for macros which
+        // generate 'expression' Property properties.
+        function spoofArgNames(fn, newNames) {
+            const oldToString = fn.toString;
+            const argStr = newNames.join(', ');
+
+            fn.toString = function () {
+                return oldToString.call(this).replace(/^.*?\)/, `function (${argStr})`);
+            };
+
+            return fn;
+        }
+    ]
+});

--- a/src/foam/core/Macro.js
+++ b/src/foam/core/Macro.js
@@ -9,11 +9,6 @@ foam.CLASS({
     name: 'MacroModel',
     extends: 'foam.core.Model',
 
-    imports: [
-        // Import the methods exported by foam.APPLY_MACRO
-        'CLASS'
-    ],
-
     documentation: 'Metaprogramming construct to create FOAM models from data',
 
     properties: [

--- a/src/pom.js
+++ b/src/pom.js
@@ -44,6 +44,7 @@ foam.POM({
     { name: "foam/core/CountingSemaphore",                            flags: "js" },
     { name: "foam/core/Promised",                                     flags: "js" },
     { name: "foam/core/Interface",                                    flags: "js" },
+    { name: "foam/core/Macro",                                        flags: "js" },
     { name: "foam/core/Type",                                         flags: "js" },
     { name: "foam/core/Axiom",                                        flags: "js|java" },
     { name: "foam/core/ContextMethod",                                flags: "js" },


### PR DESCRIPTION
Meta-programming is already possible in FOAM by calling methods like `foam.CLASS` dynamically. This PR introduces explicit meta-programming support so that this behavior can be better controlled by FOAM.

The following example defines a macro that creates two models for each value it's applied to:

```javascript
foam.DEF_MACRO({
  package: 'com.example',
  name: 'ExampleMacro',
  
  code: function (name) {
    foam.CLASS({
      package: 'com.example',
      name: 'Greedy' + name
    });
    foam.CLASS({
      package: 'com.example',
      name: 'Lazy' + name
    });
  }
});
```

We can then imply models `GreedyCat`, `LazyCat`, `GreedyDog` and `LazyDog` as follows:
```javascript
foam.APPLY_MACRO('com.example.ExampleMacro', ['Cat', 'Dog']);
```

In order to justify adding explicit support, the need for meta-programming is a prerequisite justification. Sometimes it makes sense to generate individual models from tabular data in a similar fashion that FOAM can already generate models from XSD files. I came across a good example while modelling WebAssembly functions. Each instruction has different properties and creating a general model to handle all cases would add complexity and prevent adding refinements to individual instructions.

With `foam.APPLY_MACRO` I was able to represent the differences between instructions concisely in a few lines of code:
```javascript
foam.APPLY_MACRO("wasm.ins.InstructionMacro", [
    [0x25,     'table.get',  'idx:u32'],
    [0x26,     'table.set',  'idx:u32'],
    [0xFC, 12, 'table.init', 'elemIdx:u32', 'tableidx:u32'],
    [0xFC, 13, 'elem.drop',  'idx'],
    [0xFC, 14, 'table.copy', 'a:u32', 'b:u32'],
    [0xFC, 15, 'table.grow', 'idx:u32'],
    [0xFC, 16, 'table.size', 'idx:u32'],
    [0xFC, 17, 'table.fill', 'idx:u32'],
]);
```

Here are some advantages of explicit support as opposed to the meta-programming that is already possible:
- Explicit support makes it easy to spot. When you see `_MACRO`, you know meta-programming is happening.
- Generated models can be handled differently by code generators if needed.
- Helpful axioms like `documentation` can be added to the macro itself