### PR TITLE
fix NSpecFactory

### DIFF
--- a/src/foam/nanos/boot/NSpecFactory.java
+++ b/src/foam/nanos/boot/NSpecFactory.java
@@ -71,14 +71,7 @@ public class NSpecFactory
     try {
       logger.info("Creating Service", spec_.getName());
       var service = spec_.createService(nx.put(NSpec.class, spec_).put("logger", logger), null);
-      if ( service instanceof DAO ) {
-        if ( ns_ == null ) {
-          ns_ = new ProxyDAO();
-        }
-        ((ProxyDAO) ns_).setDelegate((DAO) service);
-      } else {
-        ns_ = service;
-      }
+      setNS(service);
       logger.info("Created Service", spec_.getName());
     } catch (Throwable t) {
       logger.error("Error Creating Service", spec_.getName(), t);
@@ -180,6 +173,26 @@ public class NSpecFactory
         if ( ! spec_.getLazy() ) {
           create(x_);
         }
+      }
+    }
+  }
+
+  void setNS(Object ns) {
+    if ( ns instanceof DAO ) {
+      if ( ns_ == null ) {
+        ns_ = new ProxyDAO();
+      }
+      if ( ns_ instanceof ProxyDAO ) {
+        ((ProxyDAO) ns_).setDelegate((DAO) ns);
+      }
+    } else {
+      if ( ns_ == null ) {
+        ns_ = ns;
+      } else if ( ns_ instanceof FObject && ns instanceof FObject ) {
+        // Many services may have cached the old service in instance variables,
+        // so we can't actually switch to a new object in the context because
+        // all of the cached versions will still be out there un-updated
+        ((FObject) ns_).copyFrom((FObject) ns);
       }
     }
   }

--- a/src/foam/nanos/boot/NSpecFactory.java
+++ b/src/foam/nanos/boot/NSpecFactory.java
@@ -27,7 +27,7 @@ public class NSpecFactory
       long since = 0L;
       protected Object initialValue() {
         since = System.currentTimeMillis();
-        return maybeBuildService(null);
+        return maybeBuildService();
       }
 
       public Object get() {
@@ -44,7 +44,7 @@ public class NSpecFactory
     spec_ = spec;
   }
 
-  Object buildService(X x) {
+  void buildService(X x) {
     Logger logger = null;
     if ( ! "logger".equals(spec_.getName()) && ! "PM".equals(spec_.getName()) ) {
       logger = (Logger) x.get("logger");
@@ -56,7 +56,7 @@ public class NSpecFactory
     // Avoid infinite recursions when creating services
     if ( creatingThread_ == Thread.currentThread() ) {
       logger.warning("Recursive Service Factory", spec_.getName());
-      return null;
+      return;
     }
     creatingThread_ = Thread.currentThread();
 
@@ -68,15 +68,16 @@ public class NSpecFactory
       logger.info("NSpecFactory", spec_.getName(), "ns_ not null", ns_.getClass().getName());
     }
 
-    Object ns = null;
     try {
       logger.info("Creating Service", spec_.getName());
       var service = spec_.createService(nx.put(NSpec.class, spec_).put("logger", logger), null);
       if ( service instanceof DAO ) {
-        ns = new ProxyDAO();
-        ((ProxyDAO) ns).setDelegate((DAO) service);
+        if ( ns_ == null ) {
+          ns_ = new ProxyDAO();
+        }
+        ((ProxyDAO) ns_).setDelegate((DAO) service);
       } else {
-        ns = service;
+        ns_ = service;
       }
       logger.info("Created Service", spec_.getName());
     } catch (Throwable t) {
@@ -85,10 +86,9 @@ public class NSpecFactory
       pm.log(nx);
       creatingThread_ = null;
     }
-    return ns;
   }
 
-  void initService(X x, Object ns) {
+  void initService(X x) {
     Logger logger = null;
     if ( ! "logger".equals(spec_.getName()) && ! "PM".equals(spec_.getName()) ) {
       logger = (Logger) x.get("logger");
@@ -98,6 +98,7 @@ public class NSpecFactory
     }
 
     X  nx = x_ instanceof SubX ? x_ : x_.getX();
+    Object ns = ns_;
     try {
       while ( ns != null ) {
         if ( ns instanceof ContextAware && ! ( ns instanceof ProxyX ) ) {
@@ -120,7 +121,7 @@ public class NSpecFactory
           ns = null;
         }
       }
-      logger.info("Initialized Service", spec_.getName(), ns != null ? ns.getClass().getSimpleName() : "null");
+      logger.info("Initialized Service", spec_.getName(), ns_ != null ? ns_.getClass().getSimpleName() : "null");
     } catch (Throwable t) {
       logger.error("Error Initializing Service", spec_.getName(), t);
     }
@@ -131,7 +132,7 @@ public class NSpecFactory
     if ( spec_.getThreadLocalEnabled() ) {
       ns = tlService_.get();
     } else {
-      ns = maybeBuildService(ns_);
+      ns = maybeBuildService();
     }
 
     if ( ns instanceof XFactory ) return ((XFactory) ns).create(x);
@@ -139,13 +140,12 @@ public class NSpecFactory
     return ns;
   }
 
-  public synchronized Object maybeBuildService(Object ns) {
-    if ( ns == null || ns instanceof ProxyDAO && ((ProxyDAO) ns).getDelegate() == null ) {
-      ns = buildService(x_);
-      ns_ = ns;
-      initService(x_, ns);
+  public synchronized Object maybeBuildService() {
+    if ( ns_ == null || ns_ instanceof ProxyDAO && ((ProxyDAO) ns_).getDelegate() == null ) {
+      buildService(x_);
+      initService(x_);
     }
-    return ns;
+    return ns_;
   }
 
   public synchronized void invalidate(NSpec spec) {
@@ -160,10 +160,7 @@ public class NSpecFactory
     ) {
       if ( ns_ instanceof NanoService ) {
         spec_ = spec;
-        Object ns = buildService(x_);
-        if ( ns instanceof FObject ) {
-          ((FObject) ns_).copyFrom((FObject) ns);
-        }
+        buildService(x_);
         logger.warning("Reloading Service", spec_.getName());
         ((NanoService) ns_).reload();
       } else if ( ns_ instanceof DAO ) {

--- a/src/foam/nanos/boot/NSpecFactory.java
+++ b/src/foam/nanos/boot/NSpecFactory.java
@@ -188,7 +188,7 @@ public class NSpecFactory
     } else {
       if ( ns_ == null ) {
         ns_ = ns;
-      } else if ( ns_ instanceof FObject && ns instanceof FObject ) {
+      } else if ( ns_ instanceof NanoService && ns instanceof FObject ) {
         // Many services may have cached the old service in instance variables,
         // so we can't actually switch to a new object in the context because
         // all of the cached versions will still be out there un-updated


### PR DESCRIPTION
## Summary
Instance variable `ns_` wasn't updated properly in certain scenario on reboot, and this caused some services to be created more than once. Some of the services I was able to verify were
- bareUserCapabilityJunctionDAO (if you have certain number of entries in the dao)
- localUserDAO
- localRulerDAO
- portDAO
- localInternalSessionDAO (infrequently)

In order to reproduce this issue, you would run postman tests first (this adds more entries to daos and is necessary to replicate the issue) before restarting the server (without j flag). When the server is started, you would get two logs for each service above saying that the service was created (you can use "created service,service_name" as the search term to find the relevant logs). Also when this happens, you would also get logs saying that ns_ is not null for that service (search term: "ns_ not null").


## Fix
Refactors NSpecFactory so that `ns_` is updated correctly.
