### PR TITLE
add shortName for address.countryId

### DIFF
--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -86,6 +86,7 @@ foam.CLASS({
       targetDAOKey: 'countryDAO',
       name: 'countryId',
       label: 'Country',
+      shortName: 'country',
       of: 'foam.nanos.auth.Country',
       documentation: `A foreign key into the CountryDAO which represents the country.`,
       required: true,


### PR DESCRIPTION
fixes an issue where intuit business payments couldn't continue because country field was passed with the name 'country'

need this in v3.20