### PR TITLE
MedusaEntrySupport - ensure transient: true properties are not marsha…

### DIFF
--- a/src/foam/nanos/medusa/MedusaEntrySupport.js
+++ b/src/foam/nanos/medusa/MedusaEntrySupport.js
@@ -28,12 +28,14 @@ foam.CLASS({
         JSONFObjectFormatter formatter = new JSONFObjectFormatter();
         formatter.setOutputShortNames(true);
         formatter.setOutputDefaultClassNames(false);
+        formatter.setCalculateDeltaForNestedFObjects(true);
         formatter.setPropertyPredicate(
           new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {
+            // ignore 'transient', 'storageTransient', ...
             new foam.lib.StoragePropertyPredicate(),
+            new foam.lib.NetworkPropertyPredicate(),
             new foam.lib.ClusterPropertyPredicate()
           }));
-        formatter.setCalculateDeltaForNestedFObjects(true);
         return formatter;
       }
 
@@ -52,6 +54,12 @@ foam.CLASS({
         formatter.setOutputShortNames(true);
         formatter.setOutputDefaultClassNames(false);
         formatter.setCalculateDeltaForNestedFObjects(true);
+        formatter.setPropertyPredicate(
+          new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {
+            // ignore 'transient' but not 'storageTransient'
+            new foam.lib.NetworkPropertyPredicate(),
+            new foam.lib.ClusterPropertyPredicate()
+          }));
         return formatter;
       }
 

--- a/src/foam/nanos/medusa/MedusaEntrySupport.js
+++ b/src/foam/nanos/medusa/MedusaEntrySupport.js
@@ -61,6 +61,7 @@ foam.CLASS({
         formatter.reset();
         formatter.storageTransientDetectionEnabled_ = false;
         formatter.storageTransientDetected_ = false;
+        formatter.storageTransientDetectedAt_ = null;
         return formatter;
       }
     };

--- a/src/foam/nanos/medusa/MedusaEntrySupport.js
+++ b/src/foam/nanos/medusa/MedusaEntrySupport.js
@@ -31,9 +31,7 @@ foam.CLASS({
         formatter.setCalculateDeltaForNestedFObjects(true);
         formatter.setPropertyPredicate(
           new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {
-            // ignore 'transient', 'storageTransient', ...
             new foam.lib.StoragePropertyPredicate(),
-            new foam.lib.NetworkPropertyPredicate(),
             new foam.lib.ClusterPropertyPredicate()
           }));
         return formatter;
@@ -54,12 +52,6 @@ foam.CLASS({
         formatter.setOutputShortNames(true);
         formatter.setOutputDefaultClassNames(false);
         formatter.setCalculateDeltaForNestedFObjects(true);
-        formatter.setPropertyPredicate(
-          new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {
-            // ignore 'transient' but not 'storageTransient'
-            new foam.lib.NetworkPropertyPredicate(),
-            new foam.lib.ClusterPropertyPredicate()
-          }));
         return formatter;
       }
 

--- a/src/foam/nanos/medusa/MedusaHealthStatusDAO.js
+++ b/src/foam/nanos/medusa/MedusaHealthStatusDAO.js
@@ -37,7 +37,7 @@ foam.CLASS({
              nu.getIsPrimary() != config.getIsPrimary() ) ) { 
         ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
         Agency agency = (Agency) x.get(support.getThreadPoolName());
-        Loggers.logger(x, this).info("agency", "ClusterConfigMonitorAgent", nu.getId());
+        // Loggers.logger(x, this).debug("agency", "ClusterConfigMonitorAgent", nu.getId());
         agency.submit(x, new ClusterConfigMonitorAgent(x, nu.getId()), this.getClass().getSimpleName());
       }
       return nu;

--- a/src/foam/nanos/medusa/MedusaTransientJSONFObjectFormatter.java
+++ b/src/foam/nanos/medusa/MedusaTransientJSONFObjectFormatter.java
@@ -48,6 +48,7 @@ public class MedusaTransientJSONFObjectFormatter
 
   public boolean storageTransientDetectionEnabled_ = false;
   public boolean storageTransientDetected_ = false;
+  public FObject storageTransientDetectedAt_ = null;
 
   public boolean isStorageTransientDetected() {
     return storageTransientDetected_;
@@ -57,13 +58,10 @@ public class MedusaTransientJSONFObjectFormatter
    * Called from output - new/create flow
    */
   protected boolean maybeOutputProperty(FObject fo, PropertyInfo prop, boolean includeComma) {
-    boolean maybe = super.maybeOutputProperty(fo, prop, includeComma);
-    if ( maybe &&
-         storageTransientDetectionEnabled_ &&
-         prop.getStorageTransient() ) {
-      storageTransientDetected_ = true;
+    if ( isTransient(fo, prop) ) {
+      return super.maybeOutputProperty(fo, prop, includeComma);
     }
-    return maybe;
+    return false;
   }
 
   /**
@@ -86,12 +84,38 @@ public class MedusaTransientJSONFObjectFormatter
    * Called from maybeOutputDelta - update flow
    */
   public int compare(PropertyInfo prop, FObject oldFObject, FObject newFObject) {
-    int result = prop.compare(oldFObject, newFObject);
-    if ( result != 0 &&
-         storageTransientDetectionEnabled_ &&
-         prop.getStorageTransient() ) {
-      storageTransientDetected_ = true;
+    if ( isTransient(newFObject, prop) ) return 1;
+    return super.compare(prop, oldFObject, newFObject);
+  }
+
+  protected boolean isTransient(FObject fo, PropertyInfo prop) {
+    if ( storageTransientDetectionEnabled_ ) {
+      if ( prop.getClusterTransient() ) return false;
+
+      // transient: true
+      if ( prop.getStorageTransient() &&
+           prop.getNetworkTransient() ) return false;
+
+      // storageTransient: true (only)
+      if ( prop.getStorageTransient() &&
+           ! prop.getNetworkTransient() ) {
+        if ( ! storageTransientDetected_ ) {
+          storageTransientDetected_ = true;
+          storageTransientDetectedAt_ = fo;
+        }
+        return true;
+      }
+
+      // other and nested properties
+      if ( storageTransientDetected_ ) {
+        // Suppress non-storageTransient at same model level
+        if ( ! prop.getStorageTransient() &&
+             storageTransientDetectedAt_.getClass().equals(fo.getClass()) ) {
+          return false;
+        }
+        return true;
+      }
     }
-    return result;
+    return false;
   }
 }

--- a/src/foam/nanos/medusa/MedusaTransientJSONFObjectFormatter.java
+++ b/src/foam/nanos/medusa/MedusaTransientJSONFObjectFormatter.java
@@ -84,8 +84,19 @@ public class MedusaTransientJSONFObjectFormatter
    * Called from maybeOutputDelta - update flow
    */
   public int compare(PropertyInfo prop, FObject oldFObject, FObject newFObject) {
-    if ( isTransient(newFObject, prop) ) return 1;
-    return super.compare(prop, oldFObject, newFObject);
+    if ( ! storageTransientDetectionEnabled_ )
+      return super.compare(prop, oldFObject, newFObject);
+
+    boolean isTransient = isTransient(newFObject, prop);
+
+    if ( oldFObject == null && isTransient)
+      return 1;
+
+    if ( oldFObject != null && isTransient) {
+      return super.compare(prop, oldFObject, newFObject);
+    }
+
+    return 0;
   }
 
   protected boolean isTransient(FObject fo, PropertyInfo prop) {

--- a/src/foam/nanos/medusa/menus.jrl
+++ b/src/foam/nanos/medusa/menus.jrl
@@ -77,7 +77,8 @@ p({
     "view": {
       "class": "foam.nanos.medusa.ClusterTopologyView"
     }
-  }
+  },
+  "parent":"medusa"
 })
 
 p({

--- a/src/foam/nanos/medusa/pom.js
+++ b/src/foam/nanos/medusa/pom.js
@@ -92,7 +92,9 @@ foam.POM({
     { name: "sf/SFBroadcastDAO",                                                          flags: "js|java" },
     { name: "sf/SFBroadcastReceiverDAO",                                                  flags: "js|java" },
     { name: "sf/SFMedusaClientDAO",                                                       flags: "js|java" },
+    { name: "test/MedusaEntryParseFormatTest",                                           flags: "js|java" },
     { name: "test/MedusaTestObject",                                                      flags: "js|java" },
+    { name: "test/MedusaTestObjectNested",                                                 flags: "js|java" },
     { name: "test/MedusaTestObjectDIGBenchmark",                                          flags: "js|java" },
     { name: "test/MedusaTestObjectDistributedDIGBenchmarkRunner",                         flags: "js|java" }
   ]

--- a/src/foam/nanos/medusa/test/MedusaEntryParseFormatTest.js
+++ b/src/foam/nanos/medusa/test/MedusaEntryParseFormatTest.js
@@ -53,23 +53,22 @@ foam.CLASS({
       javaCode: `
       MedusaEntrySupport entrySupport = (MedusaEntrySupport) x.get("medusaEntrySupport");
 
-      String oldValue = "old";
-      String nuValue = "nu";
+      String value = "nu";
 
       MedusaTestObject nuMto = new MedusaTestObject();
-      nuMto.setId(nuValue);
-      nuMto.setData(nuValue);
-      nuMto.setClusterTransientData(nuValue);
-      nuMto.setNetworkTransientData(nuValue);
-      nuMto.setStorageTransientData(nuValue);
-      nuMto.setTransientData(nuValue);
+      nuMto.setId(value);
+      nuMto.setData(value);
+      nuMto.setClusterTransientData(value);
+      nuMto.setNetworkTransientData(value);
+      nuMto.setStorageTransientData(value);
+      nuMto.setTransientData(value);
 
       MedusaTestObjectNested nuNested = new MedusaTestObjectNested();
-      nuNested.setData(nuValue);
-      nuNested.setClusterTransientData(nuValue);
-      nuNested.setNetworkTransientData(nuValue);
-      nuNested.setStorageTransientData(nuValue);
-      nuNested.setTransientData(nuValue);
+      nuNested.setData(value);
+      nuNested.setClusterTransientData(value);
+      nuNested.setNetworkTransientData(value);
+      nuNested.setStorageTransientData(value);
+      nuNested.setTransientData(value);
 
       nuMto.setClusterTransientFObject(nuNested);
       nuMto.setNestedFObject(nuNested);
@@ -92,38 +91,126 @@ foam.CLASS({
       MedusaEntry me = (MedusaEntry) parser_.get().parseString(message);
 
       test ( me != null, "MedusaEntry deserialized");
+      MedusaTestObject oldMto = (MedusaTestObject) validate(me, false);
 
-      MedusaTestObject dataMto = (MedusaTestObject) parser_.get().parseString(me.getData());
-      test ( dataMto != null, "D MedusaTestObject deserialized");
-      test ( ! SafetyUtil.isEmpty(dataMto.getData()), "D data != null");
-      test ( SafetyUtil.isEmpty(dataMto.getClusterTransientData()), "D clusteredTransientData == null");
-      test ( ! SafetyUtil.isEmpty(dataMto.getNetworkTransientData()), "D networkTransientData != null");
-      test ( SafetyUtil.isEmpty(dataMto.getStorageTransientData()), "D storageTransientData == null");
-      test ( SafetyUtil.isEmpty(dataMto.getTransientData()), "D transientData == null");
-      test ( dataMto.getClusterTransientFObject() == null, "D clusterTransientFObject == null");
-      test ( dataMto.getNestedFObject() != null, "D nestedFObject != null");
-      test ( dataMto.getNetworkTransientFObject() != null, "D networkTransientFObject != null");
-      test ( dataMto.getStorageTransientFObject() == null, "D storageTransientFObject ==null");
-      test ( dataMto.getTransientFObject() == null, "D transientFObject == null");
+      // Update
+      value = "updated";
+      MedusaTestObject mto = (MedusaTestObject) oldMto.fclone();
+      mto.setData(value);
+      mto.setClusterTransientData(value);
+      mto.setNetworkTransientData(value);
+      mto.setStorageTransientData(value);
+      mto.setTransientData(value);
+      MedusaTestObjectNested nested = mto.getClusterTransientFObject();
+      if ( nested == null ) {
+        nested = new MedusaTestObjectNested();
+      }
+      nested.setData(value);
+      mto.setClusterTransientFObject(nested);
 
-      MedusaTestObject transientMto = (MedusaTestObject) parser_.get().parseString(me.getTransientData());
-      test ( transientMto != null, "T MedusaTestObject deserialized");
-      test ( SafetyUtil.isEmpty(transientMto.getData()), "T data == null");
-      test ( SafetyUtil.isEmpty(transientMto.getClusterTransientData()), "T clusteredTransientData == null");
-      test ( SafetyUtil.isEmpty(transientMto.getNetworkTransientData()), "T networkTransientData == null");
-      test ( ! SafetyUtil.isEmpty(transientMto.getStorageTransientData()), "T storageTransientData != null");
-      test ( SafetyUtil.isEmpty(transientMto.getTransientData()), "T transientData == null");
-      test ( transientMto.getClusterTransientFObject() == null, "T clusterTransientFObject == null");
-      test ( transientMto.getNestedFObject() == null, "T nestedFObject == null");
-      test ( transientMto.getNetworkTransientFObject() == null, "T networkTransientFObject == null");
-      test ( transientMto.getStorageTransientFObject() != null, "T storageTransientFObject != null");
-      test ( transientMto.getTransientFObject() == null, "T transientFObject == null");
+      nested = mto.getNestedFObject();
+      if ( nested == null ) {
+        nested = new MedusaTestObjectNested();
+      }
+      nested.setData(value);
+      mto.setNestedFObject(nested);
+
+      nested = mto.getNetworkTransientFObject();
+      if ( nested == null ) {
+        nested = new MedusaTestObjectNested();
+      }
+      nested.setData(value);
+      mto.setNetworkTransientFObject(nested);
+
+      nested = mto.getStorageTransientFObject();
+      if ( nested == null ) {
+        nested = new MedusaTestObjectNested();
+      }
+      nested.setData(value);
+      nested.setClusterTransientData(value);
+      nested.setNetworkTransientData(value);
+      nested.setStorageTransientData(value);
+      nested.setTransientData(value);
+      mto.setStorageTransientFObject(nested);
+
+      if ( oldMto != null ) {
+        MedusaTestObjectNested t = oldMto.getStorageTransientFObject();
+        test ( nested.compareTo(t) != 0, "clone nested different");
+      }
+
+      nested = mto.getTransientFObject();
+      if ( nested == null ) {
+        nested = new MedusaTestObjectNested();
+      }
+      nested.setData(value);
+      mto.setTransientFObject(nested);
+
+      MedusaEntry entry = new MedusaEntry();
+      entry.setId(2L);
+      entry.setData(entrySupport.data(x, mto, oldMto, DOP.PUT));
+      entry.setTransientData(entrySupport.transientData(x, mto, oldMto, DOP.PUT));
+
+      formatter = formatter_.get();
+      formatter.setX(getX());
+      formatter.output(entry);
+      message = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(message), "MedusaEntry (update) serialized");
+
+      entry = (MedusaEntry) parser_.get().parseString(message);
+
+      test ( entry != null, "MedusaEntry (update) deserialized");
+
+      validate(entry, true);
+      `
+    },
+    {
+      name: 'validate',
+      args: 'MedusaEntry entry, boolean update',
+      type: 'foam.core.FObject',
+      javaCode: `
+      String DT = "D ";
+      if ( update ) DT = "DU ";
+
+      MedusaTestObject dataMto = (MedusaTestObject) parser_.get().parseString(entry.getData());
+      test ( dataMto != null, DT+"MedusaTestObject deserialized");
+      test ( ! SafetyUtil.isEmpty(dataMto.getData()), DT+"data != null");
+      test ( SafetyUtil.isEmpty(dataMto.getClusterTransientData()), DT+"clusteredTransientData == null");
+      test ( ! SafetyUtil.isEmpty(dataMto.getNetworkTransientData()), DT+"networkTransientData != null");
+      test ( SafetyUtil.isEmpty(dataMto.getStorageTransientData()), DT+"storageTransientData == null");
+      test ( SafetyUtil.isEmpty(dataMto.getTransientData()), DT+"transientData == null");
+      test ( dataMto.getClusterTransientFObject() == null, DT+"clusterTransientFObject == null");
+      test ( dataMto.getNestedFObject() != null, DT+"nestedFObject != null");
+      test ( dataMto.getNetworkTransientFObject() != null, DT+"networkTransientFObject != null");
+      test ( dataMto.getStorageTransientFObject() == null, DT+"storageTransientFObject ==null");
+      test ( dataMto.getTransientFObject() == null, DT+"transientFObject == null");
+
+      DT = "T ";
+      if ( update ) DT = "TU ";
+
+      MedusaTestObject transientMto = (MedusaTestObject) parser_.get().parseString(entry.getTransientData());
+      test ( transientMto != null, DT+"MedusaTestObject deserialized");
+      test ( SafetyUtil.isEmpty(transientMto.getData()), DT+"data == null");
+      test ( SafetyUtil.isEmpty(transientMto.getClusterTransientData()), DT+"clusteredTransientData == null");
+      test ( SafetyUtil.isEmpty(transientMto.getNetworkTransientData()), DT+"networkTransientData == null");
+      test ( ! SafetyUtil.isEmpty(transientMto.getStorageTransientData()), DT+"storageTransientData != null");
+      test ( SafetyUtil.isEmpty(transientMto.getTransientData()), DT+"transientData == null");
+      test ( transientMto.getClusterTransientFObject() == null, DT+"clusterTransientFObject == null");
+      test ( transientMto.getNestedFObject() == null, DT+"nestedFObject == null");
+      test ( transientMto.getNetworkTransientFObject() == null, DT+"networkTransientFObject == null");
+      test ( transientMto.getStorageTransientFObject() != null, DT+"storageTransientFObject != null");
+      test ( transientMto.getTransientFObject() == null, DT+"transientFObject == null");
+
       MedusaTestObjectNested n = (MedusaTestObjectNested) (transientMto.getStorageTransientFObject());
-      test ( ! SafetyUtil.isEmpty(n.getData()), "T storageTransient nested data != null");
-      test ( SafetyUtil.isEmpty(n.getClusterTransientData()), "T storageTransient nested clusterTransientData == null");
-      test ( ! SafetyUtil.isEmpty(n.getNetworkTransientData()), "T storageTransient nested networkTransientData != null");
-      test ( ! SafetyUtil.isEmpty(n.getStorageTransientData()), "T storageTransient nested storageTransientData != null");
-      test ( SafetyUtil.isEmpty(n.getTransientData()), "T storageTransient nested transientData == null");
+      test ( ! SafetyUtil.isEmpty(n.getData()), DT+"storageTransient nested data != null");
+      test ( SafetyUtil.isEmpty(n.getClusterTransientData()), DT+"storageTransient nested clusterTransientData == null");
+      test ( ! SafetyUtil.isEmpty(n.getNetworkTransientData()), DT+"storageTransient nested networkTransientData != null");
+      test ( ! SafetyUtil.isEmpty(n.getStorageTransientData()), DT+"storageTransient nested storageTransientData != null");
+      test ( SafetyUtil.isEmpty(n.getTransientData()), DT+"storageTransient nested transientData == null");
+
+      n = (MedusaTestObjectNested) (transientMto.getNetworkTransientFObject());
+      test ( n == null, DT+"networkTransientFObject null");
+
+      return (MedusaTestObject) dataMto.overlay(transientMto);
       `
     }
   ]

--- a/src/foam/nanos/medusa/test/MedusaEntryParseFormatTest.js
+++ b/src/foam/nanos/medusa/test/MedusaEntryParseFormatTest.js
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2022 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.medusa.test',
+  name: 'MedusaEntryParseFormatTest',
+  extends: 'foam.nanos.test.Test',
+
+  documentation: `Test MedusaEntry data serialization/deserialization with respect to transient and non-transient properties`,
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.dao.DAO',
+    'foam.dao.DOP',
+    'foam.lib.json.JSONParser',
+    'foam.nanos.medusa.*',
+    'foam.util.SafetyUtil'
+  ],
+
+  javaCode: `
+    // formatters from SocketConnectionBox for serializing MedusaEntry itself.
+    protected static final ThreadLocal<foam.lib.formatter.FObjectFormatter> formatter_ = new ThreadLocal<foam.lib.formatter.FObjectFormatter>() {
+      @Override
+      protected foam.lib.formatter.JSONFObjectFormatter initialValue() {
+        foam.lib.formatter.JSONFObjectFormatter formatter = new foam.lib.formatter.JSONFObjectFormatter();
+        formatter.setQuoteKeys(true);
+        formatter.setPropertyPredicate(new foam.lib.ClusterPropertyPredicate());
+        return formatter;
+      }
+
+      @Override
+      public foam.lib.formatter.FObjectFormatter get() {
+        foam.lib.formatter.FObjectFormatter formatter = super.get();
+        formatter.reset();
+        return formatter;
+      }
+    };
+
+      protected ThreadLocal<JSONParser> parser_ = new ThreadLocal<JSONParser>() {
+      @Override
+      protected JSONParser initialValue() {
+        return getX().create(JSONParser.class);
+      }
+    };
+  `,
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+      MedusaEntrySupport entrySupport = (MedusaEntrySupport) x.get("medusaEntrySupport");
+
+      String oldValue = "old";
+      String nuValue = "nu";
+
+      MedusaTestObject nuMto = new MedusaTestObject();
+      nuMto.setId(nuValue);
+      nuMto.setData(nuValue);
+      nuMto.setClusterTransientData(nuValue);
+      nuMto.setNetworkTransientData(nuValue);
+      nuMto.setStorageTransientData(nuValue);
+      nuMto.setTransientData(nuValue);
+
+      MedusaTestObjectNested nuNested = new MedusaTestObjectNested();
+      nuNested.setData(nuValue);
+      nuNested.setClusterTransientData(nuValue);
+      nuNested.setNetworkTransientData(nuValue);
+      nuNested.setStorageTransientData(nuValue);
+      nuNested.setTransientData(nuValue);
+
+      nuMto.setClusterTransientFObject(nuNested);
+      nuMto.setNestedFObject(nuNested);
+      nuMto.setNetworkTransientFObject(nuNested);
+      nuMto.setStorageTransientFObject(nuNested);
+      nuMto.setTransientFObject(nuNested);
+
+      // test 1 - new object
+      MedusaEntry nuEntry = new MedusaEntry();
+      nuEntry.setId(1L);
+      nuEntry.setData(entrySupport.data(x, nuMto, null, DOP.PUT));
+      nuEntry.setTransientData(entrySupport.transientData(x, nuMto, null, DOP.PUT));
+
+      foam.lib.formatter.FObjectFormatter formatter = formatter_.get();
+      formatter.setX(getX());
+      formatter.output(nuEntry);
+      String message = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(message), "MedusaEntry serialized");
+
+      MedusaEntry me = (MedusaEntry) parser_.get().parseString(message);
+
+      test ( me != null, "MedusaEntry deserialized");
+
+      MedusaTestObject dataMto = (MedusaTestObject) parser_.get().parseString(me.getData());
+      test ( dataMto != null, "D MedusaTestObject deserialized");
+      test ( ! SafetyUtil.isEmpty(dataMto.getData()), "D data != null");
+      test ( SafetyUtil.isEmpty(dataMto.getClusterTransientData()), "D clusteredTransientData == null");
+      test ( ! SafetyUtil.isEmpty(dataMto.getNetworkTransientData()), "D networkTransientData != null");
+      test ( SafetyUtil.isEmpty(dataMto.getStorageTransientData()), "D storageTransientData == null");
+      test ( SafetyUtil.isEmpty(dataMto.getTransientData()), "D transientData == null");
+      test ( dataMto.getClusterTransientFObject() == null, "D clusterTransientFObject == null");
+      test ( dataMto.getNestedFObject() != null, "D nestedFObject != null");
+      test ( dataMto.getNetworkTransientFObject() != null, "D networkTransientFObject != null");
+      test ( dataMto.getStorageTransientFObject() == null, "D storageTransientFObject ==null");
+      test ( dataMto.getTransientFObject() == null, "D transientFObject == null");
+
+      MedusaTestObject transientMto = (MedusaTestObject) parser_.get().parseString(me.getTransientData());
+      test ( transientMto != null, "T MedusaTestObject deserialized");
+      test ( SafetyUtil.isEmpty(transientMto.getData()), "T data == null");
+      test ( SafetyUtil.isEmpty(transientMto.getClusterTransientData()), "T clusteredTransientData == null");
+      test ( SafetyUtil.isEmpty(transientMto.getNetworkTransientData()), "T networkTransientData == null");
+      test ( ! SafetyUtil.isEmpty(transientMto.getStorageTransientData()), "T storageTransientData != null");
+      test ( SafetyUtil.isEmpty(transientMto.getTransientData()), "T transientData == null");
+      test ( transientMto.getClusterTransientFObject() == null, "T clusterTransientFObject == null");
+      test ( transientMto.getNestedFObject() == null, "T nestedFObject == null");
+      test ( transientMto.getNetworkTransientFObject() == null, "T networkTransientFObject == null");
+      test ( transientMto.getStorageTransientFObject() != null, "T storageTransientFObject != null");
+      test ( transientMto.getTransientFObject() == null, "T transientFObject == null");
+      MedusaTestObjectNested n = (MedusaTestObjectNested) (transientMto.getStorageTransientFObject());
+      test ( ! SafetyUtil.isEmpty(n.getData()), "T storageTransient nested data != null");
+      test ( SafetyUtil.isEmpty(n.getClusterTransientData()), "T storageTransient nested clusterTransientData == null");
+      test ( ! SafetyUtil.isEmpty(n.getNetworkTransientData()), "T storageTransient nested networkTransientData != null");
+      test ( ! SafetyUtil.isEmpty(n.getStorageTransientData()), "T storageTransient nested storageTransientData != null");
+      test ( SafetyUtil.isEmpty(n.getTransientData()), "T storageTransient nested transientData == null");
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/medusa/test/MedusaTestObject.js
+++ b/src/foam/nanos/medusa/test/MedusaTestObject.js
@@ -22,11 +22,21 @@
      },
      {
        class: 'String',
-       name: 'name'
+       name: 'description'
      },
      {
        class: 'String',
-       name: 'description'
+       name: 'data'
+     },
+     {
+       class: 'String',
+       name: 'clusterTransientData',
+       clusterTransient: true
+     },
+     {
+       class: 'String',
+       name: 'networkTransientData',
+       networkTransient: true
      },
      {
        class: 'String',
@@ -39,51 +49,48 @@
        transient: true
      },
      {
-       class: 'String',
-       name: 'clusterTransientData',
-       clusterTransient: true
+       name: 'clusterTransientFObject',
+       class: 'FObjectProperty',
+       of: 'foam.nanos.medusa.test.MedusaTestObjectNested',
+       clusterTransient: true,
+       factory: function() {
+         return foam.nanos.medusa.test.MedusaTestObjectNested.create();
+       }
      },
      {
-       class: 'String',
-       name: 'networkTransientData',
-       networkTransient: true
+       name: 'nestedFObject',
+       class: 'FObjectProperty',
+       of: 'foam.nanos.medusa.test.MedusaTestObjectNested',
+       factory: function() {
+         return foam.nanos.medusa.test.MedusaTestObjectNested.create();
+       }
      },
-     // {
-     //   name: 'specificFobject',
-     //   class: 'FObjectProperty',
-     //   of: 'foam.nanos.medusa.ClusterCommandHop',
-     //   factory: function() {
-     //     return foam.nanos.medusa.ClusterCommandHop.create();
-     //   }
-     // },
-     // {
-     //   name: 'genericFobject',
-     //   class: 'FObjectProperty',
-     //   of: 'foam.core.FObject',
-     //   factory: function() {
-     //     return foam.nanos.medusa.ClusterCommandHop.create();
-     //   },
-     //   view: 'foam.u2.view.AnyView'
-     // },
-     // {
-     //   name: 'storageTransientFobjectWithFactory',
-     //   class: 'FObjectProperty',
-     //   of: 'foam.nanos.medusa.ClusterCommandHop',
-     //   storageTransient: true,
-     //   factory: function() {
-     //     return foam.nanos.medusa.ClusterCommandHop.create();
-     //   }
-     // },
-     // {
-     //   name: 'storageTransientFobject',
-     //   class: 'FObjectProperty',
-     //   of: 'foam.nanos.medusa.ClusterCommandHop',
-     //   storageTransient: true
-     // },
      {
-       name: 'storageTransientObject',
-       class: 'Object',
-       storageTransient: true
+       name: 'networkTransientFObject',
+       class: 'FObjectProperty',
+       of: 'foam.nanos.medusa.test.MedusaTestObjectNested',
+       networkTransient: true,
+       factory: function() {2
+         return foam.nanos.medusa.test.MedusaTestObjectNested.create();
+       }
+     },
+     {
+       name: 'storageTransientFObject',
+       class: 'FObjectProperty',
+       of: 'foam.nanos.medusa.test.MedusaTestObjectNested',
+       storageTransient: true,
+       factory: function() {
+         return foam.nanos.medusa.test.MedusaTestObjectNested.create();
+       }
+     },
+     {
+       name: 'transientFObject',
+       class: 'FObjectProperty',
+       of: 'foam.nanos.medusa.test.MedusaTestObjectNested',
+       transient: true,
+       factory: function() {
+         return foam.nanos.medusa.test.MedusaTestObjectNested.create();
+       }
      }
    ]
  });

--- a/src/foam/nanos/medusa/test/MedusaTestObjectNested.js
+++ b/src/foam/nanos/medusa/test/MedusaTestObjectNested.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2022 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.CLASS({
+   package: 'foam.nanos.medusa.test',
+   name: 'MedusaTestObjectNested',
+
+   documentation: 'Copy of MedusaTestObject for testing nested transient',
+
+   properties: [
+     {
+       class: 'String',
+       name: 'data'
+     },
+     {
+       class: 'String',
+       name: 'clusterTransientData',
+       clusterTransient: true
+     },
+     {
+       class: 'String',
+       name: 'networkTransientData',
+       networkTransient: true
+     },
+     {
+       class: 'String',
+       name: 'storageTransientData',
+       storageTransient: true
+     },
+     {
+       class: 'String',
+       name: 'transientData',
+       transient: true
+     }
+   ]
+ });

--- a/src/foam/nanos/medusa/test/tests.jrl
+++ b/src/foam/nanos/medusa/test/tests.jrl
@@ -1,1 +1,1 @@
-//p({"class":"foam.nanos.medusa.test.ClusterDAOTest","id":"clusterDAOTest"})
+p({"class":"foam.nanos.medusa.test.MedusaEntryParseFormatTest","id":"MedusaEntryParseFormatTest"})


### PR DESCRIPTION
…lled.

Recently transient: true properties are being marshalled in the MedusaEntry transient logic.
Reviewing the Property logic, this should have always been the case.
The MedusaEntry transient formatter now explicitly ignores network and cluster transient.
When storageTransient is true, networkTransient is false.
When transient is true, both storageTransient and networkTransient are true.

Required in v3.20.1