### PR TITLE
NP-7608 SMTPEmailService,send failed,javax.mail.internet.ParseException

### DIFF
--- a/src/foam/nanos/notification/email/SMTPEmailService.js
+++ b/src/foam/nanos/notification/email/SMTPEmailService.js
@@ -275,7 +275,7 @@ foam.CLASS({
             }
             message.setContent(multipart);
           } else {
-            message.setContent(emailMessage.getBody(), "html; charset=utf-8");
+            message.setContent(emailMessage.getBody(), "text/html");
           }
 
           message.setSentDate(new Date());


### PR DESCRIPTION
root cause: type of setContent method should only be MIMETYPE. 