### PR TITLE
added functionality for focusW. onClose

### DIFF
--- a/src/foam/u2/wizard/agents/StepWizardAgent.js
+++ b/src/foam/u2/wizard/agents/StepWizardAgent.js
@@ -72,7 +72,7 @@ foam.CLASS({
       }
 
       view.data = controller;
-      controller.onClose= this.resolveAgent;
+      controller.onClose = this.resolveAgent;
       view.onClose = this.resolveAgent;
 
       if ( (view?.class || view?.cls_?.id).endsWith('ScrollingStepWizardView') ) {

--- a/src/foam/u2/wizard/agents/StepWizardAgent.js
+++ b/src/foam/u2/wizard/agents/StepWizardAgent.js
@@ -72,7 +72,7 @@ foam.CLASS({
       }
 
       view.data = controller;
-
+      controller.onClose= this.resolveAgent;
       view.onClose = this.resolveAgent;
 
       if ( (view?.class || view?.cls_?.id).endsWith('ScrollingStepWizardView') ) {

--- a/src/foam/u2/wizard/controllers/IncrementalWizardController.js
+++ b/src/foam/u2/wizard/controllers/IncrementalWizardController.js
@@ -178,7 +178,6 @@ foam.CLASS({
             for ( let w of this.data.wizardlets ) {
               if ( w.submit ) w.submit();
             }
-            this.onClose(x, true);
           }
         }).catch(e => {
           console.error(e);

--- a/src/foam/u2/wizard/controllers/IncrementalWizardController.js
+++ b/src/foam/u2/wizard/controllers/IncrementalWizardController.js
@@ -178,6 +178,7 @@ foam.CLASS({
             for ( let w of this.data.wizardlets ) {
               if ( w.submit ) w.submit();
             }
+            this.onClose(x, true);
           }
         }).catch(e => {
           console.error(e);


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2022-09-20 at 7 36 44 AM" src="https://user-images.githubusercontent.com/10802216/191250983-a99b67ac-18aa-4c59-b49f-f64b5f165c3c.png">

<img width="1440" alt="Screen Shot 2022-09-20 at 7 38 20 AM" src="https://user-images.githubusercontent.com/10802216/191251082-83dc7212-2b4f-4ebc-8ce0-6a2f0ed5f5df.png">


The image with menu #transfer-now was using old wizard and the #shop-rates menu image was using the focus wizard.
Issue was the final "goNext" action wasn't triggering the modal too close.

The cause of the issue, was the different design of the wizards. The first old incremental wizard (IncrementalStepWizardView) was setup with the function onClose and with the "goNext" action. However the focusWizard setup was with IncrementalWizardController - which had onClose and the "goNext" but was the controller and not the view, and actually never was calling the close.

Follow up maybe to unify these - but this pr should suffice @KernelDeimos ??
