### PR TITLE
Fix ucj put exception when removing user

### DIFF
--- a/src/foam/nanos/crunch/RemoveJunctionsOnUserRemoval.js
+++ b/src/foam/nanos/crunch/RemoveJunctionsOnUserRemoval.js
@@ -37,9 +37,12 @@ foam.CLASS({
           if ( !( ((LifecycleAware) obj).getLifecycleState() == foam.nanos.auth.LifecycleState.DELETED ) ) {
             return;
           }
-          
+
           // not possible to removeAll() because UCJ is lifecycle aware
-          DAO dao = (DAO) x.get("userCapabilityJunctionDAO");
+          // NOTE: put to bareUserCapabilityJunctionDAO to prevent rules on
+          // userCapabilityJunctionDAO from firing which could invoke sudo-ing
+          // as the deleted user then fails.
+          DAO dao = (DAO) x.get("bareUserCapabilityJunctionDAO");
           dao.where(EQ(UserCapabilityJunction.SOURCE_ID, ((User) obj).getId())).select( new AbstractSink() {
             public void put(Object o, Detachable d) {
               UserCapabilityJunction ucj = (UserCapabilityJunction) ( (FObject)o ).fclone();

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -281,7 +281,7 @@ public class ServerCrunchService
 
   public UserCapabilityJunction getJunction(X x, String capabilityId) {
     Subject subject = (Subject) x.get("subject");
-    return this.getJunctionForSubject_(x, capabilityId, subject, false);
+    return this.getJunctionForSubject(x, capabilityId, subject);
   }
 
   public boolean atLeastOneInCategory(X x, String category) {
@@ -367,7 +367,8 @@ public class ServerCrunchService
   public UserCapabilityJunction getJunctionForSubject(
     X x, String capabilityId, Subject subject
   ) {
-    return getJunctionForSubject_(x, capabilityId, subject, true);
+    var isSameUserInSubject = ((Subject) x.get("subject")).isUserInSubject(subject.getUser().getId());
+    return getJunctionForSubject_(x, capabilityId, subject, ! isSameUserInSubject);
   }
 
   protected UserCapabilityJunction getJunctionForSubject_(X x, String capabilityId, Subject subject, boolean actingAsSubject) {

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -370,7 +370,7 @@ public class ServerCrunchService
     AuthService auth = (AuthService) x.get("auth");
     if ( auth.check(x, "service.crunchService.updateUserContext") ) {
       x = Auth.sudo(x, subject.getUser(), subject.getRealUser());
-    } else throw new AuthorizationException("You don't have permission to check for UCJs");
+    }
     Predicate targetPredicate = EQ(UserCapabilityJunction.TARGET_ID, capabilityId);
     try {
       DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -281,7 +281,7 @@ public class ServerCrunchService
 
   public UserCapabilityJunction getJunction(X x, String capabilityId) {
     Subject subject = (Subject) x.get("subject");
-    return this.getJunctionForSubject(x, capabilityId, subject);
+    return this.getJunctionForSubject_(x, capabilityId, subject, false);
   }
 
   public boolean atLeastOneInCategory(X x, String category) {
@@ -367,10 +367,18 @@ public class ServerCrunchService
   public UserCapabilityJunction getJunctionForSubject(
     X x, String capabilityId, Subject subject
   ) {
+    return getJunctionForSubject_(x, capabilityId, subject, true);
+  }
+
+  protected UserCapabilityJunction getJunctionForSubject_(X x, String capabilityId, Subject subject, boolean actingAsSubject) {
     AuthService auth = (AuthService) x.get("auth");
-    if ( auth.check(x, "service.crunchService.updateUserContext") ) {
-      x = Auth.sudo(x, subject.getUser(), subject.getRealUser());
+
+    if ( actingAsSubject ) {
+      if ( auth.check(x, "service.crunchService.updateUserContext") ) {
+        x = Auth.sudo(x, subject.getUser(), subject.getRealUser());
+      } else throw new AuthorizationException("You don't have permission to check for UCJs");
     }
+
     Predicate targetPredicate = EQ(UserCapabilityJunction.TARGET_ID, capabilityId);
     try {
       DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -367,14 +367,12 @@ public class ServerCrunchService
   public UserCapabilityJunction getJunctionForSubject(
     X x, String capabilityId, Subject subject
   ) {
-    var isSameUserInSubject = ((Subject) x.get("subject")).isUserInSubject(subject.getUser().getId());
-    return getJunctionForSubject_(x, capabilityId, subject, ! isSameUserInSubject);
-  }
-
-  protected UserCapabilityJunction getJunctionForSubject_(X x, String capabilityId, Subject subject, boolean actingAsSubject) {
-    AuthService auth = (AuthService) x.get("auth");
-
-    if ( actingAsSubject ) {
+    // Sudo as the given subject when the user in the current subject and the
+    // given subject are different. Throws exception if the user doesn't have
+    // permission update user context for sudo-ing.
+    var currentSubject = (Subject) x.get("subject");
+    if ( ! currentSubject.isUserInSubject(subject.getUser().getId()) ) {
+      AuthService auth = (AuthService) x.get("auth");
       if ( auth.check(x, "service.crunchService.updateUserContext") ) {
         x = Auth.sudo(x, subject.getUser(), subject.getRealUser());
       } else throw new AuthorizationException("You don't have permission to check for UCJs");


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-7979

## Changes
- Put to bareUserCapabilityJunctionDAO to prevent rules on userCapabilityJunctionDAO from firing which could invoke sudo-ing as the deleted user then fails
- Check user in the current subject and the given subject before sudo-ing

## CI
- https://ci-jenkins.nanopay.net/view/CI/job/ci-NP-7979-Fix_tests/5/console