### PR TITLE
[NP-8004] Rule predicate reset bug fix

### DIFF
--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -4,7 +4,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
- foam.CLASS({
+foam.CLASS({
   package: 'foam.nanos.ruler',
   name: 'Rule',
   extends: 'foam.nanos.ruler.Ruled',
@@ -152,7 +152,11 @@
       writePermissionRequired: true,
       documentation: 'Defines if the rule is async. Async rule always runs after DAO put/remove, the after flag on the rule will be ignored.'
     },
-    'predicate',
+    {
+      class: 'FObjectProperty',
+      of: 'foam.mlang.predicate.Predicate',
+      name: 'predicate'
+    },
     {
       class: 'FObjectProperty',
       of: 'foam.nanos.ruler.RuleAction',


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-8004

**Issue**: 
When you save a rule from the ui, the rule object being saved had an empty predicate which caused the rule predicate to be set to True predicate.

<img width="729" alt="Screen Shot 2022-09-27 at 4 23 52 PM" src="https://user-images.githubusercontent.com/58435071/192628081-ad549cea-2f5f-428a-b31f-dc67c6409940.png">


**Fix**: 
Specify class for predicate property.  You will also be able to view the predicate in the ui after the fix

<img width="1652" alt="Screen Shot 2022-09-27 at 4 17 23 PM" src="https://user-images.githubusercontent.com/58435071/192627374-b6c2cd82-faee-4200-9301-d9ee1e474f3a.png">
