### PR TITLE
Add default value to rule predicate

### DIFF
--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -25,6 +25,10 @@ foam.CLASS({
     'userDAO?'
   ],
 
+  requires: [
+    'foam.mlang.predicate.True'
+  ],
+
   javaImports: [
     'foam.core.DirectAgency',
     'foam.dao.DAO',
@@ -155,7 +159,13 @@ foam.CLASS({
     {
       class: 'FObjectProperty',
       of: 'foam.mlang.predicate.Predicate',
-      name: 'predicate'
+      name: 'predicate',
+      factory: function() {
+        return this.True.create();
+      },
+      javaFactory: `
+        return foam.mlang.MLang.TRUE;
+      `
     },
     {
       class: 'FObjectProperty',


### PR DESCRIPTION
Rules that don't define predicate won't be triggered because the predicate defaults to null. To address this issue, we set the default predicate to true.

This needs to go to 3.20