### PR TITLE
Introduce MutableX

### DIFF
--- a/src/foam/core/MutableX.java
+++ b/src/foam/core/MutableX.java
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core;
+
+public class MutableX extends ProxyX {
+  public X put(Object name, Object value) {
+    setX(getX().put(name, value));
+
+    return this;
+  }
+
+  public X putFactory(Object name, XFactory factory) {
+    setX(getX().putFactory(name, factory));
+
+    return this;
+  }
+}

--- a/src/foam/core/OrX.java
+++ b/src/foam/core/OrX.java
@@ -36,6 +36,10 @@ public class OrX
     return new OrX(parent_, getX().put(name, value == null ? NULL : value));
   }
 
+  public X putFactory(Object name, XFactory factory) {
+    return new OrX(parent_, getX().putFactory(name, factory));
+  }
+
   public <T> T get(Class<T> key) {
     return (T) get(this, key);
   }

--- a/src/foam/core/ProxyX.java
+++ b/src/foam/core/ProxyX.java
@@ -60,15 +60,11 @@ public class ProxyX
   }
 
   public X put(Object name, Object value) {
-    setX(getX().put(name, value));
-
-    return this;
+    return new ProxyX(getX().put(name, value));
   }
 
   public X putFactory(Object name, XFactory factory) {
-    setX(getX().putFactory(name, factory));
-
-    return this;
+    return new ProxyX(getX().putFactory(name, factory));
   }
 
   public Object getInstanceOf(Object value, Class type) {

--- a/src/foam/nanos/boot/Boot.java
+++ b/src/foam/nanos/boot/Boot.java
@@ -31,7 +31,7 @@ public class Boot {
   public final static String BOOT_TIME = "BOOT_TIME";
 
   protected DAO                       serviceDAO_;
-  protected X                         root_      = new ProxyX();
+  protected X                         root_      = new MutableX();
   protected Map<String, NSpecFactory> factories_ = new HashMap<>();
 
   public Boot() {

--- a/src/foam/nanos/crunch/UserCapabilityUpdateInterceptDAO.java
+++ b/src/foam/nanos/crunch/UserCapabilityUpdateInterceptDAO.java
@@ -103,7 +103,7 @@ public class UserCapabilityUpdateInterceptDAO extends ProxyDAO {
           getLogger().debug("Update intercepted", temp);
 
           User sourceUser = (User) ((DAO)x.get("bareUserDAO")).find(ucj.getSourceId());
-          User effectiveUser = null;
+          User effectiveUser = sourceUser;
           if ( ucj instanceof AgentCapabilityJunction) {
               effectiveUser = (User) ((DAO)x.get("bareUserDAO")).find(((AgentCapabilityJunction)ucj).getEffectiveUser());
           } 

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -261,7 +261,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       `,
       javaCode: `
       Subject subject = new Subject.Builder(x).setUser(null).build();
-        return new OrX(x)
+        return x
           .put(Session.class, this)
           .put("spid", null)
           .put("subject", subject)
@@ -359,12 +359,12 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           wasAnonymous = sp != null && sp.getAnonymousUser() == subjectUser.getId();
         }
 
-        rtn = reset(x);
+        rtn = new OrX(reset(x));
 
         // Support hierarchical SPID context
         var subX = rtn.cd(user.getSpid());
         if ( subX != null ) {
-          rtn = reset(subX);
+          rtn = new OrX(reset(subX));
         }
 
         Subject subject = null;

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -261,7 +261,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       `,
       javaCode: `
       Subject subject = new Subject.Builder(x).setUser(null).build();
-        return x
+        return new OrX(x)
           .put(Session.class, this)
           .put("spid", null)
           .put("subject", subject)
@@ -359,12 +359,12 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           wasAnonymous = sp != null && sp.getAnonymousUser() == subjectUser.getId();
         }
 
-        rtn = new OrX(reset(x));
+        rtn = reset(x);
 
         // Support hierarchical SPID context
         var subX = rtn.cd(user.getSpid());
         if ( subX != null ) {
-          rtn = new OrX(reset(subX));
+          rtn = reset(subX);
         }
 
         Subject subject = null;

--- a/src/tests.jrl
+++ b/src/tests.jrl
@@ -99,6 +99,7 @@ p({
   code:"""
 import java.util.HashMap;
 
+import foam.core.MutableX;
 import foam.core.ProxyX;
 import foam.dao.ArraySink;
 import foam.dao.DAO;
@@ -114,7 +115,7 @@ import static foam.mlang.MLang.*;
 import foam.dao.ArraySink;
 
 context = null;
-root_      = new ProxyX();
+root_      = new MutableX();
 factories_ = new HashMap();
 
 context = x;


### PR DESCRIPTION
This happens for context that is a proxy of OrX, when calling put the OrX was replaced by a new OrX and the proxyX carries on with the new OrX.

This manifested when sudo-ing inside rule action outside of agency.submit.
- Before sudo-ing there is a subject in the context and spid=intuit
<img width="678" alt="Screen Shot 2022-10-06 at 5 01 04 PM" src="https://user-images.githubusercontent.com/441658/194425478-f1b13bc9-e997-438f-bf07-a78fd351d662.png">

- after sudo-ing, the original context subject and spid were cleared
<img width="846" alt="Screen Shot 2022-10-06 at 5 02 06 PM" src="https://user-images.githubusercontent.com/441658/194425475-e06a8ffd-b92c-4ddf-bd5b-82ee06f129a7.png">
