### PR TITLE
Fix sequence menu stack

### DIFF
--- a/src/foam/nanos/menu/SequenceMenu.js
+++ b/src/foam/nanos/menu/SequenceMenu.js
@@ -37,6 +37,16 @@ foam.CLASS({
       for (let fluentSpec of this.sequence) {
         fluentSpec.apply(sequence);
       }
+
+      // Add a blank view to the empty stack because empty stack causes the
+      // wizard popup created by the sequence menu to persist and not showing
+      // the view on subsequent stack.push().
+      //
+      // NOTE: it is by design for the first element of a stack to never be
+      // removed to prevent client from jumping back beyond its initial view.
+      if ( X.stack.pos <= 0 )
+        X.stack.push({ class: 'foam.u2.borders.NullBorder' });
+
       return sequence.execute();
     }
   ]


### PR DESCRIPTION
Add a blank view to the empty stack because empty stack causes the wizard popup created by the sequence menu to persist and not showing the view on subsequent stack.push().