### PR TITLE
Remove logic to default search columns to table columns.

### DIFF
--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -165,32 +165,7 @@ foam.CLASS({
       factory: null,
       expression: function(of, tableColumns) {
         var tableSearchColumns = of.getAxiomByName('searchColumns');
-
-        var filteredDefaultColumns = tableColumns.filter(c => {
-          //  to account for nested columns like approver.legalName
-          if ( c.split('.').length > 1 ) return false;
-
-          var a = of.getAxiomByName(c);
-
-          if ( ! a ) console.warn("Column does not exist for " + of.name + ": " + c);
-
-          return a
-            && ! a.storageTransient
-            && ! a.networkTransient
-            && a.searchView
-            && ! a.hidden
-        });
-
-        var allProps = of.getAxiomsByClass(foam.core.Property).filter(p => {
-          return ! p.storageTransient
-            && ! p.networkTransient
-            && p.searchView
-            && ! p.hidden
-        });
-
-        if ( tableSearchColumns ) return tableSearchColumns.columns;
-
-        return filteredDefaultColumns ? filteredDefaultColumns : allProps;
+        return tableSearchColumns ? tableSearchColumns.columns : [];
       }
     },
     {

--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -528,37 +528,6 @@ foam.CLASS({
         this.filters = columns;
         return;
       }
-
-      columns = of.getAxiomByName('tableColumns');
-      columns = columns && columns.columns;
-      columns = await this.filterPropertiesByReadPermission(columns, of.id);
-      if ( columns ) {
-        this.columns = columns.filter(function(c) {
-        //  to account for nested columns like approver.legalName
-        if ( c.split('.').length > 1 ) return false;
-
-        var a = of.getAxiomByName(c);
-
-        if ( ! a ) console.warn("Column does not exist for " + of.name + ": " + c);
-
-        return a
-          && ! a.storageTransient
-          && ! a.networkTransient
-          && a.searchView
-          && ! a.hidden
-        });
-        return;
-      }
-
-      columns = of.getAxiomsByClass(foam.core.Property)
-        .filter((p) => {
-          return ! p.storageTransient
-          && ! p.networkTransient
-          && p.searchView
-          && ! p.hidden
-        })
-        .map(foam.core.Property.NAME.f);
-      this.filters = await this.filterPropertiesByReadPermission(columns, of.id);
     }
   ],
 


### PR DESCRIPTION
Table views of DAOs with large amounts of data break when default search columns are created for non-indexed properties.