### PR TITLE
Fix reset password error not being propagated to users

### DIFF
--- a/src/foam/nanos/auth/email/ServerEmailVerificationService.js
+++ b/src/foam/nanos/auth/email/ServerEmailVerificationService.js
@@ -10,10 +10,10 @@
   implements: [ 'foam.nanos.auth.email.EmailVerificationService' ],
 
   javaImports: [
+    'foam.core.ValidationException',
     'foam.core.X',
     'foam.dao.DAO',
     'foam.dao.ArraySink',
-    'foam.nanos.auth.AuthenticationException',
     'foam.nanos.auth.DuplicateEmailException',
     'foam.nanos.auth.User',
     'foam.nanos.auth.UserNotFoundException',
@@ -90,7 +90,7 @@
           .setUserName(user.getUserName())
           .setExpiry(calendar.getTime())
           .build();
-        
+
         DAO verificationCodeDAO = (DAO) x.get("emailVerificationCodeDAO");
         code = (EmailVerificationCode) verificationCodeDAO.put(code);
 
@@ -120,7 +120,7 @@
           ((DAO) x.get("localUserDAO")).put(user);
         } else {
           sendCode(x, user, this.VERIFY_EMAIL_TEMPLATE);
-          throw new AuthenticationException(this.RESEND_MESSAGE);
+          throw new ValidationException(this.RESEND_MESSAGE);
         }
         return res;
       `
@@ -160,7 +160,7 @@
                 EQ(EmailVerificationCode.VERIFICATION_CODE, verificationCode),
                 GT(EmailVerificationCode.EXPIRY, c.getTime())
               ));
-              return code != null;     
+              return code != null;
             }
           `
         }));

--- a/src/foam/u2/dialog/NotificationMessage.js
+++ b/src/foam/u2/dialog/NotificationMessage.js
@@ -145,7 +145,7 @@ foam.CLASS({
         // Create notification message and description from
         // exception name and message.
         var ex = this.err.exception || this.err;
-        if ( ex.id ) {
+        if ( ex.id && ! this.message ) {
           this.message = ex.id.split('.').pop();
           if ( this.message.endsWith('Exception') ) {
             this.message = this.message.replace('Exception', '');


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-8548

## Changes
- Switch to ValidationException for the client-side to propagate the error to users because AuthenticationException will be intercepted by the client (eg. to forward the users to login page)
- Allow custom notification title/message to override default title which is the exception class name