### PR TITLE
[NP-8512] Wizardlets are always DynamicActionWizardlets

### DIFF
--- a/src/foam/u2/wizard/wizardlet/BaseWizardlet.js
+++ b/src/foam/u2/wizard/wizardlet/BaseWizardlet.js
@@ -7,6 +7,7 @@
 foam.CLASS({
   package: 'foam.u2.wizard.wizardlet',
   name: 'BaseWizardlet',
+  implements: ['foam.u2.wizard.DynamicActionWizardlet'],
 
   todo: [
     'rename wizardlet.loading to wizardlet.busy',


### PR DESCRIPTION
the `DynamicActionWizardlet` interface was added to CapabilityWizardlet so now it's being used everywhere and breaks when switching to BaseWizardlet. This PR fixes that issue.