### PR TITLE
DAOOMLogger - create OMs for each DAO operation

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -370,6 +370,9 @@ foam.CLASS({
             ( delegate instanceof ProxyDAO ) )
             delegate = foam.dao.PipelinePMDAO.decorate(getX(), getNSpec(), delegate, 1);
 
+        if ( getOm() )
+          delegate = new foam.nanos.om.DAOOMLogger.Builder(getX()).setNSpec(getNSpec()).setDelegate(delegate).build();
+
         if ( getPm() )
           delegate = new foam.dao.PMDAO.Builder(getX()).setNSpec(getNSpec()).setDelegate(delegate).build();
 
@@ -577,6 +580,10 @@ foam.CLASS({
       documentation: 'Enable time tracking for concurrent DAO operations',
       class: 'Boolean',
       name: 'timing'
+    },
+    {
+      class: 'Boolean',
+      name: 'om'
     },
     {
       class: 'Boolean',

--- a/src/foam/nanos/analytics/CandlestickChartView.js
+++ b/src/foam/nanos/analytics/CandlestickChartView.js
@@ -63,11 +63,13 @@ foam.CLASS({
                   E.OR(
                     E.CONTAINS_IC(foam.nanos.boot.NSpec.NAME, "candlestick"),
                     E.IN(foam.nanos.boot.NSpec.NAME, [
-                      'pmDAO',
                       'om1MinuteDAO',
                       'om5MinuteDAO',
                       'omHourlyDAO',
-                      'omDailyDAO'
+                      'omDailyDAO',
+                      'pm1MinuteDAO',
+                      'pmHourlyDAO',
+                      'pmDailyDAO'
                     ])
                   ),
                   E.NOT(E.EQ(foam.nanos.boot.NSpec.NAME, "candlestickAlarmDAO"))

--- a/src/foam/nanos/om/DAOOMLogger.js
+++ b/src/foam/nanos/om/DAOOMLogger.js
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2022 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.om',
+  name: 'DAOOMLogger',
+  extends: 'foam.dao.ProxyDAO',
+  description: 'OM DAO operations. By default, just put',
+
+  implements: [
+    'foam.nanos.auth.EnabledAware',
+    'foam.nanos.boot.NSpecAware'
+  ],
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.X',
+    'foam.dao.DOP',
+    'foam.nanos.dao.Operation',
+    'java.util.HashMap',
+    'java.util.Map'
+  ],
+
+  properties: [
+    {
+      name: 'enabled',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      documentation: 'set to true if storing multiple models in a single DAO and per model OMs are desired.',
+      name: 'multiModelDAO',
+      class: 'Boolean'
+    },
+    {
+      name: 'omOnPut',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      name: 'omOnCreate',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'omOnUpdate',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'omOnFind',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'omOnSelect',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'omOnRemove',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'omOnRemoveAll',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'omOnCmd',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      name: 'names',
+      class: 'Map',
+      javaFactory: 'return new HashMap();',
+      visibility: 'HIDDEN'
+    }
+  ],
+
+  methods: [
+    {
+      documentation: `Base implementation ignores passed object, but override for per obj OM names. Helpful if storing multiple models in a single dao`,
+      name: 'getName',
+      args: 'X x, String op, Object obj',
+      type: 'String',
+      javaCode: `
+      Object entry = getNames().get(op);
+      if ( getMultiModelDAO() && obj != null ) {
+        if ( entry == null ) {
+          entry = new HashMap();
+          getNames().put(op, entry);
+        }
+        String name = (String) ((Map) entry).get(obj.getClass());
+        if ( name == null ) {
+           name = getNSpec().getName()+"."+obj.getClass().getSimpleName()+"."+op;
+           ((Map) entry).put(obj.getClass(), name);
+        }
+        return name;
+      } else if ( entry == null ) {
+        String name = getNSpec().getName()+"."+op;
+        getNames().put(op, name);
+        return name;
+      }
+      return (String) entry;
+      `
+    },
+    {
+      name: 'put_',
+      javaCode: `
+    if ( getEnabled() && getOmOnCreate() || getEnabled() && getOmOnUpdate() ) {
+      Object old = getDelegate().find_(x, obj);
+      if ( getEnabled() && getOmOnCreate() && old == null ) {
+        ((OMLogger) x.get("OMLogger")).log(getName(x, Operation.CREATE.getLabel(), obj));
+      } else if ( getEnabled() && getOmOnUpdate() && old != null ) {
+        ((OMLogger) x.get("OMLogger")).log(getName(x, Operation.UPDATE.getLabel(), obj));
+      }
+    }
+    if ( getEnabled() && getOmOnPut() ) ((OMLogger) x.get("OMLogger")).log(getName(x, DOP.PUT.getLabel(), obj));
+    return getDelegate().put_(x, obj);
+     `
+    },
+    {
+      name: 'find_',
+      javaCode: `
+      if ( getEnabled() && getOmOnFind() ) ((OMLogger) x.get("OMLogger")).log(getName(x, DOP.FIND.getLabel(), null));
+      return getDelegate().find_(x, id);
+     `
+    },
+    {
+      name: 'select_',
+      javaCode: `
+      if ( getEnabled() && getOmOnSelect() ) ((OMLogger) x.get("OMLogger")).log(getName(x, DOP.SELECT.getLabel(), null));
+      return getDelegate().select_(x, sink, skip, limit, order, predicate);
+     `
+    },
+    {
+      name: 'remove_',
+      javaCode: `
+      if ( getEnabled() && getOmOnRemove() ) ((OMLogger) x.get("OMLogger")).log(getName(x, DOP.REMOVE.getLabel(), obj));
+      return getDelegate().remove_(x, obj);
+     `
+    },
+    {
+      name: 'removeAll_',
+      javaCode: `
+      if ( getEnabled() && getOmOnRemoveAll() ) ((OMLogger) x.get("OMLogger")).log(getName(x, DOP.REMOVE_ALL.getLabel(), null));
+      getDelegate().removeAll_(x, skip, limit, order, predicate);
+     `
+    },
+    {
+      name: 'cmd_',
+      javaCode: `
+      if ( getEnabled() && getOmOnCmd() ) ((OMLogger) x.get("OMLogger")).log(getName(x, DOP.CMD.getLabel(), null));
+      return getDelegate().cmd_(x, obj);
+     `
+    }
+  ]
+
+});

--- a/src/foam/nanos/pom.js
+++ b/src/foam/nanos/pom.js
@@ -350,6 +350,7 @@ foam.POM({
     { name: "auth/AgentAuthClient",                                                       flags: "js|java" },
     { name: "auth/ClientAgentAuthService",                                                flags: "js|java" },
     { name: "auth/UniqueUserService",                                                     flags: "js|java" },
+    { name: "om/DAOOMLogger",                                                             flags: "js|java" },
     { name: "pm/PMTemperatureCellFormatter",                                              flags: "js" },
     { name: "pm/NullPM",                                                                  flags: "js|java" },
     { name: "pm/PM",                                                                      flags: "js|java" },


### PR DESCRIPTION
PMs provide the same info, but with OMs we have chart support and potentially can query the candlestick for time-series analysis and a cron could adjust it's own schedule based on load.
But still not 100% sold on this, as it's easy enough to monitor PMs and just adjust manually.