### PR TITLE
Np 8607/authorize approval request

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -11,7 +11,6 @@ foam.CLASS({
   documentation: 'Approval requests are stored in approvalRequestDAO and represent a single approval request for a single user.',
 
   implements: [
-    'foam.nanos.auth.Authorizable',
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware',
     'foam.nanos.auth.LastModifiedAware',
@@ -700,61 +699,6 @@ foam.CLASS({
                   + oldMemo;
         return newMemo;
       }
-    },
-    {
-      name: 'authorizeOnCreate',
-      args: [
-        { name: 'x', type: 'Context' }
-      ],
-      javaThrows: ['AuthorizationException'],
-      javaCode: `
-        AuthService authService = (AuthService) x.get("auth");
-        if ( ! authService.check(x, "approval.create") ) {
-          throw new AuthorizationException();
-        }
-      `
-    },
-    {
-      name: 'authorizeOnRead',
-      args: [
-        { name: 'x', type: 'Context' }
-      ],
-      javaThrows: ['AuthorizationException'],
-      javaCode: `
-        User user = ((Subject) x.get("subject")).getUser();
-        if ( user == null || ! SafetyUtil.equals(user.getId(), getApprover()) ) {
-          throw new AuthorizationException();
-        }
-      `
-    },
-    {
-      name: 'authorizeOnUpdate',
-      args: [
-        { name: 'x', type: 'Context' },
-        { name: 'oldObj', type: 'foam.core.FObject' }
-      ],
-      javaThrows: ['AuthorizationException'],
-      javaCode: `
-        ApprovalRequest approvalRequest = (ApprovalRequest) oldObj;
-        User user = ((Subject) x.get("subject")).getUser();
-        AuthService authService = (AuthService) x.get("auth");
-        if ( user == null || ! SafetyUtil.equals(approvalRequest.getApprover(), user.getId()) && ! ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system"))) {
-          throw new AuthorizationException();
-        }
-      `
-    },
-    {
-      name: 'authorizeOnDelete',
-      args: [
-        { name: 'x', type: 'Context' }
-      ],
-      javaThrows: ['AuthorizationException'],
-      javaCode: `
-        User user = ((Subject) x.get("subject")).getUser();
-        if ( user == null  || ! ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system")) ) {
-          throw new AuthorizationException("Approval can only be deleted by system");
-        }
-      `
     }
   ],
 

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -11,6 +11,7 @@ foam.CLASS({
   documentation: 'Approval requests are stored in approvalRequestDAO and represent a single approval request for a single user.',
 
   implements: [
+    'foam.nanos.auth.Authorizable',
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware',
     'foam.nanos.auth.LastModifiedAware',
@@ -699,6 +700,61 @@ foam.CLASS({
                   + oldMemo;
         return newMemo;
       }
+    },
+    {
+      name: 'authorizeOnCreate',
+      args: [
+        { name: 'x', type: 'Context' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        AuthService authService = (AuthService) x.get("auth");
+        if ( ! authService.check(x, "approval.create") ) {
+          throw new AuthorizationException();
+        }
+      `
+    },
+    {
+      name: 'authorizeOnRead',
+      args: [
+        { name: 'x', type: 'Context' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        User user = ((Subject) x.get("subject")).getUser();
+        if ( user == null || ! SafetyUtil.equals(user.getId(), getApprover()) ) {
+          throw new AuthorizationException();
+        }
+      `
+    },
+    {
+      name: 'authorizeOnUpdate',
+      args: [
+        { name: 'x', type: 'Context' },
+        { name: 'oldObj', type: 'foam.core.FObject' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        ApprovalRequest approvalRequest = (ApprovalRequest) oldObj;
+        User user = ((Subject) x.get("subject")).getUser();
+        AuthService authService = (AuthService) x.get("auth");
+        if ( user == null || ! SafetyUtil.equals(approvalRequest.getApprover(), user.getId()) && ! ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system"))) {
+          throw new AuthorizationException();
+        }
+      `
+    },
+    {
+      name: 'authorizeOnDelete',
+      args: [
+        { name: 'x', type: 'Context' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        User user = ((Subject) x.get("subject")).getUser();
+        if ( user == null  || ! ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system")) ) {
+          throw new AuthorizationException("Approval can only be deleted by system");
+        }
+      `
     }
   ],
 

--- a/src/foam/nanos/approval/services.jrl
+++ b/src/foam/nanos/approval/services.jrl
@@ -64,9 +64,13 @@ p({
           .setOf(of)
           .setAdapter(new foam.nanos.approval.PopulateApprovalRequestSummariesAdapter(x, of, dao))
           .setSourceDAO(x.get("approvalRequestDAO"))
+          .setAuthorize(false)
           .build()
           .orderBy(foam.mlang.MLang.DESC(foam.nanos.approval.ApprovalRequest.CREATED));
-        
+    dao = new foam.nanos.auth.AuthorizationDAO.Builder(x)
+            .setDelegate(dao)
+            .setAuthorizer(new foam.nanos.approval.AuthenticatedApprovalDAOAuthorizer())
+            .build();
     return new foam.dao.PMDAO.Builder(x)
       .setDelegate(dao)
       .build();

--- a/src/foam/nanos/approval/services.jrl
+++ b/src/foam/nanos/approval/services.jrl
@@ -64,7 +64,6 @@ p({
           .setOf(of)
           .setAdapter(new foam.nanos.approval.PopulateApprovalRequestSummariesAdapter(x, of, dao))
           .setSourceDAO(x.get("approvalRequestDAO"))
-          .setAuthorize(false)
           .build()
           .orderBy(foam.mlang.MLang.DESC(foam.nanos.approval.ApprovalRequest.CREATED));
     dao = new foam.nanos.auth.AuthorizationDAO.Builder(x)


### PR DESCRIPTION
Jira: https://nanopay.atlassian.net/browse/NP-8607
This PR addresses the issue where fraud-ops user sees approval requests that are not assigned to them
* add `AuthenticatedApprovalDAOAuthorizer` to `tableViewApprovalRequestDAO`'s Nspec config