### PR TITLE
[NP-8728] Automatically go next if altflow lands on invisible

### DIFF
--- a/src/foam/u2/wizard/AlternateFlow.js
+++ b/src/foam/u2/wizard/AlternateFlow.js
@@ -129,6 +129,10 @@ foam.CLASS({
         sectionIndex: 0
       })
       wizardController.wizardPosition = pos;
+
+      if ( ! wizardController.currentWizardlet.isVisible ) {
+        wizardController.next();
+      }
     }
   ]
 })


### PR DESCRIPTION
This would cause a regression if any wizards' alternate flows depend on landing on an invisible wizard. I don't think there are any, but if this happens the solution is to add the same wizardlet's id to the `visible` section of the same AlternateFlow.