### PR TITLE
use neq instead of > to decide whether to load new wizardlet since so…

### DIFF
--- a/src/foam/u2/wizard/StepWizardController.js
+++ b/src/foam/u2/wizard/StepWizardController.js
@@ -83,7 +83,7 @@ foam.CLASS({
         });
       },
       preSet: function(o, n) {
-        if ( n?.wizardletIndex > o?.wizardletIndex )
+        if ( n?.wizardletIndex != o?.wizardletIndex )
           this.wizardlets[n.wizardletIndex].load({});
         return n;
       },


### PR DESCRIPTION
…metimes alternate flows will go to 'earlier' wizardlets