### PR TITLE
setting network error msg

### DIFF
--- a/src/foam/box/HTTPBox.js
+++ b/src/foam/box/HTTPBox.js
@@ -6,7 +6,7 @@
 foam.CLASS({
   package: 'foam.box',
   name: 'HTTPException',
-  implements: [ 'foam.core.Exception' ],
+  extends: [ 'foam.core.FOAMException' ],
   properties: [
     'response'
   ]
@@ -224,7 +224,7 @@ foam.CLASS({
         }).then((rmsg) => {
           rmsg && replyBox && replyBox.send(rmsg);
         }, function(r) {
-          replyBox && replyBox.send(foam.box.Message.create({ object: foam.box.HTTPException.create({ response: r }) }));
+          replyBox && replyBox.send(foam.box.Message.create({ object: foam.box.HTTPException.create({ response: r, message: r?.message }) }));
         });
       },
       swiftCode: `

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -1108,3 +1108,5 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.approval.ApprovalRequ
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.nanos.approval.ApprovalRequestNotification.MSG_BODY2",target:" solicitação de aprovação com id: "})
 
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.dashboard.view.DashboardView.TITLE",target:"Painel"})
+
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.net.web.HTTPRequest.GENERAL_ERROR",target:"Erro de rede, verifique sua conexão e tente novamente."})

--- a/src/foam/net/web/HTTPRequest.js
+++ b/src/foam/net/web/HTTPRequest.js
@@ -29,6 +29,10 @@ foam.CLASS({
     'data'
   ],
 
+  messages: [
+    { name: 'GENERAL_ERROR', message: 'Network Error, please check your connection and try again.' }
+  ],
+
   properties: [
     {
       class: 'String',
@@ -146,7 +150,7 @@ foam.CLASS({
         this.path,
         options);
 
-      return fetch(request).then(function(resp) {
+      return fetch(request).then(resp => {
         var resp = this.HTTPResponse.create({
           resp: resp,
           responseType: this.responseType
@@ -157,7 +161,9 @@ foam.CLASS({
         // Use Promise.reject so crappy debuggers don't pause here
         // throw resp;
         return Promise.reject(resp);
-      }.bind(this));
+      }).catch( _ => {
+        throw new Error(this.GENERAL_ERROR);
+      });
     },
 
     function addContentHeaders() {


### PR DESCRIPTION
Originally https://github.com/kgrgreer/foam3/pull/2354/files
caused an infinite loop and the reason for https://github.com/kgrgreer/foam3/pull/2368
but then the topic of what was on the templates occurred in RequestReview space... and {{message}} was used in template

SO revert both... and let's not change the FOAMException... if no getter then no infinite loop .... the client default message - does not have a template so I am just setting it as the message - has a translation because of the message in model.
Previously, set the client message to exceptionMessage, to follow the considered convention - but as noted there are some issues with that.