### PR TITLE
Clear password fields when code is verified

### DIFF
--- a/src/foam/nanos/auth/resetPassword/ResetPasswordByCode.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordByCode.js
@@ -127,7 +127,7 @@ foam.CLASS({
           var verified = await  this.emailVerificationService.verifyCode(x, this.email, this.userName, this.resetPasswordCode);
           this.codeVerified = verified;
 
-          // [NP-8692] Clear new/confirmation passwords after the reset password
+          // Clear new/confirmation passwords after the reset password
           // code is verified and user must re-enter the password fields.
           if ( this.codeVerified ) {
             this.clearProperty('newPassword');

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordByCode.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordByCode.js
@@ -126,6 +126,13 @@ foam.CLASS({
         try {
           var verified = await  this.emailVerificationService.verifyCode(x, this.email, this.userName, this.resetPasswordCode);
           this.codeVerified = verified;
+
+          // [NP-8692] Clear new/confirmation passwords after the reset password
+          // code is verified and user must re-enter the password fields.
+          if ( this.codeVerified ) {
+            this.clearProperty('newPassword');
+            this.clearProperty('confirmationPassword');
+          }
         } catch (error) {
           if ( error?.data?.exception && this.VerificationCodeException.isInstance(error.data.exception) ) {
             this.remainingAttempts = error.data.exception.remainingAttempts;


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-8692

## Issue
- The user went through forgot password, verified the reset password code and provided the new/confirmation passwords but going back to sign-in instead of submitting (could be mis-clicked) then he goes through the forgot password again and expects the new/confirmation password fields to be blank.

## Change
- Clear password fields when code is verified