### PR TITLE
Add externalId to Alarm used by external services such as google chat…

### DIFF
--- a/src/foam/nanos/alarming/AddAlarmNameDAO.js
+++ b/src/foam/nanos/alarming/AddAlarmNameDAO.js
@@ -8,8 +8,7 @@ foam.CLASS({
   package: 'foam.nanos.alarming',
   name: 'AddAlarmNameDAO',
   extends: 'foam.dao.ProxyDAO',
-  documentation: `DAO that add name to alarmConfig on Alarm.put. Used to help keep truck of
-  newly added alarms.`,
+  documentation: 'Modify severity of alarm, or disable.  If an alarm is too verbose or determined to be the wrong status, then it can be down regulated with a matching AlarmConfig.',
 
   javaImports: [
     'foam.dao.DAO',
@@ -38,7 +37,9 @@ foam.CLASS({
         try {
           configDAO.put(config);
         } catch ( Exception e ) {
-          ((Logger) x.get("logger")).error(e);
+          // NOTE: do not use warning or error as they in turn
+          // generate alarms
+          ((Logger) x.get("logger")).info("ERROR", e);
         }
       }
       return getDelegate().put_(x, alarm);

--- a/src/foam/nanos/alarming/Alarm.js
+++ b/src/foam/nanos/alarming/Alarm.js
@@ -144,6 +144,13 @@ foam.CLASS({
       menuKeys: [
         'er'
       ]
+    },
+    {
+      documentation: 'UID for external systems - such a google chat',
+      class: 'String',
+      name: 'externalId',
+      createVisibility: 'HIDDEN',
+      updateVisibility: 'RO'
     }
   ],
 

--- a/src/foam/nanos/alarming/AlarmNotificationDAO.js
+++ b/src/foam/nanos/alarming/AlarmNotificationDAO.js
@@ -36,7 +36,7 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.util.AUIDGenerator',
       javaFactory: `
-        return new AUIDGenerator(getX(), "alamrDAO");
+        return new AUIDGenerator(getX(), "alarmDAO");
       `
     }
   ],

--- a/src/foam/nanos/alarming/AlarmNotificationDAO.js
+++ b/src/foam/nanos/alarming/AlarmNotificationDAO.js
@@ -20,6 +20,8 @@ foam.CLASS({
     'foam.nanos.notification.Notification',
     'foam.nanos.theme.Theme',
     'foam.nanos.theme.Themes',
+    'foam.util.AUIDGenerator',
+    'foam.util.SafetyUtil',
     'java.util.HashMap'
   ],
 
@@ -28,6 +30,14 @@ foam.CLASS({
       name: 'notificationTemplate',
       class: 'String',
       value: 'NOC'
+    },
+    {
+      name: 'auid',
+      class: 'FObjectProperty',
+      of: 'foam.util.AUIDGenerator',
+      javaFactory: `
+        return new AUIDGenerator(getX(), "alamrDAO");
+      `
     }
   ],
 
@@ -36,24 +46,38 @@ foam.CLASS({
       name: 'put_',
       javaCode: `
       Alarm old = (Alarm) getDelegate().find_(x, ((Alarm)obj).getId());
-      Alarm alarm = (Alarm) getDelegate().put_(x, obj);
+      Alarm alarm = (Alarm) obj;
       if ( ( old != null &&
              old.getIsActive() == alarm.getIsActive() ) ||
            ( ( old == null ||
                old.getSeverity().getOrdinal() < LogLevel.WARN.getOrdinal() ) &&
                alarm.getSeverity().getOrdinal() < LogLevel.WARN.getOrdinal() ) ) {
-        return alarm;
+        getDelegate().put_(x, obj);
       }
 
       if ( "localhost".equals(System.getProperty("hostname", "localhost")) &&
            ((AppConfig) x.get("appConfig")).getMode() != Mode.TEST ) {
-        return alarm;
+        getDelegate().put_(x, obj);
       }
+
+      if ( old == null ||
+           ! old.getIsActive() && alarm.getIsActive() ) {
+        // raise alarm
+        // If alarm becomes active again, then requires new external id.
+        alarm.setExternalId(getAuid().getNextString());
+      } else if ( old.getIsActive() && ! alarm.getIsActive() ) {
+        // clear alarm
+        alarm.setExternalId(old.getExternalId());
+      }
+      alarm = (Alarm) getDelegate().put_(x, alarm);
+
       // TODO: Occuring from medusa during replay
       if ( alarm.getCreated() ==  null ) {
         alarm = (Alarm) alarm.fclone();
         alarm.setCreated(new java.util.Date());
+        alarm = (Alarm) getDelegate().put_(x, alarm);
       }
+
       // create body for non-email notifications
       StringBuilder body = new StringBuilder();
       body.append("[");
@@ -96,7 +120,7 @@ foam.CLASS({
         args.put("alarm.cleared", alarm.getLastModified().toString());
       }
       args.put("alarm.note", alarm.getNote());
-      if ( alarm.getEventRecord() != null ) {
+      if ( ! SafetyUtil.isEmpty(alarm.getEventRecord()) ) {
         args.put("alarm.eventRecord", alarm.getEventRecord());
       }
 
@@ -116,7 +140,6 @@ foam.CLASS({
         .setSeverity(alarm.getSeverity())
         .setSpid(spid)
         .setTemplate(getNotificationTemplate())
-        .setToastMessage(alarm.getName())
         .setAlarm(alarm)
         .build();
 

--- a/src/foam/nanos/alarming/alarmConfigs.jrl
+++ b/src/foam/nanos/alarming/alarmConfigs.jrl
@@ -1,10 +1,7 @@
 p({
   "class":"foam.nanos.alarming.AlarmConfig",
-  "id":"b9e8a50d-895f-7bf6-c821-29300a6b915c",
-  "name":"SMTP EMail Service ",
-  "preRequest":"Pre send email request",
-  "postRequest":"Post send email request",
-  "alarmValue":95,
-  "monitorType":1,
+  "name":"Email template config",
+  "severity":1,
+  "monitorType":2,
   "sendEmail":false
 })

--- a/src/foam/nanos/alarming/emailTemplates.jrl
+++ b/src/foam/nanos/alarming/emailTemplates.jrl
@@ -11,6 +11,6 @@ started: {{alarm.started}}
 severity: {{alarm.severity}}
 reason: {{alarm.reason}}
 {% if alarm.note %}info: {{alarm.note}}{% endif %}
-{% if alarm.eventRecord %}eventRecord: {{url}}/#er?id={{alarm.eventRecord}}{% endif %}
+{% if url && alarm.eventRecord %}eventRecord: {{url}}/#er?id={{alarm.eventRecord}}{% endif %}
   """
 })

--- a/src/foam/nanos/notification/GoogleChatSetting.js
+++ b/src/foam/nanos/notification/GoogleChatSetting.js
@@ -47,6 +47,10 @@ foam.CLASS({
           threadKey.append(System.getProperty("CLUSTER_NAME", notification.getAlarm().getHostname()));
           threadKey.append("-");
           threadKey.append(notification.getAlarm().getName().replaceAll(" ", "_"));
+          if ( ! SafetyUtil.isEmpty(notification.getAlarm().getExternalId()) ) {
+            threadKey.append("-");
+            threadKey.append(notification.getAlarm().getExternalId());
+          }
           Map thread = new HashMap();
           thread.put("threadKey", threadKey.toString());
           map.put("thread", thread);
@@ -76,7 +80,7 @@ foam.CLASS({
 
         // Loggers.logger(x, this).debug(response.body());
         if ( response.statusCode() != 200 ) {
-          Loggers.logger(x, this).warning("Failed posting to Google", response.statusCode(), response.body());
+          Loggers.logger(x, this).warning("Failed posting to Google", response.statusCode(), response.body(), "message", message);
         }
       } catch (Throwable t) {
         Loggers.logger(x, this).error(t);

--- a/src/foam/nanos/notification/NotificationTemplateDAO.js
+++ b/src/foam/nanos/notification/NotificationTemplateDAO.js
@@ -91,7 +91,8 @@ the notification will be handled. `,
               return notification;
             }
           } else {
-            logger.warning("Template not found", notification.getTemplate());
+            // NOTE: do not generate an error or warning log as this in tern generates an alarm which in tern generates a notification
+            logger.info("WARN,Template not found", notification.getTemplate());
             return notification;
           }
         }

--- a/src/foam/nanos/notification/email/ApplyBaseArgumentsEmailPropertyService.js
+++ b/src/foam/nanos/notification/email/ApplyBaseArgumentsEmailPropertyService.js
@@ -67,7 +67,7 @@ foam.CLASS({
         // template name check
         String templateName = (String) templateArgs.get("template");
         if ( SafetyUtil.isEmpty(templateName) ) {
-          logger.info("EmailTemplate not found");
+          logger.warning("EmailTemplate not found");
           return emailMessage;
         }
 

--- a/src/foam/nanos/notification/email/ApplyBaseArgumentsEmailPropertyService.js
+++ b/src/foam/nanos/notification/email/ApplyBaseArgumentsEmailPropertyService.js
@@ -67,7 +67,7 @@ foam.CLASS({
         // template name check
         String templateName = (String) templateArgs.get("template");
         if ( SafetyUtil.isEmpty(templateName) ) {
-          logger.warning("EmailTemplate not found");
+          logger.debug("EmailTemplate not found");
           return emailMessage;
         }
 

--- a/src/foam/nanos/notification/email/EmailTemplateEngine.js
+++ b/src/foam/nanos/notification/email/EmailTemplateEngine.js
@@ -15,8 +15,6 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.lib.json.*',
     'foam.lib.parse.*',
-    'foam.nanos.alarming.Alarm',
-    'foam.nanos.alarming.AlarmReason',
     'foam.nanos.logger.Logger',
     'foam.nanos.logger.Loggers',
     'foam.nanos.logger.PrefixLogger',
@@ -69,29 +67,8 @@ foam.CLASS({
             String value = (String) ((Map) x.get("values")).get(v.toString());
             if ( value == null ) {
               value = "";
-
-              final String message = "No value provided for variable "+v;
-              foam.nanos.logger.StdoutLogger.instance().warning(message);
-              // At runtime, getX() is valid, during test case run
-              // XLocator is valid.  Need to determine which X to use.
-              X y = getX();
-              Agency agency = (Agency) y.get("threadPool");
-              if ( agency == null ) {
-                y = foam.core.XLocator.get();
-                agency = (Agency) y.get("threadPool");
-              }
-              if ( agency != null ) {
-                agency.submit(y, new ContextAgent() {
-                  public void execute(X x) {
-                    Alarm alarm = new Alarm();
-                    alarm.setName("Email template config");
-                    alarm.setReason(AlarmReason.CONFIGURATION);
-                    alarm.setNote(message);
-                    alarm.setClusterable(false);
-                    ((DAO) x.get("alarmDAO")).put(alarm);
-                  }
-                }, this.getClass().getSimpleName()+"-alarm");
-              }
+              // NOTE: do not log warn or error as these generate alarms which in turn generate notifications and emails.
+              foam.nanos.logger.StdoutLogger.instance().info("WARN,No value provided for variable",v);
             }
             ((StringBuilder) x.get("sb")).append(value);
             return value;
@@ -291,24 +268,9 @@ foam.CLASS({
               templateName.append(val0[i]);
             }
 
-            // At runtime, getX() is valid, during test case run
-            // XLocator is valid.  Need to determine which X to use.
-            X y = getX();
-            DAO alarmDAO = (DAO) y.get("alarmDAO");
-            if ( alarmDAO == null ) {
-              y = foam.core.XLocator.get();
-              alarmDAO = (DAO) y.get("alarmDAO");
-            }
-            EmailTemplate extendedEmailTemplate = EmailTemplateSupport.findTemplate(y, templateName.toString());
+            EmailTemplate extendedEmailTemplate = EmailTemplateSupport.findTemplate(getX(), templateName.toString());
             if ( extendedEmailTemplate == null ) {
-              foam.nanos.logger.StdoutLogger.instance().warning("Extended template not found", templateName);
-              if ( alarmDAO != null ) {
-                Alarm alarm = new Alarm();
-                alarm.setName("Email template config");
-                alarm.setReason(AlarmReason.CONFIGURATION);
-                alarm.setNote("Extended template not found " + templateName);
-                alarmDAO.put(alarm);
-              }
+              foam.nanos.logger.StdoutLogger.instance().info("WARN,Extended template not found", templateName);
               return val;
             }
             StringBuilder content = new StringBuilder();
@@ -345,7 +307,7 @@ foam.CLASS({
       }, (Logger) x.get("logger"));
       EmailTemplate template = EmailTemplateSupport.findTemplate(x, id);
       if ( template == null ) {
-        logger.warning("Template not found");
+        logger.info("WARN,Template not found");
         throw new RuntimeException("Template not found");
       }
       return renderTemplate(x.put("logger", logger), template.getBody(), values);


### PR DESCRIPTION
… to match raise and clearing alarms.  Also remove a number of useless alarms related to email templates and missing parameters. Log messages are still generated but the alarms didn't carry enough information to be useful in tracking down the issue.  And the notification and email template issues were in turn generating alarms which cause feedback as they generate notification and emails which also can have template issues