### PR TITLE
NP-8702 Data in updated object column in ExchangeRateHistoryDAO is overlapped 

### DIFF
--- a/src/foam/dao/history/HistoryRecord.js
+++ b/src/foam/dao/history/HistoryRecord.js
@@ -29,7 +29,11 @@ foam.CLASS({
       name: 'objectId',
       label: 'Updated Object',
       documentation: 'Id of object related to history record.',
-      tableWidth: 150
+      tableWidth: 150,
+      tableCellFormatter: function(value, _) {
+        if ( ! value ) return;
+        this.add(!! value.toSummary ? value.toSummary() : value);
+      }
     },
     {
       class: 'FObjectProperty',

--- a/src/foam/dao/history/HistoryRecord.js
+++ b/src/foam/dao/history/HistoryRecord.js
@@ -31,8 +31,8 @@ foam.CLASS({
       documentation: 'Id of object related to history record.',
       tableWidth: 150,
       tableCellFormatter: function(value, _) {
-        if ( ! value ) return;
-        this.add(!! value.toSummary ? value.toSummary() : value);
+        if ( !value ) return;
+        this.add(!!value.toSummary ? value.toSummary() : value);
       }
     },
     {


### PR DESCRIPTION
link ticket: https://nanopay.atlassian.net/browse/NP-8702
root cause: objectId render entire object in table cell. 
fix: customize cell render method(tableCellFormatter)
before fix :
<img width="1359" alt="Screenshot 2023-01-05 at 1 08 31 PM" src="https://user-images.githubusercontent.com/56833131/213196587-2f73cb29-a463-4047-9010-0c226d7a7ea2.png">

after fix:
<img width="891" alt="Screen Shot 2023-01-17 at 3 51 31 PM" src="https://user-images.githubusercontent.com/56833131/213196863-7e3939d5-be15-4cce-94c6-dfcf8cf8f705.png">