### PR TITLE
[NP-8849] Fix CreateLoader, UCJLoader, and make EasyLoader make more sense

### DIFF
--- a/src/foam/u2/wizard/data/CreateLoader.js
+++ b/src/foam/u2/wizard/data/CreateLoader.js
@@ -7,7 +7,7 @@
 foam.CLASS({
   package: 'foam.u2.wizard.data',
   name: 'CreateLoader',
-  implements: ['foam.u2.wizard.data.Loader'],
+  extends: 'foam.u2.wizard.data.ProxyLoader',
 
   imports: [
     'wizardletOf?'
@@ -43,6 +43,15 @@ foam.CLASS({
 
   methods: [
     async function load(o) {
+      // If CreateLoader has a delegate we assume copyFrom is expected
+      if ( this.delegate ) {
+        const delegateResult = await this.delegate.load(o);
+        if ( delegateResult ) {
+          return delegateResult.copyFrom(this.args);
+        }
+      }
+
+      // Otherwise behave as before
       return o?.old ?? this.of.create(this.args, this);
     }
   ]

--- a/src/foam/u2/wizard/data/EasyLoader.js
+++ b/src/foam/u2/wizard/data/EasyLoader.js
@@ -16,8 +16,10 @@ foam.CLASS({
       name: 'loaders',
       postSet: function (_, n) {
         if ( n.length < 2 ) return;
-        for ( let i = 1 ; i < n.length ; i++ ) {
-          n[i].delegate = n[i-1];
+        for ( let i = 0 ; i < n.length - 1 ; i++ ) {
+          if ( ! foam.u2.wizard.data.ProxyLoader.isInstance(n[i]) )
+            console.log('Loaders inside EasyLoader must extend ProxyLoader');
+          n[i].delegate = n[i+1];
         }
       }
     }
@@ -25,7 +27,9 @@ foam.CLASS({
 
   methods: [
     async function load({ old }) {
-      return await this.loaders[this.loaders.length - 1].load(...arguments);
+      if ( ! this.loaders[this.loaders.length-1].delegate )
+        this.loaders[this.loaders.length-1].delegate = this.delegate;
+      return await this.loaders[0].load(...arguments);
     }
   ]
 });

--- a/src/foam/u2/wizard/data/EasyLoader.js
+++ b/src/foam/u2/wizard/data/EasyLoader.js
@@ -18,7 +18,7 @@ foam.CLASS({
         if ( n.length < 2 ) return;
         for ( let i = 0 ; i < n.length - 1 ; i++ ) {
           if ( ! foam.u2.wizard.data.ProxyLoader.isInstance(n[i]) )
-            console.log('Loaders inside EasyLoader must extend ProxyLoader');
+            console.warn('Loaders inside EasyLoader must extend ProxyLoader');
           n[i].delegate = n[i+1];
         }
       }

--- a/src/foam/u2/wizard/data/UserCapabilityJunctionLoader.js
+++ b/src/foam/u2/wizard/data/UserCapabilityJunctionLoader.js
@@ -36,9 +36,9 @@ foam.CLASS({
 
         // Finally, apply new data to wizardlet
         if ( wizardlet.data ) {
-          wizardlet.data.copyFrom(loadedData);
+          return old.copyFrom(loadedData);
         } else {
-          wizardlet.data = loadedData.clone(wizardlet.__subSubContext__);
+          return loadedData.clone(wizardlet.__subSubContext__);
         }
       } catch (e) {
         console.warn(e);


### PR DESCRIPTION
- CreateLoader now acts like a "CopyFromLoader" when it has a delegate
- UCJLoader properly implements Loader behavior
  - it was changing wizardlet data directly, which Loaders should never do
- EasyLoader is no longer backwards; it's now parent->delegate order
  - **requires re-peg on nano side**