### PR TITLE
NP-8839 Only Show Sections with Titles

### DIFF
--- a/src/foam/u2/detail/TabbedDetailView.js
+++ b/src/foam/u2/detail/TabbedDetailView.js
@@ -64,7 +64,7 @@ foam.CLASS({
 
           return self.E()
             .add(arraySlot.map(visibilities => {
-              var availableSections = visibilities.length == sections.length ? sections.filter((_, i) => visibilities[i]) : sections;
+              var availableSections = visibilities.length == sections.length ? sections.filter((s, i) => s.title && visibilities[i]) : sections;
               var e = availableSections.length == 1 ?
                 this.E().start(self.CardBorder).addClass(self.myClass('wrapper'))
                   .tag(self.SectionView, { data$: self.data$, section: availableSections[0], showTitle: false })


### PR DESCRIPTION
For some reason, the sections array has an extra entry at the end that is 'visible' but it is just the data for the entity and not actually a section. The way we distinguish whether to show a section is if it has a title, so I'm adding that to the filtering.

This fixes: https://nanopay.atlassian.net/browse/NP-8839

![image](https://user-images.githubusercontent.com/43998323/214694427-fef222cb-6d95-4da1-9b0e-ad8144a09616.png)
