### PR TITLE
[NP-8834] Remove LoadWizardletsAgent from transient wizards

### DIFF
--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -213,6 +213,7 @@ foam.CLASS({
           .remove('CheckNoDataAgent')
           .remove('AutoSaveWizardletsAgent')
           .remove('SaveAllAgent')
+          .remove('LoadWizardletsAgent')
           .remove('WizardStateAgent') // does not make sense in transient wizards
           .remove('FilterGrantModeAgent') // breaks for non-CapabilityWizardlet
           .remove('GrantedEditAgent')


### PR DESCRIPTION
Not guaranteed to fix anything (still can't reproduce NP-8834 issue), but this context agent definitely shouldn't be enabled here and I didn't think that it was.