### PR TITLE
[NP-8834] Fix WizardletChainLoader

### DIFF
--- a/src/foam/u2/wizard/data/WizardletChainLoader.js
+++ b/src/foam/u2/wizard/data/WizardletChainLoader.js
@@ -10,7 +10,12 @@ foam.CLASS({
   implements: ['foam.u2.wizard.data.Loader'],
 
   documentation: `
-    Delegates to the loader in the specified wizardlet
+    Delegates to the loader in the specified wizardlet.
+
+    It is important to note that the loader from the wizardlet
+    specified will execute under that wizardlet's subcontext
+    rather than the subcontext of the wizardlet which is using
+    WizardletChainLoader.
   `,
 
   imports: [
@@ -48,7 +53,8 @@ foam.CLASS({
         foam.assert(false, errorMsg);
       }
 
-      const loader = foam.json.parse(wizardlet.wao.loader, undefined, this.__subContext__);
+      const loader = foam.json.parse(
+        wizardlet.wao.loader, undefined, wizardlet.__subContext__);
       foam.u2.wizard.data.ensureTerminal(loader, this.ProxyLoader, this.NullLoader);
       return await loader.load({ ...a, old: wizardlet.data });
     }


### PR DESCRIPTION
## TL;DR Summary
- Fixes address and phone number loading (for good this time?)
- Does not fix duplicate onboarding, but makes it consistently reproducible

## Long Explanation
This description is a little more verbose than usual because
I'm hoping to start a log of issues like this and I figure
if I'm writing this text anyway I might as well include it in
the PR description.

An issue occured when trying to use WizardletChainLoader to
load a UserLoader on an upcoming wizardlet.

**WizardletChainLoader**
> WizardletChainLoader is used to load data intended for an
> upcoming wizardlet at an earlier stage in the wizard flow.
> This is useful when combined with MapLoader to populate
> a facade wizardlet without making the wizardlets it then
> populates dependant on it.

**UserLoader**
> UserLoader gets an up-to-date user object from userDAO based
> on the current subject's user id and populates a new instance
> of wizardlet.of with the user's properties using `copyFrom`

Since UserLoader does not have a delegate it uses the `wizardletOf`
value from context. Since it was run by WizardletChainLoader, it was
running under the subcontext of a facade wizardlet rather than the
wizardlet it's normally attached to. This meant `wizardletOf` was the
facade model instead of the model applicable to UserLoader.

From this issue I decided it makes sense that WizardletChainLoader
always runs the loader of the specified wizardlet in that wizardlet's
context.

This could be thought to imply that a wizardlet's loader should always
be run under the context of the wizardlet it was specified on.

Alternatively, it could instead suggest that relying on wizardlet-identifing
context values in a loader should be avoided. For example, if UserLoader
was a ProxyLoader it could instead delegate creation of the object to
a CreateLoader with an explicit `of`.
