### PR TITLE
Np 8906/rfi view remove validate auth

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -856,20 +856,10 @@ foam.CLASS({
           throw new AuthenticationException("User disabled");
         }
 
-        // check if user login enabled
-        if ( ! this.getLoginEnabled() ) {
-          throw new AuthenticationException("Login disabled");
-        }
-
         // fetch context from session and check two factor success if enabled.
         Session session = x.get(Session.class);
         if ( session == null ) {
           throw new AuthenticationException("No session exists.");
-        }
-
-        // check for two-factor authentication
-        if ( this.getTwoFactorEnabled() && ! session.getTwoFactorSuccess() ) {
-          throw new AuthenticationException("User requires two-factor authentication");
         }
 
         if ( this instanceof LifecycleAware && ((LifecycleAware) this).getLifecycleState() != LifecycleState.ACTIVE ) {

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -148,8 +148,7 @@ foam.CLASS({
         if ( user == null ) {
           throw new UserNotFoundException();
         }
-        // check that the user is active
-        assertUserIsActive(user);
+        user.validateAuth(x);
         // check if user enabled
         if ( ! user.getEnabled() ) {
           throw new AccessDeniedException();

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -113,6 +113,8 @@ foam.CLASS({
         }
         // get user from session id
         User user = (User) ((DAO) getLocalUserDAO()).find(session.getUserId());
+        user.validateAuth(x);
+
         // check if group enabled
         Group group = getCurrentGroup(x);
         if ( group != null && ! group.getEnabled() ) {
@@ -172,6 +174,10 @@ foam.CLASS({
         }
 
         Session session = x.get(Session.class);
+        // check for two-factor authentication
+        if ( user.getTwoFactorEnabled() && ! session.getTwoFactorSuccess() ) {
+          throw new AuthenticationException("User requires two-factor authentication");
+        }
         // Re use the session context if the current session context's user id matches the id of the user trying to log in
         if ( session.getUserId() == user.getId() ) {
           return user;


### PR DESCRIPTION
* removes checks for `loginEnabled` and `twoFactorEnabled` from `User.validateAuth()`
* adds check for `twoFactorEnabled` to `loginHelper()`