### PR TITLE
finding the correct context - EmailTemplateEngine

### DIFF
--- a/src/foam/nanos/notification/email/EmailTemplateEngine.js
+++ b/src/foam/nanos/notification/email/EmailTemplateEngine.js
@@ -268,10 +268,14 @@ foam.CLASS({
             }
 
             // At runtime, getX() is valid, during test case run
-            // XLocator is valid.  Need to determine which X to use.
-            X y = foam.core.XLocator.get();
-            if ( y.get("emailTemplateDAO") == null ) {
+            // notice passed context is set on ParserContext
+            X y = (X) x.get("x");
+            if ( y == null || y.get("emailTemplateDAO") == null ) {
               y = getX();
+            }
+            // XLocator is valid.  Need to determine which X to use.
+            if ( y == null || y.get("emailTemplateDAO") == null ) {
+              y = foam.core.XLocator.get();
             }
             EmailTemplate extendedEmailTemplate = EmailTemplateSupport.findTemplate(y, templateName.toString());
             if ( extendedEmailTemplate == null ) {
@@ -337,6 +341,7 @@ foam.CLASS({
       parserX.set("values", values);
       parserX.set("logger", x.get("logger"));
       parserX.set("alarmDAO", x.get("alarmDAO"));
+      parserX.set("x", x);
       getGrammar().parse(ps, parserX, "");
       return sb;
       `

--- a/src/foam/nanos/notification/email/EmailTemplateEngine.js
+++ b/src/foam/nanos/notification/email/EmailTemplateEngine.js
@@ -341,7 +341,6 @@ foam.CLASS({
       parserX.set("values", values);
       parserX.set("logger", x.get("logger"));
       parserX.set("alarmDAO", x.get("alarmDAO"));
-      parserX.set("x", x);
       getGrammar().parse(ps, parserX, "");
       return sb;
       `


### PR DESCRIPTION
Previous updates https://github.com/kgrgreer/foam3/pull/2398/files#diff-7456e5cd38e00d0c224d81b365dd20a6bfd2cd74d9bbacfc023016015706ac49R270-R276
<img width="921" alt="Screen Shot 2023-02-10 at 8 58 35 AM" src="https://user-images.githubusercontent.com/10802216/218109911-06995382-cde7-405e-8d14-f8ec02613df7.png">

Issue:
<img width="943" alt="Screen Shot 2023-02-10 at 8 59 13 AM" src="https://user-images.githubusercontent.com/10802216/218111535-c3a8513f-2230-4083-b508-74c20e726503.png">
<img width="757" alt="Screen Shot 2023-02-10 at 9 06 48 AM" src="https://user-images.githubusercontent.com/10802216/218111716-e388d86a-7040-40d9-ad39-59a6860957a6.png">

tracing the bug I come to understand the issue is the context.
By the time we get to:
https://github.com/kgrgreer/foam3/blob/389d2e9ffc32e4d3f77a103a4c76f60ad1daed3e/src/foam/nanos/notification/email/EmailTemplateSupport.java#L111
The user is null.

That is cause of the call passing in a context without a valid subject.
The call being:
https://github.com/kgrgreer/foam3/blob/bc3e362852ac0f63f71280116ed5a945b15ef220/src/foam/nanos/notification/email/EmailTemplateEngine.js#L276
Images show just a few lines above ^, where we evaluate the context.
Note the three options x.get("x"), getX(), XLocator()
<img width="1440" alt="Screen Shot 2023-02-10 at 8 54 03 AM" src="https://user-images.githubusercontent.com/10802216/218111040-5925427c-2fab-44ad-8664-14ae659648aa.png">
<img width="1440" alt="Screen Shot 2023-02-10 at 8 54 14 AM" src="https://user-images.githubusercontent.com/10802216/218111068-b7924ea1-82d1-4a53-9714-81f6f31ff8c6.png">
<img width="1440" alt="Screen Shot 2023-02-10 at 8 54 44 AM" src="https://user-images.githubusercontent.com/10802216/218111134-0a8974b6-3a98-45a7-98d1-6503b9fada1c.png">

Also note: joinTemplates - is the only one using the includeGrammer call, and that sets `x.get("x")`
Decided to leave this in a cascade for lease error...