### PR TITLE
Fix authorizeAnonymous not updating session user id

### DIFF
--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -71,7 +71,7 @@ foam.CLASS({
       },
       required: true,
       updateVisibility: 'RO',
-      storageOptional: true
+      storageTransient: true
     },
     {
       class: 'Reference',


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-8983

## Issues
- When authorizeAnonymous right after logout the only change to the session object is the userId but since the userId is storageOptional MedusaAdapterDAO return the session without adding medusa entry to the nodes
- MDAO of the mediators only get updated when they have consensus from the nodes but the put doesn't occur

## Changes
- Change session userId to storageTransient because storageOptional prevents MedusaAdapterDAO from saving to the session to the nodes and mediators MDAO