### PR TITLE
ApprovalDAO reputObject update

### DIFF
--- a/src/foam/nanos/approval/ApprovalDAO.js
+++ b/src/foam/nanos/approval/ApprovalDAO.js
@@ -96,22 +96,25 @@ foam.CLASS({
         FObject obj = dao.find(request.getObjId()).fclone();
 
         DAO userDAO = (DAO) x.get("localUserDAO");
+        Subject subject = new Subject();
+        if ( ((ApprovalRequest) request).getCreatedForAgent() != 0 ) {
+          User initiatingAgent = (User) userDAO.find(((ApprovalRequest) request).getCreatedForAgent());
+          subject.setUser(initiatingAgent);
+        }
 
         User initiatingUser = (User) userDAO.find(((ApprovalRequest) request).getCreatedBy());
         if ( ((ApprovalRequest) request).getCreatedFor() != 0 ) {
           initiatingUser = (User) userDAO.find(((ApprovalRequest) request).getCreatedFor());
         }
-        
-        // Update subject user but keep subject realUser
-        // realUser previlieges need to be maintained
-        ((Subject) x.get("subject")).setUser(initiatingUser);
+        subject.setUser(initiatingUser);
 
-        x = x.put(ApprovalRequest.class, request);
+        X initiatingUserX = x.put("subject", subject)
+                             .put(ApprovalRequest.class, request);
 
         if ( ((ApprovalRequest) request).getOperation() == Operation.REMOVE ) {
-          dao.inX(x).remove(obj);
+          dao.inX(initiatingUserX).remove(obj);
         } else {
-          dao.inX(x).put(obj);
+          dao.inX(initiatingUserX).put(obj);
         }
       `
     },


### PR DESCRIPTION
Use initiating agent in the context (the group belongs to the approver) - all the groups who are allowed to approve approval requests have the permission to update ucjs (crunch.service.unsafe...) so using initiating agent in the context shouldn't break the approval flow when admin/ops are acting on the user