### PR TITLE
DIG (Java client) unAdapt - convert reply of Object[] to FObject[].

### DIFF
--- a/src/foam/nanos/dig/DIG.js
+++ b/src/foam/nanos/dig/DIG.js
@@ -51,6 +51,7 @@ NOTE: when using the java client, the first call to a newly started instance may
     'java.net.URI',
     'java.net.URLEncoder',
     'java.time.Duration',
+    'java.util.Arrays',
     'java.util.Base64',
     'javax.net.ssl.SSLContext',
     'javax.servlet.http.HttpServletRequest',
@@ -721,10 +722,23 @@ NOTE: when using the java client, the first call to a newly started instance may
       javaCode: `
       PM pm = PM.create(x, "DIG", "unAdapt", getPostURL(), getDaoKey(), dop);
       try {
-        Object result = parser_.get().parseString(data.toString(), getOf().getObjClass());
+        Object result = null;
+        String text = data.toString();
+        if ( ! foam.util.SafetyUtil.isEmpty(text) ) {
+          if ( text.startsWith("[") ) {
+            result = parser_.get().parseStringForArray(text, getOf().getObjClass());
+            // convert Object[] to FObject[]
+            if ( result != null &&
+                 result instanceof Object[] ) {
+              result = Arrays.copyOf((Object[]) result, ((Object[]) result).length, FObject[].class);
+            }
+          } else if ( text.startsWith("{") ) {
+            result = parser_.get().parseString(text, getOf().getObjClass());
+          }
+        }
         if ( result == null ) {
           // ClassReferenceParser returns null when data is not a modelled class
-          return data.toString();
+          return text;
         }
         if ( result instanceof FOAMException ) {
           throw (FOAMException) result;


### PR DESCRIPTION
Since last use, JSONParser has changed. Previously parseString returned FObject[], but now parseStringForArray must be called which returns Object[]. All existing DIG Java client uses are expected FObject[]