### PR TITLE
ExecGradle - set shell to ''. It defaults to 'node' which is incorrec…

### DIFF
--- a/src/foam/foobar/ExecGradle.js
+++ b/src/foam/foobar/ExecGradle.js
@@ -10,6 +10,10 @@ foam.CLASS({
       factory: function () {
         return process.platform === 'win32' ? 'gradle.bat' : 'gradle';
       }
+    },
+    {
+      name: 'shell',
+      value: ''
     }
   ]
 })


### PR DESCRIPTION
…t for running gradle