### PR TITLE
MedusaEntry.objectId - handle multipart keys

### DIFF
--- a/src/foam/nanos/medusa/MedusaEntry.js
+++ b/src/foam/nanos/medusa/MedusaEntry.js
@@ -111,8 +111,11 @@ The data of a MedusaEntry is the json delta of the original put or remove DAO op
       }
     },
     {
-      // NOTE: previously storageTransient, but objectId required for compaction
-      document: 'FObject id',
+      document: `FObject id.
+Initially this was storageTransient and thus not persisted on the nodes.
+With 'compaction' object id is used ensure we only process each ojbect once.
+But with this change from storageTransient, multipart ids are stored as classes which may not exists on the nodes, and thus fail replay.
+Using the UnknownFObjectParser allows the nodes to process the multipart ids as 'Strings'`,
       class: 'Object',
       name: 'objectId',
       visibility: 'RO',
@@ -122,7 +125,8 @@ The data of a MedusaEntry is the json delta of the original put or remove DAO op
       }
       if ( o1 == null && o2 == null) return 0;
       return o1 == null ? -1 : 1;
-      `
+      `,
+      javaJSONParser: 'new foam.lib.json.UnknownFObjectParser()'
     },
     {
       document: 'FObject on route to Primary',


### PR DESCRIPTION
objectid was originally storageTransient and thus not persisted on nodes. With compaction objectId was retained - now persisted. ObjectId is type Object and multiplart ids are models. On parsing the multipart id class must exists, but this is not the case with nodes, as they are not built with the entire application source. UnknownFObjectParser is used to parse the objectId property, allowing all existing logic to remain, by simply treating the json model as a string.