### PR TITLE
Set serviceproviderware to false

### DIFF
--- a/src/foam/nanos/notification/email/services.jrl
+++ b/src/foam/nanos/notification/email/services.jrl
@@ -47,6 +47,7 @@ p({
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("emailMessages")
       .setSAF(true)
+      .setServiceProviderAware(false)
       .setFixedSize(new foam.dao.FixedSizeDAO.Builder(x)
         .setComparator(foam.mlang.MLang.DESC(foam.nanos.notification.email.EmailMessage.CREATED) )
         .setSize(100000)
@@ -66,6 +67,7 @@ p({
       .setInnerDAO((foam.dao.DAO) x.get("localEmailMessageDAO"))
       .setRuler(false)
       .setEnableInterfaceDecorators(false)
+      .setServiceProviderAware(false)
       .setOrder(new foam.mlang.order.Comparator[] { new foam.mlang.order.Desc.Builder(x).setArg1(foam.nanos.notification.email.EmailMessage.CREATED).build() })
       .build();
   """,


### PR DESCRIPTION
We want to be able to put to emailMessageDAO with system context but still able to set spid on the email from the user property of EmailMessage. Setting ServiceProviderAware to false allows decorators on the emailMessageDAO to set spid from the user property of emailMessage or from the user in context if there is no user on the emailmessage.

Needed by https://github.com/nanoPayinc/NANOPAY/pull/16362