### PR TITLE
[NP-9471] Fix approval request authorizer

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -95,9 +95,12 @@ foam.CLASS({
       class: 'foam.comics.v2.CannedQuery',
       label: 'Assigned',
       predicateFactory: function(e) {
-        return e.EQ(
-          foam.nanos.approval.ApprovalRequest.ASSIGNED_TO,
-          foam.nanos.approval.ApprovalRequest.APPROVER
+        return e.AND(
+          e.NEQ(foam.nanos.approval.ApprovalRequest.ASSIGNED_TO, 0),
+          e.EQ(
+            foam.nanos.approval.ApprovalRequest.ASSIGNED_TO,
+            foam.nanos.approval.ApprovalRequest.APPROVER
+          )
         );
       }
     },

--- a/src/foam/nanos/approval/AuthenticatedApprovalDAOAuthorizer.js
+++ b/src/foam/nanos/approval/AuthenticatedApprovalDAOAuthorizer.js
@@ -35,9 +35,10 @@ foam.CLASS({
         if ( user == null )
           throw new AuthorizationException();
 
-        // The approval request is settled, anyone can see it
+        // The approval request is settled, anyone in the approval groups can see it
         if ( approvalRequest.getAssignedTo() == 0
           && approvalRequest.getStatus() != ApprovalStatus.REQUESTED
+          && isInApprovalGroup(approvalRequest, user)
         ) return;
 
         // The approval request is in pending, only the approver can see it
@@ -96,6 +97,22 @@ foam.CLASS({
         return user.getId() == User.SYSTEM_USER_ID ||
                "system".equals(user.getGroup()) ||
                "admin".equals(user.getGroup());
+      `
+    },
+    {
+      name: 'isInApprovalGroup',
+      type: 'Boolean',
+      args: 'ApprovalRequest approvalRequest, User user',
+      javaCode: `
+        if ( user.getGroup().equals(approvalRequest.getGroup()) )
+          return true;
+
+        if ( approvalRequest.getAdditionalGroups() != null )
+          for ( var group : approvalRequest.getAdditionalGroups() )
+            if ( user.getGroup().equals(group) )
+              return true;
+
+        return false;
       `
     }
   ]

--- a/src/foam/nanos/approval/AuthenticatedApprovalDAOAuthorizer.js
+++ b/src/foam/nanos/approval/AuthenticatedApprovalDAOAuthorizer.js
@@ -32,11 +32,17 @@ foam.CLASS({
       javaCode: `
         var approvalRequest = (ApprovalRequest) obj;
         User user = ((Subject) x.get("subject")).getUser();
-        if ( user == null ||
-             ( ! canApprove(approvalRequest, user)
-              && approvalRequest.getStatus() == ApprovalStatus.REQUESTED ) ) {
+        if ( user == null )
           throw new AuthorizationException();
-        }
+
+        // The approval request is settled, anyone can see it
+        if ( approvalRequest.getAssignedTo() == 0
+          && approvalRequest.getStatus() != ApprovalStatus.REQUESTED
+        ) return;
+
+        // The approval request is in pending, only the approver can see it
+        if ( ! canApprove(approvalRequest, user) )
+          throw new AuthorizationException();
       `
     },
     {


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-9417
- https://github.com/kgrgreer/foam3/pull/2715
- https://github.com/kgrgreer/foam3/pull/2502

## Issues
- Approval requests were only visible to the approver even when the status was approved/rejected

## Changes
- Update "Assigned" canned query to check assignedTo != 0
- Allow anyone in the approval groups to see the approval requests that are settled (status in Approved/Rejected/Cancelled and assignedTo=0)
- If the approval request is in pending (ie. status=Requested), only the approver can see it