### PR TITLE
boxThreadPool - add threadpool for socket based boxes.

### DIFF
--- a/src/foam/box/services.jrl
+++ b/src/foam/box/services.jrl
@@ -1,0 +1,11 @@
+p({
+  "class": "foam.nanos.boot.NSpec",
+  "name": "boxThreadPool",
+  "lazy": false,
+  "serve": false,
+  "serviceScript": `
+    return new foam.nanos.pool.ThreadPoolAgency.Builder(x)
+      .setPrefix("box")
+      .build();
+  `
+})

--- a/src/foam/box/sf/SFManager.js
+++ b/src/foam/box/sf/SFManager.js
@@ -24,7 +24,10 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.nanos.logger.Logger',
     'foam.nanos.logger.PrefixLogger',
+    'foam.util.concurrent.AbstractAssembly',
     'foam.util.concurrent.AssemblyLine',
+    'foam.util.concurrent.AsyncAssemblyLine',
+    'foam.util.concurrent.SyncAssemblyLine',
     'foam.util.retry.RetryForeverStrategy',
     'foam.util.retry.RetryStrategy',
     'java.util.concurrent.locks.Condition',
@@ -60,7 +63,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'threadPoolName',
-      value: 'threadPool'
+      value: 'boxThreadPool'
     },
     {
       name: 'logger',
@@ -103,11 +106,11 @@ foam.CLASS({
         Agency pool = (Agency) x.get(getThreadPoolName());
 
         //TODO: use below code after finish testing.
-        // final AssemblyLine assemblyLine = x.get("threadPool") == null ?
-        //   new foam.util.concurrent.SyncAssemblyLine()   :
-        //   new foam.util.concurrent.AsyncAssemblyLine(x) ;
+        // final AssemblyLine assemblyLine = x.get(getThreadPoolName()) == null ?
+        //   new SyncAssemblyLine()   :
+        //   new AsyncAssemblyLine(x) ;
 
-        final AssemblyLine assemblyLine = new foam.util.concurrent.SyncAssemblyLine();
+        final AssemblyLine assemblyLine = new SyncAssemblyLine();
 
         pool.submit(x, new ContextAgent() {
           volatile long count = 0;
@@ -119,7 +122,7 @@ foam.CLASS({
               if ( queue.size() > 0 ) {
                 if ( queue.peek().getScheduledTime() <= System.currentTimeMillis() ) {
                   SFEntry e = queue.poll();
-                  assemblyLine.enqueue(new foam.util.concurrent.AbstractAssembly() { 
+                  assemblyLine.enqueue(new AbstractAssembly() { 
                     public void executeJob() {
                       try {
                         //getLogger().info("sfID: " + e.getSf().getId(), "sfObject: " + e.getObject());

--- a/src/foam/box/socket/SocketConnectionBoxManager.js
+++ b/src/foam/box/socket/SocketConnectionBoxManager.js
@@ -53,6 +53,11 @@ foam.CLASS({
       value: 10000
     },
     {
+      class: 'String',
+      name: 'threadPoolName',
+      value: 'boxThreadPool'
+    },
+    {
       class: 'Map',
       name: 'boxes',
       javaFactory: `
@@ -191,17 +196,18 @@ foam.CLASS({
           socket.connect(address, getConnectTimeout());
           box = new SocketConnectionBox(x, key, socket);
           add(box);
-          Agency agency = (Agency) x.get("threadPool");
+          Agency agency = (Agency) x.get(getThreadPoolName());
           agency.submit(x, (ContextAgent) box, socket.getRemoteSocketAddress().toString());
           return box;
         } catch ( java.net.ConnectException |
-                   java.net.NoRouteToHostException e ) {
+                   java.net.NoRouteToHostException |
+                   java.net.UnknownHostException e ) {
           remove(box);
           getLogger().warning(key, e.getClass().getSimpleName(), e.getMessage());
           throw new RuntimeException(e);
         } catch ( Throwable t ) { // All other IOExceptions
           remove(box);
-          getLogger().error(key, t.getClass().getSimpleName(), t.getMessage());
+          getLogger().error(key, t.getClass().getSimpleName(), t.getMessage(), t);
           throw new RuntimeException(t);
         }
       `

--- a/src/foam/box/socket/SocketServer.js
+++ b/src/foam/box/socket/SocketServer.js
@@ -38,7 +38,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'threadPoolName',
-      value: 'threadPool'
+      value: 'boxThreadPool'
     },
     {
       documentation: 'So not to block server shutdown, have sockets timeout. Catch and continue on SocketTimeoutException.',
@@ -78,6 +78,7 @@ foam.CLASS({
                   while ( true ) {
                     Socket client = serverSocket.accept();
                     client.setSoTimeout(getSoTimeout());
+                    logger.info("accept", client.getRemoteSocketAddress().toString());
                     agency.submit(
                       x,
                       new SocketServerProcessor(getX(), client),

--- a/src/foam/box/socket/SocketServer.js
+++ b/src/foam/box/socket/SocketServer.js
@@ -78,7 +78,6 @@ foam.CLASS({
                   while ( true ) {
                     Socket client = serverSocket.accept();
                     client.setSoTimeout(getSoTimeout());
-                    logger.info("accept", client.getRemoteSocketAddress().toString());
                     agency.submit(
                       x,
                       new SocketServerProcessor(getX(), client),


### PR DESCRIPTION
This is step one of a larger project to replace socket threading which currently uses agency/threadpool with explicit threads. The socket threads are long running and using a pool doesn't make sense. Believe it was used out of convinience for setting up ThreadGroup threads.