### PR TITLE
Execute boot script before invoking non-lazy nspecs.

### DIFF
--- a/src/foam/nanos/bench/BenchmarkResultSystemDAO.js
+++ b/src/foam/nanos/bench/BenchmarkResultSystemDAO.js
@@ -27,7 +27,7 @@ foam.CLASS({
 
       // br.setJavaVersion(System.getProperty("java.version"));
       // br.setJavaCompiler(System.getProperty("java.compiler"));
-      br.setJavaFullversion(System.getProperty("java.fullversion"));
+      br.setJavaFullversion(String.valueOf(Runtime.version().version().get(0)));
       // br.setJavaRuntimeVersion(System.getProperty("java.runtime.version"));
       br.setOsArch(System.getProperty("os.arch"));
       br.setOsName(System.getProperty("os.name"));

--- a/src/foam/nanos/boot/Boot.java
+++ b/src/foam/nanos/boot/Boot.java
@@ -157,16 +157,6 @@ public class Boot {
         .setAuthorizer(new foam.nanos.auth.AuthorizableAuthorizer("service"))
         .build());
 
-    serviceDAO_.where(EQ(NSpec.LAZY, false)).select(new AbstractSink() {
-      @Override
-      public void put(Object obj, Detachable sub) {
-        NSpec sp = (NSpec) obj;
-
-        logger.info("Invoking Service", sp.getName());
-        root_.get(sp.getName());
-      }
-    });
-
     String startScript = System.getProperty("foam.main", "main");
     if ( startScript != null ) {
       DAO scriptDAO = (DAO) root_.get("bootScriptDAO");
@@ -182,6 +172,16 @@ public class Boot {
         logger.warning("Boot, Script not found", startScript);
       }
     }
+
+    serviceDAO_.where(EQ(NSpec.LAZY, false)).select(new AbstractSink() {
+      @Override
+      public void put(Object obj, Detachable sub) {
+        NSpec sp = (NSpec) obj;
+
+        logger.info("Invoking Service", sp.getName());
+        root_.get(sp.getName());
+      }
+    });
   }
 
   protected List perfectList(List src) {


### PR DESCRIPTION
The main boot script sets up AppConfig properties such as version and mode and must be executed before normal operations begin. Script execution was moved before invoking non-lazy nspecs which may require appConfig.  Additionally, any nspecs required by the bootscript will be invoked regardless.