### PR TITLE
Reset regionId only when changing to a different country

### DIFF
--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -110,7 +110,7 @@ foam.CLASS({
         }
       `,
       postSet: function(oldValue, newValue) {
-        if ( oldValue !== newValue ) {
+        if ( oldValue !== newValue && ! this.regionId.startsWith(newValue) ) {
           this.regionId = undefined;
         }
       },


### PR DESCRIPTION
## Issue
- The regionId was reset if the countryId was assigned after it

## Script to reproduce
```
var address = foam.nanos.auth.Address.create({ regionId: 'CA-ON',  countryId: 'CA' });
console.log(address.regionId); // return empty
```

## Changes
- Only reset regionId when changing to a different country