### PR TITLE
Election - rework dissolve to force election when in voting state.

### DIFF
--- a/src/foam/nanos/medusa/ElectoralServiceServer.js
+++ b/src/foam/nanos/medusa/ElectoralServiceServer.js
@@ -181,10 +181,6 @@ foam.CLASS({
         return;
       }
 
-      if ( getState() == ElectoralServiceState.VOTING ) {
-        return;
-      }
-
       if ( getState() == ElectoralServiceState.ELECTION &&
         getElectionTime() > 0L ) {
         getLogger().debug("dissolve", getState(), "since", getElectionTime());

--- a/src/foam/nanos/medusa/MedusaConsensusDAO.js
+++ b/src/foam/nanos/medusa/MedusaConsensusDAO.js
@@ -300,12 +300,9 @@ This is the heart of Medusa.`,
         .setClusterable(false)
         .build();
 
-      NanoService monitor = (NanoService) x.get("medusaConsensusMonitor");
-
       long lastLogTime = 0L;
       long lastLogIndex = 0L;
       try {
-        monitor.start();
         while ( true ) {
           ReplayingInfo replaying = (ReplayingInfo) x.get("replayingInfo");
           DaggerService dagger = (DaggerService) x.get("daggerService");
@@ -379,8 +376,7 @@ This is the heart of Medusa.`,
           } finally {
             pm.log(x);
           }
-          if ( entry == null &&
-               ! replaying.getReplaying() ) {
+          if ( entry == null ) {
             try {
               synchronized ( promoterLock_ ) {
                 promoterLock_.wait(replaying.getReplaying() ? 500 : getTimerInterval());
@@ -403,6 +399,7 @@ This is the heart of Medusa.`,
         alarm.setNote(e.getMessage());
         ((DAO) x.get("alarmDAO")).put(alarm);
         logger.error("exit");
+        NanoService monitor = (NanoService) x.get("medusaConsensusMonitor");
         monitor.stop();
       }
      `


### PR DESCRIPTION
Scenarios such as PrimaryNotFound can result in muiltiple mediators in VOTING state.  ClusterConfigStatusDAO attempts to dissolve, but a new Election was not called if already Voting. Only a vote request with a later election time would trigger a new election. Also support DISSOLVE from MedusaStatusWatcher - /tmp/DISSOLVE