### PR TITLE
Np 1498/replay no wait

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -569,6 +569,12 @@ foam.CLASS({
       name: 'journalName'
     },
     {
+      documentation: `See JDAO.  Force caller to wait on nspec initailzation. The first call to 'get' for an nspec (x.get(servicename)) will have the calling thread wait on reply of service. This is the default behaviour and should be used for all essential services.  Also this should be used if the model is using SeqNo or NUID for id generation.`,
+      class: 'Boolean',
+      name: 'waitReplay',
+      value: true
+    },
+    {
       class: 'FObjectProperty',
       of: 'foam.dao.Journal',
       generateJava: false,
@@ -909,7 +915,13 @@ model from which to test ServiceProvider ID (spid)`,
           if ( getWriteOnly() ) {
             delegate = new foam.dao.WriteOnlyJDAO(x, delegate, getOf(), getJournalName());
           } else {
-            delegate = new foam.dao.java.JDAO(x, delegate, getJournalName(), getCluster() && !getSAF());
+            foam.dao.java.JDAO jdao = new foam.dao.java.JDAO();
+            jdao.setX(x);
+            jdao.setFilename(getJournalName());
+            jdao.setCluster(getCluster() && !getSAF());
+            jdao.setWaitReplay(getWaitReplay());
+            jdao.setDelegate(delegate);
+            delegate = jdao;
           }
         }
         return delegate;

--- a/src/foam/dao/java/JDAO.js
+++ b/src/foam/dao/java/JDAO.js
@@ -14,16 +14,19 @@ foam.CLASS({
 In this current implementation setDelegate must be called last.`,
 
   javaImports: [
-    'foam.nanos.fs.ResourceStorage',
+    'foam.core.Agency',
+    'foam.core.ContextAgent',
     'foam.core.X',
     'foam.dao.CompositeJournal',
     'foam.dao.DAO',
     'foam.dao.F3FileJournal',
+    'foam.dao.Journal',
     'foam.dao.MDAO',
     'foam.dao.NullJournal',
-    'foam.nanos.boot.NSpec',
     'foam.dao.ReadOnlyF3FileJournal',
     'foam.dao.WriteOnlyF3FileJournal',
+    'foam.nanos.boot.NSpec',
+    'foam.nanos.fs.ResourceStorage',
     'foam.nanos.ndiff.NDiffJournal'
   ],
 
@@ -68,6 +71,12 @@ In this current implementation setDelegate must be called last.`,
       value: true
     },
     {
+      documentation: `Force caller to wait on nspec initailzation. The first call to 'get' for an nspec (x.get(servicename)) will have the calling thread wait on reply of service. This is the default behaviour and should be used for all essential services.  Also this should be used if the model is using SeqNo or NUID for id generation.`,
+      class: 'Boolean',
+      name: 'waitReplay',
+      value: true
+    },
+    {
       name: 'delegate',
       class: 'foam.dao.DAOProperty',
       javaFactory: 'return new MDAO(getOf());',
@@ -109,12 +118,13 @@ In this current implementation setDelegate must be called last.`,
             // if NSpec present in X then go through NDiff
             // (set up in EasyDAO's decorator chain)
             NSpec nspec = (NSpec)getX().get(NSpec.NSPEC_CTX_KEY);
-            
-            if ( nspec != null ) {
-              String nSpecName = nspec.getName();
 
-              new CompositeJournal.Builder(resourceStorageX)
-              .setDelegates(new foam.dao.Journal[] {
+            String nSpecName = getFilename();
+            Journal[] journals = null;
+
+            if ( nspec != null ) {
+              nSpecName = nspec.getName();
+              journals = new Journal[] {
                 // replays the repo journal
                 new NDiffJournal.Builder(resourceStorageX)
                 .setDelegate(journal0)
@@ -128,17 +138,28 @@ In this current implementation setDelegate must be called last.`,
                 .setNSpecName(nSpecName)
                 .setRuntimeOrigin(true) 
                 .build()
-              })
-              .build()
-              .replay(resourceStorageX, delegate);
+              };
             } else {
-              new CompositeJournal.Builder(resourceStorageX)
-                .setDelegates(new foam.dao.Journal[] {
-                  journal0,
-                  getJournal()
-                })
-                .build()
-                .replay(resourceStorageX, delegate);
+              journals = new Journal[] {
+                    journal0,
+                    getJournal()
+              };
+            }
+            final Journal jnl = new CompositeJournal.Builder(resourceStorageX)
+              .setDelegates(journals)
+              .build();
+ 
+            if ( getWaitReplay() ) {
+              jnl.replay(resourceStorageX, delegate);
+            } else {
+              final X y = resourceStorageX;
+              final String name = nSpecName;
+              Agency agency = (Agency) getX().get("threadPool");
+              agency.submit(getX(), new ContextAgent() {
+                public void execute(X x) {
+                  jnl.replay(y, delegate);
+                }
+              }, this.getClass().getSimpleName()+"-replay");
             }
     `
     }

--- a/src/foam/nanos/analytics/services.jrl
+++ b/src/foam/nanos/analytics/services.jrl
@@ -16,6 +16,7 @@ p({
       .setSAF(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("analyticEvents")
+      .setWaitReplay(false)
       .setDecorator(
         new foam.nanos.analytics.AnalyticEventOMDAO.Builder(x).setDelegate(
         new foam.nanos.analytics.AnalyticEventTimestampDAO.Builder(x).setDelegate(

--- a/src/foam/nanos/er/services.jrl
+++ b/src/foam/nanos/er/services.jrl
@@ -9,6 +9,7 @@ p({
       .setSAF(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("eventRecords")
+      .setWaitReplay(false)
       .setPm(true)
       .setDecorator(
         new foam.nanos.er.EventRecordResponseDAO.Builder(x).setDelegate(

--- a/src/foam/nanos/medusa/ClusterConfigReplayDAO.js
+++ b/src/foam/nanos/medusa/ClusterConfigReplayDAO.js
@@ -99,16 +99,18 @@ foam.CLASS({
           if ( replaying.getReplaying() ) {
             replaying.getReplayDetails().put(config.getId(), details);
 
-            if ( replaying.getStartTime() == null ) {
-              replaying.setStartTime(new java.util.Date());
-              replaying.updateIndex(x, dagger.getGlobalIndex(x));
-              ((foam.nanos.om.OMLogger) x.get("OMLogger")).log("medusa.replay.start");
-            }
-            if ( details.getMaxIndex() > dagger.getGlobalIndex(x)) {
-              dagger.setGlobalIndex(x, details.getMaxIndex());
-            }
-
             synchronized ( this ) {
+
+              if ( replaying.getStartTime() == null ) {
+                replaying.setStartTime(new java.util.Date());
+                replaying.updateIndex(x, dagger.getGlobalIndex(x));
+
+                ((foam.nanos.om.OMLogger) x.get("OMLogger")).log("medusa.replay.start");
+                logger.info("replay,start,test");
+              }
+              if ( details.getMaxIndex() > dagger.getGlobalIndex(x)) {
+                dagger.setGlobalIndex(x, details.getMaxIndex());
+              }
 
               if ( details.getMaxIndex() > replaying.getReplayIndex() ) {
                 replaying.setReplayIndex(details.getMaxIndex());

--- a/src/foam/nanos/medusa/ElectoralServiceServer.js
+++ b/src/foam/nanos/medusa/ElectoralServiceServer.js
@@ -365,6 +365,8 @@ foam.CLASS({
           if ( time <= winnerTime_.get() ) {
             getLogger().info("vote", id, time, getState(), "ignore", "wtime", winnerTime_.get());
           } else {
+            // TODO/REVIEW - big issue with votes arriving just after election decided with a later time.
+            // could ignore the first and wait for another?
             getLogger().info("vote", id, time, getState(), "->", ElectoralServiceState.VOTING, "wtime", winnerTime_.get());
             setState(ElectoralServiceState.VOTING);
             setElectionTime(0L);
@@ -486,8 +488,10 @@ foam.CLASS({
       getLogger().info("report", getState(), "primary", "winner", winnerId, time);
 
       // NOTE: set winner time early to hopefully discard late arriving vote requests.
-      winnerTime_.set(time);
-
+      // Initially was setting this to the time of the election that won, but the late votes are from an election started, and presumably abandoned, after the winning election started.
+      // Now setting winner time to local time to hopefully ignore anything after the time this instance believe the election was won.
+      // winnerTime_.set(time);
+      winnerTime_.set(System.currentTimeMillis());
       ClusterConfig winner = (ClusterConfig) dao.find(winnerId);
       ClusterConfig primary = null;
       try {

--- a/src/foam/nanos/medusa/MedusaHealthHeartbeatService.js
+++ b/src/foam/nanos/medusa/MedusaHealthHeartbeatService.js
@@ -34,6 +34,9 @@ foam.CLASS({
       javaCode: `
       // service order is important
       getX().get("daggerService");
+      getX().get("socketServer");
+      getX().get("MedusaConensusMonitor");
+
       super.start();
       `
     },

--- a/src/foam/nanos/notification/email/EmailMessage.js
+++ b/src/foam/nanos/notification/email/EmailMessage.js
@@ -85,7 +85,7 @@ foam.CLASS({
 
   properties: [
     {
-      class: 'Long',
+      class: 'String',
       name: 'id',
       includeInDigest: true,
       section: 'emailInformation',

--- a/src/foam/nanos/notification/email/services.jrl
+++ b/src/foam/nanos/notification/email/services.jrl
@@ -46,6 +46,7 @@ p({
       .setFuid(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("emailMessages")
+      .setWaitReplay(false)
       .setSAF(true)
       .setServiceProviderAware(false)
       .setFixedSize(new foam.dao.FixedSizeDAO.Builder(x)

--- a/src/foam/nanos/notification/email/test/MockSMTPAgentTest.js
+++ b/src/foam/nanos/notification/email/test/MockSMTPAgentTest.js
@@ -54,7 +54,7 @@ foam.CLASS({
       DAO emailMessageDAO = (DAO) x.get("emailMessageDAO");
       for ( int i = 0; i < send; i++ ) {
         EmailMessage msg = new EmailMessage();
-        msg.setId(i);
+        msg.setId(String.valueOf(i));
         msg.setUser(1L); // system
         msg.setFrom("noreply@test.com");
         msg.setTo(new String[] { "test@test.com" });

--- a/src/foam/nanos/notification/services.jrl
+++ b/src/foam/nanos/notification/services.jrl
@@ -19,6 +19,7 @@ p({
       .setFuid(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("notifications")
+      .setWaitReplay(false)
       .setFixedSize(new foam.dao.FixedSizeDAO.Builder(x)
         .setComparator(foam.mlang.MLang.COMPOUND(new foam.mlang.order.Comparator[] {
           foam.mlang.MLang.DESC(foam.nanos.notification.Notification.CREATED),

--- a/src/foam/nanos/notification/sms/services.jrl
+++ b/src/foam/nanos/notification/sms/services.jrl
@@ -12,6 +12,7 @@ p({
       .setSeqNo(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("smsMessages")
+      .setWaitReplay(false)
       .setFixedSize(new foam.dao.FixedSizeDAO.Builder(x)
         .setComparator(foam.mlang.MLang.DESC(foam.nanos.notification.sms.SMSMessage.CREATED))
         .setPredicate(foam.mlang.MLang.EQ(foam.nanos.notification.sms.SMSMessage.STATUS, foam.nanos.notification.sms.SMSStatus.SENT))


### PR DESCRIPTION
WaitReplay - support executing replay via Agency so caller does not block. Existing data of many services such as emailMessageDAO and AnalyticEventDAO are not required during startup and/or not impacted by new data, so replay can occur asynchronously. 

EmailMessage Id changed from NUID to AUID so that an initial select(Max) is not required to initialize the FUID, allowing for  asynchronous replay. 

During Medusa startup and replay, large non-clustered DAOs such as emailMessageDAO can take 5 to 10 minutes to load and block the startup/replay while doing so. 