### PR TITLE
Fix uid seqNo bound and overflow

### DIFF
--- a/src/foam/util/NUIDGenerator.js
+++ b/src/foam/util/NUIDGenerator.js
@@ -22,7 +22,7 @@ foam.CLASS({
     'foam.nanos.logger.Logger',
     'foam.nanos.logger.Loggers',
     'static foam.util.UIDSupport.*',
-    'java.util.concurrent.atomic.AtomicInteger',
+    'java.util.concurrent.atomic.AtomicLong',
     'java.util.concurrent.atomic.AtomicBoolean'
   ],
 
@@ -35,7 +35,7 @@ foam.CLASS({
     init_();
   }
 
-  AtomicInteger seqNo_ = new AtomicInteger();
+  AtomicLong seqNo_ = new AtomicLong();
   AtomicBoolean initMaxSeqNo_ = new AtomicBoolean(false);
   `,
 

--- a/src/foam/util/UIDGenerator.js
+++ b/src/foam/util/UIDGenerator.js
@@ -99,7 +99,7 @@ foam.CLASS({
         // Take the mod of "id" + "000" (ie, appending three digits to the id).
         // Breaking the multiplication to avoid overflow before mod-ing,
         // (ab mod m) = ((a mod m) * (b mod m)) mod m.
-        var idMod     = mod(mod(Long.parseLong(id, 16)) * mod(0x1000));
+        var idMod     = mod(mod16(id) * mod(0x1000));
 
         // Calculate the checksum to add to the id so that the hash of the final
         // id (id * 0x1000 + checksum) is the same as the targetMod.

--- a/src/foam/util/UIDSupport.java
+++ b/src/foam/util/UIDSupport.java
@@ -109,7 +109,7 @@ public class UIDSupport {
    */
   public static int hash(String uid) {
     var hex = undoPermute(uid);
-    return mod(Long.parseLong(hex, 16));
+    return mod16(hex);
   }
 
   /**
@@ -140,6 +140,28 @@ public class UIDSupport {
    */
   public static int mod(long n) {
     return (int) (n % CHECKSUM_MOD);
+  }
+
+  /**
+   * Calculate the checksum of a hexadecimal number.
+   *
+   * Traverse the hexadecimal number from right to left and iteratively compute
+   * the checksum modulus without converting the hexadecimal number to decimal
+   * to prevent potential conversion overflow.
+   *
+   * @param hex The hexadecimal number in string format
+   * @return checksum
+   */
+  public static int mod16(String hex) {
+    int modulo = 0;
+    int base = 1;
+
+    for ( int i = hex.length() - 1; i >=0 ; i-- ) {
+      int digit = Character.digit(hex.charAt(i), 16);
+      modulo = mod(modulo + digit * base);
+      base = mod(base * 16);
+    }
+    return modulo;
   }
 
   /**


### PR DESCRIPTION
## Issues
- Although nuid is a long integer it's currently failing when seqNo passes Integer.MAX_VALUE and becoming negative eg. Integer.MAX_VALUE + 1 = -2147483648.
- Two's complement binary representation of the negative integer converted to long hex string then appended with the machine id causes it to overflow.
- checksum converts a hex string to decimal which could overflow and throw exception

## Changes
- Fix nuid seqNo bound to long
- Calculate checksum of a hex string without converting to decimal to overcome potential overflow issue

## Script to reproduce
```
import foam.dao.*;
import foam.nanos.logger.*;
import foam.nanos.pm.*;
import foam.util.*;
import foam.util.test.DummyNuid;
import java.util.*;

logger = StdoutLogger.instance();

dao = new MDAO(DummyNuid.getOwnClassInfo());
uidgen = new NUIDGenerator(x, "nuidDAO", dao, DummyNuid.ID);

long i = 0L;
long id = 0L;
int e = 0;

pm = PM.create(x, false, new String[] { "UID generator", "exhaustive numeric unique id" });
while ( true ) {
  try {
    i += 1;
    id = uidgen.getNextLong();
    if ( i == Math.pow(2, e) ) {
      e++;
      logger.debug(new Object[] { id, "(" +i+ ")" });
    }
  } catch ( Exception ex ) {
    print("Exception: " + ex.getMessage());
    logger.error(new Object[] {"Failed to generate next long.", ex});
    break;
  }
}
pm.log(x);

print("i: " + i);
print("lastId: " + id);
print("DONE");
```