### PR TITLE
Fix choice view displaying '.name' for empty text in read mode

### DIFF
--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -22,7 +22,10 @@ foam.CLASS({
 
   implements: [ 'foam.mlang.Expressions' ],
 
-  imports: [ 'warn' ],
+  imports: [
+    'translationService?',
+    'warn'
+  ],
 
   documentation: `
     Wraps a tag that represents a singular choice. That is,
@@ -244,9 +247,10 @@ foam.CLASS({
               .enableClass('selection-made', self.index$.map((index) => index !== -1))
             .end();
         }
-        return self.text ?
-          self.E().translate(self.text + ".name", self.text) :
-          self.E().add(self.text$);
+
+        return self.E().add(self.text$.map(t => {
+          return t ? self.translationService.getTranslation(foam.locale, t + '.name', t) : '';
+        }));
       }));
 
       this.dao$proxy.on.sub(this.onDAOUpdate);

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -249,7 +249,8 @@ foam.CLASS({
         }
 
         return self.E().add(self.text$.map(t => {
-          return t ? self.translationService.getTranslation(foam.locale, t + '.name', t) : '';
+          return t && self.translationService ?
+            self.translationService.getTranslation(foam.locale, t + '.name', t) : '';
         }));
       }));
 

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -229,7 +229,7 @@ foam.CLASS({
 
       this.onDAOUpdate();
 
-      this.add(this.slot(function(mode) {
+      this.add(this.slot(function(mode, text) {
         if ( mode !== foam.u2.DisplayMode.RO ) {
           return self.E()
             .start(self.selectSpec, {
@@ -248,10 +248,7 @@ foam.CLASS({
             .end();
         }
 
-        return self.E().add(self.text$.map(t => {
-          return t && self.translationService ?
-            self.translationService.getTranslation(foam.locale, t + '.name', t) : '';
-        }));
+        return text ? self.E().translate(text + '.name', text) : '';
       }));
 
       this.dao$proxy.on.sub(this.onDAOUpdate);

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -22,10 +22,7 @@ foam.CLASS({
 
   implements: [ 'foam.mlang.Expressions' ],
 
-  imports: [
-    'translationService?',
-    'warn'
-  ],
+  imports: [ 'warn' ],
 
   documentation: `
     Wraps a tag that represents a singular choice. That is,

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -244,8 +244,9 @@ foam.CLASS({
               .enableClass('selection-made', self.index$.map((index) => index !== -1))
             .end();
         }
-
-        return self.E().translate(self.text + ".name", self.text);
+        return self.text ?
+          self.E().translate(self.text + ".name", self.text) :
+          self.E().add(self.text$);
       }));
 
       this.dao$proxy.on.sub(this.onDAOUpdate);


### PR DESCRIPTION
ref: https://nanopay.atlassian.net/browse/NP-9752

issue: Empty text gets translated to `.name` in choice view read mode

<img width="692" alt="Screenshot 2023-06-12 at 2 37 04 PM" src="https://github.com/kgrgreer/foam3/assets/58435071/49aeca88-5c2b-40f7-932e-980059a83605">


note: needs to be cherry-picked into 4.30
