### PR TITLE
Rule Predicate Bug Fix

### DIFF
--- a/src/foam/nanos/ruler/Ruled.js
+++ b/src/foam/nanos/ruler/Ruled.js
@@ -4,7 +4,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
- foam.CLASS({
+foam.CLASS({
   package: 'foam.nanos.ruler',
   name: 'Ruled',
   abstract: true,
@@ -53,7 +53,6 @@
       javaFactory: `
         return foam.mlang.MLang.TRUE;
       `,
-      view: { class: 'foam.u2.view.JSONTextView' },
       tableCellFormatter: function(value) {
         this.add(value.toString());
       }


### PR DESCRIPTION
Using JSONTextView causes rule predicate to reset to True when the rule is saved from the client. Replacing JSONTextView with the default view fixes the problem.

Note: needs to go into 3.30