### PR TITLE
[NP-9759] Block access to view reference for disabled users

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -39,11 +39,13 @@ foam.CLASS({
   ],
 
   requires: [
-    'foam.u2.dialog.Popup',
     'foam.log.LogLevel',
     'foam.nanos.approval.ApprovalStatus',
     'foam.nanos.approval.CustomViewReferenceApprovable',
-    'foam.u2.stack.StackBlock'
+    'foam.nanos.auth.LifecycleState',
+    'foam.u2.dialog.Popup',
+    'foam.u2.stack.StackBlock',
+    'net.nanopay.admin.model.AccountStatus'
   ],
 
   imports: [
@@ -54,7 +56,8 @@ foam.CLASS({
     'notify',
     'stack',
     'subject',
-    'translationService'
+    'translationService',
+    'userDAO'
   ],
 
   searchColumns: [
@@ -869,6 +872,16 @@ foam.CLASS({
            (self.status == foam.nanos.approval.ApprovalStatus.APPROVED && self.operation == foam.nanos.dao.Operation.REMOVE) ) {
              console.warn('Object is inaccessible')
              return;
+        }
+
+        // Disabled users are not authorized to access their ucjs
+        let createdFor = await this.userDAO.find(this.createdFor);
+        if (
+          createdFor.lifecycleState === this.LifecycleState.DISABLED ||
+          createdFor.status === this.AccountStatus.DISABLED || ! createdFor.enabled
+        ) {
+          this.notify('User is disabled', '', this.LogLevel.ERROR, true);
+          return;
         }
 
         var daoKey = self.refDaoKey;


### PR DESCRIPTION
**ref:** https://nanopay.atlassian.net/browse/NP-9759

**Summary**
--
Addresses the second task in the ticket - Disabled users are not authorized to access their ucjs. If we allow ops users to view view reference for disabled users, it will generate numerous exceptions from the server when the wizardlets call crunchService from the client to load the ucjs in the wizardlets for the disabled users. The simplest fix to this problem is to block access to view reference for disabled users so that the underlying work to load the user's ucjs in the wizardlets is never executed.

<img width="1687" alt="Screenshot 2023-06-19 at 5 17 16 PM" src="https://github.com/kgrgreer/foam3/assets/58435071/56875513-22d8-4e4e-871c-a3b177ae161d">



Note: Making the view reference button disabled/unavailable was also considered, but decided to go with the notification so that ops team is aware what is happening when they click the button.


