### PR TITLE
Support before and after build tasks

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -154,7 +154,9 @@ function execSync(cmd, options) {
 
 
 function task(f) {
-  tasks.push(f.name);
+  if ( tasks.indexOf(f.name) === -1 )
+    tasks.push(f.name);
+
   var fired = false;
   var rec   = [ ];
   globalThis[f.name] = function() {
@@ -701,7 +703,8 @@ const ARGS = {
         console.log('  -' + a + ': ' + ARGS[a][0]);
       });
       tasks.sort();
-      console.log('\nTasks:', tasks.join(', '));
+      var excludes = /^(before|after)_/;
+      console.log('\nTasks:', tasks.filter(t => ! excludes.test(t)).join(', '));
       quit(0);
     } ],
   i: [ 'Install npm and git hooks',
@@ -879,15 +882,8 @@ task(function all() {
 });
 
 // Install POM tasks
-if ( TASKS ) {
-  TASKS.forEach(f => {
-    if ( tasks.indexOf(f.name) > -1 ) {
-      task(f);
-    } else {
-      globalThis[f.name] = f;
-    }
-  });
-}
+if ( TASKS )
+  TASKS.forEach(f => task(f));
 
 all();
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -541,7 +541,7 @@ task(function getNanopayGitHash() {
 
 
 task(function getFOAMGitHash() {
-  FOAM_REVISION = execSync('cd foam3; git rev-parse --short HEAD').toString().trim();
+  FOAM_REVISION = execSync('git -C foam3 rev-parse --short HEAD').toString().trim();
 });
 
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -119,6 +119,9 @@ var PROJECT;
 // Short-form of PROJECT.version
 var VERSION;
 
+// Root POM tasks
+var TASKS;
+
 // These are different for an unknown historic reason and should be merged.
 // var BUILD_DIR  = './build3', TARGET_DIR = './build3';
 var BUILD_DIR  = './build', TARGET_DIR = './target';
@@ -128,6 +131,7 @@ globalThis.foam = {
     // console.log('POM:', pom);
     PROJECT = pom;
     VERSION = pom.version;
+    TASKS   = pom.tasks;
   }
 };
 require(PWD+'/pom.js');
@@ -158,6 +162,10 @@ function task(f) {
     fired = true;
     summary.push(rec);
 
+    // before_task
+    if ( typeof globalThis['before_' + f.name] === 'function' )
+      globalThis['before_' + f.name]();
+
     info(`Starting Task :: ${f.name}`);
     var start = Date.now();
     rec[0] = ''.padEnd(2*depth) + f.name;
@@ -169,6 +177,10 @@ function task(f) {
     var dur = ((end-start)/1000).toFixed(1);
     info(`Finished Task :: ${f.name} in ${dur} seconds`);
     rec[1] = dur;
+
+    // after_task
+    if ( typeof globalThis['after_' + f.name] === 'function' )
+      globalThis['after_' + f.name]();
   }
 }
 
@@ -865,6 +877,17 @@ task(function all() {
     startNanos();
   }
 });
+
+// Install POM tasks
+if ( TASKS ) {
+  TASKS.forEach(f => {
+    if ( tasks.indexOf(f.name) > -1 ) {
+      task(f);
+    } else {
+      globalThis[f.name] = f;
+    }
+  });
+}
 
 all();
 


### PR DESCRIPTION
## Changes
- Support calling foam3/tools/build.js from project root directory
- Support defining before_task and before_task
- Support adding new task and overwriting existing tasks
- Support invoking other tasks and accessing env variables

## Example
```
foam.POM({
  tasks: [
    // call before `versions' task
    function before_versions() {
      console.log('---------- before versions');
    },

    // overwrite `versions' task
    function versions() {
      // call `myVersions' task
      myVersion();
    },

    // call after `versions' task
    function after_versions(build) {
      console.log('---------- after versions');
      showManifest();
    },

    // define new task
    function myVersion() {
      // access to `JAR_OUT' env variable
      console.log('---------- my versions', JAR_OUT);
    }
  ]
});
```