### PR TITLE
ArrayDAO - implement Java methods

### DIFF
--- a/src/foam/dao/ArrayDAO.js
+++ b/src/foam/dao/ArrayDAO.js
@@ -47,9 +47,6 @@ foam.CLASS({
       hidden: true
     },
     {
-      // NOTE: The javascript FScriptParser does not yet support
-      // 'if', so 'if(name exists){name}else{null}' is not supported
-      // to return a particular properties value as the identity func.
       documentation: 'Property for comparing. Defaults to ID. Intented to support models without an id property.',
       class: 'foam.mlang.ExprProperty',
       name: 'identityExpr',

--- a/src/foam/dao/ArrayDAO.js
+++ b/src/foam/dao/ArrayDAO.js
@@ -1,27 +1,27 @@
 /**
  * @license
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2016 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 
 foam.CLASS({
   package: 'foam.dao',
   name: 'ArrayDAO',
   extends: 'foam.dao.AbstractDAO',
-  abstract: true,
 
   documentation: 'DAO implementation backed by an array.',
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.PropertyInfo',
+    'foam.dao.ArraySink',
+    'foam.mlang.Expr',
+    'foam.mlang.predicate.Predicate',
+    'foam.util.SafetyUtil',
+    'java.util.ArrayList',
+    'java.util.Comparator',
+    'java.util.List'
+  ],
 
   requires: [
     'foam.dao.ArraySink',
@@ -33,99 +33,158 @@ foam.CLASS({
       class: 'Class',
       name: 'of',
       factory: function() {
-        if ( this.array.length === 0 ) return this.__context__.lookup('foam.core.FObject');
-        return null;
-      }
+        return this.array.length === 0 ? this.__context__.lookup('foam.core.FObject') : null;
+      },
+      hidden: true
     },
     {
+      class: 'List',
+      of: 'foam.core.FObject',
       name: 'array',
-      factory: function() { return []; }
+      factory: function() { return []; },
+      javaFactory: 'return new ArrayList();',
+      transient: true,
+      hidden: true
+    },
+    {
+      documentation: 'Property for comparing. Defaults to ID. Intented to support models without an id property.',
+      class: 'foam.mlang.ExprProperty',
+      name: 'identityExpr',
+      javaType: 'foam.mlang.Expr',
+      factory: function(of) { return of.model_.ID; },
+      javaFactory: 'return new foam.mlang.IdentityExpr();',
+      hidden: true
     }
   ],
 
   methods: [
-    function put_(x, obj) {
-      for ( var i = 0 ; i < this.array.length ; i++ ) {
-        if ( obj.ID.compare(obj, this.array[i]) === 0 ) {
-          this.array[i] = obj;
-          break;
-        }
-      }
-
-      if ( i == this.array.length ) this.array.push(obj);
-      this.on.put.pub(obj);
-
-      return Promise.resolve(obj);
-    },
-
-    // written by OpenAI
-    function remove_(x, obj) {
-      for ( var i = 0 ; i < this.array.length ; i++ ) {
-        if ( obj.ID.compare(obj, this.array[i]) === 0 ) {
-          this.array.splice(i, 1);
-          break;
-        }
-      }
-
-      this.on.remove.pub(obj);
-
-      return Promise.resolve(obj);
-    },
-
-    function select_(x, sink, skip, limit, order, predicate) {
-      var resultSink = sink || this.ArraySink.create({ of: this.of });
-
-      sink = this.decorateSink_(resultSink, skip, limit, order, predicate);
-
-      var detached = false;
-      var sub = foam.core.FObject.create();
-      sub.onDetach(function() { detached = true; });
-
-      var self = this;
-
-      return new Promise(function(resolve, reject) {
-        for ( var i = 0 ; i < self.array.length ; i++ ) {
-          if ( detached ) break;
-
-          sink.put(self.array[i], sub);
-        }
-
-        sink.eof();
-
-        resolve(resultSink);
-      });
-    },
-
-    function removeAll_(x, skip, limit, order, predicate) {
-      predicate = predicate || this.True.create();
-      skip = skip || 0;
-      limit = foam.Number.isInstance(limit) ? limit : Number.MAX_VALUE;
-
-      for ( var i = 0 ; i < this.array.length && limit > 0 ; i++ ) {
-        if ( predicate.f(this.array[i]) ) {
-          if ( skip > 0 ) {
-            skip--;
-            continue;
+    {
+      name: 'put_',
+      code: function(x, obj) {
+        for ( var i = 0 ; i < this.array.length ; i++ ) {
+          if ( obj.compareTo(this.identityExpr.f(this.array[i])) === 0 ) {
+            this.array[i] = obj;
+            break;
           }
-          var obj = this.array.splice(i, 1)[0];
-          i--;
-          limit--;
-          this.on.remove.pub(obj);
         }
-      }
+        if ( i == this.array.length ) this.array.push(obj);
+        this.on.put.pub(obj);
 
-      return Promise.resolve();
+        return Promise.resolve(obj);
+      },
+      javaCode: `
+        getArray().add(obj);
+        return obj;
+      `
+    },
+    {
+      name: 'remove_',
+      code: function(x, obj) {
+        // written by OpenAI
+        for ( var i = 0 ; i < this.array.length ; i++ ) {
+          if ( obj.compareTo(this.identityExpr.f(this.array[i])) === 0 ) {
+            this.array.splice(i, 1);
+            break;
+          }
+        }
+
+        this.on.remove.pub(obj);
+
+        return Promise.resolve(obj);
+      },
+      javaCode: `
+        ((List)getArray()).remove(obj);
+        return obj;
+      `
     },
 
-    function find_(x, key) {
-      var id = this.of.isInstance(key) ? key.id : key;
-      for ( var i = 0 ; i < this.array.length ; i++ ) {
-        if ( foam.util.equals(id, this.array[i].id) ) {
-          return Promise.resolve(this.array[i]);
-        }
-      }
+    {
+      name: 'select_',
+      code: function(x, sink, skip, limit, order, predicate) {
+        var resultSink = sink || this.ArraySink.create({ of: this.of });
 
-      return Promise.resolve(null);
+        sink = this.decorateSink_(resultSink, skip, limit, order, predicate);
+
+        var detached = false;
+        var sub = foam.core.FObject.create();
+        sub.onDetach(function() { detached = true; });
+
+        var self = this;
+
+        return new Promise(function(resolve, reject) {
+          for ( var i = 0 ; i < self.array.length ; i++ ) {
+            if ( detached ) break;
+
+            sink.put(self.array[i], sub);
+          }
+
+          sink.eof();
+
+          resolve(resultSink);
+        });
+      },
+      javaCode: `
+      Sink resultSink = prepareSink(sink);
+      sink = decorateSink(x, resultSink, skip, limit, order, predicate);
+      for ( Object o : getArray() ) {
+        sink.put(o, null);
+      }
+      return resultSink;
+      `
+    },
+    {
+      name: 'removeAll_',
+      code: function(x, skip, limit, order, predicate) {
+        predicate = predicate || this.True.create();
+        skip = skip || 0;
+        limit = foam.Number.isInstance(limit) ? limit : Number.MAX_VALUE;
+
+        for ( var i = 0 ; i < this.array.length && limit > 0 ; i++ ) {
+          if ( predicate.f(this.array[i]) ) {
+            if ( skip > 0 ) {
+              skip--;
+              continue;
+            }
+            var obj = this.array.splice(i, 1)[0];
+            i--;
+            limit--;
+            this.on.remove.pub(obj);
+          }
+        }
+
+        return Promise.resolve();
+      }
+    },
+    {
+      name: 'find_',
+      code: function(x, key) {
+        // Predicate handled in AbstractDAO
+        if ( this.of.isInstance(key) ) {
+          var expr = this.identityExpr
+          for ( var i = 0 ; i < this.array.length ; i++ ) {
+            if ( foam.util.equals(id.f(this.array[i])) ) {
+              return Promise.resolve(this.array[i]);
+            }
+          }
+        } else {
+          var id = this.of.isInstance(key) ? key.id : key;
+          for ( var i = 0 ; i < this.array.length ; i++ ) {
+            if ( foam.util.equals(id, this.array[i].id) ) {
+              return Promise.resolve(this.array[i]);
+            }
+          }
+        }
+        return Promise.resolve(null);
+      },
+      javaCode: `
+      // Predicate handled in AbstractDAO
+      Expr identity = getIdentityExpr();
+      Object val = id instanceof FObject ? identity.f(id) : id;
+      for ( Object o : getArray() ) {
+        if ( SafetyUtil.equals(identity.f(o), val) ) return (FObject) o;
+      }
+      return null;
+      `
     }
   ]
 });

--- a/src/foam/dao/test/ArrayDAOTest.js
+++ b/src/foam/dao/test/ArrayDAOTest.js
@@ -26,8 +26,8 @@ foam.CLASS({
       name: 'runTest',
       javaCode: `
       ArrayDAO dao = new ArrayDAO(x);
-      dao.setOf(foam.core.Currency.getOwnClassInfo());
-      dao.setIdentityExpr(new foam.mlang.predicate.FScript(x, "if(symbol exists){symbol}else{null}", null));
+      dao.setOf(Currency.getOwnClassInfo());
+      dao.setIdentityExpr(Currency.SYMBOL);
 
       // setup
       Currency cur = new Currency(x);

--- a/src/foam/dao/test/ArrayDAOTest.js
+++ b/src/foam/dao/test/ArrayDAOTest.js
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2023 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'ArrayDAOTest',
+  extends: 'foam.nanos.test.Test',
+
+  javaImports: [
+    'foam.core.Currency',
+    'foam.dao.DAO',
+    'foam.dao.ArrayDAO',
+    'foam.dao.ArraySink',
+    'static foam.mlang.MLang.EQ',
+    'foam.mlang.predicate.FScript',
+    'foam.mlang.predicate.FScriptPredicate',
+    'java.util.ArrayList',
+    'java.util.List'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+      ArrayDAO dao = new ArrayDAO(x);
+      dao.setOf(foam.core.Currency.getOwnClassInfo());
+      dao.setIdentityExpr(new foam.mlang.predicate.FScript(x, "if(symbol exists){symbol}else{null}", null));
+
+      // setup
+      Currency cur = new Currency(x);
+      cur.setId("CA1");
+      cur.setNumericCode(1L);
+      cur.setCountry("CA");
+      cur.setSymbol("1");
+      dao.put(cur);
+
+      cur = new Currency(x);
+      cur.setId("CA2");
+      cur.setNumericCode(2L);
+      cur.setCountry("CA");
+      cur.setSymbol("2");
+      dao.put(cur);
+
+      cur = new Currency(x);
+      cur.setId("CA3");
+      cur.setNumericCode(3L);
+      cur.setCountry("CA");
+      cur.setSymbol("3");
+      dao.put(cur);
+
+      // Select
+      List results = (List) ((ArraySink)dao.select(new ArraySink())).getArray();
+      test(results != null, "Select All not null");
+      test(results.size() == 3, "Select All size 3");
+
+      // Find by FObject, compare with IdentityExpr
+      Currency c = (Currency) dao.find(cur); // last one is 3
+      test(c != null, "Find FObject 3 not null");
+      test(c != null && c.getSymbol().equals("3"), "Find FObject 3");
+
+      // Find by property of identityExpr
+      c = (Currency) dao.find("2");
+      test(c != null, "Find Identity 2 not null");
+      test(c != null && c.getSymbol().equals("2"), "Find Identity 2");
+
+      // Find with predicate
+      c = (Currency) dao.find(EQ(Currency.NUMERIC_CODE, 1));
+      test(c != null, "Find Predicate 1 not null");
+      test(c != null && c.getSymbol().equals("1"), "Find Predidicate 1");
+
+      // Select with Predicate
+      results = (List) ((ArraySink)dao.select_(x, new ArraySink(), 0, 0, null, EQ(Currency.NUMERIC_CODE, 1))).getArray();
+      test(results != null, "Select Predicate not null");
+      test(results.size() == 1, "Select Predicate size expected 1, found "+results.size());
+
+      // Find with FScriptPredicate
+      c = (Currency) dao.find(new FScriptPredicate("symbol==\\"1\\"", null));
+      test(c != null, "Find FScriptPredicate 1 not null");
+      test(c != null && c.getSymbol().equals("1"), "Find FScriptPredicate 1");
+
+      // Select with FScriptPredicate
+      results = (List) ((ArraySink)dao.select_(x, new ArraySink(), 0, 0, null, new FScriptPredicate("symbol==\\"3\\"", null))).getArray();
+      test(results != null, "Select FScriptPredicate not null");
+      test(results.size() == 1, "Select FScriptPredicate size expected 1, found "+results.size());
+
+      // remove
+      dao.remove(cur);
+
+      // test size reduced after remove
+      results = (List) ((ArraySink)dao.select(new ArraySink())).getArray();
+      test(results != null && results.size() == 2, "Select size 2");
+
+      // test correct removed item removed.
+      c = (Currency) dao.find(cur); // last one is 3
+      test(c == null, "Find FObject 3 not found");
+      `
+    }
+  ]
+});

--- a/src/foam/dao/test/tests.jrl
+++ b/src/foam/dao/test/tests.jrl
@@ -3,3 +3,7 @@ p({
   id:"FileRollCmdTest",
   description:"Tests Journal backup and writing to new empty journal"
 })
+p({
+  class:"foam.dao.test.ArrayDAOTest",
+  id:"ArrayDAOTest"
+})

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -4232,6 +4232,9 @@ foam.CLASS({
       if (ps == null)
         return null;
 
+      if ( ps.value() instanceof foam.mlang.Expr ) {
+        return ((foam.mlang.Expr) ps.value()).f(obj);
+      }
       return ((foam.mlang.predicate.Nary) ps.value()).f(obj);
       `
     }
@@ -4558,8 +4561,16 @@ foam.CLASS({
   methods: [
     {
       name: 'f',
-      code: function(o) { return o; },
-      javaCode: 'return obj;'
+      code: function(o) {
+        return o.model_.ID && o.model_ID.get(o) || o;
+      },
+      javaCode: `
+      if ( obj instanceof foam.core.FObject ) {
+        foam.core.PropertyInfo id = (foam.core.PropertyInfo) ((foam.core.FObject) obj).getClassInfo().getAxiomByName("id");
+        if ( id != null ) return id.get(obj);
+      }
+      return obj;
+      `
     }
   ]
 });

--- a/src/pom.js
+++ b/src/pom.js
@@ -1102,6 +1102,7 @@ foam.POM({
     { name: "foam/dao/WriteOnlyJDAO",                                 flags: "js|java" },
     { name: "foam/dao/WriteOnlyFileJournal",                          flags: "js|java" },
     { name: "foam/dao/WriteOnlyF3FileJournal",                        flags: "js|java" },
+    { name: "foam/dao/test/ArrayDAOTest",                             flags: "js|java" },
     { name: "foam/dao/test/FileRollCmdTest",                          flags: "js|java" },
     { name: "foam/nanos/actioncommand/ActionCommand",                 flags: "js|java" },
     { name: "foam/nanos/session/LocalSettingSessionDAO",              flags: "js|java" },


### PR DESCRIPTION
Since ArrayDAO can be used by models without and ID property, an IdentityExpr property was added to support find(key). IdentityExpr defaults to property ID.
FScriptParser supports both Expr and Predicate result values, allowing find and select to take FScriptPredicates.

NOTE: The Javascript FScriptParser is missing 'if' support.  'if' is used to return a property value, like a get(): 'if(lastName exists){lastName}else{null}'
So, for now, on the javascript side, only a PropertyInfo is supported as the IdentityExpr.  User.ID (for example). 