### PR TITLE
Build task decoration

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -935,6 +935,7 @@ if ( TASKS ) {
 
   // Exports local variables and functions for POM tasks
   EXPORTS = {
+    JOURNAL_CONFIG,
     TARGET_DIR,
     copyFile,
     copyDir

--- a/tools/build.js
+++ b/tools/build.js
@@ -730,7 +730,7 @@ const ARGS = {
   d: [ 'Run with JDPA debugging enabled on port 8000',
     () => DEBUG = true ],
   D: [ 'PORT : JDPA debugging enabled on port PORT.',
-    args => { ARGS.d[1](); DEBUG_PORT = args; } ],
+    args => { ARGS.d[1](); DEBUG_PORT = args; info('DEBUG_PORT=' + DEBUG_PORT); } ],
   e: [ 'Skipping genJava task.',
     () => {
       warning('Skipping genJava task');

--- a/tools/build.js
+++ b/tools/build.js
@@ -749,8 +749,7 @@ const ARGS = {
         console.log('  -' + a + ': ' + ARGS[a][0]);
       });
       tasks.sort();
-      var excludes = /^(before|after)_/;
-      console.log('\nTasks:', tasks.filter(t => ! excludes.test(t)).join(', '));
+      console.log('\nTasks:', tasks.join(', '));
       quit(0);
     } ],
   i: [ 'Install npm and git hooks',

--- a/tools/build.js
+++ b/tools/build.js
@@ -174,7 +174,7 @@ function task(f) {
       depth++;
     }
 
-    f(Object.assign({ SUPER }, EXPORTS));
+    f.bind(Object.assign({ SUPER }, EXPORTS))();
 
     running[f.name] -= 1;
     if ( running[f.name] === 0 ) {

--- a/tools/build.js
+++ b/tools/build.js
@@ -143,6 +143,7 @@ process.on('unhandledRejection', e => {
 var summary = [];
 var depth   = 1;
 var tasks   = [];
+var running = {};
 
 
 function execSync(cmd, options) {
@@ -157,30 +158,32 @@ function task(f) {
 
   var fired = false;
   var rec   = [ ];
+
+  var SUPER = globalThis[f.name] || function() { };
   globalThis[f.name] = function() {
     if ( fired ) return;
     fired = true;
-    summary.push(rec);
 
-    // before_task
-    if ( typeof globalThis['before_' + f.name] === 'function' )
-      globalThis['before_' + f.name](EXPORTS);
+    running[f.name] = (running[f.name] || 0) + 1;
+    if ( running[f.name] === 1 ) {
+      summary.push(rec);
+      info(`Starting Task :: ${f.name}`);
+      var start = Date.now();
+      rec[0] = ''.padEnd(2*depth) + f.name;
+      rec[2] = start;
+      depth++;
+    }
 
-    info(`Starting Task :: ${f.name}`);
-    var start = Date.now();
-    rec[0] = ''.padEnd(2*depth) + f.name;
-    rec[2] = start;
-    depth++;
-    f(EXPORTS);
-    depth--;
-    var end = Date.now();
-    var dur = ((end-start)/1000).toFixed(1);
-    info(`Finished Task :: ${f.name} in ${dur} seconds`);
-    rec[1] = dur;
+    f(Object.assign({ SUPER }, EXPORTS));
 
-    // after_task
-    if ( typeof globalThis['after_' + f.name] === 'function' )
-      globalThis['after_' + f.name](EXPORTS);
+    running[f.name] -= 1;
+    if ( running[f.name] === 0 ) {
+      depth--;
+      var end = Date.now();
+      var dur = ((end-start)/1000).toFixed(1);
+      info(`Finished Task :: ${f.name} in ${dur} seconds`);
+      rec[1] = dur;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes
- Decorate build task, support chaining
- Remove before and after tasks

## Examples
```
foam.POM({
  tasks: [
    function versions({ SUPER }) {
      // call before `versions' task
      console.log('---------- before versions');

      // call the delegate i.e versions task
      SUPER();

      // call after `versions' task
      console.log('---------- after versions');

      // call other task
      showManifest();
    }
  ]
});
```
