### PR TITLE
CreatedBy - move read permission from CreatedByAware to User.

### DIFF
--- a/src/foam/nanos/auth/CreatedByAware.js
+++ b/src/foam/nanos/auth/CreatedByAware.js
@@ -18,7 +18,7 @@ foam.INTERFACE({
       documentation: 'User who created the entry',
       tableCellFormatter: { class: 'foam.u2.view.ReferenceToSummaryCellFormatter' },
       section: 'userInformation',
-      readPermissionRequired: true,
+      columnPermissionRequired: true,
       gridColumns: 6
     },
     {
@@ -28,10 +28,8 @@ foam.INTERFACE({
       documentation: 'Agent acting as User who created the entry',
       createVisibility: 'HIDDEN',
       updateVisibility: 'RO',
-      columnPermissionRequired: true,
       tableCellFormatter: { class: 'foam.u2.view.ReferenceToSummaryCellFormatter' },
       section: 'userInformation',
-      readPermissionRequired: true,
       columnPermissionRequired: true,
       gridColumns: 6
     }

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -446,6 +446,7 @@ foam.CLASS({
       name: 'created',
       includeInDigest: true,
       documentation: 'The date and time of when the User was created in the system.',
+      readPermissionRequired: true,
       order: 250
     },
     {


### PR DESCRIPTION
Not all models require read permission on CreatedBy, Account in particular.