### PR TITLE
Refactor FindRuledCommand

### DIFF
--- a/src/foam/nanos/ruler/FindRuledCommand.js
+++ b/src/foam/nanos/ruler/FindRuledCommand.js
@@ -8,11 +8,21 @@ foam.CLASS({
   package: 'foam.nanos.ruler',
   name: 'FindRuledCommand',
 
+  javaCode: `
+    public FindRuledCommand(String ruleGroup) {
+      this(ruleGroup, null);
+    }
+  `,
+
   properties: [
     {
       class: 'Reference',
       of: 'foam.nanos.ruler.RuleGroup',
       name: 'ruleGroup'
+    },
+    {
+      class: 'FObjectProperty',
+      name: 'target'
     }
   ]
 })
@@ -20,5 +30,11 @@ foam.CLASS({
 foam.CLASS({
   package: 'foam.nanos.ruler',
   name: 'SelectRuledCommand',
-  extends: 'foam.nanos.ruler.FindRuledCommand'
+  extends: 'foam.nanos.ruler.FindRuledCommand',
+
+  javaCode: `
+    public SelectRuledCommand(String ruleGroup) {
+      this(ruleGroup, null);
+    }
+  `
 })

--- a/src/foam/nanos/ruler/Ruled.js
+++ b/src/foam/nanos/ruler/Ruled.js
@@ -78,7 +78,7 @@ foam.CLASS({
 
         var obj = x.get("OBJ");
         try {
-          return getPredicate().f(obj != null ? obj : this);
+          return getPredicate().f(obj != null ? obj : x);
         } catch ( Throwable t ) {
           ((Logger) x.get("logger")).error("Failed to evaluate predicate on",
             "class: " + getClass().getName(),

--- a/src/foam/nanos/ruler/RuledDAO.js
+++ b/src/foam/nanos/ruler/RuledDAO.js
@@ -40,6 +40,10 @@ foam.CLASS({
         if ( obj instanceof FindRuledCommand ) {
           var isSelectCmd = obj instanceof SelectRuledCommand;
 
+          // Setup target context for ruled matching
+          var target  = ((FindRuledCommand) obj).getTarget();
+          var targetX = target != null ? x.put("OBJ", target) : x;
+
           var sink = new ArraySink();
           getDelegate()
             .where(EQ(Ruled.RULE_GROUP, ((FindRuledCommand) obj).getRuleGroup()))
@@ -47,7 +51,7 @@ foam.CLASS({
             .select(new AbstractSink() {
               @Override
               public void put(Object o, Detachable s) {
-                if ( ((Ruled) o).f(x) ) {
+                if ( ((Ruled) o).f(targetX) ) {
                   sink.put(o, s);
                   if ( ! isSelectCmd ) s.detach();
                 }

--- a/src/foam/nanos/ruler/test/RuledDAOTest.js
+++ b/src/foam/nanos/ruler/test/RuledDAOTest.js
@@ -30,8 +30,8 @@ foam.CLASS({
         RuledDAOTest_find_ruled_obj_order_by_priority(x);
         RuledDAOTest_find_ruled_obj_with_truthy_predicate(x);
         RuledDAOTest_find_ruled_obj_with_falsely_predicate(x);
-        RuledDAOTest_find_ruled_obj_predicating_on_OBJ_in_context(x);
-        RuledDAOTest_find_ruled_obj_with_self_object_predicate(x);
+        RuledDAOTest_find_ruled_obj_predicating_on_OBJ_injected_in_context(x);
+        RuledDAOTest_find_ruled_obj_predicating_on_a_target_object(x);
         RuledDAOTest_SelectRuledCommand(x);
       `
     },
@@ -106,7 +106,7 @@ foam.CLASS({
       `
     },
     {
-      name: 'RuledDAOTest_find_ruled_obj_predicating_on_OBJ_in_context',
+      name: 'RuledDAOTest_find_ruled_obj_predicating_on_OBJ_injected_in_context',
       args: [
         { type: 'Context', name: 'x' }
       ],
@@ -115,20 +115,21 @@ foam.CLASS({
         var obj = dao.put(new RuledDummy.Builder(x).setRuleGroup("test").setPredicate(EQ(User.ID, 1234)).build());
 
         var found = dao.inX(x.put("OBJ", new User.Builder(x).setId(1234).build())).cmd(new FindRuledCommand("test"));
-        test(found != null && obj.equals(found), "Find ruled obj with context predicate");
+        test(found != null && obj.equals(found), "Find ruled obj with context predicate with injecting OBJ");
       `
     },
     {
-      name: 'RuledDAOTest_find_ruled_obj_with_self_object_predicate',
+      name: 'RuledDAOTest_find_ruled_obj_predicating_on_a_target_object',
       args: [
         { type: 'Context', name: 'x' }
       ],
       javaCode: `
         var dao = setUpDAO(x, RuledDummy.getOwnClassInfo());
-        var obj = dao.put(new RuledDummy.Builder(x).setProp("foo").setRuleGroup("test").setPredicate(EQ(RuledDummy.PROP, "foo")).build());
+        var obj = dao.put(new RuledDummy.Builder(x).setRuleGroup("test").setPredicate(EQ(User.ID, 1234)).build());
 
-        var found = dao.cmd(new FindRuledCommand("test"));
-        test(found != null && obj.equals(found), "Find ruled obj with self object predicate");
+        var target = new User.Builder(x).setId(1234).build();
+        var found = dao.cmd(new FindRuledCommand("test", target));
+        test(found != null && obj.equals(found), "Find ruled obj with context predicate with target object");
       `
     },
     {


### PR DESCRIPTION
Refactor FindRuledCommand to allow for constructing target context on the fly without requiring client to inject OBJ in the context at the call site.

Example:
```
// Previously, OBJ needs to be explicitly injected at the call site
sink = plannerRequirementDAO.inX(x.put("OBJ", obj)).cmd(new SelectRuledCommand("PlannerRequirementSelector"));

// Now, no need to mess with the context
sink = plannerRequirementDAO.cmd(new SelectRuledCommand("PlannerRequirementSelector", obj));
```