### PR TITLE
Fix sub context put

### DIFF
--- a/src/foam/core/SubX.java
+++ b/src/foam/core/SubX.java
@@ -65,7 +65,7 @@ public class SubX extends ProxyX {
   @Override
   public X put(Object key, Object value) {
     if ( getX() instanceof ProxyX ) {
-      getX().put(key, value);
+      setX(getX().put(key, value));
       serviceKeys_.add(key);
       return this;
     }
@@ -75,7 +75,7 @@ public class SubX extends ProxyX {
   @Override
   public X putFactory(Object key, XFactory factory) {
     if ( getX() instanceof ProxyX ) {
-      getX().putFactory(key, factory);
+      setX(getX().putFactory(key, factory));
       serviceKeys_.add(key);
       return this;
     }

--- a/src/foam/nanos/boot/Boot.java
+++ b/src/foam/nanos/boot/Boot.java
@@ -106,7 +106,7 @@ public class Boot {
       // or
       //      x.get("foo/test");
       //
-      if ( x != null )
+      if ( x != root_ )
         root_.putFactory(sp.getName(), factory);
     }
 

--- a/src/foam/nanos/boot/Boot.java
+++ b/src/foam/nanos/boot/Boot.java
@@ -97,6 +97,17 @@ public class Boot {
       factories_.put(sp.getName(), factory);
       logger.info("Registering", sp.getName());
       x.putFactory(serviceName, factory);
+
+      // Register link to the service added to the sub context, allowing the
+      // service to be accessible via both the sub context and the root context.
+      // Eg. "foo/test" nspec can be instantiated by
+      //
+      //      x.cd("foo").get("test");
+      // or
+      //      x.get("foo/test");
+      //
+      if ( x != null )
+        root_.putFactory(sp.getName(), factory);
     }
 
     serviceDAO_.listen(new AbstractSink() {


### PR DESCRIPTION
## Changes
- Fix subX put not storing the nspec in the delegate due to the current behaviour of ProxyX put/putFactory is to create new proxy instead of modifying the delegate
- Register link to the service added to the sub context