### PR TITLE
Fix payroll build

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -484,7 +484,7 @@ task('Build Java JAR file.', [ 'versions', 'jarWebroot', 'jarImages' ], function
 task('Package files into a TAR archive', [], function buildTar() {
   // Notice that the argument to the second -C is relative to the directory from the first -C, since -C
   // switches the current directory.
-  fs.mkdirSync(TARGET_DIR + '/package', {recursive: true});
+  ensureDir(TARGET_DIR + '/package');
   execSync(`tar -a -cf ${TARGET_DIR}/package/${PROJECT.name}-deploy-${VERSION}.tar.gz -C ./deploy bin etc -C ../ -C${TARGET_DIR} lib`);
 });
 

--- a/tools/pmake.js
+++ b/tools/pmake.js
@@ -109,8 +109,8 @@ var SUPER = foam.POM;
 var seen  = {};
 
 foam.POM = function(pom) {
-  if ( seen[foam.cwd] ) return;
-  seen[foam.cwd] = true;
+  if ( seen[foam.sourceFile] ) return;
+  seen[foam.sourceFile] = true;
 
   pom.location = foam.cwd;
   pom.path     = foam.sourceFile;

--- a/tools/pmake.js
+++ b/tools/pmake.js
@@ -116,7 +116,8 @@ foam.POM = function(pom) {
   pom.path     = foam.sourceFile;
   MAKERS.forEach(v => v.visitPOM && v.visitPOM(pom));
   SUPER(pom);
-  processDir(pom, foam.cwd, false);
+  if ( ! seen[foam.cwd] ) processDir(pom, foam.cwd, false);
+  seen[foam.cwd] = true;
   MAKERS.forEach(v => v.endVisitPOM && v.endVisitPOM(pom));
 }
 

--- a/tools/pmake.js
+++ b/tools/pmake.js
@@ -115,9 +115,9 @@ foam.POM = function(pom) {
   pom.location = foam.cwd;
   pom.path     = foam.sourceFile;
   MAKERS.forEach(v => v.visitPOM && v.visitPOM(pom));
-  SUPER(pom);
   if ( ! seen[foam.cwd] ) processDir(pom, foam.cwd, false);
   seen[foam.cwd] = true;
+  SUPER(pom);
   MAKERS.forEach(v => v.endVisitPOM && v.endVisitPOM(pom));
 }
 


### PR DESCRIPTION
## Changes
- Support multi-pom build eg. `pmake.js -pom=pom1,pom2`, previously pom2 was not being loaded
- Fix top-level POM excludes not taking effect, node_modules directory was included (unexpected)