### PR TITLE
Add discardStale to listeners

### DIFF
--- a/src/foam/core/Listener.js
+++ b/src/foam/core/Listener.js
@@ -66,6 +66,7 @@ foam.CLASS({
     { class: 'Boolean', name: 'isMerged',   value: false },
     { class: 'Boolean', name: 'isIdled',    value: false },
     { class: 'Int',     name: 'delay',      value: 16, units: 'ms' },
+    { class: 'Boolean', name: 'discardStale', value: false},
     // legacy support, aliases to 'delay'
     { class: 'Int',     name: 'mergeDelay', value: 16,
       getter: function() { return this.delay; },
@@ -105,12 +106,13 @@ foam.CLASS({
           foam.core.Listener.isInstance(superAxiom),
         'Attempt to override non-listener', this.name);
 
-      var name     = this.name;
-      var code     = this.override_(proto, foam.Function.setName(this.code, name), superAxiom);
-      var isMerged = this.isMerged;
-      var isIdled  = this.isIdled;
-      var isFramed = this.isFramed;
-      var delay    = this.delay;
+      var name         = this.name;
+      var code         = this.override_(proto, foam.Function.setName(this.code, name), superAxiom);
+      var isMerged     = this.isMerged;
+      var isIdled      = this.isIdled;
+      var isFramed     = this.isFramed;
+      var delay        = this.delay;
+      var discardStale = this.discardStale;
 
       var obj = Object.defineProperty(proto, name, {
         get: function listenerGetter() {
@@ -129,6 +131,8 @@ foam.CLASS({
               l = this.__context__.idled(l, delay);
             } else if ( isFramed ) {
               l = this.__context__.framed(l);
+            } else if ( discardStale ) {
+              l = this.__context__.discardStale(l);
             }
             this.setPrivate_(name, l);
           }

--- a/src/foam/core/Window.js
+++ b/src/foam/core/Window.js
@@ -53,6 +53,7 @@ foam.CLASS({
     'console',
     'debug',
     'delayed',
+    'discardStale',
     'document',
     'error',
     'framed',
@@ -226,6 +227,10 @@ foam.CLASS({
 
         return f;
       }(), 'framed(' + l.name + ')');
+    },
+
+    function discardStale(l) {
+      return foam.events.discardStale(l);
     },
 
     function setTimeout(f, t) {

--- a/src/foam/core/events.js
+++ b/src/foam/core/events.js
@@ -37,6 +37,20 @@ foam.LIB({
         console.log(args);
         listener && listener.apply(this, args);
       };
+    },
+
+    function discardStale(listener) {
+      let ret =  function() {
+        ret.callId = {}.$UID;
+        const localId = ret.callId;
+        return listener.call(this, ...arguments).then(v => {
+          if ( localId == ret.callId ) {
+            return v;
+          }
+          throw new Error('stale response');
+        });
+      };
+      return ret;
     }
   ]
 });


### PR DESCRIPTION
- Add foam.events.discardStale that discards stale responses from any function as long as they return a promise
- Add discardStale flag to Listeners, note: discardStale is not compatible with isMerged, isIdled or isFramed. It also goes against typical listener convention where listeners dont return anything