### PR TITLE
AuthWebAgent session setup - do not replace/use session with response…

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -219,7 +219,13 @@ public class AuthWebAgent
           if ( ! SafetyUtil.isEmpty(sessionId) ) {
             session.setId(sessionId);
           }
-          session = (Session) sessionDAO.put(session);
+          // NOTE: don't use returned session. This fails in
+          // clustered environment as session.context is
+          // clusterTransient and null after put.
+          Session saved = (Session) sessionDAO.put(session);
+          if ( SafetyUtil.isEmpty(session.getId()) ) {
+            session.setId(saved.getId());
+          }
         }
         session.touch();
 


### PR DESCRIPTION
… from sessionDAO.put.

Session.context is clusterTransient, and in a clustered environment the response session context is reset to null. A Secondary login results in NPE while Primary is fine.