### PR TITLE
[NP-9880] Fix the label on the Customer address to display 'Province' instead of 'Region'

### DIFF
--- a/src/foam/i18n/en_us/locales.jrl
+++ b/src/foam/i18n/en_us/locales.jrl
@@ -1,5 +1,3 @@
-p({class:"foam.i18n.Locale",locale:"en",source:"*.foam.nanos.auth.Address.REGION.label",target:"Region"})
-p({class:"foam.i18n.Locale",locale:"en",source:"*.foam.nanos.auth.Address.REGION.error",target:"Region required"})
 p({class:"foam.i18n.Locale",locale:"en",variant:"US",locale_variant:"en-US",source:"*.foam.nanos.auth.Address.REGION.label",target:"Region"})
 p({class:"foam.i18n.Locale",locale:"en",variant:"US",locale_variant:"en-US",source:"*.foam.nanos.auth.Address.REGION.error",target:"Region required"})
 p({class:"foam.i18n.Locale",locale:"en",variant:"US",locale_variant:"en-US",source:"us.foam.nanos.auth.Address.REGION.label",target:"State"})


### PR DESCRIPTION
[NP-9880/Fix-the-label-on-the-Customer-address-to-display-Province-instead-of-region](https://nanopay.atlassian.net/browse/NP-9880)