### PR TITLE
Fix checking user is anonymous

### DIFF
--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -469,11 +469,8 @@ foam.CLASS({
 
         // For anonymous users, we shouldn't reinstall the language
         // because the user's language setting isn't meaningful.
-        if ( self?.subject?.realUser ) {
-          var spid = await self.subject.realUser.spid$find;
-          if ( self.subject.realUser.id !== spid.anonymousUser ) {
-            await self.maybeReinstallLanguage(self.client);
-          }
+        if ( self?.subject?.realUser && ! (await client.auth.isAnonymous()) ) {
+          await self.maybeReinstallLanguage(self.client);
         }
 
         self.languageInstalled.resolve();


### PR DESCRIPTION
Check isAnonymous using auth service directly because spid$find can throw 
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'find')

        at Object.classGetter (types.js:1008:32)
        at ApplicationController.js:474:50
```

if the user doesn't have service permission