### PR TITLE
Reload only if needed

### DIFF
--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -228,11 +228,14 @@ foam.CLASS({
               if ( ! this.pureLoginFunction ) await this.nextStep();
             }
 
-            this.loginSuccess = true;
-            await this.ctrl.reloadClient();
-            // Temp fix to prevent breaking wizard sign in since that also calls this function
-            if ( ! this.pureLoginFunction )
-              await this.ctrl.onUserAgentAndGroupLoaded();
+            // Reload only if it wasn't done by the 'nextStep()' call
+            if ( ! this.loginSuccess ) {
+              this.loginSuccess = true;
+              await this.ctrl.reloadClient();
+              // Temp fix to prevent breaking wizard sign in since that also calls this function
+              if ( ! this.pureLoginFunction )
+                await this.ctrl.onUserAgentAndGroupLoaded();
+            }
           } catch (err) {
             this.loginFailed = true;
             let e = err && err.data ? err.data.exception : err;


### PR DESCRIPTION
## Issue
- The extra `onUserAgentAndGroupLoaded()` call prevents the stack from popping when the wizard is completed