### PR TITLE
BUG: fix css on wizard on that button do not cover the input fields

### DIFF
--- a/src/foam/u2/dialog/ApplicationPopup.js
+++ b/src/foam/u2/dialog/ApplicationPopup.js
@@ -113,7 +113,7 @@ foam.CLASS({
       width: 100%;
     }
     ^fullHeightBody {
-      height: 650px;
+      height: auto;
     }
     ^fullHeightBody > *{
       flex-grow: 1;


### PR DESCRIPTION
Pre:
<img width="1017" alt="Screen Shot 2023-09-15 at 10 20 30 AM" src="https://github.com/kgrgreer/foam3/assets/56833131/016e89b8-b6b1-4705-b803-8de84e14e15f">
after:
<img width="516" alt="Screen Shot 2023-09-15 at 10 23 45 AM" src="https://github.com/kgrgreer/foam3/assets/56833131/41c5fde9-abba-48bc-90d9-5fe06d9582c8">
