### PR TITLE
Fix deprecation warning

### DIFF
--- a/tools/buildlib.js
+++ b/tools/buildlib.js
@@ -103,7 +103,7 @@ function emptyDir(dir) {
 
 function rmdir(dir) {
   if ( fs_.existsSync(dir) && fs_.lstatSync(dir).isDirectory() ) {
-    fs_.rmdirSync(dir, {recursive: true, force: true});
+    fs_.rmSync(dir, {recursive: true, force: true});
   }
 }
 


### PR DESCRIPTION
(node:19173) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead (Use `node --trace-deprecation ...` to show where the warning was created)