### PR TITLE
only skip authentication when session is unauthenticated

### DIFF
--- a/src/foam/nanos/menu/Menu.js
+++ b/src/foam/nanos/menu/Menu.js
@@ -211,8 +211,16 @@
     {
       name: 'authorizeOnRead',
       javaCode: `
-        if ( ! getAuthenticate() ) return;
         AuthService auth = (AuthService) x.get("auth");
+        boolean unauthenticated = false;
+        try {
+          var subject = auth.getCurrentSubject(x);
+          if ( subject == null || auth.isUserAnonymous(x, subject.getUser().getId()) ) 
+            unauthenticated = true;
+        } catch(foam.nanos.auth.AuthenticationException e) {
+          unauthenticated = true;
+        }
+        if ( ! getAuthenticate() && unauthenticated ) return;
         if ( ! ( f(x) &&
                  auth.check(x, "menu.read." + getId()) ) ) {
           throw new AuthorizationException("You do not have permission to read this menu.");


### PR DESCRIPTION
prevents users going to unauthenticated menus such as unauthenticated-transfer, sign-in, sign-up when session is authenticated