### PR TITLE
Set HttpServletResponse.status to 403 (forbidden) for permission deni…

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -66,6 +66,8 @@ public class AuthWebAgent
       PrintWriter out = x.get(PrintWriter.class);
       out.println("Access denied. Need permission: " + permission_);
       ((foam.nanos.logger.Logger) x.get("logger")).debug("Access denied, requires permission", permission_,"subject", x.get("subject"));
+      HttpServletResponse response = x.get(HttpServletResponse.class);
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
       return;
     }
 


### PR DESCRIPTION
Set HttpServletResponse.status to 403 (forbidden) for permission denied failures. 
This matches the behaviour of DIGWebAgent with 403 for AuthorizationExceptions. 