### PR TITLE
DIGLastHttpResponse

### DIFF
--- a/src/foam/nanos/crunch/ruler/CheckUCJOwnershipOnPut.js
+++ b/src/foam/nanos/crunch/ruler/CheckUCJOwnershipOnPut.js
@@ -43,7 +43,7 @@ foam.CLASS({
             
             if (
               isUpdating && auth.check(x, "usercapabilityjunction.update.*") ||
-              ! isUpdating && auth.check(x, "usercapabilityjunction.create.*")
+              ! isUpdating && auth.check(x, "usercapabilityjunction.create")
             ) return;
 
             boolean isOwner = ucj.getSourceId() == user.getId() || ucj.getSourceId() == realUser.getId();

--- a/src/foam/nanos/crunch/ruler/InvokeEditBehaviourRuleAction.js
+++ b/src/foam/nanos/crunch/ruler/InvokeEditBehaviourRuleAction.js
@@ -35,9 +35,6 @@ foam.CLASS({
           @Override
           public void execute (X x) {
 
-            // If user has permission to update junctions for other users
-            // then we ignore edit behaviour entirely.
-            AuthService auth = (AuthService) x.get("auth");
             if ( ucj.getSkipEditBehaviour() == true ) {
               ucj.setSkipEditBehaviour(false);
               return;

--- a/src/foam/nanos/crunch/ruler/rules.jrl
+++ b/src/foam/nanos/crunch/ruler/rules.jrl
@@ -45,7 +45,7 @@ p({
   daoKey: 'userCapabilityJunctionDAO',
   operation: 1,
   after: false,
-  enabled: true,
+  enabled: false,
   action: {
     class: 'foam.nanos.crunch.ruler.InvokeEditBehaviourRuleAction'
   },

--- a/src/foam/nanos/dig/DIG.js
+++ b/src/foam/nanos/dig/DIG.js
@@ -473,8 +473,14 @@ NOTE: when using the java client, the first call to a newly started instance may
     },
     {
       documentation: 'submit() returns null for a 200 with an empty response body, retrieving the response code of 200 can be useful for text based clients (not expecting FObjects)',
-      name: 'lastResponseCode',
+      name: 'lastHttpResponseCode',
       class: 'Int',
+      transient: true,
+      hidden: true
+    },
+    {
+      name: 'lastHttpResponse',
+      class: 'Object',
       transient: true,
       hidden: true
     }
@@ -591,7 +597,7 @@ NOTE: when using the java client, the first call to a newly started instance may
         return null;
       }
       if ( result instanceof String &&
-           getLastResponseCode() != 200 ) {
+           getLastHttpResponseCode() != 200 ) {
         throw new FOAMException((String) result);
       }
       if ( result instanceof String ) {
@@ -621,7 +627,7 @@ NOTE: when using the java client, the first call to a newly started instance may
 
       Object result = submit(x, DOP.PUT, adapt(x, DOP.PUT, obj));
       if ( result instanceof String &&
-           getLastResponseCode() != 200 ) {
+           getLastHttpResponseCode() != 200 ) {
         throw new FOAMException((String) result);
       }
       if ( result instanceof String ) {
@@ -866,7 +872,8 @@ NOTE: when using the java client, the first call to a newly started instance may
         } finally {
           pm.log(x);
         }
-        setLastResponseCode(response.statusCode());
+        setLastHttpResponse(response);
+        setLastHttpResponseCode(response.statusCode());
         String body = response.body();
         if ( response.statusCode() != 200 ) {
           Loggers.logger(x, this).warning("submit", "request", dop, url, "response", response.statusCode(), body);

--- a/src/foam/nanos/http/test/DIGBroadcastWebAgentTest.js
+++ b/src/foam/nanos/http/test/DIGBroadcastWebAgentTest.js
@@ -66,7 +66,7 @@ foam.CLASS({
 
       Object reply = client.submit(x, getDop(), getData());
       test ( reply != null, "recieved non-null reply: "+reply);
-      test ( client.getLastResponseCode() == 200, "response code 200: "+client.getLastResponseCode());
+      test ( client.getLastHttpResponseCode() == 200, "response code 200: "+client.getLastHttpResponseCode());
 
 
       client = new DIG.Builder(x)
@@ -79,7 +79,7 @@ foam.CLASS({
         reply = client.submit(x, getDop(), getData());
         test ( false, "expected exception: "+reply);
       } catch (Exception e) {
-        test ( client.getLastResponseCode() != 200, "response code ! 200: "+client.getLastResponseCode());
+        test ( client.getLastHttpResponseCode() != 200, "response code ! 200: "+client.getLastHttpResponseCode());
         test ( e instanceof foam.core.FOAMException, "expected FOAMException: "+e.getClass().getSimpleName());
       }
       `


### PR DESCRIPTION
Provide access to the last HttpResponse object, so caller can check uri, for example. 

- added lastHttpResponse storing HttpResponse, 
- and renamed lastResponseCode to lastHttpResponseCode to be consistent