### PR TITLE
Replace 'extends' refinement with actual method implementations.

### DIFF
--- a/src/foam/nanos/medusa/MedusaSupport.js
+++ b/src/foam/nanos/medusa/MedusaSupport.js
@@ -8,10 +8,13 @@ foam.CLASS({
   package: 'foam.nanos.medusa',
   name: 'MedusaSupport',
 
-  documentation: `Provided for the nanos system to determine if the application
-is running in clustered environment and if should be responsible for tasks which
-should only run on the primary.
-This model is refined by the real medusa system.`,
+  documentation: `Provided for the nanos system to determine if the
+application is running in clustered environment and if should be
+responsible for tasks which should only run on the primary.
+This model is refined by the real medusa system to use the
+real ClusterConfigSupport.
+See MedusaSupportRefinement
+`,
 
   methods: [
     {
@@ -20,7 +23,7 @@ only run on the primary mediator.`,
       name: 'cronEnabled',
       args: 'Context x, boolean clusterable',
       type: 'Boolean',
-      javaCode: 'return false;'
+      javaCode: 'return true;'
     },
     {
       documentation: 'test if system is replaying',

--- a/src/foam/nanos/medusa/MedusaSupportRefinement.js
+++ b/src/foam/nanos/medusa/MedusaSupportRefinement.js
@@ -8,7 +8,44 @@ foam.CLASS({
   package: 'foam.nanos.medusa',
   name: 'MedusaSupportRefinement',
   refines: 'foam.nanos.medusa.MedusaSupport',
-  extends: 'foam.nanos.medusa.ClusterConfigSupport',
 
-  documentation: 'Enabled by the main medusa pom.'
+  documentation: 'Enabled by the main medusa pom.',
+
+  javaImports: [
+    'foam.nanos.medusa.ClusterConfigSupport'
+  ],
+
+  methods: [
+    {
+      documentation: `check for primary as clusterable cron jobs should
+only run on the primary mediator.`,
+      name: 'cronEnabled',
+      args: 'Context x, boolean clusterable',
+      type: 'Boolean',
+      javaCode: `
+      ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+      return support.cronEnabled(x, clusterable);
+      `
+    },
+    {
+      documentation: 'test if system is replaying',
+      name: 'isReplaying',
+      args: 'Context x',
+      type: 'Boolean',
+      javaCode: `
+      ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+      return support.isReplaying(x);
+      `
+    },
+    {
+      documentation: `Decorate the root serviceDAO to 'cluster' serviceDAO updates`,
+      name: 'clusterServiceDAO',
+      args: 'Context x, foam.dao.DAO delegate',
+      type: 'foam.dao.DAO',
+      javaCode: `
+      ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+      return support.clusterServiceDAO(x, delegate);
+      `
+    }
+  ]
 })


### PR DESCRIPTION
Refinement of 'extends' is not supported.
The refinement is added only when building Medusa proper.  Replaced extends with actual method overrides which call out to ClusterConfigSupport.