### PR TITLE
Select returns [{..}] regardless of number of results, unless 'id' provided

### DIFF
--- a/src/foam/nanos/dig/drivers/DigJsonDriver.js
+++ b/src/foam/nanos/dig/drivers/DigJsonDriver.js
@@ -22,6 +22,7 @@ foam.CLASS({
     'foam.nanos.dig.*',
     'foam.nanos.dig.exception.*',
     'foam.nanos.http.*',
+    'foam.util.SafetyUtil',
     'java.io.PrintWriter',
     'java.util.ArrayList',
     'java.util.Arrays',
@@ -124,10 +125,14 @@ foam.CLASS({
         outputterJson.setMultiLine(true);
       }
 
-      if ( fobjects.size() == 1 )
+      // NOTE: only json output has this one element behaviour
+      if ( fobjects.size() == 1 &&
+          // 'id' property indicates 'find' rather than 'select'
+          ! SafetyUtil.isEmpty(p.getParameter("id")) ) {
         outputterJson.output(fobjects.get(0));
-      else
+      } else {
         outputterJson.output(fobjects.toArray());
+      }
 
       // Output the formatted data
       out.println(outputterJson.toString());

--- a/src/foam/nanos/dig/test/DigJsonDriverTest.js
+++ b/src/foam/nanos/dig/test/DigJsonDriverTest.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright
+ * @license 2023 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.dig.test',
+  name: 'DigJsonDriverTest',
+  extends: 'foam.nanos.test.Test',
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.X',
+    'foam.dao.DAO',
+    'foam.dao.DOP',
+    'static foam.mlang.MLang.EQ',
+    'foam.nanos.auth.LifecycleState',
+    'foam.nanos.auth.User',
+    'foam.nanos.dig.DIG',
+    'foam.nanos.logger.Logger',
+    'foam.nanos.logger.Loggers',
+    'foam.nanos.session.Session',
+    'foam.util.SafetyUtil',
+    'java.net.http.HttpResponse'
+  ],
+
+  properties: [
+    {
+      documentation: 'long time to support debugger debugging',
+      name: 'requestTimeout',
+      class: 'Long',
+      value: 360000
+    }
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      args: 'X x',
+      javaCode: `
+      // pull http from context to ensure it's started.
+      test ( x.get("http") != null, "http initialized" );
+
+      Logger logger = Loggers.logger(x, this);
+
+      User user = new User();
+      user.setId(102686180L);
+      user.setSpid("test");
+      user.setFirstName("test");
+      user.setMiddleName("dig");
+      user.setLastName("json");
+      user.setEmail("test-dig-json-driver@foam.foam");
+      user.setUserName("test-dig-json-driver");
+      user.setGroup("test");
+      user.setEmailVerified(true);
+      user.setLifecycleState(LifecycleState.ACTIVE);
+      user = (User) ((DAO)x.get("userDAO")).put(user);
+
+      Session session = new Session();
+      session.setUserId(user.getId());
+      session = (Session) ((DAO) x.get("sessionDAO")).put(session);
+
+      DIG client = new DIG.Builder(x)
+        .setDaoKey("userDAO")
+        .setSessionId(session.getId())
+        .setRequestTimeout(getRequestTimeout())
+        .build();
+
+      User u = (User) client.find(user.getId());
+      test ( u != null, "User found");
+
+      HttpResponse response = (HttpResponse) client.getLastHttpResponse();
+      String body = String.valueOf(response.body());
+      test ( body != null && body.startsWith("{"), "Find return {...}");
+
+      Object result = client.submit(x, DOP.SELECT, "q=group=test");
+      test ( result != null, "Select results found");
+      FObject[] results = (FObject[]) result;
+      test ( results.length == 1, "Select size 1 "+results.length);
+
+      response = (HttpResponse) client.getLastHttpResponse();
+      body = String.valueOf(response.body());
+      test ( body != null && body.startsWith("["), "Select return [...]");
+      `
+    }
+  ]
+})

--- a/src/foam/nanos/dig/test/tests.jrl
+++ b/src/foam/nanos/dig/test/tests.jrl
@@ -1,0 +1,4 @@
+p({
+  class:"foam.nanos.dig.test.DigJsonDriverTest"
+  id:"DigJsonDriverTest"
+})

--- a/src/foam/nanos/pom.js
+++ b/src/foam/nanos/pom.js
@@ -524,6 +524,7 @@ foam.POM({
     { name: "dig/LinkView",                                                               flags: "js" },
     { name: "dig/ResultView",                                                             flags: "js" },
     { name: "dig/SUGAR",                                                                  flags: "js|java" },
+    { name: "dig/test/DigJsonDriverTest",                                                 flags: "js|java" },
     { name: "notification/email/ClientPOP3EmailService",                                  flags: "js|java" },
     { name: "notification/email/POP3Email",                                               flags: "js|java" },
     { name: "ruler/RuleGroup",                                                            flags: "js|java" },


### PR DESCRIPTION
Select returns [{..}] regardless of number of results, unless 'id' property is explicitly provided, then it acts like find(id) and returns {...}