### PR TITLE
[DO_NOT_MERGE]] Fix spid specific nspec service pointer

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -61,13 +61,8 @@ public class SessionServerBox
     PM      pm         = PM.create(x, "SessionServerBox", spec.getName());
 
     // Save skeleton delegateObj in case it's overwritten by subX
-    var skeleton       = (Skeleton) delegate;
-    Object delegateObj = null;
-    try {
-      // REVIEW: Cannot call getDelegate() directly because DELEGATE axiom is not added to the <Interface>Skeleton classInfo
-      var delegateMethod = skeleton.getClass().getMethod("getDelegate");
-      delegateObj = delegateMethod.invoke(skeleton);
-    } catch ( Exception e ) { /* noop */ }
+    var skeleton       = (AbstractSkeleton) delegate;
+    var delegateObj    = skeleton.getProperty("delegate");
 
     try {
       HttpServletRequest req = x.get(HttpServletRequest.class);

--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -60,7 +60,7 @@ public class SessionServerBox
     String  sessionID  = null;
     PM      pm         = PM.create(x, "SessionServerBox", spec.getName());
 
-    // Save skeleton delegateObj in case it's overwritten by subX
+    // Save skeleton delegateObj in case it's overridden by subX
     var skeleton       = (AbstractSkeleton) delegate;
     var delegateObj    = skeleton.getProperty("delegate");
 

--- a/src/foam/java/Skeleton.js
+++ b/src/foam/java/Skeleton.js
@@ -53,11 +53,6 @@ foam.CLASS({
       cls.name    = this.name;
       cls.extends = 'foam.box.AbstractSkeleton';
 
-      foam.core.FObjectProperty.create({
-        name: 'delegate',
-        type: this.of.id
-      }).buildJavaClass(cls);
-
       cls.method({
         type: 'void',
         visibility: 'public',
@@ -73,6 +68,29 @@ foam.CLASS({
         args: [ { name: 'obj', type: 'Object' } ],
         body: "setDelegate((" + this.of.id + ") obj);"
       });
+
+      // Add classInfo to store delegate property axiom
+      cls.fields.push(foam.java.ClassInfo.create({ id: this.id }));
+      cls.method({
+        name: 'getClassInfo',
+        type: 'foam.core.ClassInfo',
+        visibility: 'public',
+        body: 'return classInfo_;',
+        forceJavaOutputter:true
+      });
+      cls.method({
+        name: 'getOwnClassInfo',
+        visibility: 'public',
+        static: true,
+        type: 'foam.core.ClassInfo',
+        body: 'return classInfo_;',
+        forceJavaOutputter:true
+      });
+
+      foam.core.FObjectProperty.create({
+        name: 'delegate',
+        type: this.of.id
+      }).buildJavaClass(cls);
 
       return cls;
     }

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -363,7 +363,8 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         // Support hierarchical SPID context
         var subX = rtn.cd(user.getSpid());
         if ( subX != null ) {
-          rtn = new OrX(reset(subX));
+          subX = reset(((foam.core.SubX) subX).fclone());
+          rtn  = new OrX(rtn, subX);
         }
 
         Subject subject = null;

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -363,6 +363,8 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         // Support hierarchical SPID context
         var subX = rtn.cd(user.getSpid());
         if ( subX != null ) {
+          // NOTE: call subX.fclone() to prevent implicit fclone/re-freeze on
+          // every put to the subX since it was already frozen after startup.
           subX = reset(((foam.core.SubX) subX).fclone());
           rtn  = new OrX(rtn, subX);
         }


### PR DESCRIPTION
Allow for sub context inference routing to spid/xxxDAO from client based on the user spid. For example, smte user can hits smte/transactionSummaryDAO with x.transactionSummaryDAO.select(console.log).