### PR TITLE
Java21 - replace deprecated constructor calls

### DIFF
--- a/src/foam/box/sf/SF.js
+++ b/src/foam/box/sf/SF.js
@@ -16,7 +16,7 @@ foam.CLASS({
     'foam.box.Message',
     'foam.dao.*',
     'foam.core.FObject',
-    'foam.mlang.sink.Max;',
+    'foam.mlang.sink.Max',
     'foam.nanos.logger.Logger',
     'foam.nanos.logger.PrefixLogger',
     'foam.nanos.fs.Storage',

--- a/src/foam/nanos/column/TableColumnOutputter.js
+++ b/src/foam/nanos/column/TableColumnOutputter.js
@@ -233,7 +233,7 @@ foam.CLASS({
         case "BOOLEAN":
           return obj;
         case "CURRENCY":
-          return new Long(obj.toString()) / 100.0 ;
+          return Long.valueOf(obj.toString()) / 100.0 ;
         case "DATE":
           return obj.toString().substring(0, 10);
         case "DATETIME":

--- a/src/foam/nanos/http/ThreadsWebAgent.java
+++ b/src/foam/nanos/http/ThreadsWebAgent.java
@@ -100,9 +100,9 @@ public class ThreadsWebAgent
       out.println(thread.getState());
       Integer count = threadsInState.get(thread.getState());
       if ( count == null ) {
-        threadsInState.put(thread.getState(), new Integer(1));
+        threadsInState.put(thread.getState(), Integer.valueOf(1));
       } else {
-        threadsInState.put(thread.getState(), new Integer(count.intValue() + 1));
+        threadsInState.put(thread.getState(), Integer.valueOf(count.intValue() + 1));
       }
       out.println("</td>");
       out.println("<td>");

--- a/src/foam/nanos/tomcat/TomcatRouter.java
+++ b/src/foam/nanos/tomcat/TomcatRouter.java
@@ -142,7 +142,7 @@ public class TomcatRouter
           return;
         }
 
-        foam.core.X requestContext = getX().put("returnBox", returnBox_).put("webSocketId", new Integer(id_));
+        foam.core.X requestContext = getX().put("returnBox", returnBox_).put("webSocketId", Integer.valueOf(id_));
 
         foam.core.FObject request = requestContext.create(foam.lib.json.JSONParser.class).parseString(message);
 


### PR DESCRIPTION
Java21 - replace new Interger with Integer.valueOf, similar for Long, Double.  new Integer is deprecated