### PR TITLE
Add a static TranslationService.t() method as a shortcut to get translation method

### DIFF
--- a/src/foam/core/Currency.js
+++ b/src/foam/core/Currency.js
@@ -13,6 +13,7 @@
 
   javaImports: [
     'foam.core.XLocator',
+    'static foam.i18n.TranslationService.t',
     'foam.util.SafetyUtil'
   ],
 

--- a/src/foam/core/Currency.js
+++ b/src/foam/core/Currency.js
@@ -13,7 +13,6 @@
 
   javaImports: [
     'foam.core.XLocator',
-    'foam.i18n.TranslationService',
     'foam.util.SafetyUtil'
   ],
 
@@ -226,11 +225,8 @@
         String delimiter = getDelimiter();
         String decimalCharacter = getDecimalCharacter();
         try {
-          TranslationService ts = (TranslationService) x.get("translationService");
-          String locale = (String) x.get("locale.language");
-
-          delimiter = ts.getTranslation(locale, "Currency.delimiter", this.getDelimiter());
-          decimalCharacter = ts.getTranslation(locale, "Currency.decimalCharacter", this.getDecimalCharacter());
+          delimiter = t(x, "Currency.delimiter", this.getDelimiter());
+          decimalCharacter = t(x, "Currency.decimalCharacter", this.getDecimalCharacter());
         } catch (NullPointerException e) {
           foam.nanos.logger.Loggers.logger(x, this).debug(e);
         }

--- a/src/foam/core/FOAMException.js
+++ b/src/foam/core/FOAMException.js
@@ -20,6 +20,7 @@ foam.CLASS({
   javaImports: [
     'foam.core.PropertyInfo',
     'foam.core.XLocator',
+    'static foam.i18n.TranslationService.t',
     'foam.util.SafetyUtil',
     'java.util.HashMap',
     'java.util.List',

--- a/src/foam/core/FOAMException.js
+++ b/src/foam/core/FOAMException.js
@@ -20,7 +20,6 @@ foam.CLASS({
   javaImports: [
     'foam.core.PropertyInfo',
     'foam.core.XLocator',
-    'foam.i18n.TranslationService',
     'foam.util.SafetyUtil',
     'java.util.HashMap',
     'java.util.List',
@@ -136,19 +135,7 @@ foam.CLASS({
         return msg;
       },
       javaCode: `
-      try {
-        TranslationService ts = (TranslationService) XLocator.get().get("translationService");
-        if ( ts != null ) {
-          String locale = (String) XLocator.get().get("locale.language");
-          if ( SafetyUtil.isEmpty(locale) ) {
-            locale = "en";
-          }
-          return renderMessage(ts.getTranslation(locale, getClass().getName()+"."+getExceptionMessage(), getExceptionMessage()));
-        }
-      } catch (NullPointerException e) {
-        // noop - Expected when not yet logged in, as XLocator is not setup.
-      }
-      return renderMessage(getExceptionMessage());
+      return renderMessage(t(XLocator.get(), getClass().getName()+"."+getExceptionMessage(), getExceptionMessage()));
      `
     },
     {

--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -8,8 +8,10 @@ package foam.core;
 
 import foam.crypto.hash.Hashable;
 import foam.crypto.sign.Signable;
+import foam.i18n.TranslationService;
 import foam.lib.json.Outputter;
 import foam.nanos.logger.StdoutLogger;
+import foam.util.SafetyUtil;
 import foam.util.SecurityUtil;
 import java.security.*;
 import java.util.ArrayList;
@@ -618,6 +620,26 @@ public interface FObject
     throws UnsupportedOperationException
   {
     if ( isFrozen() ) throw new UnsupportedOperationException("Object is frozen.");
+  }
+
+  /**
+   * Shortcut method to call translation service with context locale.language.
+   *
+   * For example, when calling inside FObject
+   *
+   *    t(x, "source", "defaultText");
+   *
+   */
+  default String t(X x, String source, String defaultText) {
+    if ( x == null ) return defaultText;
+
+    var ts = (TranslationService) x.get("translationService");
+    if ( ts == null ) return defaultText;
+
+    var locale = (String) x.get("locale.language");
+    if ( SafetyUtil.isEmpty(locale) ) locale = "en";
+
+    return ts.getTranslation(locale, source, defaultText);
   }
 
   default String toSummary() {

--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -623,11 +623,17 @@ public interface FObject
   }
 
   /**
-   * Shortcut method to call translation service with context locale.language.
+   * Shortcut method to call translation service.
    *
-   * For example, when calling inside FObject
+   * Allow for abbreviating
    *
-   *    t(x, "source", "defaultText");
+   *    TranslationService ts = (TranslationService) x.get("translationService");
+   *    String locale = (String) x.get("locale.language");
+   *    String text = ts.getTranslation(locale, source, defaultText);
+   *
+   * by
+   *
+   *    String text = t(x, source, defaultText);
    *
    */
   default String t(X x, String source, String defaultText) {

--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -8,13 +8,11 @@ package foam.core;
 
 import foam.crypto.hash.Hashable;
 import foam.crypto.sign.Signable;
-import foam.i18n.TranslationService;
 import foam.lib.json.Outputter;
 import foam.nanos.logger.StdoutLogger;
-import foam.util.SafetyUtil;
 import foam.util.SecurityUtil;
+
 import java.security.*;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -620,32 +618,6 @@ public interface FObject
     throws UnsupportedOperationException
   {
     if ( isFrozen() ) throw new UnsupportedOperationException("Object is frozen.");
-  }
-
-  /**
-   * Shortcut method to call translation service.
-   *
-   * Allow for abbreviating
-   *
-   *    TranslationService ts = (TranslationService) x.get("translationService");
-   *    String locale = (String) x.get("locale.language");
-   *    String text = ts.getTranslation(locale, source, defaultText);
-   *
-   * by
-   *
-   *    String text = t(x, source, defaultText);
-   *
-   */
-  default String t(X x, String source, String defaultText) {
-    if ( x == null ) return defaultText;
-
-    var ts = (TranslationService) x.get("translationService");
-    if ( ts == null ) return defaultText;
-
-    var locale = (String) x.get("locale.language");
-    if ( SafetyUtil.isEmpty(locale) ) locale = "en";
-
-    return ts.getTranslation(locale, source, defaultText);
   }
 
   default String toSummary() {

--- a/src/foam/i18n/TranslationService.js
+++ b/src/foam/i18n/TranslationService.js
@@ -37,5 +37,26 @@ foam.INTERFACE({
       ],
       type: 'String'
     }
+  ],
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.methods.push(`
+          static String t(foam.core.X x, String source, String defaultText) {
+            if ( x == null ) return defaultText;
+
+            var ts = (TranslationService) x.get("translationService");
+            if ( ts == null ) return defaultText;
+
+            var locale = (String) x.get("locale.language");
+            if ( foam.util.SafetyUtil.isEmpty(locale) ) locale = "en";
+
+            return ts.getTranslation(locale, source, defaultText);
+          }
+        `);
+      }
+    }
   ]
 });

--- a/src/foam/nanos/approval/ApprovalRequestClassification.js
+++ b/src/foam/nanos/approval/ApprovalRequestClassification.js
@@ -12,12 +12,6 @@
     'translationService'
   ],
 
-  javaImports:[
-    'foam.i18n.TranslationService',
-    'foam.nanos.auth.Subject',
-    'foam.nanos.auth.User'
-  ],
-
   properties: [
     {
       class: 'String',
@@ -41,10 +35,7 @@
         return this.translationService.getTranslation(foam.locale, this.id + ".name", this.name);
       },
       javaCode: `
-        TranslationService ts = (TranslationService) getX().get("translationService");
-        Subject subject = (Subject) getX().get("subject");
-        String locale = (String) getX().get("foam.nanos.auth.LocaleSupport.CONTEXT_KEY");
-        return ts.getTranslation(locale, getId() + ".name", getName());
+        return t(getX(), getId() + ".name", getName());
       `
     }
   ]

--- a/src/foam/nanos/approval/ApprovalRequestClassification.js
+++ b/src/foam/nanos/approval/ApprovalRequestClassification.js
@@ -12,6 +12,10 @@
     'translationService'
   ],
 
+  javaImports: [
+    'static foam.i18n.TranslationService.t'
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate.js
+++ b/src/foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate.js
@@ -18,6 +18,7 @@ foam.CLASS({
     'foam.core.ContextAgent',
     'foam.core.X',
     'foam.dao.DAO',
+    'static foam.i18n.TranslationService.t',
     'foam.nanos.auth.User',
     'foam.nanos.auth.Subject',
     'foam.nanos.crunch.TopLevelCapabilityStatusUpdateNotification',

--- a/src/foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate.js
+++ b/src/foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate.js
@@ -18,7 +18,6 @@ foam.CLASS({
     'foam.core.ContextAgent',
     'foam.core.X',
     'foam.dao.DAO',
-    'foam.i18n.TranslationService',
     'foam.nanos.auth.User',
     'foam.nanos.auth.Subject',
     'foam.nanos.crunch.TopLevelCapabilityStatusUpdateNotification',
@@ -47,10 +46,8 @@ foam.CLASS({
 
           User user = (User) subject.getRealUser();
 
-          TranslationService ts = (TranslationService) x.get("translationService");
-          String locale = user.getLanguage().getCode().toString();
-          String capabilityName = ts.getTranslation(locale, cap.getId() + ".name", cap.getName());
-          String junctionStatus = ts.getTranslation(locale, "foam.nanos.crunch.CapabilityJunctionStatus." + junction.getStatus().getName() + ".label", junction.getStatus().getLabel());
+          String capabilityName = t(x, cap.getId() + ".name", cap.getName());
+          String junctionStatus = t(x, "foam.nanos.crunch.CapabilityJunctionStatus." + junction.getStatus().getName() + ".label", junction.getStatus().getLabel());
 
           HashMap<String, Object> args = new HashMap<>();
           args.put("capNameEn", cap.getName());

--- a/src/foam/nanos/crunch/TopLevelCapabilityStatusUpdateNotification.js
+++ b/src/foam/nanos/crunch/TopLevelCapabilityStatusUpdateNotification.js
@@ -17,12 +17,6 @@ foam.CLASS({
     'translationService'
   ],
 
-  javaImports: [
-    'foam.i18n.TranslationService',
-     'foam.nanos.auth.Subject',
-     'foam.nanos.auth.User'
-  ],
-
   properties: [
     {
       class: 'String',
@@ -44,14 +38,11 @@ foam.CLASS({
       name: 'body',
       transient: true,
       javaGetter: `
-        Subject subject = (foam.nanos.auth.Subject) foam.core.XLocator.get().get("subject");
-        String locale = ((foam.nanos.auth.User) subject.getRealUser()).getLanguage().getCode().toString();
-        TranslationService ts = (TranslationService) foam.core.XLocator.get().get("translationService");
-
-        String t1 = ts.getTranslation(locale, getClassInfo().getId()+ ".NOTIFICATION_BODY_P1", this.NOTIFICATION_BODY_P1);
-        String capName = ts.getTranslation(locale, getCapabilitySource(), getCapabilityName());
-        String t2 = ts.getTranslation(locale, getClassInfo().getId()+ ".NOTIFICATION_BODY_P2", this.NOTIFICATION_BODY_P2) + getJunctionStatus();
-        String status = ts.getTranslation(locale, getJunctionSource(), getJunctionStatus());
+        var x = foam.core.XLocator.get();
+        String t1 = t(x, getClassInfo().getId()+ ".NOTIFICATION_BODY_P1", this.NOTIFICATION_BODY_P1);
+        String capName = t(x, getCapabilitySource(), getCapabilityName());
+        String t2 = t(x, getClassInfo().getId()+ ".NOTIFICATION_BODY_P2", this.NOTIFICATION_BODY_P2) + getJunctionStatus();
+        String status = t(x, getJunctionSource(), getJunctionStatus());
 
         return t1 + capName + t2 + status;
       `,

--- a/src/foam/nanos/crunch/TopLevelCapabilityStatusUpdateNotification.js
+++ b/src/foam/nanos/crunch/TopLevelCapabilityStatusUpdateNotification.js
@@ -17,6 +17,10 @@ foam.CLASS({
     'translationService'
   ],
 
+  javaImports: [
+    'static foam.i18n.TranslationService.t'
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
@@ -22,7 +22,6 @@ foam.CLASS({
     'foam.comics.v2.userfeedback.UserFeedback',
     'foam.comics.v2.userfeedback.UserFeedbackException',
     'foam.comics.v2.userfeedback.UserFeedbackStatus',
-    'foam.i18n.TranslationService',
     'foam.nanos.approval.Approvable',
     'foam.nanos.approval.ApprovalRequest',
     'foam.nanos.approval.ApprovalStatus',
@@ -156,11 +155,8 @@ foam.CLASS({
                   .setIsUsingNestedJournal(true)
                   .setPropertiesToUpdate(propertiesToApprove).build());
 
-                TranslationService ts = (TranslationService) x.get("translationService");
-                Subject subject = (Subject) x.get("subject");
-                String locale = ((User) subject.getRealUser()).getLanguage().getCode().toString();
-                String capName = ts.getTranslation(locale, capability.getId() + ".name", capability.getName());
-                String objName = ts.getTranslation(locale, obj.getClass().getName() + ".name", obj.getClassInfo().getObjClass().getSimpleName());
+                String capName = t(x, capability.getId() + ".name", capability.getName());
+                String objName = t(x, obj.getClass().getName() + ".name", obj.getClassInfo().getObjClass().getSimpleName());
 
                 ApprovalRequest approvalRequest = new ApprovalRequest.Builder(getX())
                   .setDaoKey("approvableDAO")

--- a/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableCreateApprovalsRuleAction.js
@@ -22,6 +22,7 @@ foam.CLASS({
     'foam.comics.v2.userfeedback.UserFeedback',
     'foam.comics.v2.userfeedback.UserFeedbackException',
     'foam.comics.v2.userfeedback.UserFeedbackStatus',
+    'static foam.i18n.TranslationService.t',
     'foam.nanos.approval.Approvable',
     'foam.nanos.approval.ApprovalRequest',
     'foam.nanos.approval.ApprovalStatus',


### PR DESCRIPTION
Allow for abbreviating
```
TranslationService ts = (TranslationService) x.get("translationService");
String locale = (String) x.get("locale.language");
String text = ts.getTranslation(locale, source, defaultText);
```
by
```
String text = t(x, source, defaultText);
```