### PR TITLE
Fix session not being applied after restart

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -229,6 +229,7 @@ public class AuthWebAgent
             session.setId(saved.getId());
           }
         }
+        session.setContext(session.applyTo(x));
         session.touch();
 
         try {


### PR DESCRIPTION
Currently affected DIG request with a long-term sessionId as the session context doesn't have a subject after restart.