### PR TITLE
Medusa NERF Updates

### DIFF
--- a/src/foam/nanos/medusa/ClusterConfigReplayDAO.js
+++ b/src/foam/nanos/medusa/ClusterConfigReplayDAO.js
@@ -55,17 +55,14 @@ foam.CLASS({
 
         ClusterConfig config = nu;
 
-        // replay from NODE to zone and zone + 1
+        // Replay from Node to Mediator in zone, zone+1
+        // REVIEW: can't replay from mediator as data is 'cleaned'
+        // Need NERF replay from Mediators for bootstrap indexes.
         if (
             ( config.getType() == MedusaType.NODE &&
-              ( ( myConfig.getType() == MedusaType.MEDIATOR &&
-                  config.getZone() == myConfig.getZone() ) ||
-                ( myConfig.getType() == MedusaType.NERF &&
-                  ( config.getZone() == myConfig.getZone() ||
-                    config.getZone() == myConfig.getZone() -1 ) ) ) ) ||
-
-              // replay from MEDIATOR to get Bootstrap indexes
-            ( config.getType() == MedusaType.MEDIATOR &&
+              myConfig.getType() == MedusaType.MEDIATOR &&
+              config.getZone() == myConfig.getZone() )  ||
+            ( config.getType() == MedusaType.NODE &&
               myConfig.getType() == MedusaType.NERF &&
               config.getZone() == myConfig.getZone() -1 )
           ) {
@@ -137,28 +134,28 @@ foam.CLASS({
             }
 
             // Detect baseline - no data.
-            // Have to check almost all nodes.
-            int online = 0;
-            List<ClusterConfig> nodes = support.getReplayNodes();
-            for ( ClusterConfig cfg : nodes ) {
-              if ( cfg.getStatus() == Status.ONLINE ) online++;
-            }
-            logger.debug("test for baseline", "online", online, "nodes", ( nodes.size() - ( support.getNodeQuorum() - 1 ) ), "index", replaying.getIndex(), "replayingIndex", replaying.getReplayIndex());
-            if ( online >= ( nodes.size() - ( support.getNodeQuorum() - 1 ) ) ) {
-              // found enough online nodes, now test if all reporting zero index.
-              if ( replaying.getIndex() >= replaying.getReplayIndex() &&
-                 ( myConfig.getType() == MedusaType.MEDIATOR &&
-                   support.getHasNodeQuorum() ) ||
-                 ( myConfig.getType() == MedusaType.NERF &&
-                   support.getHasMediatorQuorum() ) ) {
-                logger.info("baseline dectected");
-                replaying.updateIndex(x, dagger.getGlobalIndex(x));
-                replaying.setReplayIndex(replaying.getIndex());
-                ((DAO) x.get("medusaEntryMediatorDAO")).cmd(new ReplayCompleteCmd());
+            // TODO: NERF baseline detection.
+            if ( myConfig.getType() == MedusaType.MEDIATOR ||
+                 myConfig.getType() == MedusaType.NERF ) {
+              // Have to check almost all nodes.
+              int online = 0;
+              List<ClusterConfig> nodes = support.getReplayNodes();
+              for ( ClusterConfig cfg : nodes ) {
+                if ( cfg.getStatus() == Status.ONLINE ) online++;
+              }
+              logger.debug("test for baseline", "online", online, "nodes", ( nodes.size() - ( support.getNodeQuorum() - 1 ) ), "index", replaying.getIndex(), "replayingIndex", replaying.getReplayIndex());
+              if ( online >= ( nodes.size() - ( support.getNodeQuorum() - 1 ) ) ) {
+                // found enough online nodes, now test if all reporting zero index.
+                if ( replaying.getIndex() >= replaying.getReplayIndex() &&
+                     support.getHasNodeQuorum() ) {
+                  logger.info("baseline dectected");
+                  replaying.updateIndex(x, dagger.getGlobalIndex(x));
+                  replaying.setReplayIndex(replaying.getIndex());
+                  ((DAO) x.get("medusaEntryMediatorDAO")).cmd(new ReplayCompleteCmd());
+                }
               }
             }
           }
-
           if ( details.getMaxIndex() >= minIndex ) {
             ReplayCmd cmd = new ReplayCmd();
             details = (ReplayDetailsCmd) details.fclone();

--- a/src/foam/nanos/medusa/ClusterConfigStatusDAO.js
+++ b/src/foam/nanos/medusa/ClusterConfigStatusDAO.js
@@ -270,7 +270,8 @@ foam.CLASS({
       javaCode: `
       ClusterConfigSupport support = (ClusterConfigSupport) getX().get("clusterConfigSupport");
       ClusterConfig config = support.getConfig(x, support.getConfigId());
-      if ( config.getStatus() == Status.ONLINE ) {
+      if ( support.canVote(x, config) &&
+           config.getStatus() == Status.ONLINE ) {
         try {
           support.getPrimary(x);
         } catch (MultiplePrimariesException e) {

--- a/src/foam/nanos/medusa/CompactionDAO.js
+++ b/src/foam/nanos/medusa/CompactionDAO.js
@@ -764,17 +764,16 @@ TODO: handle node roll failure - or timeout
              return;
           }
 
-          DAO mdao = (DAO) support.getMdao(x, entry.getNSpecName());
-          // Object nspec = x.get(entry.getNSpecName());
-          //  if ( nspec == null ) {
-          //   logger.warning("NSpec not found", entry.getNSpecName());
-          //   return;
-          // }
-          // if ( ! ( nspec instanceof DAO ) ) {
-          //   logger.warning("NSpec not DAO", entry.getNSpecName());
-          //   return;
-          // }
-          // DAO mdao = (DAO) support.getMdao(x, entry.getNSpecName());
+          DAO mdao = null;
+          try {
+            mdao = (DAO) support.getMdao(x, entry.getNSpecName());
+          } catch (IllegalArgumentException e) {
+            logger.warning(e.getMessage());
+            // Don't throw, the caller can decide if compaction should
+            // be aborted. It is not uncommon for a service entry to
+            // be removed.
+            return;
+          }
           FObject found = mdao.find(entry.getObjectId());
           if ( found == null ) {
             if ( entry.getDop().equals(DOP.REMOVE) ) {

--- a/src/foam/nanos/medusa/DefaultDaggerService.js
+++ b/src/foam/nanos/medusa/DefaultDaggerService.js
@@ -158,9 +158,10 @@ foam.CLASS({
 
       ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
       ClusterConfig config = support.getConfig(x, support.getConfigId());
+      // TODO/REVIEW: Presently NERF requires Dagger, restricting to zone 0 and 1, here and in reconfigure
       if ( config == null ||
            config.getType() == MedusaType.NODE ||
-           config.getZone() > 0L ) {
+           config.getZone() > 1L ) {
         logger.debug("start", "exit");
       }
 
@@ -195,7 +196,7 @@ foam.CLASS({
       ClusterConfig config = support.getConfig(x, support.getConfigId());
       if ( config == null ||
            config.getType() == MedusaType.NODE ||
-           config.getZone() > 0L ) {
+           config.getZone() > 1L ) {
         logger.debug("exit");
         return bootstrap;
       }

--- a/src/foam/nanos/medusa/ReplayMediatorDAO.js
+++ b/src/foam/nanos/medusa/ReplayMediatorDAO.js
@@ -9,7 +9,9 @@ foam.CLASS({
   name: 'ReplayMediatorDAO',
   extends: 'foam.dao.ProxyDAO',
 
-  documentation: `Response to ReplayCmd on Mediators`,
+  documentation: `Response to ReplayCmd on Mediators.
+NOTE: Only replay bootstrap as all other entries may have
+been 'cleaned' (data removed).`,
 
   javaImports: [
     'foam.core.FObject',

--- a/src/foam/nanos/medusa/ReplayMediatorDAO.js
+++ b/src/foam/nanos/medusa/ReplayMediatorDAO.js
@@ -10,7 +10,7 @@ foam.CLASS({
   extends: 'foam.dao.ProxyDAO',
 
   documentation: `Response to ReplayCmd on Mediators.
-NOTE: Only replay bootstrap as all other entries may have
+TODO: Only replay bootstrap as all other entries may have
 been 'cleaned' (data removed).`,
 
   javaImports: [


### PR DESCRIPTION
Replaying to NERF instances has changed.  Previously NERF would replay from Mediators, now, they must replay from Nodes.
Mediators 'clean' older MedusaEntry entries, removing the 'data' values. The data is required for hash calculation, as a result NERF cannot perform consensus on data replayed from Mediators.  
This PR reconfigures things such that zone 1 NERF instances replay from Nodes.  
But post replay updates are pushed (broadcast) by the zone 0 mediators (as before).  
