### PR TITLE
MedusaFormatter

### DIFF
--- a/src/foam/box/sf/SF.js
+++ b/src/foam/box/sf/SF.js
@@ -29,7 +29,6 @@ foam.CLASS({
     'foam.lib.json.Outputter',
     'foam.lib.json.OutputterMode',
     'foam.lib.NetworkPropertyPredicate',
-    'foam.lib.formatter.JSONFObjectFormatter',
     'foam.lib.StoragePropertyPredicate',
     'foam.log.LogLevel',
     'foam.nanos.er.EventRecord',

--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -17,7 +17,6 @@ foam.CLASS({
     'foam.core.ProxyX',
     'foam.core.X',
     'foam.core.AbstractFObjectPropertyInfo',
-    'foam.lib.formatter.FObjectFormatter',
     'foam.lib.formatter.JSONFObjectFormatter',
     'foam.lib.json.ExprParser',
     'foam.lib.json.JSONParser',
@@ -66,14 +65,15 @@ foam.CLASS({
     protected static ThreadLocal<JSONFObjectFormatter> formatter = new ThreadLocal<JSONFObjectFormatter>() {
       @Override
       protected JSONFObjectFormatter initialValue() {
-        return new JSONFObjectFormatter();
+        JSONFObjectFormatter b = new JSONFObjectFormatter();
+        b.setPropertyPredicate(new StoragePropertyPredicate());
+        b.setOutputShortNames(true);
+        return b;
       }
       @Override
       public JSONFObjectFormatter get() {
         JSONFObjectFormatter b = super.get();
         b.reset();
-        b.setPropertyPredicate(new StoragePropertyPredicate());
-        b.setOutputShortNames(true);
         return b;
       }
     };

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2023 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.lib.formatter.test',
+  name: 'JSONFObjectFormatterParserTest',
+  extends: 'foam.nanos.test.Test',
+
+  documentation: 'Test formatting and parsing json',
+
+  javaImports: [
+    'foam.lib.formatter.JSONFObjectFormatter',
+    'foam.lib.json.JSONParser',
+    'foam.util.SafetyUtil'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+
+      JSONFObjectFormatter formatter = null;
+      JSONParser parser = null;
+      String json = null;
+      String testId = null;
+
+      // Test output and parsing of fobject with predicate TRUE/FALSE.
+      // The TRUE/FALSE predicate only outputs it's default class name
+
+      // This combination should produce invalid json.
+      // Setting OutputDefaultClassNames(false) will set OutputDefaultValues(false)
+      // but this test case explicitly setOutputDefaultValues(true)
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:true";
+      formatter = new JSONFObjectFormatter();
+      formatter.setOutputDefaultClassNames(false);
+      formatter.setOutputDefaultValues(true);
+      var rg = new foam.nanos.ruler.RuleGroup();
+      rg.setId(this.getClass().getSimpleName());
+      // predicate defaults to TRUE
+      formatter.output(rg);
+      json = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(json) && json.contains(":,"), testId+" INVALID json generated "+json.toString());
+      parser = new JSONParser();
+      try {
+        Object o = parser.parseString(json);
+        test ( o == null, testId+" json NOT parsed");
+      } catch ( Throwable t ) {
+        // Should fail parsing, but not through exception
+        test ( false, testId+" Error parsing: "+t.getMessage());
+      }
+
+      testId = "OutputDefaultClassNames:true-OutputDefaultValues:true";
+      formatter = new JSONFObjectFormatter();
+      // formatter.setOutputDefaultClassNames(true); - default
+      formatter.setOutputDefaultValues(true);
+      rg = new foam.nanos.ruler.RuleGroup();
+      rg.setId(this.getClass().getSimpleName());
+      // predicate defaults to TRUE
+      formatter.output(rg);
+      json = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
+      parser = new JSONParser();
+      try {
+        Object o = parser.parseString(json);
+        test ( o != null, testId+" json parsed");
+      } catch ( Throwable t ) {
+        test ( false, testId+" Error parsing: "+t.getMessage());
+      }
+
+      testId = "OutputDefaultClassNames:true-OutputDefaultValues:false";
+      formatter = new JSONFObjectFormatter();
+      // formatter.setOutputDefaultClassNames(true); - default
+      // formatter.setOutputDefaultValues(false); - default
+      rg = new foam.nanos.ruler.RuleGroup();
+      rg.setId(this.getClass().getSimpleName());
+      // predicate defaults to TRUE
+      formatter.output(rg);
+      json = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
+      parser = new JSONParser();
+      try {
+        Object o = parser.parseString(json);
+        test ( o != null, testId+" json parsed");
+      } catch ( Throwable t ) {
+        test ( false, testId+" Error parsing: "+t.getMessage());
+      }
+
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:false";
+      formatter = new JSONFObjectFormatter();
+      formatter.setOutputDefaultClassNames(false);
+      // formatter.setOutputDefaultValues(false); - default
+      rg = new foam.nanos.ruler.RuleGroup();
+      rg.setId(this.getClass().getSimpleName());
+      // predicate defaults to TRUE
+      formatter.output(rg);
+      json = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
+      parser = new JSONParser();
+      try {
+        Object o = parser.parseString(json);
+        test ( o != null, testId+" json parsed");
+      } catch ( Throwable t ) {
+        test ( false, testId+" Error parsing: "+t.getMessage());
+      }
+      `
+    }
+  ]
+})

--- a/src/foam/lib/formatter/test/tests.jrl
+++ b/src/foam/lib/formatter/test/tests.jrl
@@ -1,0 +1,1 @@
+p({"class":"foam.lib.formatter.test.JSONFObjectFormatterParserTest","id":"JSONFObjectFormatterParserTest"})

--- a/src/foam/nanos/medusa/ClusterConfigSupport.js
+++ b/src/foam/nanos/medusa/ClusterConfigSupport.js
@@ -124,7 +124,7 @@ configuration for contacting the primary node.`,
       javaFactory: 'return new HashMap();',
       visibility: 'HIDDEN'
     },
-   {
+    {
       name: 'nodeBuckets',
       class: 'List',
       visibility: 'RO',

--- a/src/foam/nanos/medusa/MedusaConsensusDAO.js
+++ b/src/foam/nanos/medusa/MedusaConsensusDAO.js
@@ -446,10 +446,7 @@ This is the heart of Medusa.`,
               er.setResponseMessage(cause.getMessage());
               er.setClusterable(false);
               ((DAO) x.get("eventRecordDAO")).put(er);
-              if ( replaying.getReplaying() ) {
-                // report to log
-                getLogger().error("promoter", "Failed to parse", cause.getMessage(), entry.toSummary(), data, cause);
-              }
+              getLogger().error("promoter", "Error parsing", cause.getMessage(), entry.toSummary(), "data", data, cause);
               throw new MedusaException("Failed to parse", cause);
             }
 
@@ -458,6 +455,7 @@ This is the heart of Medusa.`,
               er.setRequestMessage(data);
               er.setClusterable(false);
               ((DAO) x.get("eventRecordDAO")).put(er);
+              getLogger().error("promoter", "Failed to parse", entry.toSummary(), "data", data);
               throw new MedusaException("Failed to parse");
             }
 
@@ -502,6 +500,7 @@ This is the heart of Medusa.`,
               er.setResponseMessage(cause.getMessage());
               er.setClusterable(false);
               ((DAO) x.get("eventRecordDAO")).put(er);
+              getLogger().error("promoter", "Error parsing", cause.getMessage(), entry.toSummary(), "transientData", entry.getTransientData(), cause);
               throw new MedusaException("Failed to parse.", cause);
             }
             if ( tran == null ) {

--- a/src/foam/nanos/medusa/MedusaEntrySupport.js
+++ b/src/foam/nanos/medusa/MedusaEntrySupport.js
@@ -27,7 +27,6 @@ foam.CLASS({
       protected JSONFObjectFormatter initialValue() {
         JSONFObjectFormatter formatter = new JSONFObjectFormatter();
         formatter.setOutputShortNames(true);
-        formatter.setCalculateDeltaForNestedFObjects(true);
         formatter.setPropertyPredicate(
           new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {
             new foam.lib.StoragePropertyPredicate(),
@@ -49,7 +48,6 @@ foam.CLASS({
       protected MedusaTransientJSONFObjectFormatter initialValue() {
         MedusaTransientJSONFObjectFormatter formatter = new MedusaTransientJSONFObjectFormatter();
         formatter.setOutputShortNames(true);
-        formatter.setCalculateDeltaForNestedFObjects(true);
         return formatter;
       }
 

--- a/src/foam/nanos/medusa/MedusaEntrySupport.js
+++ b/src/foam/nanos/medusa/MedusaEntrySupport.js
@@ -27,7 +27,6 @@ foam.CLASS({
       protected JSONFObjectFormatter initialValue() {
         JSONFObjectFormatter formatter = new JSONFObjectFormatter();
         formatter.setOutputShortNames(true);
-        formatter.setOutputDefaultClassNames(false);
         formatter.setCalculateDeltaForNestedFObjects(true);
         formatter.setPropertyPredicate(
           new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {
@@ -50,7 +49,6 @@ foam.CLASS({
       protected MedusaTransientJSONFObjectFormatter initialValue() {
         MedusaTransientJSONFObjectFormatter formatter = new MedusaTransientJSONFObjectFormatter();
         formatter.setOutputShortNames(true);
-        formatter.setOutputDefaultClassNames(false);
         formatter.setCalculateDeltaForNestedFObjects(true);
         return formatter;
       }

--- a/src/foam/nanos/medusa/test/MedusaEntryParseFormatTest.js
+++ b/src/foam/nanos/medusa/test/MedusaEntryParseFormatTest.js
@@ -26,7 +26,7 @@ foam.CLASS({
       @Override
       protected foam.lib.formatter.JSONFObjectFormatter initialValue() {
         foam.lib.formatter.JSONFObjectFormatter formatter = new foam.lib.formatter.JSONFObjectFormatter();
-        formatter.setQuoteKeys(true);
+        formatter.setOutputShortNames(true);
         formatter.setPropertyPredicate(new foam.lib.ClusterPropertyPredicate());
         return formatter;
       }
@@ -161,6 +161,17 @@ foam.CLASS({
       test ( entry != null, "MedusaEntry (update) deserialized");
 
       validate(entry, true);
+
+      // test an object with a predicate
+      String json = entrySupport.data(x, new foam.nanos.ruler.RuleGroup.Builder(x).setId("id").build(), null, DOP.PUT);
+      test ( ! json.contains(":,"), "valid json "+json);
+      JSONParser parser = parser_.get();
+      try {
+        Object o = parser.parseString(json);
+        test ( o != null, "json parsed");
+      } catch ( Throwable t ) {
+        test ( false, "Error parsing: "+t.getMessage());
+      }
       `
     },
     {

--- a/src/pom.js
+++ b/src/pom.js
@@ -860,6 +860,7 @@ foam.POM({
     { name: "foam/lib/StorageOptionalPropertyPredicate",              flags: "js|java" },
     { name: "foam/lib/StoragePropertyPredicate",                      flags: "js|java" },
     { name: "foam/lib/AndPropertyPredicate",                          flags: "js|java" },
+    { name: "foam/lib/formatter/test/JSONFObjectFormatterParserTest", flags: "js|java"},
     { name: "foam/lib/json/JSONParser",                               flags: "js|java" },
     { name: "foam/lib/json/OutputterMode",                            flags: "js|java" },
     { name: "foam/lib/json/ClassReferenceParserTest",                 flags: "js|java" },


### PR DESCRIPTION
JSONFObjectFormatter outputDefaultClassNames behaviour has changed. Can no longer disable, else output of nested FObjects such as predicates are invalid - producing predicate:, rather than predicate:{class:foam.mlang.MLang.TRUE} - for example.
Unable to determined what changed. 