### PR TITLE
CronSchedule - change getNextScheduledTime to use current time of day

### DIFF
--- a/src/foam/nanos/cron/CronSchedule.js
+++ b/src/foam/nanos/cron/CronSchedule.js
@@ -249,7 +249,7 @@ foam.CLASS({
 
       LocalDateTime last = null;
       if ( from == null ) {
-        last = LocalDate.now(zone).atStartOfDay();
+        last = LocalDateTime.now(zone);
       } else {
         last = LocalDateTime.ofInstant(from.toInstant(), zone);
       }

--- a/src/foam/nanos/cron/test/CronScheduleTest.js
+++ b/src/foam/nanos/cron/test/CronScheduleTest.js
@@ -24,6 +24,9 @@ foam.CLASS({
       // default cron should run every minute at the second the first
       // schedule is created
       CronSchedule sched = new CronSchedule();
+      var startOfDayTime = LocalDate.ofInstant(new Date().toInstant(), ZoneOffset.UTC).atStartOfDay();
+      Date startOfDayDate = Date.from(startOfDayTime.atZone(ZoneOffset.UTC).toInstant());
+
       Date last = sched.getNextScheduledTime(x, null);
       LocalDateTime lastTime = LocalDateTime.ofInstant(last.toInstant(), ZoneOffset.UTC);
       Date next = sched.getNextScheduledTime(x, last);
@@ -51,12 +54,14 @@ foam.CLASS({
       // hours
       sched = new CronSchedule();
       sched.setHours("23,1");
-      last = sched.getNextScheduledTime(x, null);
+      last = sched.getNextScheduledTime(x, startOfDayDate);
       lastTime = LocalDateTime.ofInstant(last.toInstant(), ZoneOffset.UTC);
+      diff = ChronoUnit.HOURS.between(startOfDayTime, lastTime);
+      test ( diff == 1, "Hour {23, 1} same day. diff: "+diff+" last: "+startOfDayTime.toString()+ " next: "+lastTime.toString() );
       next = sched.getNextScheduledTime(x, last);
       nextTime = LocalDateTime.ofInstant(next.toInstant(), ZoneOffset.UTC);
       diff = ChronoUnit.HOURS.between(lastTime, nextTime);
-      test ( diff == 22, "Hour {23, 1} same day. diff: "+diff+" last: "+lastTime.toString()+ " next: "+nextTime.toString() );
+      test ( diff == 22, "Hour {23, 1} next same day. diff: "+diff+" last: "+lastTime.toString()+ " next: "+nextTime.toString() );
 
       next = sched.getNextScheduledTime(x, next);
       nextTime = LocalDateTime.ofInstant(next.toInstant(), ZoneOffset.UTC);


### PR DESCRIPTION
CronSchedule - change getNextScheduledTime to use current time of day rather than start of day, when lastRunDate is null.

getNextScheduledTime calculates the next time to run a cron job. The 'next' time follows the 'lastRunDate'.
Cron.lastRunDate is storageTransient to avoid journal entries for every cron job run. After system start, all 'lastRunDate' values are null, and the first call to getNextScheduledTime has to select a suitable 'from' date to perform calculations.  Hitherto this value was now.startofday (0:00).  In a Medusa cluster when the Primary changes, the new Primary's table of cron jobs still has null for all lastRunDate properties (as this value is also not clustered - see StorageOptional). As a result the new Primary getNextScheduledTime calls will calculate from startofday, which is incorrect and results in cron jobs running twice in one day, for example. Changing the default 'from' time to the current time of day resolves this issue. Only the hour test case required adjustment as it assumed the initial 'from' time was start of day. All other 24 test cases passed without adjustment. Note that it was the behaviour for an instant to run all jobs for the day regardless of when it was started.  It is not the responsibility of the operator to verify and manually run any jobs which should have run earlier than when the server started.