### PR TITLE
build support to control log level during test and benchmark runs. Of…

### DIFF
--- a/src/foam/nanos/script/TestRunnerScript.js
+++ b/src/foam/nanos/script/TestRunnerScript.js
@@ -12,6 +12,7 @@ foam.CLASS({
   javaImports: [
     'foam.dao.DAO',
     'foam.dao.ArraySink',
+    'foam.log.LogLevel',
     'foam.nanos.script.Language',
     'foam.nanos.script.TestRunnerConfig',
     'foam.nanos.test.Test',
@@ -77,9 +78,16 @@ foam.CLASS({
 
         // turn off logging to get rid of clutter.
         LogLevelFilterLogger loggerFilter = (LogLevelFilterLogger) x.get("logger");
-        loggerFilter.setLogDebug(false);
-        loggerFilter.setLogInfo(false);
-        loggerFilter.setLogWarning(false);
+        LogLevel logLevel = LogLevel.valueOf(System.getProperty("log.level", "ERROR"));
+        if ( logLevel.getOrdinal() <= LogLevel.DEBUG.getOrdinal() ) {
+          loggerFilter.setLogDebug(true);
+        }
+        if ( logLevel.getOrdinal() <= LogLevel.INFO.getOrdinal() ) {
+          loggerFilter.setLogInfo(true);
+        }
+        if ( logLevel.getOrdinal() <= LogLevel.WARN.getOrdinal() ) {
+          loggerFilter.setLogWarning(true);
+        }
 
         String testSuite = null;
         TestRunnerConfig config = (TestRunnerConfig) x.get("testRunnerConfig");

--- a/tools/build.js
+++ b/tools/build.js
@@ -94,6 +94,7 @@ var
   HOST_NAME                 = 'localhost',
   INSTANCE                  = 'localhost',
   JOURNAL_CONFIG            = '',
+  LOG_LEVEL                 = null,
   MODE                      = '',
   PACKAGE                   = false,
   POM                       = 'pom',
@@ -505,6 +506,10 @@ task('Start NANOS application server.', [ 'setenv' ], function startNanos() {
     CLASSPATH = `${BUILD_DIR}/lib/\*:${BUILD_DIR}/classes/java/main`;
 
     if ( TEST || BENCHMARK ) {
+      if ( LOG_LEVEL ) {
+        JAVA_OPTS = ` -Dlog.level=${LOG_LEVEL} ${JAVA_OPTS}`;
+      }
+
       JAVA_OPTS += ' -Dresource.journals.dir=journals';
       JAVA_OPTS += ' -DRES_JAR_HOME=' + JAR_OUT;
 
@@ -680,7 +685,10 @@ function moreUsage() {
 }
 
 const ARGS = {
-  a: [ 'turn on verbose mode', () => VERBOSE = '-flags=verbose' ],
+  a: [ 'turn on build verbose mode', () => VERBOSE = '-flags=verbose' ],
+  A: [ 'in combination with tTbB, set JVM log level (one of: ERROR, WARN, INFO, DEBUG)',
+       args => { ARGS.a[1]; LOG_LEVEL = args; }
+     ],
   b: [ 'run all benchmarks.',
     () => {
       BENCHMARK = true;

--- a/tools/build.js
+++ b/tools/build.js
@@ -687,7 +687,7 @@ function moreUsage() {
 const ARGS = {
   a: [ 'turn on build verbose mode', () => VERBOSE = '-flags=verbose' ],
   A: [ 'in combination with tTbB, set JVM log level (one of: ERROR, WARN, INFO, DEBUG)',
-       args => { ARGS.a[1]; LOG_LEVEL = args; }
+       args => { LOG_LEVEL = args; }
      ],
   b: [ 'run all benchmarks.',
     () => {

--- a/tools/build.js
+++ b/tools/build.js
@@ -685,10 +685,8 @@ function moreUsage() {
 }
 
 const ARGS = {
-  a: [ 'turn on build verbose mode', () => VERBOSE = '-flags=verbose' ],
-  A: [ 'in combination with tTbB, set JVM log level (one of: ERROR, WARN, INFO, DEBUG)',
-       args => { LOG_LEVEL = args; }
-     ],
+  a: [ 'Delete runtime logs.',
+    () => DELETE_RUNTIME_LOGS = true ],
   b: [ 'run all benchmarks.',
     () => {
       BENCHMARK = true;
@@ -727,8 +725,10 @@ const ARGS = {
     } ],
   k: [ 'Package up a deployment tarball.',
     () => { BUILD_ONLY = PACKAGE = true; } ],
-  l: [ 'Delete runtime logs.',
-    () => DELETE_RUNTIME_LOGS = true ],
+  l: [ 'turn on build logging/verbose mode', () => VERBOSE = '-flags=verbose' ],
+  L: [ 'in combination with tTbB, set JVM log level (one of: ERROR, WARN, INFO, DEBUG)',
+       args => { LOG_LEVEL = args; }
+     ],
   m: [ "Enable Medusa clustering. Not required for 'nodes'. Same as -Ctrue",
     () => CLUSTER = true ],
   N: [ `NAME : start another instance with given instance name. Deployed to /opt/${PROJECT.name}_NAME.`,


### PR DESCRIPTION
…ten while troubleshooting test cases themselves one needs more than ERROR level log reporting. 
Swapped with 'a', 'l' is now for verbose and 'L' argument will be passed to JVM as log.level