### PR TITLE
System to Load a medusa system from an existing non-medusa system

### DIFF
--- a/deployment/m/scripts.jrl
+++ b/deployment/m/scripts.jrl
@@ -36,3 +36,22 @@ try {
 }
   """
 })
+p({
+  class:"foam.nanos.script.Script",
+  id:"MedusaLoad",
+  description:"Initiate MedusaEntryDAO Loading",
+  code:"""
+import foam.nanos.medusa.LoadingAgent;
+try {
+  a = new LoadingAgent(x);
+  a.execute(x);
+  print("INFO: Loading complete. System OK");
+} catch (IllegalStateException e) {
+  print(e.getMessage());
+  print("WARNING: Loading aborted. System OK");
+} catch (Throwable t) {
+  print(t.getMessage());
+  print("ERROR: Loading failed.  System OFFLINE. Intervention required.");
+}
+  """
+})

--- a/deployment/mm/compactions.jrl
+++ b/deployment/mm/compactions.jrl
@@ -4,11 +4,33 @@ p({
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "localAnalyticEventDAO"
+  nSpec: "alarmDAO",
+  loadable: false
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "analyticEventDAO"
+  nSpec: "localAlarmDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "localAnalyticEventDAO",
+  loadable: true
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "analyticEventDAO",
+  loadable: true
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "benchmarkResultDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "localBenchmarkResultDAO",
+  loadable: false
 })
 p({
   class: "foam.nanos.medusa.Compaction",
@@ -16,19 +38,46 @@ p({
 })
 p({
   class: "foam.nanos.medusa.Compaction",
+  nSpec: "capabilityPayloadRecordDAO"
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "cronJobEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec:  "localCronJobEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "CSPViolationsDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
   nSpec: "counterDAO"
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "localEmailMessageDAO"
+  nSpec: "localEmailMessageDAO",
+  loadable: true
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "emailMessageDAO"
+  nSpec: "emailMessageDAO",
+  loadable: true
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "eventRecordDAO"
+  nSpec: "eventRecordDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "localEventRecordDAO",
+  loadable: false
 })
 p({
   class: "foam.nanos.medusa.Compaction",
@@ -36,11 +85,17 @@ p({
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "localNotificationDAO"
+  nSpec: "monitorReportDAO"
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "notificationDAO"
+  nSpec: "localNotificationDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "notificationDAO",
+  loadable: false
 })
 p({
   class: "foam.nanos.medusa.Compaction",
@@ -56,11 +111,23 @@ p({
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "localSessionDAO"
+  nSpec: "scriptEventDAO",
+  loadable: false
 })
 p({
   class: "foam.nanos.medusa.Compaction",
-  nSpec: "sessionDAO"
+  nSpec: "localScriptEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "localSessionDAO",
+  loadable: false
+})
+p({
+  class: "foam.nanos.medusa.Compaction",
+  nSpec: "sessionDAO",
+  loadable: false
 })
 p({
   class: "foam.nanos.medusa.Compaction",

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -907,6 +907,7 @@ model from which to test ServiceProvider ID (spid)`,
             jdao.setFilename(getJournalName());
             jdao.setCluster(getCluster() && !getSAF());
             jdao.setWaitReplay(getWaitReplay());
+            // Setting of delegate must be last as it triggers replay
             jdao.setDelegate(delegate);
             delegate = jdao;
           }

--- a/src/foam/nanos/medusa/Compaction.js
+++ b/src/foam/nanos/medusa/Compaction.js
@@ -66,6 +66,25 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.dao.Sink',
       view: { class: 'foam.u2.view.JSONTextView' }
+    },
+    {
+      documentation: 'An nspec is eligible for reading into a medusa system for bootstrapping.',
+      name: 'loadable',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      documentation: 'Name for JDAO creation during loading. Default is best gues. Required when nspec has JDAO setup outside of EasyDAO.',
+      name: 'journalName',
+      class: 'String',
+      javaFactory: `
+      var name = getNSpec();
+      name = name.replace("DAO", "");
+      name = name.replace("local", "");
+      name = name.toLowerCase();
+      name = name + "s";
+      return name;
+      `
     }
   ]
 });

--- a/src/foam/nanos/medusa/CompactionDAO.js
+++ b/src/foam/nanos/medusa/CompactionDAO.js
@@ -732,7 +732,7 @@ TODO: handle node roll failure - or timeout
       name: 'NSpecSink',
       extends: 'foam.dao.ProxySink',
 
-      documentation: 'Creates new MedusaEntry for current Object',
+      documentation: `Creates new MedusaEntry for current Object. Consults Compaction entries to determine if this nspec should be compacted.`,
 
       javaCode: `
         public NSpecSink(X x, CompactionDAO self, ProxySink delegate) {
@@ -865,7 +865,7 @@ TODO: handle node roll failure - or timeout
       name: 'CompactibleSink',
       extends: 'foam.dao.ProxySink',
 
-      documentation: 'Skip entries which are not compactible',
+      documentation: 'Skip MedusaEntries which are not compactible:true. This is flag is seperate from the Compaction model which acts at the nspec level.',
 
       properties: [
         {

--- a/src/foam/nanos/medusa/LoadingAgent.js
+++ b/src/foam/nanos/medusa/LoadingAgent.js
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.medusa',
+  name: 'LoadingAgent',
+  implements: [ 'foam.core.ContextAgent',
+                  'foam.core.ContextAware' ],
+
+  documentation: `
+Requirement:
+Load a medusa system from an existing non-medusa system.
+Data residing in individual journals, replayed into mdaos, and then output as medusa entries to a ledger.
+
+Considerations:
+All but transactions can be loaded into their respective MDAO without side effects. Meaning, loading accounts for users that do not exist yet is viable.
+Transactions had additional requirements:
+All Transactions versions must be replayed as replay rebuilds associated account balances. This process has side effects, transaction replay validates both users and accounts.
+Future compaction requires all transaction versions are retained. Hithertoo this is accomplished via retaining the associated MedusaEntry for each.
+
+Process:
+Replay each file journal through a MedusaAdaptorDAO.
+Given any regularly configured medusa cluster, for each DAO nspec that has a journal, create a JDAO which delegates to MedusaAdapterDAO.  This feeds all 'put's from the journal into medusa as any other.
+`,
+
+  javaImports: [
+    'foam.core.X',
+    'foam.dao.ArraySink',
+    'foam.dao.DAO',
+    'foam.dao.EasyDAO',
+    'foam.dao.JournalType',
+    'foam.dao.ProxyDAO',
+    'foam.dao.java.JDAO',
+    'foam.log.LogLevel',
+    'foam.nanos.boot.NSpec',
+    'foam.nanos.er.EventRecord',
+    'foam.nanos.logger.Loggers',
+    'foam.nanos.logger.Logger',
+    'foam.nanos.medusa.MedusaAdapterDAO',
+    'foam.nanos.pm.PM',
+    'foam.util.SafetyUtil',
+    'foam.util.concurrent.AbstractAssembly',
+    'foam.util.concurrent.AssemblyLine',
+    'foam.util.concurrent.AsyncAssemblyLine',
+    'java.time.Duration',
+    'java.util.List',
+  ],
+
+  methods: [
+    {
+      name: 'execute',
+      args: 'X x',
+      javaCode: `
+      Logger logger = Loggers.logger(x, this, "execute");
+      ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+
+      ReplayingInfo replaying = (ReplayingInfo) x.get("replayingInfo");
+      if ( replaying.getReplaying() ) {
+        Loggers.logger(x, this, "cmd").warning("Load not allowed during replay");
+        throw new IllegalStateException("Load not allowed during Replay");
+      }
+
+      ClusterConfig config = support.getConfig(x, support.getConfigId());
+      if ( ! config.getIsPrimary() ) {
+        throw new IllegalStateException("Load not allowed from Secondaries");
+      }
+
+      long startTime = System.currentTimeMillis();
+      logger.info("start");
+      EventRecord er = (EventRecord) ((DAO) x.get("eventRecordDAO")).put(new EventRecord(x, "Medusa", "loading", "start")).fclone();
+      er.clearId();
+
+      try {
+        // system check
+        logger.info("health");
+        health(x);
+
+        // load
+        logger.info("load");
+        long loadTime = load(x);
+
+        logger.info("end");
+        er.setMessage("complete");
+        ((DAO) x.get("eventRecordDAO")).put(er);
+      } catch (Throwable t) {
+        er.setMessage(t.getMessage());
+        er.setSeverity(LogLevel.ERROR);
+        ((DAO) x.get("eventRecordDAO")).put(er);
+        throw t;
+      } finally {
+        logger.info("end", "duration", Duration.ofMillis(System.currentTimeMillis() - startTime));
+      }
+      `
+    },
+    {
+      documentation: 'System check - make sure all nodes and mediators are online',
+      name: 'health',
+      args: 'X x',
+      javaCode: `
+      Logger logger = Loggers.logger(x, this, "health");
+      ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+      DAO healthDAO = (DAO) x.get("healthDAO");
+
+      List<ClusterConfig> nodes = support.getReplayNodes();
+      for ( ClusterConfig cfg : nodes ) {
+        MedusaHealth health = (MedusaHealth) healthDAO.find(cfg.getId());
+        if ( health == null ||
+             health.getMedusaStatus() != Status.ONLINE ) {
+          logger.warning(cfg.getId(), "OFFLINE");
+          throw new IllegalStateException(cfg.getId()+" OFFLINE");
+        }
+      }
+
+      ClusterConfig[] mediators = support.getSfBroadcastMediators();
+      for ( ClusterConfig cfg : mediators ) {
+        MedusaHealth health = (MedusaHealth) healthDAO.find(cfg.getId());
+        if ( health == null ||
+             health.getMedusaStatus() != Status.ONLINE ) {
+          logger.warning(cfg.getId(), "OFFLINE");
+          throw new IllegalStateException(cfg.getId()+" OFFLINE");
+        }
+      }
+      `
+    },
+    {
+      name: 'load',
+      args: 'X x',
+      type: 'Long',
+      javaCode: `
+      final Logger logger = Loggers.logger(x, this, "loading");
+      logger.info("start");
+      final long startTime = System.currentTimeMillis();
+      ClusterConfigSupport support = (ClusterConfigSupport) x.get("clusterConfigSupport");
+      AssemblyLine line = new AsyncAssemblyLine(x, null, support.getThreadPoolName());
+      DAO serviceDAO = new JDAO(x, new foam.dao.MDAO(NSpec.getOwnClassInfo()), "services", false);
+      List<NSpec> services = (List) ((ArraySink) serviceDAO.select(new ArraySink())).getArray();
+      for ( NSpec service : services ) {
+        final EasyDAO easyDAO = getEasyDAO(x, service);
+        if ( easyDAO == null ) continue;
+
+        line.enqueue(new AbstractAssembly() {
+          public void executeJob() {
+            logger.info("load", "start", service.getId());
+            DAO delegate = null;
+            if ( easyDAO.getSAF() ) {
+              delegate = new foam.nanos.medusa.sf.SFBroadcastDAO.Builder(x)
+                .setNSpec(service)
+                .setDelegate(easyDAO.getLastDao())
+                .build();
+            } else {
+              // Use the nspec setup MedusaAdapterDAO if available
+              delegate = getMedusaAdapterDAO(x, easyDAO);
+              if ( delegate == null ) {
+                delegate = new MedusaAdapterDAO.Builder(x)
+                  .setNSpec(service)
+                  .setDelegate(easyDAO.getLastDao())
+                  .build();
+              }
+            }
+            JDAO jdao = new JDAO();
+            jdao.setX(x);
+            if ( SafetyUtil.isEmpty(easyDAO.getJournalName()) ) {
+              // handle custom nspecs with explicit jdao or clustering setup
+              Compaction compaction = (Compaction) ((DAO) x.get("compactionDAO")).find(service.getId());
+              if ( compaction != null &&
+                   ! SafetyUtil.isEmpty(compaction.getJournalName()) ) {
+                jdao.setFilename(compaction.getJournalName());
+              } else {
+                logger.warning("load", service.getId(), "JournalName not found");
+                return;
+              }
+            } else {
+              jdao.setFilename(easyDAO.getJournalName());
+            }
+            jdao.setReadOnly(true);
+            jdao.setRuntimeOnly(true);
+            // this will trigger replay
+            jdao.setDelegate(delegate);
+            logger.info("load", "end", service.getId());
+          }
+        });
+      }
+      logger.info("shutdown,wait");
+      line.shutdown();
+      logger.info("end");
+      return System.currentTimeMillis() - startTime;
+      `
+    },
+    {
+      name: 'getEasyDAO',
+      args: 'X x, NSpec service',
+      type: 'foam.dao.EasyDAO',
+      javaCode: `
+      Compaction compaction = (Compaction) ((DAO) x.get("compactionDAO")).find(service.getId());
+      if ( compaction != null &&
+           ! compaction.getLoadable() ) {
+        Loggers.logger(x, this).info("getEasyDAO", service.getId(), "not loadable");
+        return null;
+      }
+      if ( SafetyUtil.isEmpty(service.getServiceScript()) ) {
+        Loggers.logger(x, this).info("getEasyDAO", service.getId(), "no service script");
+        return null;
+      }
+      if ( ! service.getServiceScript().contains("EasyDAO") ) {
+        Loggers.logger(x, this).info("getEasyDAO", service.getId(), "not EasyDAO script");
+        return null;
+      }
+      if ( ! ( x.get(service.getId()) instanceof DAO ) ) {
+        Loggers.logger(x, this).info("getEasyDAO", service.getId(), "service not DAO");
+        return null;
+      }
+      DAO dao = (DAO) x.get(service.getId());
+      while ( dao != null ) {
+        if ( dao instanceof EasyDAO ) {
+          EasyDAO easyDAO = (EasyDAO) dao;
+          if ( easyDAO.getNullify() ) {
+            Loggers.logger(x, this).info("getEasyDAO", service.getId(), "nullify");
+            return null;
+          }
+          if ( ! easyDAO.getCluster() ) {
+            if ( ! service.getServiceScript().contains("MedusaAdapterDAO") ) {
+              // custom nspec may explicitly setup clustering
+              Loggers.logger(x, this).info("getEasyDAO", service.getId(), "not clustered");
+              return null;
+            }
+          }
+          if ( ! easyDAO.getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
+            if ( ! service.getServiceScript().contains("JDAO") ) {
+              // custom nspec may explicitly setup journalling
+              Loggers.logger(x, this).info("getEasyDAO", service.getId(), "no journal");
+              return null;
+            }
+          }
+          return easyDAO;
+        }
+        if ( dao instanceof ProxyDAO ) {
+          dao = ((ProxyDAO) dao).getDelegate();
+        } else {
+          break;
+        }
+      }
+      Loggers.logger(x, this).warning("getEasyDAO", service.getId(), "not found");
+      return null;
+      `
+    },
+    {
+      name: 'getMedusaAdapterDAO',
+      args: 'X x, DAO dao',
+      type: 'MedusaAdapterDAO',
+      javaCode: `
+      while ( dao != null ) {
+        if ( dao instanceof MedusaAdapterDAO ) {
+          return (MedusaAdapterDAO) dao;
+        }
+        if ( dao instanceof ProxyDAO ) {
+          dao = ((ProxyDAO) dao).getDelegate();
+        } else {
+          break;
+        }
+      }
+      return null;
+      `
+    },
+    {
+      name: 'getJDAO',
+      args: 'X x, DAO dao',
+      type: 'JDAO',
+      javaCode: `
+      while ( dao != null ) {
+        if ( dao instanceof JDAO ) {
+          return (JDAO) dao;
+        }
+        if ( dao instanceof ProxyDAO ) {
+          dao = ((ProxyDAO) dao).getDelegate();
+        } else {
+          break;
+        }
+      }
+      return null;
+      `
+    }
+  ]
+})

--- a/src/foam/nanos/medusa/pom.js
+++ b/src/foam/nanos/medusa/pom.js
@@ -66,6 +66,8 @@ foam.POM({
       flags: "js|java" },
     { name: "ElectoralServiceServer",
       flags: "js|java" },
+    { name: "LoadingAgent",
+      flags: "js|java" },
     { name: "MedusaEntryRefinement",
       flags: "js|java" },
     { name: "MedusaEntryNoRemoveDAO",


### PR DESCRIPTION
System to Load a medusa system from an existing non-medusa system with minimal downtime.

Data residing in individual journals, replayed into mdaos, and then output as medusa entries to a ledger.

**Considerations**:
All but transactions can be loaded into their respective MDAO without side effects. Meaning, loading accounts for users that do not exist yet is viable. Transactions had additional requirements:
All Transactions versions must be replayed as replay rebuilds associated account balances. This process has side effects, transaction replay validates both users and accounts. 
Future compaction requires all transaction versions are retained. Hitherto this is accomplished via retaining the associated MedusaEntry for each.

**Process**:
Replay each file journal through a MedusaAdaptorDAO. Given any regularly configured medusa cluster, for each DAO nspec that has a journal, create a JDAO which delegates to MedusaAdapterDAO.  This feeds all 'put's from the journal into medusa as any other.

**Using LoadingAgent**
From the primary of a completely ONLINE new medusa cluster 
2. copy all journals to be processed, except that of transactions, into the journal folder of the primary
3.   execute LoadingAgent
4.   remove all processed journals
5.   copy the transaction journal into th journal folder of the primary
6.   execute LoadingAgent
7.   remove the transactions journal
8.   No restart is required, the cluster is viable.