### PR TITLE
Suppress stacktrace when reporting exceptions thrown to client, and a…

### DIFF
--- a/src/foam/java/Skeleton.js
+++ b/src/foam/java/Skeleton.js
@@ -136,7 +136,7 @@ foam.CLASS({
           throw clientE;
         }
       }
-      ((foam.nanos.logger.Logger) getMessageX(message).get("logger")).debug("returning skeleton exception", t);
+      ((foam.nanos.logger.Logger) getMessageX(message).get("logger")).debug("returning skeleton exception", t.toString());
       // NOTE: this is required for SocketClientReplyBox to find the socket that this request arrived on.  The localAttributes 'x' does not have access to the socket.
       message.setX(getX());
       message.replyWithException(t);

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -104,7 +104,7 @@ foam.CLASS({
         try {
           authorizeAnonymous(x);
         } catch ( AuthorizationException e ) {
-          ((foam.nanos.logger.Logger) x.get("logger")).warning(e.getMessage());
+          foam.nanos.logger.Loggers.logger(x, this).warning(e.toString());
         }
         Session session = x.get(Session.class);
         // fetch context and check if not null or user id is 0


### PR DESCRIPTION
…uthorization exceptions - to reduce noise in the logs. The stack traces are of little use