### PR TITLE
[NP-10331] Exporting users from the user table(url with #nbp.users) doesnt export all the users

### DIFF
--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -253,7 +253,7 @@ foam.CLASS({
             href = result;
           }
 
-          if ( href.length > 524288 ) {
+          if ( href.length > 100000 ) {
             var blob = new Blob([result], { type: self.exportDriverReg.mimeType });
             href = URL.createObjectURL(blob);
           }


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-10331

I couldn't find any docs to explain size limit change, but files over 127363 already caused this bug on Chrome 120