### PR TITLE
Add Template Support to Messages

### DIFF
--- a/src/foam/i18n/Messages.js
+++ b/src/foam/i18n/Messages.js
@@ -66,6 +66,8 @@ foam.CLASS({
   package: 'foam.i18n',
   name: 'MessageAxiom',
 
+  requires: ['foam.i18n.TranslationFormatStringParser'],
+
   properties: [
     {
       class: 'String',
@@ -109,6 +111,10 @@ foam.CLASS({
     {
       class: 'Simple',
       name: 'message_'
+    },
+    {
+      class: 'Boolean',
+      name: 'template'
     }
   ],
 
@@ -130,13 +136,32 @@ foam.CLASS({
 
     function installInProto(proto) {
       var name = this.name;
-      Object.defineProperty(
-        proto,
-        this.name,
-        {
-          get: function() { return this.cls_[name]; },
-          configurable: false
+      let self = this;
+      if ( this.template ) {
+        let parser = self.TranslationFormatStringParser.create({
+          value: proto.cls_[name]
+        })
+        Object.defineProperty(proto, name, {
+          get: function() {
+            return function(replacementMap) {
+              parser.onMatchFn = function(a) {
+                return replacementMap[a[1]] ?? a[1];
+              }
+              parser.reParse();
+              return parser.parsedValue;
+            };
+          },
+          configurable: true
         });
+      } else {
+        Object.defineProperty(
+          proto,
+          this.name,
+          {
+            get: function() { return this.cls_[name]; },
+            configurable: false
+          });
+      }
     }
   ]
 });

--- a/src/foam/i18n/TranslationFormatStringParser.js
+++ b/src/foam/i18n/TranslationFormatStringParser.js
@@ -58,27 +58,41 @@ foam.CLASS({
     },
     {
       name: 'valueParserResults',
-      hidden: true,
-      expression: function(value, stringSymbol) {
+      hidden: true
+    },
+  ],
+  methods: [
+    function init() {
+      this.reParse();
+    }
+  ],
+  listeners: [
+    {
+      name: 'reParse',
+      on: ['this.propertyChange.value', 'this.propertyChange.stringSymbol'],
+      code: function() {
+        let self = this;
         var matches = {};
-        this.onMatchFn = function(a) {
-          if (!matches[a[1]]) {
-            matches[a[1]] = [
-              '%',
-              Object.keys(matches).length + 1,
-              '$',
-              stringSymbol
-            ].join('');
-          }
-          return matches[a[1]];
-        };
-        var parsedValue = this.grammar.parseString(value);
-        return {
+        if ( ! this.onMatchFn ) {
+          this.onMatchFn = function(a) {
+            if ( ! matches[a[1]] ) {
+              matches[a[1]] = [
+                '%',
+                Object.keys(matches).length + 1,
+                '$',
+                self.stringSymbol
+              ].join('');
+            }
+            return matches[a[1]];
+          };
+        }
+        var parsedValue = this.grammar.parseString(this.value);
+        this.valueParserResults = {
           matches: matches,
           parsedValue: parsedValue,
-        }
-      },
-    },
+        };
+      }
+    }
   ],
   grammars: [
     {


### PR DESCRIPTION
- Message templates follow the same format as JS template literals, ie. all `${var}` are replaced by the value of `var`
- Make any message a template by setting `template: true` in the axiom
- Template messages are installed in the proto as a function that can be called with one argument, an object with the replacement strings for every variable