### PR TITLE
Add templates to messages

### DIFF
--- a/src/foam/i18n/MessageTemplateParser.js
+++ b/src/foam/i18n/MessageTemplateParser.js
@@ -1,0 +1,69 @@
+/**
+* @license
+* Copyright 2024 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  package: 'foam.i18n',
+  name: 'MessageTemplateParser',
+  requires: [
+    'foam.parse.Parsers',
+    'foam.parse.ImperativeGrammar',
+  ],
+  properties: [
+    {
+      name: 'value',
+      // Test Value
+      // value: 'Hello ${toName} from ${fromName}',
+    },
+    {
+      name: 'valueParserResults',
+      hidden: true,
+      expression: function(value) {
+        var parsedValue = this.grammar.parseString(value);
+        return parsedValue;
+      }
+    },
+  ],
+  methods: [
+    function addLiteral(a) {
+      let str = a.join('');
+      return () => { return str; } 
+    },
+    function addParam(a) {
+      return map => { return map[a[1]] } 
+    }
+  ],
+  grammars: [
+    {
+      name: 'grammar',
+      language: 'foam.parse.json.Parsers',
+      symbols: function() {
+        return {
+          START: sym('string'),
+          string: repeat(
+              alt(sym('literal'), sym('parameter'))
+          ),
+          literal: repeat(not(sym('parameter'), anyChar()), null, 1),
+          parameter: seq('${', sym('identifier'), '}'),
+          identifier: repeat(not('}', anyChar()))
+        };
+      },
+      actions: [
+        function literal(a) {
+          return this.addLiteral(a);
+        },
+        function parameter(a) {
+          return this.addParam(a);
+        },
+        function identifier(a) {
+          return a.join('');
+        },
+        function string(a) {
+          return a;
+        }
+      ],
+    },
+  ],
+});

--- a/src/foam/i18n/MessageTemplateParser.js
+++ b/src/foam/i18n/MessageTemplateParser.js
@@ -32,7 +32,7 @@ foam.CLASS({
       return () => { return str; } 
     },
     function addParam(a) {
-      return map => { return map[a[1]] } 
+      return map => { return map[a] } 
     }
   ],
   grammars: [
@@ -55,7 +55,7 @@ foam.CLASS({
           return this.addLiteral(a);
         },
         function parameter(a) {
-          return this.addParam(a);
+          return this.addParam(a[1]);
         },
         function identifier(a) {
           return a.join('');

--- a/src/foam/i18n/Messages.js
+++ b/src/foam/i18n/Messages.js
@@ -111,6 +111,10 @@ foam.CLASS({
     {
       class: 'Simple',
       name: 'message_'
+    },
+    {
+      class: 'Boolean',
+      name: 'template'
     }
   ],
 

--- a/src/foam/i18n/Messages.js
+++ b/src/foam/i18n/Messages.js
@@ -146,6 +146,15 @@ foam.CLASS({
           },
           configurable: true
         });
+      } else {
+        Object.defineProperty(
+          proto,
+          this.name,
+          {
+            get: function() { return this.cls_[name]; },
+            configurable: false
+          });
+      }
     }
   ]
 });

--- a/src/foam/i18n/Messages.js
+++ b/src/foam/i18n/Messages.js
@@ -66,6 +66,8 @@ foam.CLASS({
   package: 'foam.i18n',
   name: 'MessageAxiom',
 
+  requires: ['foam.i18n.MessageTemplateParser'],
+
   properties: [
     {
       class: 'String',
@@ -130,12 +132,19 @@ foam.CLASS({
 
     function installInProto(proto) {
       var name = this.name;
-      Object.defineProperty(
-        proto,
-        this.name,
-        {
-          get: function() { return this.cls_[name]; },
-          configurable: false
+      let self = this;
+      if ( this.template ) {
+        let parser = self.MessageTemplateParser.create({
+          value: proto.cls_[name]
+        });
+        Object.defineProperty(proto, name, {
+          get: function() {
+            return function(replacementMap) {
+              let parsedValue = parser.valueParserResults;
+              return parsedValue.reduce(function(ret, v) {return ret + v(replacementMap)}, '');
+            };
+          },
+          configurable: true
         });
     }
   ]

--- a/src/foam/u2/tag/Button.js
+++ b/src/foam/u2/tag/Button.js
@@ -76,10 +76,6 @@ foam.CLASS({
       flex-direction: row-reverse;
     }
 
-    ^ + ^ {
-      margin-left: 8px;
-    }
-
     ^:hover:not(:disabled) {
       cursor: pointer;
     }

--- a/src/pom.js
+++ b/src/pom.js
@@ -97,6 +97,7 @@ foam.POM({
     { name: "foam/parsers/FON",                                       flags: "js" },
     { name: "foam/core/templates",                                    flags: "js" },
     { name: "foam/i18n/Messages",                                     flags: "js" },
+    { name: "foam/i18n/MessageTemplateParser",                        flags: "js" },
     { name: "foam/core/Validation",                                   flags: "js" },
     { name: "foam/core/Action",                                       flags: "js|java" },
     { name: "foam/core/Static",                                       flags: "js" },


### PR DESCRIPTION
- Message templates follow the same format as JS template literals, ie. all ${var} are replaced by the value of var
- Make any message a template by setting template: true in the axiom
- Template messages are installed in the proto as a function that can be called with one argument, an object with the replacement strings for every variable