### PR TITLE
[NP-10440] Fix required property validation

### DIFF
--- a/src/foam/core/AbstractPropertyInfo.java
+++ b/src/foam/core/AbstractPropertyInfo.java
@@ -95,14 +95,6 @@ public abstract class AbstractPropertyInfo
   }
 
   @Override
-  // ???: Is this still used?
-  public void validate(X x, FObject obj)
-    throws IllegalStateException
-  {
-    /* Template Method: override in subclasses if required. */
-  }
-
-  @Override
   public boolean includeInDigest() {
     if ( getStorageTransient() || getClusterTransient() )
       return false;

--- a/src/foam/core/PropertyInfo.js
+++ b/src/foam/core/PropertyInfo.js
@@ -28,8 +28,7 @@ foam.INTERFACE({
     'Expr',
     'Hasher',
     'Signer',
-    'SQLStatement',
-    'Validator'
+    'SQLStatement'
   ],
 
   // TODO: break into XML, CSV, SQL, Sheets, PII, crypto

--- a/src/foam/core/PropertyInfo.js
+++ b/src/foam/core/PropertyInfo.js
@@ -114,7 +114,7 @@ foam.INTERFACE({
     'boolean containsDeletablePII() { return false; }',
     `void validateObj(foam.core.X x, foam.core.FObject obj) {
        /* Template Method: override in subclass if required. */
-       if ( getRequired() && ! isSet(obj) ) {
+       if ( getRequired() && (! isSet(obj) || isDefaultValue(obj)) ) {
          throw new ValidationException(getName() + " required");
        }
     }`,


### PR DESCRIPTION
## Changes
- Add `isDefaultValue` check on required field
- Remove Validator interface from PropertyInfo because it was legacy, `validateObj()` is its successor for holding property validation logic