### PR TITLE
Fix missing arg1 on Not.create

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -335,7 +335,7 @@ foam.CLASS({
   documentation: 'Property for Predicate values.',
 
   properties: [
-    [ 'type', 'foam.mlang.predicate.AbstractPredicate' ],
+    [ 'type', 'foam.mlang.predicate.Predicate' ],
     {
       name: 'adapt',
       value: function(_, o, prop) {
@@ -2447,12 +2447,12 @@ foam.CLASS({
           return this.Gt.create({arg1: this.arg1.arg1, arg2: this.arg1.arg2});
         } else if (this.And.isInstance(this.arg1)) {
           for ( var i = 0; i < this.arg1.args.length; i++ ) {
-            this.arg1.args[i] = this.Not.create(this.arg1.args[i]);
+            this.arg1.args[i] = this.Not.create({ arg1: this.arg1.args[i] });
           }
           return this.Or.create({args: this.arg1.args[i]});
         } else if (this.Or.isInstance(this.arg1)) {
           for ( var i = 0; i < this.arg1.args.length; i++ ) {
-            this.arg1.args[i] = this.Not.create(this.arg1.args[i]);
+            this.arg1.args[i] = this.Not.create({ arg1: this.arg1.args[i] });
           }
           return this.And.create({args: this.arg1.args[i]});
         }


### PR DESCRIPTION
![Screenshot 2024-03-12 at 11:08:44 PM](https://github.com/kgrgreer/foam3/assets/441658/e6e070c6-e36f-4c72-b0a8-4ce45292fffc)

## Issues
During NOT predicate optimization, it was passing binary predicate to the create method and the arg1 was taken from the binary predicate. Not.arg1 is a predicate but Binary.arg1 is an expression, this casuses the predicate property adapt to try to create a new predicate and failed because Predicate is an interface.

Eg.

    pred: NOT( AND( EQ( prop1, val1),  EQ(prop2, val2) ) )
    and it was trying to create Not(arg1: prop1) instead of Not(arg1: EQ)

The previous solution of changing 'type' of PredicateProperty to AbstractPredicate causes java compilation error because we code to Predicate interface instead of the abstract class. We could add 'javaType' to point back to the interface but the deviation will become a technical debt for the future.