### PR TITLE
Np 10476/remove message javagetter

### DIFF
--- a/src/foam/core/FOAMException.js
+++ b/src/foam/core/FOAMException.js
@@ -88,11 +88,7 @@ foam.CLASS({
       name: 'message',
       class: 'String',
       storageTransient: true,
-      visibility: 'RO',
-      javaGetter: `
-        // Return non-translated template rendered exceptionMessage
-        return renderMessage(getExceptionMessage());
-      `
+      visibility: 'RO'
     },
     {
       documentation: 'Override title of notification messages',
@@ -217,7 +213,7 @@ foam.CLASS({
         sb.append(getErrorCode());
         sb.append("),");
       }
-      sb.append(getMessage());
+      sb.append(renderMessage(getExceptionMessage()));
       return sb.toString();
       `
     },

--- a/src/foam/core/FOAMExceptionTest.js
+++ b/src/foam/core/FOAMExceptionTest.js
@@ -23,26 +23,30 @@ foam.CLASS({
         throw new FOAMException();
       } catch (FOAMException e) {
         String expected = "";
-        test(e.getMessage() == null || expected.equals(e.getMessage()), "expecting: "+expected+", found: \\\""+e.getMessage()+"\\\"");
+        String res = e.renderMessage(e.getExceptionMessage());
+        test(res == null || expected.equals(res), "expecting: "+expected+", found: \\\""+res+"\\\"");
       }
       try {
         throw new FOAMException("test message");
       } catch (FOAMException e) {
         String expected = "test message";
-        test(expected.equals(e.getMessage()), "expecting: "+expected+", found: \\\""+e.getMessage()+"\\\"");
+        String res = e.renderMessage(e.getExceptionMessage());
+        test(expected.equals(res), "expecting: "+expected+", found: \\\""+res+"\\\"");
       }
 
       try {
         throw new FOAMExceptionTestTestException();
       } catch (FOAMExceptionTestTestException e) {
         String expected = "ExceptionMessage , ErrorCode:";
-        test(expected.equals(e.getMessage()), "expecting: "+expected+", found: \\\""+e.getMessage()+"\\\"");
+        String res = e.renderMessage(e.getExceptionMessage());
+        test(expected.equals(res), "expecting: "+expected+", found: \\\""+res+"\\\"");
       }
       try {
         throw new FOAMExceptionTestTestException("inner message");
       } catch (FOAMExceptionTestTestException e) {
         String expected = "ExceptionMessage inner message, ErrorCode:";
-        test(expected.equals(e.getMessage()), "expecting: "+expected+", found: \\\""+e.getMessage()+"\\\"");
+        String res = e.renderMessage(e.getExceptionMessage());
+        test(expected.equals(res), "expecting: "+expected+", found: \\\""+res+"\\\"");
       }
 
       // test templating
@@ -50,7 +54,8 @@ foam.CLASS({
         throw new FOAMExceptionTestTestException("inner message", "16");
       } catch (FOAMExceptionTestTestException e) {
         String expected = "ExceptionMessage inner message, ErrorCode: 16";
-        test(expected.equals(e.getMessage()), "expecting: "+expected+", found: \\\""+e.getMessage()+"\\\"");
+        String res = e.renderMessage(e.getExceptionMessage());
+        test(expected.equals(res), "expecting: "+expected+", found: \\\""+res+"\\\"");
         System.out.println("toString: "+e.toString());
       }
 

--- a/src/foam/nanos/dig/exception/DigErrorMessage.js
+++ b/src/foam/nanos/dig/exception/DigErrorMessage.js
@@ -36,6 +36,12 @@ foam.CLASS({
       name: 'status'
     },
     {
+      name: 'message',
+      javaGetter: `
+        return renderMessage(getExceptionMessage());
+      `
+    },
+    {
       class: 'String',
       name: 'type',
       javaFactory: `


### PR DESCRIPTION
needs https://github.com/nanoPayinc/NANOPAY/pull/17607

fix issues of exceptionmessage being rendered on the server and rendered again on the client resulting in messages such as "2 attempts remaining attempts remaining" https://nanopay.atlassian.net/browse/NP-10476