### PR TITLE
Disable the DuplicateEmailRule

### DIFF
--- a/src/foam/nanos/auth/ruler/rules.jrl
+++ b/src/foam/nanos/auth/ruler/rules.jrl
@@ -35,7 +35,7 @@ p({
   "id":"user-prevent-duplicate-email-rule",
   "name":"Prevent Duplicate Email Rule",
   "priority": 100,
-  "enabled": true,
+  "enabled": false,
   "ruleGroup": "auth",
   "documentation": "Prevent Duplicate Email Rule",
   "daoKey": "localUserDAO",


### PR DESCRIPTION
Duplicate username is required, but duplicate email is optional.  It should be enabled on per app bases