### PR TITLE
[NP-10331] Exporting users from the user table(url with #nbp.users) doesnt export all the users

### DIFF
--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -247,14 +247,11 @@ foam.CLASS({
           var link = document.createElement('a');
           var href = '';
           if ( self.exportDriverReg.mimeType && self.exportDriverReg.mimeType.length != 0 ) {
-            var prefix = 'data:' + self.exportDriverReg.mimeType + ',';
-            href = encodeURI(prefix + result);
+            var blob = new Blob([result], { type: self.exportDriverReg.mimeType });
+            href = URL.createObjectURL(blob);
           } else {
-            href = result;
+            console.error("Data type for export not specified");
           }
-
-          var blob = new Blob([result], { type: self.exportDriverReg.mimeType });
-          href = URL.createObjectURL(blob);
           link.setAttribute('href', href);
           link.setAttribute('download', 'data.' + self.exportDriverReg.extension);
           document.body.appendChild(link);

--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -250,7 +250,7 @@ foam.CLASS({
             var blob = new Blob([result], { type: self.exportDriverReg.mimeType });
             href = URL.createObjectURL(blob);
           } else {
-            console.error("Data type for export not specified");
+            throw new Error('Data type for export not specified');
           }
           link.setAttribute('href', href);
           link.setAttribute('download', 'data.' + self.exportDriverReg.extension);

--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -253,10 +253,8 @@ foam.CLASS({
             href = result;
           }
 
-          if ( href.length > 100000 ) {
-            var blob = new Blob([result], { type: self.exportDriverReg.mimeType });
-            href = URL.createObjectURL(blob);
-          }
+          var blob = new Blob([result], { type: self.exportDriverReg.mimeType });
+          href = URL.createObjectURL(blob);
           link.setAttribute('href', href);
           link.setAttribute('download', 'data.' + self.exportDriverReg.extension);
           document.body.appendChild(link);


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-10331

When link.href is a string and the data contains # the result will be truncated. Probably everything after # considered as hyperlink. This is the reason why on production, downloading partial data that contains # in table entry will result in broken csv file. On the other hand, when all the data is downloaded, due to size of the file, href is not string but blob, so # doesn't create a problem.