### PR TITLE
Auth.sudo - if requested user is System explicitly build Subject

### DIFF
--- a/src/foam/util/Auth.java
+++ b/src/foam/util/Auth.java
@@ -65,6 +65,10 @@ public class Auth {
     if ( hasAgent ) session.setAgentId(realUser.getId());
 
     X y = session.applyTo(x);
+    if ( user.getId() == User.SYSTEM_USER_ID ) {
+      // Session.applyTo does not setup subject when user is System.
+      y = y.put("subject", new Subject(user));
+    }
     session.setContext(y);
     y = y.put(Session.class, session);
 


### PR DESCRIPTION
if requested user is System explicitly build Subject as Session.applyTo does not do this for user System.  Supports test cases which are run as System, but downstream logic invoked during testing performs Auth.sudo and expects Subject in context