### PR TITLE
Add support for a copyPredicate on detail view.

### DIFF
--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -242,6 +242,17 @@ foam.CLASS({
     },
     {
       class: 'foam.mlang.predicate.PredicateProperty',
+      name: 'copyPredicate',
+      documentation: 'If set to false, the "Copy" button will not be visible.',
+      factory: function() {
+        return this.createPredicate;
+      },
+      javaFactory: `
+        return getCreatePredicate();
+      `
+    },
+    {
+      class: 'foam.mlang.predicate.PredicateProperty',
       name: 'editPredicate',
       documentation: 'True to enable the edit button.',
       factory: function() {

--- a/src/foam/comics/v2/DAOSummaryView.js
+++ b/src/foam/comics/v2/DAOSummaryView.js
@@ -204,7 +204,7 @@ foam.CLASS({
       },
       isAvailable: function(config) {
         try {
-          return config.createPredicate.f();
+          return config.copyPredicate.f();
         } catch(e) {
           return false;
         }

--- a/src/foam/comics/v3/DetailView.js
+++ b/src/foam/comics/v3/DetailView.js
@@ -301,7 +301,7 @@ foam.CLASS({
       isAvailable: function(config, controllerMode) {
         if ( controllerMode == 'EDIT' ) return false;
         try {
-          return config.createPredicate.f();
+          return config.copyPredicate.f();
         } catch(e) {
           return false;
         }

--- a/src/foam/nanos/so/SystemNotification.js
+++ b/src/foam/nanos/so/SystemNotification.js
@@ -33,11 +33,17 @@ foam.CLASS({
       javaFactory: `
         return UUID.randomUUID().toString();
       `,
-      visibility: 'HIDDEN'
+      visibility: 'RO'
     },
     {
       class: 'String',
-      name: 'message'
+      name: 'message',
+      createVisibility: 'RW',
+      updateVisibility: function(dismissible) {
+        return dismissible ?
+          foam.u2.DisplayMode.RO :
+          foam.u2.DisplayMode.RW;
+      }
     },
     {
       class: 'foam.core.Enum',

--- a/src/foam/nanos/so/menus.jrl
+++ b/src/foam/nanos/so/menus.jrl
@@ -13,3 +13,20 @@ p({
   },
   parent:"admin"
 })
+
+p({
+  class:"foam.nanos.menu.Menu",
+  id:"systemOutageTasks",
+  label:"System Outage Tasks",
+  keywords: ["system", "outage", "task", "banner", "notification", "alarm"],
+  handler:{
+    class:"foam.nanos.menu.DAOMenu2",
+    config:{
+      class:"foam.comics.v2.DAOControllerConfig",
+      daoKey:"systemOutageTaskDAO",
+      browseTitle:"System Outage Tasks",
+      copyPredicate:{"class":"foam.mlang.predicate.False"}
+    }
+  },
+  parent:"admin"
+})


### PR DESCRIPTION
Defaults to createPredicate for backward compatibility. Make use of copyPredicate to force creation of new dismissible System Notifications so the dimiss is changes so user will see an update message for an existing outage.