### PR TITLE
Fix parsing xml to fobject

### DIFF
--- a/src/foam/core/XMLSupport.java
+++ b/src/foam/core/XMLSupport.java
@@ -109,7 +109,7 @@ public class XMLSupport {
   public static void copyFromXML(X x, FObject obj, XMLStreamReader reader) throws XMLStreamException {
     try {
       var cInfo = obj.getClassInfo();
-      var objClassName = obj.getClass().getSimpleName();
+      var objElName = reader.getLocalName();
       while ( reader.hasNext() ) {
         int eventType;
         eventType = reader.next();
@@ -122,7 +122,7 @@ public class XMLSupport {
             }
             break;
           case XMLStreamConstants.END_ELEMENT:
-            if ( reader.getLocalName().equals(objClassName) ) {
+            if ( reader.getLocalName().equals(objElName) ) {
               return;
             }
             break;

--- a/src/foam/core/XMLSupport.java
+++ b/src/foam/core/XMLSupport.java
@@ -41,11 +41,12 @@ public class XMLSupport {
         eventType = xmlr.next();
         switch ( eventType ) {
           case XMLStreamConstants.START_ELEMENT:
-            if ( xmlr.getLocalName().equals("object") ) {
-              FObject obj = createObj(x, xmlr, defaultClass);
-              if ( obj != null ) {
-                objList.add(obj);
-              }
+            var elName = xmlr.getLocalName();
+            var objClass = defaultClass != null && elName.equals(defaultClass.getSimpleName()) ? defaultClass : null;
+
+            var obj = createObj(x, xmlr, objClass);
+            if ( obj != null ) {
+              objList.add(obj);
             }
             break;
         }
@@ -84,7 +85,7 @@ public class XMLSupport {
       Logger logger = (Logger) x.get("logger");
       logger.error("Error while reading file");
     } catch (Throwable t) {
-      Logger logger = (Logger) x.get("logger");
+      // noop
     }
     return (FObject) clsInstance;
   }
@@ -107,21 +108,21 @@ public class XMLSupport {
 
   public static void copyFromXML(X x, FObject obj, XMLStreamReader reader) throws XMLStreamException {
     try {
-      PropertyInfo prop = null;
+      var cInfo = obj.getClassInfo();
+      var objClassName = obj.getClass().getSimpleName();
       while ( reader.hasNext() ) {
         int eventType;
         eventType = reader.next();
         switch ( eventType ) {
           case XMLStreamConstants.START_ELEMENT:
-            ClassInfo cInfo = obj.getClassInfo();
-            prop = (PropertyInfo) cInfo.getAxiomByName(reader.getLocalName());
+            var prop = (PropertyInfo) cInfo.getAxiomByName(reader.getLocalName());
             if ( prop != null ) {
               prop.set(obj, prop.fromXML(x, reader));
               prop = null;
             }
             break;
           case XMLStreamConstants.END_ELEMENT:
-            if ( reader.getLocalName().equals("object") ) {
+            if ( reader.getLocalName().equals(objClassName) ) {
               return;
             }
             break;


### PR DESCRIPTION
Uses defaultClass if it's the same as the xml element name otherwise looks for the element class attribute.

### Sample XMLs
```
<Person><name>Amy</name><age>23</age></Person>
```
```
<P class="test.Person"><name>Amy</name><age>23</age></P>
```
```
<People><Person><name>Amy</name><age>23</age></Person><Person><name>Joe</name><age>30</age></Person></People>
```