### PR TITLE
[NP-10912] PreventDuplicateEmail - invert logic.  Allowed by default on foam.

### DIFF
--- a/src/foam/nanos/auth/UserPropertyAvailabilityService.js
+++ b/src/foam/nanos/auth/UserPropertyAvailabilityService.js
@@ -45,8 +45,8 @@ foam.CLASS({
 
         Theme theme = (Theme) ((Themes) x.get("themes")).findTheme(x);
         var spid = theme.getSpid();
-        if ( "email".equals(targetProperty) && PreventDuplicateEmailAction.spidGrantsDuplicateEmailPermission(getX(), spid) ) {
-          return true;
+        if ( "email".equals(targetProperty) && PreventDuplicateEmailAction.spidPreventDuplicateEmailPermission(getX(), spid) ) {
+          return false;
         }
 
         DAO userDAO = ((DAO) getX().get("localUserDAO")).inX(x);

--- a/src/foam/nanos/auth/UserPropertyAvailabilityService.js
+++ b/src/foam/nanos/auth/UserPropertyAvailabilityService.js
@@ -45,16 +45,25 @@ foam.CLASS({
 
         Theme theme = (Theme) ((Themes) x.get("themes")).findTheme(x);
         var spid = theme.getSpid();
-        if ( "email".equals(targetProperty) && PreventDuplicateEmailAction.spidPreventDuplicateEmailPermission(getX(), spid) ) {
-          return false;
-        }
-
         DAO userDAO = ((DAO) getX().get("localUserDAO")).inX(x);
+        if ( "email".equals(targetProperty) ) {
+          if ( PreventDuplicateEmailAction.spidPreventDuplicateEmailPermission(getX(), spid) ) {
+            return
+              (
+                userDAO
+                .find(AND(
+                  EQ(User.EMAIL, value),
+                  EQ(User.TYPE, "User"),
+                  EQ(User.SPID, spid)))
+              ) == null;
+          }
+          return true;
+        }
         return
           (
             userDAO
             .find(AND(
-              EQ("email".equals(targetProperty) ? User.EMAIL : User.USER_NAME, value),
+              EQ(User.USER_NAME, value),
               EQ(User.TYPE, "User"),
               EQ(User.SPID, spid)))
           ) == null;

--- a/src/foam/nanos/auth/ruler/PreventDuplicateEmailAction.js
+++ b/src/foam/nanos/auth/ruler/PreventDuplicateEmailAction.js
@@ -31,9 +31,9 @@ foam.CLASS({
 
   constants: [
     {
-      name: 'ALLOW_DUPLICATE_EMAIL_PERMISSION_NAME',
+      name: 'PREVENT_DUPLICATE_EMAIL_PERMISSION_NAME',
       type: 'String',
-      value: 'spid.default.allowDuplicateEmails'
+      value: 'prevent-duplicate-email'
     }
   ],
 
@@ -65,13 +65,11 @@ foam.CLASS({
           spid = subject.getUser().getSpid();
         }
 
-        // check if the allowDuplicateEmail permission has been granted;
+        // check if the preventDuplicateEmail permission has been granted;
         // if it has, then skip over the duplicate email check below.
-        if ( spidGrantsDuplicateEmailPermission(getX(), spid) ) {
-          return;
+        if ( spidPreventDuplicateEmailPermission(getX(), spid) ) {
+          checkExistingUsers(x, user, spid);
         }
-
-        checkExistingUsers(x, user, spid);
       `
     },
     {
@@ -99,7 +97,7 @@ foam.CLASS({
 
   static: [
     {
-      name: 'spidGrantsDuplicateEmailPermission',
+      name: 'spidPreventDuplicateEmailPermission',
       type: 'Boolean',
       documentation: `
       Common function for checking if the given SPID allows
@@ -126,7 +124,7 @@ foam.CLASS({
       // a crash
       sp.setX(x);
 
-      return sp.grantsPermission(x, ALLOW_DUPLICATE_EMAIL_PERMISSION_NAME);
+      return sp.grantsPermission(x, PREVENT_DUPLICATE_EMAIL_PERMISSION_NAME);
       `
     }
   ]

--- a/src/foam/nanos/auth/ruler/rules.jrl
+++ b/src/foam/nanos/auth/ruler/rules.jrl
@@ -31,7 +31,7 @@ p({
   "lifecycleState":1
 })
 p({
-  "class":"foam.nanos.ruler.PermissionedUserRule",
+  "class":"foam.nanos.ruler.Rule",
   "id":"user-prevent-duplicate-email-rule",
   "name":"Prevent Duplicate Email Rule",
   "priority": 100,

--- a/src/foam/nanos/auth/ruler/rules.jrl
+++ b/src/foam/nanos/auth/ruler/rules.jrl
@@ -31,11 +31,11 @@ p({
   "lifecycleState":1
 })
 p({
-  "class":"foam.nanos.ruler.Rule",
+  "class":"foam.nanos.ruler.PermissionedUserRule",
   "id":"user-prevent-duplicate-email-rule",
   "name":"Prevent Duplicate Email Rule",
   "priority": 100,
-  "enabled": false,
+  "enabled": true,
   "ruleGroup": "auth",
   "documentation": "Prevent Duplicate Email Rule",
   "daoKey": "localUserDAO",


### PR DESCRIPTION
Invert logic of PreventDuplicateEmail. The foam system can handle duplicate emails. It is application features using foam which may require no duplicates.  
If an application requires no duplicates then grant 'prevent-duplicate-emails' to that applications spid capability. 