### PR TITLE
During image copy, don't copy favicon folders nested under images/

### DIFF
--- a/src/foam/nanos/images/pom.js
+++ b/src/foam/nanos/images/pom.js
@@ -1,0 +1,3 @@
+foam.POM({
+  name:'images'
+});

--- a/src/foam/u2/images/pom.js
+++ b/src/foam/u2/images/pom.js
@@ -1,0 +1,3 @@
+foam.POM({
+  name:'images'
+})

--- a/tools/ImageMaker.js
+++ b/tools/ImageMaker.js
@@ -15,7 +15,8 @@ exports.init = function() {
 
 
 exports.visitDir = function(pom, f, fn) {
-  if ( f.name === 'images' || f.name === 'favicon' ) {
+  if ( f.name === 'images' ||
+       ( f.name === 'favicon' && ! fn.includes('images') ) ) {
     console.log(`[Image Maker] Copying ${fn} to ${X.imagedir}`);
     b_.copyDir(fn, X.imagedir);
   }


### PR DESCRIPTION
This is a follow up fix for changes introduce in JettyUpgrade PR. 