### PR TITLE
Np 10949/x forwarded for

### DIFF
--- a/src/foam/nanos/jetty/HttpServer.js
+++ b/src/foam/nanos/jetty/HttpServer.js
@@ -366,30 +366,6 @@ foam.CLASS({
 
         this.configHttps(server);
 
-        /*
-          The following for loop will accomplish the following:
-          1. Prevent Jetty server from broadcasting its version number in the HTTP
-          response headers.
-          2. Configure Jetty server to interpret the X-Fowarded-for header
-        */
-
-        for ( org.eclipse.jetty.server.Connector conn : server.getConnectors() ) {
-          for ( org.eclipse.jetty.server.ConnectionFactory f : conn.getConnectionFactories() ) {
-            if ( f instanceof org.eclipse.jetty.server.HttpConnectionFactory ) {
-              HttpConfiguration config = ((org.eclipse.jetty.server.HttpConnectionFactory) f).getHttpConfiguration();
-
-              // 1. hiding the version number in response headers
-              config.setSendServerVersion(false);
-
-              // 2. enable X-Forwarded-For headers
-              ForwardedRequestCustomizer forwarded = new ForwardedRequestCustomizer();
-              config.addCustomizer(forwarded);
-
-              config.setIdleTimeout(10000L);
-            }
-          }
-        }
-
         server.start();
         setServer(server);
       } catch(Exception e) {
@@ -497,6 +473,9 @@ foam.CLASS({
 
           // Enable https
           HttpConfiguration config = new HttpConfiguration();
+          ForwardedRequestCustomizer forwarded = new ForwardedRequestCustomizer();
+          config.addCustomizer(forwarded);
+          config.setSendServerVersion(false);
 
           SecureRequestCustomizer src = new SecureRequestCustomizer();
           src.setSniHostCheck(!getDisableSNIHostCheck());

--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -154,6 +154,7 @@ Later themes:
           // }
         }
         if ( td != null ) {
+          // logger.debug("Themes", "ThemeDomain found", domain, td.getId());
           theme = (Theme) themeDAO.find(
             MLang.AND(
               MLang.EQ(Theme.ID, td.getTheme()),
@@ -163,6 +164,7 @@ Later themes:
           //   logger.debug("Themes", "Theme not found", td.getTheme());
           // }
           if ( theme != null ) {
+            // logger.debug("Themes", "Theme found", domain, theme.getId());
             theme = (Theme) theme.fclone();
           }
         }
@@ -206,9 +208,10 @@ Later themes:
 
       // Merge the theme with group and user themes
       // Turn off group theme merging until fixed
+      Group group = null;
       if ( false && user != null ) {
         DAO groupDAO = (DAO) x.get("groupDAO");
-        Group group = user.findGroup(x);
+        group = user.findGroup(x);
         String[] defaultMenu = group != null ? group.getDefaultMenu() : null;
         while ( group != null ) {
           Theme groupTheme = group.findTheme(x);
@@ -247,6 +250,8 @@ Later themes:
           appConfig.setUrl("https://"+domain);
         }
       }
+
+      // logger.debug("Themes", "domain", domain, "user", (user != null ? user.getId() : "null"), "group", (group != null ? group.getId() : "null") , "theme", theme.getId());
 
       return theme;
       `

--- a/src/foam/net/IPSupport.js
+++ b/src/foam/net/IPSupport.js
@@ -38,6 +38,10 @@ foam.CLASS({
       if ( req == null ) {
         return null;
       }
+
+      // TODO: add support for Forwarded:
+      // https://www.rfc-editor.org/rfc/rfc7239
+
       String forwardedForHeader = req.getHeader("X-Forwarded-For");
       if ( ! foam.util.SafetyUtil.isEmpty(forwardedForHeader) ) {
         String[] addresses = forwardedForHeader.split(",");


### PR DESCRIPTION
nanopay issues were a haproxy version issue.  Testing environment was 2.0, production was 2.4 with different rewrite behaviour. An upgrade to 2.8 reverted behaviour to that of 2.0, where original requested server name is available from HttpServletRequest.getServerName(). 

Also, with upgrade to Jetty 11 and H2, the ForwardedCustomizer was not placed on the correct HttpConfiguration.   Addressed passed to InetAccessHandler is now that of X-Forwarded-For, as expected. 