### PR TITLE
bug fix: it is using empty context

### DIFF
--- a/src/foam/nanos/http/SessionWebAgent.java
+++ b/src/foam/nanos/http/SessionWebAgent.java
@@ -90,7 +90,7 @@ public class SessionWebAgent
 
       // execute delegate
       // Update session context with support setup from earlier WebAgents.
-      getDelegate().execute(applyX.put(HttpServletResponse.class, resp).put(HttpServletRequest.class, req));
+      getDelegate().execute(applyX);
 
     } catch ( AuthorizationException e ) {
       // report permission issues

--- a/src/foam/nanos/http/SessionWebAgent.java
+++ b/src/foam/nanos/http/SessionWebAgent.java
@@ -83,13 +83,14 @@ public class SessionWebAgent
       // check permissions
       Subject subject = new Subject.Builder(x).setUser(user).build();
       session.setContext(session.getContext().put("subject", subject));
-      if ( ! auth.check(session.getContext(), permission_) ) {
+      var applyX = session.applyTo(x);
+      if ( ! auth.check(applyX, permission_) ) {
         throw new AuthorizationException();
       }
 
       // execute delegate
       // Update session context with support setup from earlier WebAgents.
-      getDelegate().execute(session.getContext().put(HttpServletResponse.class, resp).put(HttpServletRequest.class, req));
+      getDelegate().execute(applyX.put(HttpServletResponse.class, resp).put(HttpServletRequest.class, req));
 
     } catch ( AuthorizationException e ) {
       // report permission issues

--- a/src/foam/nanos/http/SessionWebAgent.java
+++ b/src/foam/nanos/http/SessionWebAgent.java
@@ -81,8 +81,6 @@ public class SessionWebAgent
       }
 
       // check permissions
-      Subject subject = new Subject.Builder(x).setUser(user).build();
-      session.setContext(session.getContext().put("subject", subject));
       var applyX = session.applyTo(x);
       if ( ! auth.check(applyX, permission_) ) {
         throw new AuthorizationException();


### PR DESCRIPTION
SessionWebAgent is using empty Context for auth check and subsequent calls.
For long-term session,  they all reload from journal(session.jrl). For those sessions, session.getContext() will return empty context. So need to use applyTo for those session.