### PR TITLE
[NP-10983] Notification refactor for UI creation

### DIFF
--- a/src/foam/nanos/notification/NotificationExpansionDAO.js
+++ b/src/foam/nanos/notification/NotificationExpansionDAO.js
@@ -43,7 +43,8 @@ foam.CLASS({
         DAO userDAO = (DAO) x.get("localUserDAO");
         Notification notif = (Notification) obj;
 
-        if (getDelegate().find_(x, notif.getId()) != null) return getDelegate().put_(x, notif);
+        if (getDelegate().find_(x, notif.getId()) != null)
+          return getDelegate().put_(x, notif);
 
         if ( notif.getBroadcasted() ) {
           Notification notification = (Notification) notif.fclone();

--- a/src/foam/nanos/notification/NotificationSetting.js
+++ b/src/foam/nanos/notification/NotificationSetting.js
@@ -8,7 +8,7 @@
 foam.CLASS({
   package: 'foam.nanos.notification',
   name: 'NotificationSetting',
-  label: 'In-App Notifications',
+  label: 'In-App Notification Setting',
 
   implements: [
     'foam.nanos.auth.Authorizable',
@@ -30,6 +30,13 @@ foam.CLASS({
     'foam.nanos.theme.Themes',
     'foam.util.Auth',
     'java.util.HashSet'
+  ],
+
+  tableColumns: [
+    'id',
+    'enabled',
+    'type',
+    'spid'
   ],
 
   messages: [
@@ -60,6 +67,19 @@ foam.CLASS({
       class: 'Boolean',
       name: 'enabled',
       value: true
+    },
+    {
+      class: 'String',
+      name: 'type',
+      documentation: 'Notification settings are identified by their class, this property exposes that in UI.',
+      visibility: 'RO',
+      transient: true,
+      getter: function() {
+        return this.cls_.nane;
+      },
+      javaGetter: `
+        return getClass().getSimpleName();
+      `
     },
     {
       class: 'Reference',
@@ -129,32 +149,40 @@ foam.CLASS({
       name: 'authorizeOnCreate',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkSpid(x) ) throw new AuthorizationException(LACKS_CREATE_PERMISSION);
-      if ( ! checkOwnership(x) && ! auth.check(x, "notificationsetting.create") )  throw new AuthorizationException(LACKS_CREATE_PERMISSION);
+      if ( ! checkSpid(x) &&
+           ! checkOwnership(x) &&
+           ! auth.check(x, "notificationsetting.create") )
+        throw new AuthorizationException(LACKS_CREATE_PERMISSION);
       `
     },
     {
       name: 'authorizeOnUpdate',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkSpid(x) ) throw new AuthorizationException(LACKS_UPDATE_PERMISSION);
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("update")) ) throw new AuthorizationException(LACKS_UPDATE_PERMISSION);
+      if ( ! checkSpid(x) &&
+           ! checkOwnership(x) &&
+           ! auth.check(x, createPermission("update")) )
+        throw new AuthorizationException(LACKS_UPDATE_PERMISSION);
       `
     },
     {
       name: 'authorizeOnDelete',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkSpid(x) ) throw new AuthorizationException(LACKS_DELETE_PERMISSION);
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("remove")) ) throw new AuthorizationException(LACKS_DELETE_PERMISSION);
+      if ( ! checkSpid(x) &&
+           ! checkOwnership(x) &&
+           ! auth.check(x, createPermission("remove")) )
+        throw new AuthorizationException(LACKS_DELETE_PERMISSION);
       `
     },
     {
       name: 'authorizeOnRead',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkSpid(x) ) throw new AuthorizationException(LACKS_READ_PERMISSION);
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("read")) ) throw new AuthorizationException(LACKS_READ_PERMISSION);
+      if ( ! checkSpid(x) &&
+           ! checkOwnership(x) &&
+           ! auth.check(x, createPermission("read")) )
+        throw new AuthorizationException(LACKS_READ_PERMISSION);
       `
     },
     {

--- a/src/foam/nanos/notification/NotificationTemplateDAO.js
+++ b/src/foam/nanos/notification/NotificationTemplateDAO.js
@@ -26,6 +26,8 @@ the notification will be handled. `,
     'foam.dao.ArraySink',
     'foam.dao.DAO',
     'foam.dao.Sink',
+    'static foam.mlang.MLang.EQ',
+    'static foam.mlang.MLang.OR',
     'foam.nanos.auth.User',
     'foam.nanos.logger.Logger',
     'foam.nanos.logger.Loggers',
@@ -62,7 +64,11 @@ the notification will be handled. `,
         if ( ! foam.util.SafetyUtil.isEmpty(notification.getTemplate()) ) {
           List templates = ((ArraySink) ((DAO) x.get("notificationTemplateDAO"))
             .limit(2)
-            .where(foam.mlang.MLang.EQ(Notification.TEMPLATE, notification.getTemplate()))
+            .where(
+              OR(
+                EQ(Notification.ID, notification.getTemplate()),
+                EQ(Notification.TEMPLATE, notification.getTemplate())
+              ))
             .select(new ArraySink()))
             .getArray();
 

--- a/src/foam/nanos/notification/email/EmailTemplateCitationView.js
+++ b/src/foam/nanos/notification/email/EmailTemplateCitationView.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.notification.email',
+  name: 'EmailTemplateCitationView',
+  extends: 'foam.u2.CitationView',
+
+  documentation: 'A single row in a list of email templates.',
+
+  css: `
+    ^summary {
+      color: $black;
+    }
+
+    ^email {
+      color: $grey400;
+    }
+  `,
+
+  properties: [
+    {
+      class: 'FObjectProperty',
+      of: 'foam.nanos.notification.email.EmailTemplate',
+      name: 'data',
+      documentation: 'Set this to the template you want to display in this row.'
+    }
+  ],
+
+  methods: [
+    function render() {
+      this
+        .addClass(this.myClass())
+        .start()
+          .start()
+            .addClass('p-legal-light', this.myClass('summary'))
+            .add(this.data.name, ' (', this.data.id, ')')
+          .end()
+          .start()
+            .addClass('p-xs', this.myClass('email'))
+            .add('group: ', this.data.group, ', locale: ', this.data.locale)
+          .end()
+        .end();
+    }
+  ]
+});
+

--- a/src/foam/nanos/notification/strategyReferences.jrl
+++ b/src/foam/nanos/notification/strategyReferences.jrl
@@ -1,0 +1,30 @@
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "NotificationSetting-EmailSetting",
+  "desiredModelId": "foam.nanos.notification.NotificationSetting",
+  "strategy": "foam.nanos.notification.EmailSetting"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "NotificationSetting-SlackSetting",
+  "desiredModelId": "foam.nanos.notification.NotificationSetting",
+  "strategy": "foam.nanos.notification.SlackSetting"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "NotificationSetting-GoolgeChatSetting",
+  "desiredModelId": "foam.nanos.notification.NotificationSetting",
+  "strategy": "foam.nanos.notification.GoogleChatSetting"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "NotificationSetting-SMSSetting",
+  "desiredModelId": "foam.nanos.notification.NotificationSetting",
+  "strategy": "foam.nanos.notification.sms.SMSSetting"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "NotificationSetting-PushSetting",
+  "desiredModelId": "foam.nanos.notification.NotificationSetting",
+  "strategy": "foam.nanos.notification.push.PushSetting"
+})

--- a/src/foam/nanos/pom.js
+++ b/src/foam/nanos/pom.js
@@ -445,6 +445,7 @@ foam.POM({
     { name: "notification/email/EmailMessageStatusRuleAction",                            flags: "js|java" },
     { name: "notification/email/EmailServiceConfig",                                      flags: "js|java" },
     { name: "notification/email/EmailTemplate",                                           flags: "js|java" },
+    { name: "notification/email/EmailTemplateCitationView",                               flags: "js" },
     { name: "notification/email/EmailTemplateSource",                                     flags: "js|java" },
     { name: "notification/email/SMTPAgent",                                               flags: "js|java" },
     { name: "notification/email/SMTPConfig",                                               flags: "js|java" },


### PR DESCRIPTION
Refactor Notification model such that it is suitable for creation via the UI.

Notifications were never intended to be explicitly created from a regular
detail view. These changes set appropriate visibility for create, update.
Additionally, the notification template and email templates are now
references to the notificationTemplateDAO and emailTemplateDAO respectively.

**On create, a notification may or may not be created**. 
The notification create request is submitted and for each user a notification is 
created if that user has any enabled notification settings (see next section). 

NotificationSettings can now also be created via the UI.

A NotificationSetting is defined by it's class, such as EmailSetting, PushSetting, ... 
That class is now visible as the 'type'.  StrategyReference allow the operator
to select the type of NotificationSetting for a new setting instance.