### PR TITLE
[NP-10983] Additional refactoring to make Send Notification the official way to manually create a Notification

### DIFF
--- a/src/foam/nanos/auth/Relationships.js
+++ b/src/foam/nanos/auth/Relationships.js
@@ -54,6 +54,9 @@ foam.RELATIONSHIP({
     hidden: true
   },
   sourceDAOKey: 'agentJunctionDAO',
+  targetProperty: {
+    hidden: true
+  },
   targetDAOKey: 'notificationSettingDAO',
   unauthorizedTargetDAOKey: 'localNotificationSettingDAO'
 });
@@ -69,5 +72,31 @@ foam.RELATIONSHIP({
     columnPermissionRequired: true
   },
   targetDAOKey: 'notificationSettingDAO',
-  unauthorizedTargetDAOKey: 'localNotificationSettingDAO'
+  unauthorizedTargetDAOKey: 'localNotificationSettingDAO',
+  targetProperty: {
+    view: function(_, X) {
+      var userDAOSlot = X.data.slot(spid => {
+        if ( spid ) {
+          return X.userDAO.where(X.data.EQ(X.data.User.SPID, spid));
+        } else {
+          return X.userDAO;
+        }
+      });
+      return {
+        class: 'foam.u2.view.ModeAltView',
+        readView: 'foam.u2.view.ReadReferenceView',
+        writeView: {
+          class: 'foam.u2.view.RichChoiceReferenceView',
+          sections: [
+            {
+              heading: 'Owner',
+              dao$: userDAOSlot
+            }
+          ],
+          placeholder: '--'
+        }
+      }
+    },
+    tableCellFormatter: { class: 'foam.u2.view.ReferenceToSummaryCellFormatter' }
+  }
 });

--- a/src/foam/nanos/menus.jrl
+++ b/src/foam/nanos/menus.jrl
@@ -1,3 +1,4 @@
+// User's own notification settings
 p({
   class: 'foam.nanos.menu.Menu',
   id: 'notification-settings',

--- a/src/foam/nanos/notification/EmailSetting.js
+++ b/src/foam/nanos/notification/EmailSetting.js
@@ -27,6 +27,14 @@ foam.CLASS({
     'static foam.mlang.MLang.EQ'
   ],
 
+  properties: [
+    {
+      name: 'enabled',
+      readPermissionRequired: false,
+      writePermissionRequired: true
+    },
+  ],
+
   methods: [
     {
       name: 'resolveNotificationArguments',

--- a/src/foam/nanos/notification/Notification.js
+++ b/src/foam/nanos/notification/Notification.js
@@ -19,6 +19,9 @@ foam.CLASS({
   documentation: 'Notification model responsible for system and integrated messaging notifications.',
 
   javaImports: [
+    'foam.core.XLocator',
+    'foam.dao.DAO',
+    'static foam.mlang.MLang.EQ',
     'foam.nanos.auth.AuthService',
     'foam.nanos.auth.AuthorizationException',
     'foam.nanos.auth.Subject',
@@ -40,8 +43,7 @@ foam.CLASS({
     'notificationType',
     'broadcasted',
     'userId.id',
-    'groupId.id',
-    'emailName'
+    'groupId.id'
   ],
 
   sections: [
@@ -103,24 +105,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'template',
-      label: 'Notification Template',
-      view: function(_, X) {
-        var dao = X.notificationTemplateDAO;
-        return {
-          class: 'foam.u2.view.ModeAltView',
-          readView: { class: 'foam.u2.view.StringView' },
-          writeView: {
-            class: 'foam.u2.view.RichChoiceView',
-            sections: [
-              {
-                heading: 'Notification Templates',
-                dao: dao
-              }
-            ],
-            placeholder: '--'
-          }
-        };
-      }
+      documentation: `This is the 'id' property used to find a template.`,
     },
     {
       class: 'String',
@@ -238,7 +223,11 @@ foam.CLASS({
       of: 'foam.nanos.notification.email.EmailTemplate',
       targetDAOKey: 'emailTemplateDAO',
       label: 'Email Template',
-      documentation: 'Email template name.'
+      documentation: 'Email template name.',
+      menuKeys: [
+        'emailtemplates',
+        'notification.emailtemplates'
+      ]
     },
     {
       class: 'Boolean',

--- a/src/foam/nanos/notification/NotificationSetting.js
+++ b/src/foam/nanos/notification/NotificationSetting.js
@@ -11,6 +11,7 @@ foam.CLASS({
   label: 'In-App Notification Setting',
 
   implements: [
+    'foam.mlang.Expressions',
     'foam.nanos.auth.Authorizable',
     'foam.nanos.auth.ServiceProviderAware'
   ],
@@ -35,8 +36,10 @@ foam.CLASS({
   tableColumns: [
     'id',
     'enabled',
+    'name',
     'type',
-    'spid'
+    'spid',
+    'owner'
   ],
 
   messages: [
@@ -72,12 +75,14 @@ foam.CLASS({
       class: 'String',
       name: 'type',
       documentation: 'Notification settings are identified by their class, this property exposes that in UI.',
-      visibility: 'RO',
-      transient: true,
-      getter: function() {
-        return this.cls_.nane;
+      createVisibility: 'HIDDEN',
+      updateVisibility: 'RO',
+      storageTransient: true,
+      clusterTransient: true,
+      factory: function() {
+        return this.cls_.name;
       },
-      javaGetter: `
+      javaFactory: `
         return getClass().getSimpleName();
       `
     },

--- a/src/foam/nanos/notification/NotificationSetting.js
+++ b/src/foam/nanos/notification/NotificationSetting.js
@@ -64,7 +64,9 @@ foam.CLASS({
   properties: [
     {
       class: 'String',
-      name: 'id'
+      name: 'id',
+      createVisibility: 'HIDDEN',
+      updateVisibility: 'RW'
     },
     {
       class: 'Boolean',

--- a/src/foam/nanos/notification/NotificationTemplateDAO.js
+++ b/src/foam/nanos/notification/NotificationTemplateDAO.js
@@ -27,7 +27,6 @@ the notification will be handled. `,
     'foam.dao.DAO',
     'foam.dao.Sink',
     'static foam.mlang.MLang.EQ',
-    'static foam.mlang.MLang.OR',
     'foam.nanos.auth.User',
     'foam.nanos.logger.Logger',
     'foam.nanos.logger.Loggers',
@@ -64,11 +63,7 @@ the notification will be handled. `,
         if ( ! foam.util.SafetyUtil.isEmpty(notification.getTemplate()) ) {
           List templates = ((ArraySink) ((DAO) x.get("notificationTemplateDAO"))
             .limit(2)
-            .where(
-              OR(
-                EQ(Notification.ID, notification.getTemplate()),
-                EQ(Notification.TEMPLATE, notification.getTemplate())
-              ))
+            .where(EQ(Notification.TEMPLATE, notification.getTemplate()))
             .select(new ArraySink()))
             .getArray();
 

--- a/src/foam/nanos/notification/broadcast/BroadcastNotification.js
+++ b/src/foam/nanos/notification/broadcast/BroadcastNotification.js
@@ -14,7 +14,6 @@ foam.CLASS({
     'body',
     'notificationType',
     'broadcasted',
-    'groupId.id',
     'createdBy.userName'
   ],
 });

--- a/src/foam/nanos/notification/broadcast/BroadcastNotificationFacade.js
+++ b/src/foam/nanos/notification/broadcast/BroadcastNotificationFacade.js
@@ -8,19 +8,25 @@ foam.CLASS({
   package: 'foam.nanos.notification.broadcast',
   name: 'BroadcastNotificationFacade',
 
+  implements: [
+    'foam.mlang.Expressions'
+  ],
   imports: [
     'auth?',
     'broadcastNotificationDAO',
     'ctrl',
-    'notificationDAO'
+    'notificationDAO',
+    'notificationTemplateDAO',
+    'userDAO'
   ],
   requires: [
+    'foam.nanos.auth.User',
     'foam.nanos.notification.Notification',
     'foam.nanos.notification.broadcast.BroadcastNotification'
   ],
   messages: [
-    { name: 'GROUP_REQUIRED',       message: 'Group is required' },
-    { name: 'BODY_REQUIRED',        message: 'Notification body is required' },
+    { name: 'GROUP_OR_USERS_REQUIRED', message: 'Group or Users are required' },
+    { name: 'BODY_OR_TEMPLATE_REQUIRED', message: 'Notification body and/or template is required' },
     { name: 'TOAST_REQUIRED',       message: 'Toast Message is required when showing toast' },
     { name: 'NOTIFICATION_SENT',    message: 'Notification Sent' },
     { name: 'NOTIFICAITON_SUMMARY', message: 'notification to ' },
@@ -29,35 +35,102 @@ foam.CLASS({
   properties: [
     {
       __copyFrom__: 'foam.nanos.notification.Notification.GROUP_ID',
-      label: 'Send To',
-      validateObj: function(groupId) {
-        if ( ! groupId ) {
-          return this.GROUP_REQUIRED;
+      label: 'Send To Group',
+      validateObj: function(groupId, users) {
+        if ( ! groupId && ! ( users && users.length ) ) {
+          return this.GROUP_OR_USERS_REQUIRED;
         }
       },
       view: function(_, X) {
-        const e = foam.mlang.Expressions.create();
-        const group = foam.nanos.auth.Group;
         var dao = X[X.data.GROUP_ID.targetDAOKey] || X.data[X.data.GROUP_ID.name + '$dao'];
         // TODO: find a better way to only pick children
-        let dao$ = foam.core.PromiseSlot.create({
-          promise: X.auth.check(null, '*').then(value => {
-            if ( value ) return dao;
-            return dao.where(e.CONTAINS(group.ID, X.subject.user.spid));
-          })
-        }, X);
-        return { class: 'foam.u2.view.ReferenceView', dao$: dao$ };
+        // dao = dao.where(X.data.CONTAINS(group.ID, X.subject.user.spid));
+        return { class: 'foam.u2.view.ReferenceView', dao: dao };
+      }
+    },
+    {
+      class: 'Array',
+      name: 'users',
+      label: 'Send to Users',
+      view: function(_, X) {
+        var userDAOSlot = X.data.slot(groupId => {
+          if ( groupId ) {
+            return X.userDAO.where(X.data.EQ(X.data.User.GROUP, groupId));
+          } else {
+            return X.userDAO.where(X.data.EQ(X.data.User.SPID, X.subject.user.spid));
+          }
+        });
+        return {
+          class: 'foam.u2.view.ReferenceArrayView',
+          daoKey: 'userDAO',
+          allowDuplicates: false,
+          valueView: {
+            class: 'foam.u2.view.RichChoiceReferenceView',
+            search: true,
+            sections: [
+              {
+                heading: 'Users',
+                dao$: userDAOSlot
+              }
+            ]
+          }
+        }
+      },
+      validateObj: function(groupId, users) {
+        if ( ! groupId && ! ( users && users.length ) ) {
+          return this.GROUP_OR_USERS_REQUIRED;
+        }
+      }
+    },
+    {
+      class: 'Reference',
+      name: 'notificationTemplate',
+      of: 'foam.nanos.notification.Notification',
+      view: function(_, X) {
+        var dao = X.notificationTemplateDAO;
+        return {
+          class: 'foam.u2.view.ModeAltView',
+          readView: { class: 'foam.u2.view.StringView' },
+          writeView: {
+            class: 'foam.u2.view.RichChoiceReferenceView',
+            sections: [
+              {
+                heading: 'Notification Templates',
+                dao: dao
+              }
+            ],
+            placeholder: '--'
+          }
+        };
+      },
+      postSet: function(_, n) {
+        var self = this;
+        this.notificationTemplateDAO.find(n).then(function(t) {
+          self.template = t.template;
+        })
+      },
+      validateObj: function(body, notificationTemplate) {
+        if ( ( ! body || ! body.length || ! body.trim() ) &&
+             ( ! notificationTemplate ) ) {
+          return this.BODY_OR_TEMPLATE_REQUIRED;
+        }
       }
     },
     {
       __copyFrom__: 'foam.nanos.notification.Notification.BODY',
       label: 'Notification Body',
       view: { class: 'foam.u2.view.RichTextView' },
-      validateObj: function(body) {
-        if ( ! body || ! body.length || ! body.trim() ) {
-          return this.BODY_REQUIRED;
+      validateObj: function(body, notificationTemplate) {
+        if ( ( ! body || ! body.length || ! body.trim() ) &&
+             ( ! notificationTemplate ) ) {
+          return this.BODY_OR_TEMPLATE_REQUIRED;
         }
       }
+    },
+    {
+      __copyFrom__: 'foam.nanos.notification.Notification.EMAIL_ARGS',
+      label: "Email Template Args",
+      visibility: 'RW',
     },
     {
       class: 'Boolean',
@@ -93,26 +166,58 @@ foam.CLASS({
         return ! errors_;
       },
       code: function() {
-        var a = this.BroadcastNotification.create({
+        var self = this;
+        var notif = this.BroadcastNotification.create({
+          template: this.template,
           body: this.body,
           toastMessage: this.toastMessage,
           groupId: this.groupId,
+          users: this.users,
+          emailArgs: this.emailArgs,
           severity: 'INFO',
           transient: false,
           toastState: this.showToast ? 'REQUESTED' : 'NONE'
         });
-        this.broadcastNotificationDAO.put(a).then(obj => {
-          this.notificationDAO.put(a).then(() => {
+        if ( this.users && this.users.length > 0 ) {
+          this.broadcastNotificationDAO.put(notif).then(obj => {
+            this.users.forEach((uid) => {
+              var n = notif;
+              n.groupId = undefined;
+              n.userId = uid;
+              this.notificationDAO.put(n).then(() => {
+              }, e => {
+                this.ctrl.notify(this.NOTIFICATION_ERROR, e.message, 'ERROR', true);
+              });
+            });
             // Reset all props
+            this.notificationTemplate = undefined;
+            this.template = undefined;
             this.body = undefined;
             this.toastMessage = undefined;
             this.showToast = undefined;
             this.groupId = undefined;
+            this.users = undefined;
+            this.emailArgs = undefined;
             this.ctrl.notify(this.NOTIFICATION_SENT, '', 'INFO', true);
-          }, e => {
-            this.ctrl.notify(this.NOTIFICATION_ERROR, e.message, 'ERROR', true);
           });
-        });
+        } else if ( this.groupId ) {
+          this.broadcastNotificationDAO.put(notif).then(obj => {
+            this.notificationDAO.put(notif).then(() => {
+              // Reset all props
+              this.notificationTemplate = undefined;
+              this.template = undefined;
+              this.body = undefined;
+              this.toastMessage = undefined;
+              this.showToast = undefined;
+              this.groupId = undefined;
+              this.users = undefined;
+              this.emailArgs = undefined;
+              this.ctrl.notify(this.NOTIFICATION_SENT, '', 'INFO', true);
+            }, e => {
+              this.ctrl.notify(this.NOTIFICATION_ERROR, e.message, 'ERROR', true);
+            });
+          });
+        }
       }
     }
   ]

--- a/src/foam/nanos/notification/broadcast/menus.jrl
+++ b/src/foam/nanos/notification/broadcast/menus.jrl
@@ -1,0 +1,26 @@
+p({
+  "class":"foam.nanos.menu.Menu",
+  "id":"notification.broadcastnotifications",
+  "label":"Broadcasted Notifications",
+  "handler": {
+    "class":"foam.nanos.menu.DAOMenu2",
+    "config": {
+      "class":"foam.comics.v2.DAOControllerConfig",
+      "daoKey":"broadcastNotificationDAO",
+      "cannedQueries": []
+    }
+  },
+  "parent":"notification"
+})
+
+p({
+  "class":"foam.nanos.menu.Menu",
+  "id":"notification.send-notification",
+  "label":"Send Notification",
+  "keywords": ["notification","broadcast"],
+  "handler":{
+    "class":"foam.nanos.menu.ViewMenu",
+    "view": { "class": "foam.nanos.notification.broadcast.SendNotificationView" }
+  },
+  "parent":"notification"
+})

--- a/src/foam/nanos/notification/email/menus.jrl
+++ b/src/foam/nanos/notification/email/menus.jrl
@@ -1,6 +1,6 @@
 p({
   class:"foam.nanos.menu.Menu",
-  id:"emailServiceConfig",
+  id:"notification.emailServiceConfig",
   label:"Email Service Configuration",
   keywords: ["email","config","smtp"],
   handler:{
@@ -11,25 +11,28 @@ p({
       browseTitle:"Email Service Configuration"
     }
   },
-  parent:"admin"
+  parent:"notification"
 })
 p({
   "class":"foam.nanos.menu.Menu",
-  "id":"emailmessages",
+  "id":"notification.emailmessages",
   "label":"Email Messages",
   "keywords": ["email","message"],
   "handler":{
     "class":"foam.nanos.menu.DAOMenu2",
     "config":{
       "class":"foam.comics.v2.DAOControllerConfig",
-      "daoKey":"emailMessageDAO"
+      "daoKey":"emailMessageDAO",
+      "editPredicate":{"class":"foam.mlang.predicate.False"},
+      "createPredicate":{"class":"foam.mlang.predicate.False"},
+      "deletePredicate":{"class":"foam.mlang.predicate.False"}
     }
   },
-  "parent":"admin"
+  "parent":"notification"
 })
 p({
   "class":"foam.nanos.menu.Menu",
-  "id":"emailtemplates",
+  "id":"notification.emailtemplates",
   "label":"Email Templates",
   "keywords": ["email","message","template"],
   "handler":{
@@ -39,5 +42,5 @@ p({
       "daoKey":"emailTemplateDAO"
     }
   },
-  "parent":"admin"
+  "parent":"notification"
 })

--- a/src/foam/nanos/notification/menus.jrl
+++ b/src/foam/nanos/notification/menus.jrl
@@ -1,14 +1,81 @@
 p({
   "class":"foam.nanos.menu.Menu",
-  "id":"admin.broadcastNotifications",
-  "label":"Broadcasted Notifications",
-  "handler": {
+  "id":"notification",
+  "label":"Notifications",
+  "handler":{
+    "class":"foam.nanos.menu.SubMenu"
+  }
+})
+
+p({
+  "class":"foam.nanos.menu.Menu",
+  "id":"notification.notificationtemplates",
+  "label":"Notification Templates",
+  "keywords": ["notification","template","pwa"],
+  "handler":{
     "class":"foam.nanos.menu.DAOMenu2",
-    "config": {
+    "config":{
       "class":"foam.comics.v2.DAOControllerConfig",
-      "daoKey":"broadcastNotificationDAO",
-      "cannedQueries": []
+      "daoKey":"notificationTemplateDAO",
+      of: "foam.nanos.notification.Notification",
+      browseTitle:"Notification Templates"
     }
   },
-  "parent":"admin"
+  "parent":"notification"
+})
+
+p({
+  class: "foam.nanos.menu.Menu",
+  id: "notification.notifications",
+  label: "Notifications",
+  handler: {
+    class: "foam.nanos.menu.DAOMenu2",
+    config: {
+      class: "foam.comics.v2.DAOControllerConfig",
+      daoKey: "notificationDAO",
+      of: "foam.nanos.notification.Notification",
+      browseTitle: "Notifications",
+      createPredicate: {class:"foam.mlang.predicate.True"},
+      editPredicate: {class:"foam.mlang.predicate.True"},
+      deletePredicate: {class:"foam.mlang.predicate.True"}
+    }
+  },
+  parent:"notification"
+})
+p({
+  class: "foam.nanos.menu.Menu",
+  id: "notification.notificationsettingdefaults",
+  label: "Default Notification Settings",
+  handler: {
+    class: "foam.nanos.menu.DAOMenu2",
+    config: {
+      class: "foam.comics.v2.DAOControllerConfig",
+      daoKey: "notificationSettingDefaultsDAO",
+      of: "foam.nanos.notification.NotificationSetting",
+      browseTitle: "Default Notification Settings",
+      createPredicate: {class:"foam.mlang.predicate.True"},
+      editPredicate: {class:"foam.mlang.predicate.True"},
+      deletePredicate: {class:"foam.mlang.predicate.True"}
+    }
+  },
+  parent:"notification"
+})
+
+p({
+  class: "foam.nanos.menu.Menu",
+  id: "notification.notificationsettingusers",
+  label: "User Notification Settings",
+  handler: {
+    class: "foam.nanos.menu.DAOMenu2",
+    config: {
+      class: "foam.comics.v2.DAOControllerConfig",
+      daoKey: "notificationSettingDAO",
+      of: "foam.nanos.notification.NotificationSetting",
+      browseTitle: "User Notification Settings",
+      createPredicate: {class:"foam.mlang.predicate.True"},
+      editPredicate: {class:"foam.mlang.predicate.True"},
+      deletePredicate: {class:"foam.mlang.predicate.False"}
+    }
+  },
+  parent:"notification"
 })

--- a/src/foam/nanos/theme/menus.jrl
+++ b/src/foam/nanos/theme/menus.jrl
@@ -40,14 +40,3 @@ p({
   },
   "parent":"admin"
 })
-
-p({
-  "class":"foam.nanos.menu.Menu",
-  "id":"admin.send-notification",
-  "label":"Send Notification",
-  "handler":{
-    "class":"foam.nanos.menu.ViewMenu",
-    "view": { "class": "foam.nanos.notification.broadcast.SendNotificationView" }
-  },
-  "parent":"admin"
-})


### PR DESCRIPTION
Additional refactoring to make Send Notification the official way to manually create a Notification.

The BroadcastNotificationFacade updated with notification template, email args, multiple users.
Allows the operator to manually send a notification using a notification template, which itself may have an email template, and provide email args for the email template. Or explicitly set the entire notification body. 
Users are filtered by the group if selected. If group is selected and no users, then the notification goes to all users in the group (which have notification settings). 

![Screenshot 2024-10-25 at 3 50 23 PM](https://github.com/user-attachments/assets/78185f72-1fc4-4c0c-8ecf-972d3d7d71c2)
