### PR TITLE
HttpServer - set ALPN default protocol to http1.1 regardless of reque…

### DIFF
--- a/src/foam/nanos/jetty/HttpServer.js
+++ b/src/foam/nanos/jetty/HttpServer.js
@@ -496,11 +496,7 @@ foam.CLASS({
 
           ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
           // default protocol when there is no negotiation.
-          if ( getHttpVersion() == HttpVersion.V2 ) {
-            alpn.setDefaultProtocol(http2.getProtocol());
-          } else {
-            alpn.setDefaultProtocol(http11.getProtocol());
-          }
+          alpn.setDefaultProtocol(http11.getProtocol());
 
           SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
 

--- a/src/foam/nanos/jetty/curl-tests.sh
+++ b/src/foam/nanos/jetty/curl-tests.sh
@@ -3,10 +3,12 @@
 
 # HTTP Version
 # http1
-curl -k -v --http1.1 https://localhost:8443/index.html
+curl -k -v --http1.1 https://localhost:8443/service/health?format=html
+curl -k -v --http1.1 --tlsv1.1 https://localhost:8443/service/health?format=html
+curl -k -v --http1.0 --tlsv1.1 https://localhost:8443/service/health?format=html
 
 # http2
-curl -k -v --http2-prior-knowledge https://localhost:8443/index.html
+curl -k -v --http2-prior-knowledge https://localhost:8443/service/health?format=html
 
 # GZIP Compression
 # output of this should be larger than following
@@ -14,3 +16,9 @@ curl -k -v --silent --write-out "%{size_download}\n" --output /dev/null -H "Acce
 
 # no compression
 curl -k -v --silent --write-out "%{size_download}\n" --output /dev/null https://localhost:8300/foam-bin-4.35.js
+
+# through load-balancer
+curl https://foree-staging.nanopay.net/service/health?format=html
+
+# idm webagent
+curl -k -v --http1.1 https://localhost:8443/service/identityMindWebAgent


### PR DESCRIPTION
…st nspec version configuration.  This is used as the fallback when a client does not negotiate a version