### PR TITLE
FScriptParser - Refactor constructors

### DIFF
--- a/src/foam/parse/FScriptParser.java
+++ b/src/foam/parse/FScriptParser.java
@@ -57,6 +57,17 @@ public class FScriptParser {
     return p;
   }
 
+  // Strongly consider using FScriptParser.create() instead
+  public static FScriptParser create(ClassInfo classInfo, List expressions) {
+    if ( expressions == null ||
+         expressions.size() == 0 ) {
+      return FScriptParser.create(classInfo);
+    }
+    FScriptParser p = new FScriptParser(classInfo);
+    p.addExpressions(expressions);
+    return p;
+  }
+
   ClassInfo classInfo_;
   protected List expressions;
 
@@ -66,13 +77,12 @@ public class FScriptParser {
     setup(property.getClassInfo(), props);
   }
 
-  // Strongly consider using FScriptParser.create() instead
-  public FScriptParser(ClassInfo classInfo) {
+  private FScriptParser(ClassInfo classInfo) {
     Map props = new HashMap<String, PropertyInfo>();
     setup(classInfo, props);
   }
 
-  public void addExpressions(List expressions) {
+  private void addExpressions(List expressions) {
     this.expressions.addAll(expressions);
     this.expressions.sort(Comparator.comparing(LiteralIC::getString).reversed());
     // foam.nanos.logger.StdoutLogger.instance().info(this.getClass().getSimpleName(), "expressions", this.expressions.stream().map(Object::toString).collect(java.util.stream.Collectors.joining(",")));

--- a/src/foam/parse/test/FScriptParserTest.js
+++ b/src/foam/parse/test/FScriptParserTest.js
@@ -419,7 +419,6 @@ foam.CLASS({
     sps.setString("instanceof foam.nanos.ruler.Rule");
     test(((Predicate) parser.parse(sps, px).value()).f(rule), "thisValue instanceof foam.nanos.ruler.Rule");
 
-    parser = FScriptParser.create(foam.parse.test.FScriptParserTestUser.getOwnClassInfo());
     List<LiteralIC> expressions = new ArrayList();
     expressions.add(new LiteralIC("lit_int_10", new Constant(10)));
     expressions.add(new LiteralIC("lit_int_20", new Constant(20)));
@@ -428,7 +427,7 @@ foam.CLASS({
     expressions.add(new LiteralIC("lit_float_222", new Constant(222.0)));
     expressions.add(new LiteralIC("lit_float_333", new Constant(333.0)));
     expressions.add(new LiteralIC("region", new Constant("CA-ON")));
-    parser.addExpressions(expressions);
+    parser = FScriptParser.create(foam.parse.test.FScriptParserTestUser.getOwnClassInfo(), expressions);
 
     sps.setString("if (address.regionId==region) {firstName} else {null}");
     result = (String) ((Expr)parser.parse(sps, px).value()).f(user);


### PR DESCRIPTION
Refactor constructors such that initialization with expressions uses a cached parser if expressions are null/empty.

With this FeeFScript calls create(object, expressions). 