### PR TITLE
Fix TableExportDriver

### DIFF
--- a/src/foam/nanos/export/TableExportDriver.js
+++ b/src/foam/nanos/export/TableExportDriver.js
@@ -65,7 +65,7 @@ foam.CLASS({
       var expr = ( foam.nanos.column.ExpressionForArrayOfNestedPropertiesBuilder.create() ).buildProjectionForPropertyNamesArray(dao.of, propertyNamesToQuery, projectionSafe);
       var sink = await dao.select(expr);
       if (sink.exprs.length < propertyNamesToQuery.length) {
-        // re-populate propNamesToQuery to remove properties that cannot be queried (e.g., properties in many-to-one relationthips)
+        // re-populate propNamesToQuery to remove properties that cannot be queried (e.g., properties in many-to-one relationships)
         propToColumnMapping  = this.columnConfigToPropertyConverter.returnPropertyColumnMappings(dao.of, sink.exprs.map(e => e.name));
         propertyNamesToQuery = this.columnHandler.returnPropNamesToQuery(propToColumnMapping);
       }

--- a/src/foam/nanos/export/TableExportDriver.js
+++ b/src/foam/nanos/export/TableExportDriver.js
@@ -64,9 +64,10 @@ foam.CLASS({
       let projectionSafe = ! propToColumnMapping.some(p => ! p.property.projectionSafe );
       var expr = ( foam.nanos.column.ExpressionForArrayOfNestedPropertiesBuilder.create() ).buildProjectionForPropertyNamesArray(dao.of, propertyNamesToQuery, projectionSafe);
       var sink = await dao.select(expr);
-      if (sink.exprs.length < propertyNamesToQuery.length) {
-        // re-populate propNamesToQuery to remove properties that cannot be queried (e.g., properties in many-to-one relationships)
-        propToColumnMapping  = this.columnConfigToPropertyConverter.returnPropertyColumnMappings(dao.of, sink.exprs.map(e => e.name));
+      if (sink.exprs.length !== propertyNamesToQuery.length) {
+        // re-populate propNamesToQuery to match result in sink (e.g., remove property names in many-to-one relationships)
+        propNames = sink.exprs.map(e => e.name);
+        propToColumnMapping  = this.columnConfigToPropertyConverter.returnPropertyColumnMappings(dao.of, propNames);
         propertyNamesToQuery = this.columnHandler.returnPropNamesToQuery(propToColumnMapping);
       }
       return await this.outputter.returnTable(X, dao.of, propertyNamesToQuery, sink.projection, propNames.length, this.addUnits);

--- a/src/foam/nanos/export/TableExportDriver.js
+++ b/src/foam/nanos/export/TableExportDriver.js
@@ -72,10 +72,6 @@ foam.CLASS({
       return await this.outputter.returnTable(X, dao.of, propertyNamesToQuery, sink.projection, propNames.length, this.addUnits);
     },
 
-    function getPropNamesToQuery(dao, propToColumnMapping) {
-      return this.columnHandler.returnPropNamesToQuery(propToColumnMapping);
-    },
-
     function getPropName(X, of) {
       var propNames = X.filteredTableColumns ? X.filteredTableColumns : this.outputter.getAllPropertyNames(of);
       return this.columnConfigToPropertyConverter.filterExportedProps(of, propNames);


### PR DESCRIPTION
Remove props that cannot be queried (e.g., properties in many-to-one relationships with the model being exported)