### PR TITLE
Turn Off autoSave for capabilities by default

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -284,7 +284,7 @@ foam.CLASS({
       name: 'autoSave',
       documentation: 'If false, disable auto save for wizardlets associated to this capability.',
       hidden: true,
-      value: true
+      // value: true
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
This currently doesn't work properly, it causes desync when server calls take too long and with the use of incrementalWizards rather than scrolling wizards this doesnt change user input behaviour anyway