### PR TITLE
DateView - build Date only date string

### DIFF
--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -1001,6 +1001,9 @@ foam.LIB({
       let newValue = date.valueOf() - offsetInMillis;
       date = new Date(newValue)
       return date.toISOString().substring(0,16);
+    },
+    function toInputCompatibleDateString(date) {
+      return foam.Date.toInputCompatibleDateTimeString(date).substring(0, 10);
     }
   ]
 });

--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -55,13 +55,13 @@ foam.CLASS({
       var slot    = this.attrSlot(); //null, this.onKey ? 'input' : null);
 
       function updateSlot() {
-        var date = self.data;
         if ( focused ) return;
+        var date = self.data;
         if ( foam.Number.isInstance(date) ) date = new Date(date);
         if ( ! date ) {
           slot.set('');
         } else {
-          slot.set(foam.Date.toInputCompatibleDateTimeString(date));
+          slot.set(foam.Date.toInputCompatibleDateString(date));
         }
       }
 


### PR DESCRIPTION
DateView requires Input format yyyy-mm-dd.
Previously it was receiving date-time format yyyy-mm-ddThh:mm