### PR TITLE
Cleanup of DateTimeView(s) to match DateView(s)

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -32,7 +32,7 @@ foam.CLASS({
     'auth',
     'notify',
     'routeTo',
-    'ticketDAO'
+    'ticketDAO?'
   ],
 
   javaImports: [

--- a/src/foam/u2/DateTimeView.js
+++ b/src/foam/u2/DateTimeView.js
@@ -1,18 +1,7 @@
 /**
  * @license
- * Copyright 2017 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 
 // TODO: Add datalist support.
@@ -27,17 +16,29 @@ foam.CLASS({
   mixins: [ 'foam.u2.TextInputCSS' ],
 
   css: `
-    ^ {
-      height: $inputHeight;
+    ^:read-only:not(:disabled) { border: none; background: rgba(0,0,0,0); margin-left: -8px; }
+    ^ { height: $inputHeight; min-width: 130px; }
     }
   `,
 
+  messages: [
+    { name: 'DATE_FORMAT', message: 'yyyy-mm-dd hh:mm' }
+  ],
+
   properties: [
-    [ 'placeholder', 'yyyy/mm/dd hh:mm' ],
+    [ 'placeholder', this.DATE_FORMAT ],
     [ 'type', 'datetime-local' ]
   ],
 
   methods: [
+    function render() {
+      this.SUPER();
+
+      // Scroll listener needed because DateView generates scroll event
+      // in some foreign locales which conflicts with ScrollWizard.
+      this.on('scroll', e => { e.preventDefault(); e.stopPropagation(); });
+    },
+
     function link() {
       if ( this.linked ) return;
       this.linked = true;
@@ -46,12 +47,12 @@ foam.CLASS({
       var slot    = this.attrSlot(); //null, this.onKey ? 'input' : null);
 
       function updateSlot() {
+        if ( focused ) return;
         var date = self.data;
+        if ( foam.Number.isInstance(date) ) date = new Date(date);
         if ( ! date ) {
           slot.set('');
         } else {
-          if ( ! foam.Date.isInstance(date) )
-            date = new Date(date);
           slot.set(foam.Date.toInputCompatibleDateTimeString(date));
         }
       }

--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -26,11 +26,14 @@ foam.CLASS({
     { name: 'DATE_FORMAT', message: 'yyyy-mm-dd' }
   ],
 
+  properties: [
+    [ 'placeholder', this.DATE_FORMAT ],
+    [ 'type', 'date' ]
+  ],
+
   methods: [
     function render() {
-      this.setAttribute('type', 'date');
       this.setAttribute('max', '9999-12-31');
-      this.setAttribute('placeholder', this.DATE_FORMAT);
 
       this.SUPER();
 

--- a/src/foam/u2/view/DateTimeView.js
+++ b/src/foam/u2/view/DateTimeView.js
@@ -16,17 +16,6 @@ foam.CLASS({
     'foam.u2.view.date.DateTimePicker'
   ],
 
-//   properties: [
-//     {
-//       name: 'readView',
-// //      value: { class: 'foam.u2.view.RODateTimeView' }
-//       value: { class: 'foam.u2.DateTimeView' }
-//     },
-//     {
-//       name: 'writeView',
-//       value: { class: 'foam.u2.DateTimeView' }
-//     }
-//   ]
   constants: [
     {
       // Choose the writeView delegate based on browser compatibility.

--- a/src/foam/u2/view/DateTimeView.js
+++ b/src/foam/u2/view/DateTimeView.js
@@ -13,17 +13,55 @@ foam.CLASS({
 
   requires: [
     'foam.u2.DateTimeView',
-    'foam.u2.view.ValueView'
+    'foam.u2.view.date.DateTimePicker'
+  ],
+
+//   properties: [
+//     {
+//       name: 'readView',
+// //      value: { class: 'foam.u2.view.RODateTimeView' }
+//       value: { class: 'foam.u2.DateTimeView' }
+//     },
+//     {
+//       name: 'writeView',
+//       value: { class: 'foam.u2.DateTimeView' }
+//     }
+//   ]
+  constants: [
+    {
+      // Choose the writeView delegate based on browser compatibility.
+      // Safari doesn't support date input types.
+      name: 'READ_DELEGATE',
+      factory: function() {
+        var e = document.createElement('input');
+        e.setAttribute('type', 'date');
+        return e.type === 'text' ?
+          'foam.u2.view.date.DateTimePicker' :
+          'foam.u2.view.RODateTimeView' ;
+      }
+    },
+    {
+      // Choose the writeView delegate based on browser compatibility.
+      // Safari doesn't support date input types.
+      name: 'WRITE_DELEGATE',
+      factory: function() {
+        var e = document.createElement('input');
+        e.setAttribute('type', 'date');
+        return e.type === 'text' ?
+          'foam.u2.view.date.DateTimePicker' :
+          'foam.u2.DateTimeView' ;
+      }
+    }
   ],
 
   properties: [
     {
       name: 'readView',
-      value: { class: 'foam.u2.view.RODateTimeView' }
+      factory: function() { return { class: this.READ_DELEGATE }; }
     },
     {
       name: 'writeView',
-      value: { class: 'foam.u2.DateTimeView' }
+      factory: function() { return { class: this.WRITE_DELEGATE }; }
     }
-  ],
+  ]
 });

--- a/src/foam/u2/view/DateView.js
+++ b/src/foam/u2/view/DateView.js
@@ -13,8 +13,7 @@ foam.CLASS({
 
   requires: [
     'foam.u2.DateView',
-    'foam.u2.view.date.DateTimePicker',
-    'foam.u2.view.ValueView'
+    'foam.u2.view.date.DateTimePicker'
   ],
 
   constants: [
@@ -26,8 +25,8 @@ foam.CLASS({
         var e = document.createElement('input');
         e.setAttribute('type', 'date');
         return e.type === 'text' ?
-          'foam.u2.view.date.RODateView' :
-          'foam.u2.DateView' ;
+          'foam.u2.view.date.DateTimePicker' :
+          'foam.u2.view.date.RODateView' ;
       }
     },
     {

--- a/src/foam/u2/view/RODateTimeView.js
+++ b/src/foam/u2/view/RODateTimeView.js
@@ -26,7 +26,7 @@ foam.CLASS({
       this.SUPER();
       this.start().
         addClass(this.myClass()).
-        add(this.data$.map(d => d ? d.toLocaleString(foam.locale, this.options) : foam.u2.DateView.DATE_FORMAT)).
+        add(this.data$.map(d => d ? d.toLocaleString(foam.locale, this.options) : foam.u2.DateTimeView.DATE_FORMAT)).
       end();
     }
   ]

--- a/src/foam/u2/view/date/RODateView.js
+++ b/src/foam/u2/view/date/RODateView.js
@@ -16,7 +16,7 @@ foam.CLASS({
       this.SUPER();
       this.start().
         addClass(this.myClass()).
-        add(this.data$.map(d => d ? d.toLocaleDateString() : foam.u2.DateView.DATE_FORMAT)).
+        add(this.data$.map(d => d ? d.toLocaleDateString(foam.locale, this.options) : foam.u2.DateView.DATE_FORMAT)).
       end();
     }
   ]


### PR DESCRIPTION
Occurred during troubleshooting of some Date issues. 
Brings DateTime inline with Date css styling, Input property setup, and also ensures the correct default Date Format is used. 