### PR TITLE
build.js - use 'a' option to configure system to run from jar file

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -726,7 +726,7 @@ function moreUsage() {
 
 const ARGS = {
   a: [ 'Run/launch from Java jar file.',
-    () => RUN_JAR = true; ],
+    () => RUN_JAR = true ],
   b: [ 'run all benchmarks.',
     () => {
       BENCHMARK = true;

--- a/tools/build.js
+++ b/tools/build.js
@@ -501,11 +501,6 @@ task('Delete runtime journals.', [], function deleteRuntimeJournals() {
 });
 
 
-task('Delete runtime logs.', [], function deleteRuntimeLogs() {
-  info('Runtime logs deleted.');
-  emptyDir(LOG_HOME);
-});
-
 task('Copy required files to APP_HOME deployment directory.', [], function deployToHome() {
   copyDir('./foam3/tools/deploy/bin', join(APP_HOME, 'bin'));
   copyDir('./foam3/tools/deploy/etc', join(APP_HOME, 'etc'));
@@ -730,8 +725,8 @@ function moreUsage() {
 }
 
 const ARGS = {
-  a: [ 'Delete runtime logs.',
-    () => DELETE_RUNTIME_LOGS = true ],
+  a: [ 'Run/launch from Java jar file.',
+    () => RUN_JAR = true; ],
   b: [ 'run all benchmarks.',
     () => {
       BENCHMARK = true;
@@ -906,8 +901,6 @@ function all() {
   stopNanos();
 
   if ( DELETE_RUNTIME_JOURNALS ) deleteRuntimeJournals();
-
-  if ( DELETE_RUNTIME_LOGS     ) deleteRuntimeLogs();
 
   if ( STOP_ONLY ) quit(0);
 


### PR DESCRIPTION
build.js - use 'a' option to configure system to run from jar file without the additional resources considerations of option 'u'

(does not work for nanopay deployments, but that's ok, as long as we keep 'u').  