### PR TITLE
crunch rules - fscript parser fails to parse 'exists' with surroundin…

### DIFF
--- a/src/foam/nanos/crunch/ruler/rules.jrl
+++ b/src/foam/nanos/crunch/ruler/rules.jrl
@@ -217,7 +217,7 @@ p({
   "enabled":true,
   predicate: {
     class: 'foam.nanos.ruler.predicate.FScriptRulePredicate',
-    query: '( o !exists || o.status != n.status ) && n.status == foam.nanos.crunch.CapabilityJunctionStatus.GRANTED'
+    query: '(o !exists||o.status != n.status) && n.status == foam.nanos.crunch.CapabilityJunctionStatus.GRANTED'
   },
   "action":{"class":"foam.nanos.crunch.ruler.ConfigureUCJExpiryOnGranted"},
   "lifecycleState":1,
@@ -290,7 +290,7 @@ p({
   "enabled":true,
   predicate: {
     class: 'foam.nanos.ruler.predicate.FScriptRulePredicate',
-    query: '( o !exists || o.status != n.status ) && n.status == foam.nanos.crunch.CapabilityJunctionStatus.APPROVED'
+    query: '(o !exists||o.status != n.status) && n.status == foam.nanos.crunch.CapabilityJunctionStatus.APPROVED'
   },
   "action":{"class":"foam.nanos.crunch.ruler.SetUCJStatusOnPut"},
   "lifecycleState":1,


### PR DESCRIPTION
…g spaces
This fixes the rules. 
Parsing fix is future work. 