### PR TITLE
Schedulable - Disable run and disable action permissions

### DIFF
--- a/src/foam/nanos/cron/Schedulable.js
+++ b/src/foam/nanos/cron/Schedulable.js
@@ -362,14 +362,14 @@ foam.CLASS({
     }
   ],
 
-  actions: [
-    {
-      name: 'disable',
-      availablePermissions: ['foam.nanos.cron.Schedule.disable']
-    },
-    {
-      name: 'run',
-      availablePermissions: ['foam.nanos.cron.Schedule.run']
-    }
-  ]
+//   actions: [
+//     {
+//       name: 'disable',
+//       availablePermissions: ['foam.nanos.cron.Schedule.disable']
+//     },
+//     {
+//       name: 'run',
+//       availablePermissions: ['foam.nanos.cron.Schedule.run']
+//     }
+//   ]
 });


### PR DESCRIPTION
The run and disable action permissions are failing isAvailable checks even from Admin.  
Disabling for now as it breaks Schedulable objecs in the Cron view.  
Will continue to investigate