### PR TITLE
Schdulable - remove actions adding available permissions.  

### DIFF
--- a/src/foam/nanos/cron/Schedulable.js
+++ b/src/foam/nanos/cron/Schedulable.js
@@ -357,19 +357,7 @@ foam.CLASS({
         } else {
           return ! alreadyRanToday;
         }
-
       `
     }
-  ],
-
-//   actions: [
-//     {
-//       name: 'disable',
-//       availablePermissions: ['foam.nanos.cron.Schedule.disable']
-//     },
-//     {
-//       name: 'run',
-//       availablePermissions: ['foam.nanos.cron.Schedule.run']
-//     }
-//   ]
+  ]
 });


### PR DESCRIPTION
This method of setting just the permissions does not work, but regardless the end user does not have access to Cron so these permissions are presently meaningless. 