### PR TITLE
build.js: Refactor so that deployment dir is only hit when necessary

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -823,8 +823,8 @@ function all() {
     }
 
     // Tests and benchmarks run from a deployed jar
-    if ( TEST || BENCHMARK ) {
-      deploy()
+    if ( BUILD_JAR || TEST || BENCHMARK ) {
+      deploy();
     }
 
     if ( PACKAGE ) {

--- a/tools/build.js
+++ b/tools/build.js
@@ -371,11 +371,6 @@ task('Remove generated files.', [], function clean() {
 });
 
 
-task('Copy Java libraries from BUILD_DIR/lib to APP_HOME/lib.', [], function copyLib() {
-  copyDir(join(BUILD_DIR, 'lib'), join(APP_HOME, 'lib'));
-});
-
-
 task("Call pmake with JS Maker to build 'foam-bin.js'.", [], function genJS() {
   execSync(`rm -f ${BUILD_DIR}/js/foam-bin-* >/dev/null 2>&1`);
   var version = foamBinVersion();
@@ -436,9 +431,8 @@ task('Get Maven java sources.', [], function mavenGetSources(value) {
   }
 });
 
-task('Generate and compile java source.', [ 'genJava', 'copyLib' ], function buildJava() {
+task('Generate and compile java source.', [ 'genJava' ], function buildJava() {
   genJava();
-  copyLib();
 });
 
 
@@ -461,11 +455,13 @@ task('Package files into a TAR archive', [], function buildTar() {
   // Notice that the argument to the second -C is relative to the directory from the first -C, since -C
   // switches the current directory.
   ensureDir(BUILD_DIR + '/package');
-  execSync(`tar -a -cf ${BUILD_DIR}/package/${APP_NAME}-deploy-${VERSION}.tar.gz -C ./foam3/tools/deploy bin etc -C ../../../ -C${BUILD_DIR} lib`);
+  execSync(`tar -a -cf ${BUILD_DIR}/package/${APP_NAME}-deploy-${VERSION}.tar.gz -C ./foam3/tools/deploy bin etc -C${require('path').resolve(BUILD_DIR)} lib`);
 });
 
 
-task('Copy required files to APP_HOME deployment directory.', [], function deployToHome() {
+task('Copy deployment files to APP_HOME deployment directory.', [], function deploy() {
+  deployJournals();
+  deployDocuments();
   copyDir('./foam3/tools/deploy/bin', join(APP_HOME, 'bin'));
   copyDir('./foam3/tools/deploy/etc', join(APP_HOME, 'etc'));
   copyDir(BUILD_DIR + '/lib', join(APP_HOME, 'lib'));
@@ -582,20 +578,22 @@ task('Show application information.', [], function appName() {
 
 task('Create empty build and deployment directory structures if required.', [], function setupDirs() {
   try {
-    ensureDir(APP_HOME);
-    if ( ensureDir(BUILD_DIR + '/lib') ) {
+    if ( ! BUILD_ONLY ) {
+      ensureDir(APP_HOME);
+      ensureDir(`${APP_HOME}/lib`);
+      ensureDir(`${APP_HOME}/bin`);
+      ensureDir(`${APP_HOME}/etc`);
+      ensureDir(LOG_HOME);
+      ensureDir(JOURNAL_HOME);
+      ensureDir(DOCUMENT_HOME);
+    }
+    if (ensureDir(BUILD_DIR + '/lib')) {
       // Remove stale pom.xml if the /lib dir needed to be created
       // Wouldn't be necessary if pom.xml were written into the BUILD_DIR but then
       // you couldn't check it in to get dependbot warnings.
       rmfile('pom.xml');
     }
-    ensureDir(`${APP_HOME}/lib`);
-    ensureDir(`${APP_HOME}/bin`);
-    ensureDir(`${APP_HOME}/etc`);
-    ensureDir(LOG_HOME);
     ensureDir(JOURNAL_OUT);
-    ensureDir(JOURNAL_HOME);
-    ensureDir(DOCUMENT_HOME);
     ensureDir(DOCUMENT_OUT);
   } catch ( e ) {
     console.log(e);
@@ -819,12 +817,14 @@ function all() {
     }
 
     buildJava();
-    deploy();
 
-    // Tests and benchmarks run from jar file
     if ( PACKAGE || BUILD_JAR || TEST || BENCHMARK ) {
       buildJar();
-      deployToHome();
+    }
+
+    // Tests and benchmarks run from a deployed jar
+    if ( TEST || BENCHMARK ) {
+      deploy()
     }
 
     if ( PACKAGE ) {


### PR DESCRIPTION
- runing without a jar only deploys runtime journals
- TEST/BENCHMARK still deploy whole app
- Running from a jar deploys whole app
- fix packaging not finding BUILD_DIR when building from foam3 directly