### PR TITLE
localUserDAO - move UserPasswordHashingDAO to localUserDAO from userDAO

### DIFF
--- a/src/foam/core/auth/resetPassword/ServerResetPasswordService.js
+++ b/src/foam/core/auth/resetPassword/ServerResetPasswordService.js
@@ -4,7 +4,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
- foam.CLASS({
+foam.CLASS({
   package: 'foam.core.auth.resetPassword',
   name: 'ServerResetPasswordService',
   implements: [ 'foam.core.auth.resetPassword.ResetPasswordService' ],
@@ -19,6 +19,7 @@
     'foam.core.auth.Subject',
     'foam.core.auth.User',
     'foam.core.auth.UserNotFoundException',
+    'foam.core.auth.UserPasswordHashingDAO',
     'foam.core.logger.Logger',
     'foam.mlang.predicate.Predicate',
     'foam.util.SafetyUtil',
@@ -86,7 +87,7 @@
           User user = findUser(x, newPasswordObj.getEmail(), newPasswordObj.getUserName());
           user = (User) user.fclone();
           user.setDesiredPassword(desiredPassword);
-          ((DAO) x.get("userDAO")).put_(x, user);
+          ((DAO) x.get("localUserDAO")).put_(x, user);
         } else {
           throw new AuthorizationException("Email verification failed");
         }

--- a/src/foam/core/auth/services.jrl
+++ b/src/foam/core/auth/services.jrl
@@ -378,6 +378,7 @@ p({
       .setFuid(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("users")
+      .setDecorator(new foam.core.auth.UserPasswordHashingDAO(x, new foam.dao.NullDAO(x, foam.core.auth.User.getOwnClassInfo())))
       .build()
       .addPropertyIndex(new foam.lang.PropertyInfo[] { foam.core.auth.User.REFERRAL_CODE });
   """
@@ -395,9 +396,8 @@ p({
       .setPermissioned(true)
       .setDecorator(
         new foam.dao.ValidatingDAO(x,
-          new foam.core.auth.UserPasswordHashingDAO(x,
-            new foam.core.auth.UserLifecycleStateDAO(x,
-            new foam.dao.NullDAO(x, foam.core.auth.User.getOwnClassInfo()))),
+          new foam.core.auth.UserLifecycleStateDAO(x,
+            new foam.dao.NullDAO(x, foam.core.auth.User.getOwnClassInfo())),
           new foam.core.auth.validators.UserGroupAndSpidValidator()
         )
       )
@@ -481,11 +481,10 @@ p({
       .setDecorator(
         new foam.core.auth.UserRegistrationSanitationDAO(x,
         new foam.core.auth.UserRegistrationDAO(x,
-        new foam.core.auth.UserPasswordHashingDAO(x,
         new foam.dao.ValidatingDAO(x,
           new foam.dao.NullDAO(x,foam.core.auth.User.getOwnClassInfo()),
           new foam.core.auth.validators.UserGroupAndSpidValidator()
-        )))))
+        ))))
       .setAuthorize(false)
       .setRuler(true)
       .setPm(true)


### PR DESCRIPTION
* Move UserPasswordHashingDAO to localUserDAO from userDAO so anonymous ResetPasswordService can update hashed password correctly.  
* Revert recent change to ServerResetPasswordService to again use unauthorized localUserDAO