### PR TITLE
Fix default menu retrieval to ensure a fallback after sign-in

### DIFF
--- a/src/foam/core/controller/ApplicationController.js
+++ b/src/foam/core/controller/ApplicationController.js
@@ -729,7 +729,12 @@ foam.CLASS({
     async function findDefaultMenu(dao) {
       var menu;
       var menuArray = this.theme?.defaultMenu.concat(this.theme?.unauthenticatedDefaultMenu);
-      if ( ! menuArray || ! menuArray.length ) return null;
+      menuArray = menuArray.filter( m => m != "" );
+      if ( ! menuArray || ! menuArray.length ) {
+        // Ensure a default - stops login screen from being visible after sign in
+        let list = (await dao.limit(1).select()).array;
+        return list.length == 1 ? list[0] : null;
+      }
       for ( menuId in menuArray ) {
         menu = await dao.find(menuArray[menuId]);
         if ( menu ) break;


### PR DESCRIPTION
Use case - either we don't set a defaultMenu on theme or the user is in a group that doesn't have access to the defaultMenu.

Issue - login screen was loaded into stack view after sign in