### PR TITLE
F3FileJournal: Don't output delta if old object is same instance as new object

### DIFF
--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -234,7 +234,7 @@ try {
 
           public void executeJob() {
             try {
-              if ( old != null ) {
+              if ( old != null && old != obj ) {
                 fmt.maybeOutputDelta(old, obj, null, of);
               } else {
                 fmt.output(obj, of);


### PR DESCRIPTION
This is a fix for persistent sessions.

SessionDAO does not write out objects correctly before this commit.

The Session class overrides .freeze() to be a no-op.  Sessions objects used in the Context are the same instance as the objects in the MDAO.  This is a performance optimization as sessions are read and updated on every request and a full clone edit put cycle would generate a lot of garbage that is typically unnecessary.

However because sessions are not cloned when read and updated from the DAO, when an updated session is .put(), the diffing mechanism in the journal fails because the old object is the same instance as the new object.

This change overrides FileJournal to always output full object records if the old object and the new object point to the same instance.