### PR TITLE
Fix SPID id validation rule (Allow chars: dot, dash and underscore)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Pavneet Kapoor <pavikapoor@gmail.com>
 Mark Dittmer <mark.s.dittmer@gmail.com>
 Chanmann Lim <chanmannlim@gmail.com>
 Joel Hughes <joel.l.hughes@proton.me>
+Mouad Kommir <mouadkommir@gmail.com>

--- a/src/foam/core/auth/ServiceProvider.js
+++ b/src/foam/core/auth/ServiceProvider.js
@@ -38,8 +38,8 @@ foam.CLASS({
       validationPredicates: [
         {
           args: ['id'],
-          query: 'id~/^[a-z0-9]+$/',
-          errorString: 'Invalid character(s) in id.'
+          query: 'id~/^[a-z0-9]+([._-][a-z0-9]+)*$/',
+          errorString: 'Invalid id format.'
         }
       ]
     },


### PR DESCRIPTION
- Valid Examples:
  - abc
  - abc-123
  - foo.bar_baz
  - a.b-c_d.1
  - parent.child.sub-child
  - parent.child.sub_child

- Invalid Examples:
  - abc__123   -> double underscore
  - abc--123   -> double hyphen
  - .abc           -> starts with a dot
  - abc.           -> ends with a dot
  - abc..def     -> double dot
  - abc_-_def  -> underscore followed by hyphen