### PR TITLE
tooling - remove all task function names

### DIFF
--- a/tools/GitTooling.js
+++ b/tools/GitTooling.js
@@ -12,7 +12,7 @@ foam.POM({
   },
 
   tasks: {
-    getFOAMRevision: ['gen-foam-revision', 'Extract FOAM git hash.', [], function getFOAMRevision() {
+    getFOAMRevision: ['gen-foam-revision', 'Extract FOAM git hash.', [], function() {
       try {
         let out = this.execSync('git -C foam3 rev-parse --short HEAD');
         FOAM_REVISION = out.toString().trim();
@@ -20,7 +20,7 @@ foam.POM({
         this.warning('Cannot determine FOAM revision', e);
       }
     }],
-    getProjectRevision: ['gen-project-revision', 'Extract project git hash.', [], function getProjectRevision() {
+    getProjectRevision: ['gen-project-revision', 'Extract project git hash.', [], function() {
       try {
         let out = this.execSync('git rev-parse --short HEAD');
         PROJECT_REVISION = out.toString().trim();
@@ -28,13 +28,13 @@ foam.POM({
         this.warning('Cannot determine project revision', e);
       }
     }],
-    buildJavaManifest: ['gen-java-manifest', 'Contribute to  Java Manifest', ['getProjectRevision', 'getFOAMRevision'], function buildJavaManifest() {
+    buildJavaManifest: ['gen-java-manifest', 'Contribute to  Java Manifest', ['getProjectRevision', 'getFOAMRevision'], function() {
       JAVA_MANIFEST += `\nImplementation-Version: ${FOAM_BIN_VERSION}`;
       JAVA_MANIFEST += `\nSpecification-Version: ${PROJECT_REVISION}`;
       JAVA_MANIFEST += `\n${APP_NAME}-Revision: ${PROJECT_REVISION}`;
       JAVA_MANIFEST += `\nFOAM-Revision: ${FOAM_REVISION}`;
     }],
-    versions: ['versions', 'Show version information.', ['getProjectRevision', 'getFOAMRevision'], function versions() {
+    versions: ['versions', 'Show version information.', ['getProjectRevision', 'getFOAMRevision'], function() {
       console.log(`${APP_NAME} revision: ${PROJECT_REVISION}`);
       console.log(`FOAM revision:       ${FOAM_REVISION}`);
     }]
@@ -43,7 +43,7 @@ foam.POM({
 
 
 // TODO/FUTURE - capture branch version from repository branch name
-// getBranchVersion: ['git-branch-version', 'Extract possible version string from branch name. ex. Release-v3.36.3 -> 3.36.3', [], function gitBranchVersion() {
+// getBranchVersion: ['git-branch-version', 'Extract possible version string from branch name. ex. Release-v3.36.3 -> 3.36.3', [], function() {
 //   var name = this.execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
 //   // let regex = new RegExp("0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$");
 //   let regex = new RegExp(/[0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?/, "gm");

--- a/tools/JSTooling.js
+++ b/tools/JSTooling.js
@@ -17,15 +17,15 @@ foam.POM({
   },
 
   tasks: {
-    cleanFOAM: ['clean-foam', 'Remove foam-bin files.', [], function cleanFOAM() {
+    cleanFOAM: ['clean-foam', 'Remove foam-bin files.', [], function() {
       this.execSync(`rm -f ${BUILD_DIR}/js/foam-bin-* >/dev/null 2>&1`);
     }],
 
-    genFoamBinVersion: ['gen-foam-bin-version', 'Generate version string for the foam-bin, with our without a timestamp', [], function genFoamBinVersion() {
+    genFoamBinVersion: ['gen-foam-bin-version', 'Generate version string for the foam-bin, with our without a timestamp', [], function() {
       FOAM_BIN_VERSION = `${VERSION}` + (TIMESTAMP_FOAM_BIN ? `-${TIMESTAMP}` : '');
     }],
 
-    genJS: ['gen-js', 'Build foam-bin.js', ['cleanFOAM', 'genFoamBinVersion'], function genJS() {
+    genJS: ['gen-js', 'Build foam-bin.js', ['cleanFOAM', 'genFoamBinVersion'], function() {
       let version = FOAM_BIN_VERSION;
       let flags = this.flag();
       let outdir = BUILD_DIR+'/js';

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -47,16 +47,16 @@ foam.POM({
   },
 
   tasks: {
-    buildJar: ['build-jar', 'Build Java JAR file.', [()=>JAR=true, 'setupDirs', 'genJS', 'genJava', 'versions', 'copy', 'genImages', 'genJavaManifest', 'jarFOAM' ], function buildJar() {
+    buildJar: ['build-jar', 'Build Java JAR file.', [()=>JAR=true, 'setupDirs', 'genJS', 'genJava', 'versions', 'copy', 'genImages', 'genJavaManifest', 'jarFOAM' ], function() {
       JAR_INCLUDES += ` -C ${BUILD_DIR} webroot `;
       this.execSync(`jar cfm ${BUILD_DIR}/lib/${JAR_NAME} ${BUILD_DIR}/MANIFEST.MF ${JAR_INCLUDES}`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
     }],
 
-    buildJavaMainArgs: ['build-java-main-args', 'Collection all options which should be passed to Java main', [], function buildJavaMainArgs() {
+    buildJavaMainArgs: ['build-java-main-args', 'Collection all options which should be passed to Java main', [], function() {
       JAVA_MAIN_ARGS = this.comma(JAVA_MAIN_ARGS, `boot.script:${BOOT_SCRIPT}`);
     }],
 
-    buildJavaManifest: ['build-java-manifest', 'Contribute to Java Manifest', ['buildJavaMainArgs'], function buildJavaManifest() {
+    buildJavaManifest: ['build-java-manifest', 'Contribute to Java Manifest', ['buildJavaMainArgs'], function() {
       JAVA_MANIFEST += `\nImplementation-Title: ${APP_NAME}`;
       JAVA_MANIFEST += `\nImplementation-Timestamp: ${TIMESTAMP}`;
       JAVA_MANIFEST += `\nImplementation-Vendor: ${JAVA_MANIFEST_VENDOR}`;
@@ -72,7 +72,7 @@ foam.POM({
       JAVA_MANIFEST += `\nClass-Path: ${jars}`;
     }],
 
-    buildJavaOpts: ['build-java-opts', 'Set Java environmental variables.', [], function buildJavaOpts() {
+    buildJavaOpts: ['build-java-opts', 'Set Java environmental variables.', [], function() {
       JAVA_OPTS += ` -DJOURNAL_HOME=${JOURNAL_HOME}`;
       JAVA_OPTS += ` -DDOCUMENT_HOME=${DOCUMENT_HOME}`;
       if ( HOST_NAME !== 'localhost' ) {
@@ -83,7 +83,7 @@ foam.POM({
       }
     }],
 
-    buildJavaTestOpts: ['build-java-test-ops', 'Add test specific JAVA_OPTS', ['buildJavaOpts'], function buildJavaTestOpts() {
+    buildJavaTestOpts: ['build-java-test-ops', 'Add test specific JAVA_OPTS', ['buildJavaOpts'], function() {
       JAVA_OPTS += ' -enableassertions';
       JAVA_OPTS += ' -Dresource.journals.dir=journals';
       JAVA_OPTS += ' -DRES_JAR_HOME=' + JAR_OUT;
@@ -92,53 +92,53 @@ foam.POM({
         JAVA_OPTS += ` -agentlib:jdwp=transport=dt_socket,server=y,suspend=${SUSPEND ? 'y' : 'n'},address=127.0.0.1:${DEBUG_PORT}`;
     }],
 
-    buildRunArgs: ['set-run-args', 'Set arguments which will be passed to run.sh to start CORE server', [], function buildRunArgs() {
+    buildRunArgs: ['set-run-args', 'Set arguments which will be passed to run.sh to start CORE server', [], function() {
       if ( WEB_PORT ) RUN_ARGS += ` -W${WEB_PORT}`;
       if ( DEBUG ) RUN_ARGS += ` -D${DEBUG_PORT}`;
       if ( SUSPEND ) RUN_ARGS += ` -s`;
       if ( HOST_NAME && HOST_NAME !== 'localhost' ) RUN_ARGS += ` -H${HOST_NAME}`;
     }],
 
-    buildTar: ['build-tar', 'Package files into a TAR archive', [()=>TAR=true, 'buildJar'], function buildTar() {
+    buildTar: ['build-tar', 'Package files into a TAR archive', [()=>TAR=true, 'buildJar'], function() {
       this.ensureDir(this.join(BUILD_DIR, 'package'));
       // Notice that the argument to the second -C is relative to the directory from the first -C, since -C
       this.execSync(`tar -a -cf ${BUILD_DIR}/package/${APP_NAME}-deploy-${VERSION}.tar.gz -C ./foam3/tools/deploy bin etc -C${require('path').resolve(BUILD_DIR)} lib`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
     }],
 
-    clean: ['clean', 'Remove generated files', ['cleanJava'], function clean() {
+    clean: ['clean', 'Remove generated files', ['cleanJava'], function() {
       if ( APP_HOME && this.existsSync(APP_HOME) ) {
         this.emptyDir(`${APP_HOME}/bin`);
         this.emptyDir(`${APP_HOME}/lib`);
       }
     }],
 
-    cleanJava: ['clean-java', 'Remove previously generated JAR.', [], function cleanJava() {
+    cleanJava: ['clean-java', 'Remove previously generated JAR.', [], function() {
       // remove previous app jar in build directory to fix classes resolution for non-jar run
       this.execSync(`rm -f ${BUILD_DIR}/lib/${APP_NAME}-*.jar >/dev/null 2>&1`);
     }],
 
-    cleanTest: ['clean-test', 'Remove entire test deployment for next run', [], function cleanTest() {
+    cleanTest: ['clean-test', 'Remove entire test deployment for next run', [], function() {
       this.rmdir(APP_HOME);
     }],
 
-    deleteRuntimeJournals: ['delete-runtime-journals', 'Delete runtime journals.', [], function deleteRuntimeJournals() {
+    deleteRuntimeJournals: ['delete-runtime-journals', 'Delete runtime journals.', [], function() {
       this.info('Runtime journals deleted.');
       this.emptyDir(JOURNAL_HOME);
     }],
 
-    genImages: ['gen-images', 'Prepare images from inclusion in jar.', [], function genImages() {
+    genImages: ['gen-images', 'Prepare images from inclusion in jar.', [], function() {
       JAR_INCLUDES += ` -C ${BUILD_DIR} images `;
 
       this.pmake.bind(this, `-makers=Image -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR}`)();
     }],
 
-    genImages: ['gen-images', 'Prepare images from inclusion in jar.', [], function genImages() {
+    genImages: ['gen-images', 'Prepare images from inclusion in jar.', [], function() {
       JAR_INCLUDES += ` -C ${BUILD_DIR} images `;
 
       this.pmake.bind(this, `-makers=Image -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR}`)();
     }],
 
-    genJava: ['gen-java', 'Generate Java source from models and complile', ['cleanJava', 'javacParameters'], function genJava() {
+    genJava: ['gen-java', 'Generate Java source from models and complile', ['cleanJava', 'javacParameters'], function() {
       JAR_INCLUDES += ` -C ${BUILD_DIR} journals `;
       JAR_INCLUDES += ` -C ${BUILD_DIR} documents `;
       JAR_INCLUDES += ` -C ${BUILD_DIR}/classes .`;
@@ -150,45 +150,45 @@ foam.POM({
       this.pmake.bind(this, `-makers=${makers} -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -d=${BUILD_DIR}/classes -journaldir=${JOURNAL_OUT} -documentdir=${DOCUMENT_OUT} -outdir=${BUILD_DIR}/src/java -libdir=${BUILD_DIR}/lib -javacParams=\'${JAVAC_PARAMETERS}\'`)();
     }],
 
-    deployBin: ['deploy-bin', 'Copy bash files to deployment', [], function deployBin() {
+    deployBin: ['deploy-bin', 'Copy bash files to deployment', [], function() {
       this.ensureDir(this.join(APP_HOME, 'bin'));
       this.copyDir('./foam3/tools/deploy/bin', this.join(APP_HOME, 'bin'));
       this.ensureDir(this.join(APP_HOME, 'etc'));
       this.copyDir('./foam3/tools/deploy/etc', this.join(APP_HOME, 'etc'));
     }],
 
-    deployDocuments: ['deploy-documents', 'Deploy documents from DOCUMENT_OUT to DOCUMENT_HOME.', ['setupDirs'], function deployDocuments() {
+    deployDocuments: ['deploy-documents', 'Deploy documents from DOCUMENT_OUT to DOCUMENT_HOME.', ['setupDirs'], function() {
       this.ensureDir(DOCUMENT_HOME);
       this.copyDir(DOCUMENT_OUT, DOCUMENT_HOME);
     }],
 
-    deployJournals: ['deploy-journals', 'Deploy journal files from JOURNAL_OUT to JOURNAL_HOME.', ['setupDirs'], function deployJournals() {
+    deployJournals: ['deploy-journals', 'Deploy journal files from JOURNAL_OUT to JOURNAL_HOME.', ['setupDirs'], function() {
       this.ensureDir(JOURNAL_HOME);
       this.copyDir(JOURNAL_OUT, JOURNAL_HOME);
     }],
 
-    deployLib: ['depoy-lib', 'Copy library files to deployment', [], function deployLib() {
+    deployLib: ['depoy-lib', 'Copy library files to deployment', [], function() {
       this.ensureDir(this.join(APP_HOME, 'lib'));
       this.copyDir(BUILD_DIR + '/lib', this.join(APP_HOME, 'lib'));
     }],
 
-    genDocuments: ['gen-documents', 'Capture repository documentation - flow docs', [], function genDocuments() {
+    genDocuments: ['gen-documents', 'Capture repository documentation - flow docs', [], function() {
       JAR_INCLUDES += ` -C ${BUILD_DIR} documents `;
       this.pmake(`-makers=Doc -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -documentdir=${DOCUMENT_OUT}`);
     }],
 
-    genJournals: ['gen-journals', 'Concatenate repository journal files into .0 files', [], function genJournals() {
+    genJournals: ['gen-journals', 'Concatenate repository journal files into .0 files', [], function() {
       JAR_INCLUDES += ` -C ${BUILD_DIR} journals `;
       this.pmake.bind(this, `-makers=Journal -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -journaldir=${JOURNAL_OUT}`)();
     }],
 
-    jarFOAM: ['jar-foam', 'Copy foam-bin files for inclusion in JAR file.', ['genJava'], function jarFOAM() {
+    jarFOAM: ['jar-foam', 'Copy foam-bin files for inclusion in JAR file.', ['genJava'], function() {
       this.ensureDir(this.join(BUILD_DIR, 'webroot'));
       this.execSync(`cp ${BUILD_DIR}/js/foam-bin-* ${BUILD_DIR}/webroot/`, {stdio: VERBOSE ? 'inherit' : 'ignore' });
     }],
 
     // TODO: not tested
-    javaBenchmarks: ['java-benchmarks', 'Run all or specified benchmarks. ex: javaBenchmarks[:Benchmark1,Benchmark2]', [/*'stopCORE'*/], function javaBenchmarks(args) {
+    javaBenchmarks: ['java-benchmarks', 'Run all or specified benchmarks. ex: javaBenchmarks[:Benchmark1,Benchmark2]', [/*'stopCORE'*/], function(args) {
       APP_ROOT = '/tmp';
       FLAGS = this.comma(FLAGS, 'test');
       // this.addJournal('test'); ??
@@ -201,19 +201,19 @@ foam.POM({
       this.execute('startCORETest', 'benchmark', args);
     }],
 
-    javacParameters: ['javac-parameters', 'Set parameters passed the Java compiler', [], function javacParameters() {
+    javacParameters: ['javac-parameters', 'Set parameters passed the Java compiler', [], function() {
       if ( ! JAVAC_PARAMETERS.includes('--release') ) {
         JAVAC_PARAMETERS += ' --release '+JAVA_RELEASE;
       }
     }],
 
-    genJavaManifest: ['gen-java-manifest', 'Generate Java Manifest File', ['buildJavaManifest'], function genJavaManifest() {
+    genJavaManifest: ['gen-java-manifest', 'Generate Java Manifest File', ['buildJavaManifest'], function() {
       JAVA_MANIFEST = 'Manifest-Version: 1.0' + JAVA_MANIFEST + '\n';
       this.writeFileSync(BUILD_DIR + '/MANIFEST.MF', JAVA_MANIFEST);
       return JAVA_MANIFEST;
     }],
 
-    javaTests: ['java-tests', 'Run all or specified test cases. ex: javaTests[:Test1,Test2]', [], function javaTests(args) {
+    javaTests: ['java-tests', 'Run all or specified test cases. ex: javaTests[:Test1,Test2]', [], function(args) {
       APP_ROOT='/tmp';
       FLAGS = this.comma(FLAGS, 'test');
       this.addJournal('test');
@@ -226,11 +226,11 @@ foam.POM({
       this.execute('startCORETest', 'test', args);
     }],
 
-    showJavaManifest: ['show-java-manifest', 'Display generated Java Manifest file.', ['buildJavaManifest'], function showJavaManifest() {
+    showJavaManifest: ['show-java-manifest', 'Display generated Java Manifest file.', ['buildJavaManifest'], function() {
       console.log('Manifest:', JAVA_MANIFEST);
     }],
 
-    setupDirs: ['setup-dirs', 'Create empty build and deployment directory structures if required.', [], function setupDirs() {
+    setupDirs: ['setup-dirs', 'Create empty build and deployment directory structures if required.', [], function() {
       try {
         if ( ! BUILD_ONLY ) {
           this.ensureDir(APP_HOME);
@@ -245,7 +245,7 @@ foam.POM({
       }
     }],
 
-    startCORE: ['start-core', 'Start CORE server (CLASSPATH).', ['setupDirs', 'deployJournals', 'deployDocuments', 'deployLib', 'buildJavaOpts', 'buildJavaMainArgs'], function startCORE() {
+    startCORE: ['start-core', 'Start CORE server (CLASSPATH).', ['setupDirs', 'deployJournals', 'deployDocuments', 'deployLib', 'buildJavaOpts', 'buildJavaMainArgs'], function() {
 
       JAVA_OPTS += ` -Dcore.webroot=${PROJECT_HOME}`;
 
@@ -260,7 +260,7 @@ foam.POM({
       this.execSync(`java -cp "${BUILD_DIR}/lib/\*:${BUILD_DIR}/classes" ${JAVA_MAIN_CLASS} "${JAVA_MAIN_ARGS}"`, { stdio: 'inherit' });
     }],
 
-    startCOREJar: ['start-core-jar', 'Start CORE server (JAR).', [/*'stopCORE'*/, 'setupDirs', 'deployBin', 'deployLib', 'buildJavaOpts', 'buildRunArgs', 'showSummary'], function startCOREJar() {
+    startCOREJar: ['start-core-jar', 'Start CORE server (JAR).', [/*'stopCORE'*/, 'setupDirs', 'deployBin', 'deployLib', 'buildJavaOpts', 'buildRunArgs', 'showSummary'], function() {
       if ( BUILD_ONLY ) return;
 
       // see etc/shrc.local for jdwp configuration
@@ -280,7 +280,7 @@ foam.POM({
       // }
     }],
 
-    startCORETest: ['start-core-test', 'Start CORE server (Test, Benchmarks).', ['deployJournals', 'deployDocuments', 'deployLib', 'buildJavaTestOpts'], function startCORETest(mode, ...tests) {
+    startCORETest: ['start-core-test', 'Start CORE server (Test, Benchmarks).', ['deployJournals', 'deployDocuments', 'deployLib', 'buildJavaTestOpts'], function(mode, ...tests) {
       MESSAGE = 'Running tests...';
 
       if ( mode === 'benchmark' ) {
@@ -308,7 +308,7 @@ foam.POM({
       }
     }],
 
-    stopCORE: ['stop-core', 'Stop CORE server.', [], function stopCORE() {
+    stopCORE: ['stop-core', 'Stop CORE server.', [], function() {
       if ( this.existsSync(CORE_PIDFILE) ) {
         let pid = this.readFileSync(CORE_PIDFILE).toString().trim();
         if ( pid ) {
@@ -329,7 +329,7 @@ foam.POM({
       }
     }],
 
-    usage: ['usage', 'Build usage examples', [], function usage() {
+    usage: ['usage', 'Build usage examples', [], function() {
       this.log('Running Java application server:');
       this.log('NOTE: All builds will still start a Java web server (CORE), unless directed otherwise.');
       this.log('  ./build.sh -aJhttps -EJAVA_OPTS:\"-Xms4g -Xmx8g\"');
@@ -349,7 +349,7 @@ foam.POM({
       this.log('    Run specified Java test cases.');
     }],
 
-    versions: ['versions', 'Show version information.', ['getProjectRevision', 'getFOAMRevision'], function versions() {
+    versions: ['versions', 'Show version information.', ['getProjectRevision', 'getFOAMRevision'], function() {
       console.log(`Application Version: ${VERSION}`);
     }]
  }

--- a/tools/MavenTooling.js
+++ b/tools/MavenTooling.js
@@ -8,16 +8,16 @@ foam.POM({
   name: 'maven',
 
   tasks: {
-    cleanAll: ['clean-all', 'Remove pom.xml and Java lib directory.', [], function cleanAll() {
+    cleanAll: ['clean-all', 'Remove pom.xml and Java lib directory.', [], function() {
       this.rmfile('pom.xml');
       this.emptyDir(BUILD_DIR + '/lib');
     }],
 
-    maven: ['maven', 'Run Maven', [], function maven() {
+    maven: ['maven', 'Run Maven', [], function() {
       this.pmake.bind(this, `-makers=Maven -flags=${this.flag()} -pom=${POMS} -libdir=${BUILD_DIR}/lib`)();
     }],
 
-    checkDeps: ['check-deps', 'Check Java dependencies for known vulnerabilities (via Maven). -XcheckDeps:score where score in range [0..11].  CVSS score (LOW:0..5 ,MEDIUM:5..7 ,HIGH:7..9 ,CRITICAL:9..10,IGNORE:11)', ['maven'], function checkDeps(score) {
+    checkDeps: ['check-deps', 'Check Java dependencies for known vulnerabilities (via Maven). -XcheckDeps:score where score in range [0..11].  CVSS score (LOW:0..5 ,MEDIUM:5..7 ,HIGH:7..9 ,CRITICAL:9..10,IGNORE:11)', ['maven'], function(score) {
       score = score || 9;
       try {
         this.execSync(`mvn dependency-check:check -DfailBuildOnCVSS=${score}`, { stdio: 'inherit' });
@@ -26,7 +26,7 @@ foam.POM({
       }
     }],
 
-    showJARs: ['show-jars', 'Show JAR structure.', ['maven'], function showJARs(value) {
+    showJARs: ['show-jars', 'Show JAR structure.', ['maven'], function(value) {
       try {
         this.execSync(`mvn dependency:tree `, { stdio: 'inherit' });
       } catch (_) {
@@ -34,7 +34,7 @@ foam.POM({
       }
     }],
 
-    mavenGetSources: ['maven-get-sources', 'Get Maven java sources.', ['maven'], function mavenGetSources(value) {
+    mavenGetSources: ['maven-get-sources', 'Get Maven java sources.', ['maven'], function(value) {
       try {
         this.execSync(`mvn dependency:resolve-sources -DincludeArtifactIds=${value} `, { stdio: 'inherit' });
       } catch (_) {

--- a/tools/NpmTooling.js
+++ b/tools/NpmTooling.js
@@ -9,7 +9,7 @@ foam.POM({
 
   tasks: {
     // TODO: install - install node, npm itself. and use 'update' for current install.
-    install: ['install', 'Install npm tools that foam and the build use.', [], function install() {
+    install: ['install', 'Install npm tools that foam and the build use.', [], function() {
       process.chdir(PROJECT_HOME);
       this.execSync('npm install', { stdio: 'inherit'} );
     }]

--- a/tools/ProfilerTooling.js
+++ b/tools/ProfilerTooling.js
@@ -13,7 +13,7 @@ foam.POM({
   },
 
   tasks: {
-    buildRunArgs: ['build-run-args', 'Add profiler port',[], function buildRunArgs() {
+    buildRunArgs: ['build-run-args', 'Add profiler port',[], function() {
       if ( PROFILER ) RUN_ARGS += ` -P${PROFILER_PORT}`;
     }]
   }

--- a/tools/StandardTooling.js
+++ b/tools/StandardTooling.js
@@ -16,7 +16,7 @@ foam.POM({
   },
 
   tasks: {
-    clean: ['clean', 'Remove generated files', [], function clean(args) {
+    clean: ['clean', 'Remove generated files', [], function(args) {
       if ( args === 'all') { // -Xclean:all
         this.execute('cleanAll');
       }
@@ -33,7 +33,7 @@ foam.POM({
       }
     }],
 
-    usage: ['usage', 'Build usage examples', [], function usage() {
+    usage: ['usage', 'Build usage examples', [], function() {
       console.log('CLI examples:');
       console.log('  ./build.sh -c');
       console.log('    Remove previously generated code, before rebuilding.');
@@ -48,7 +48,7 @@ foam.POM({
     // ############################
     // # Build steps
     // ############################
-    all: ['all', 'Execute \'standard\' build tasks.', ['pomEnvs'], function all() {
+    all: ['all', 'Execute \'standard\' build tasks.', ['pomEnvs'], function() {
       if ( ! ( TAR || BUILD_ONLY ) ) {
         this.execute('stopCORE');
       }

--- a/tools/build.js
+++ b/tools/build.js
@@ -84,10 +84,12 @@ let TOOLING_TASKS = {};
 function task() {
   var name, gnuopt, desc = '', dep = [], f, pom = 'build';
   if ( arguments.length == 1 ) {
+    // tasks from build poms
     f = arguments[0];
     name = f.name;
     gnuopt = hyphenate(f.name);
   } else if ( arguments.length == 3 ) {
+    // tasks from build.js itself
     f = arguments[2];
     name = f.name;
     gnuopt = hyphenate(f.name);
@@ -100,6 +102,7 @@ function task() {
     desc = arguments[1];
     dep = arguments[2];
   } else if ( arguments.length == 6 ) {
+    // tasks from tooling
     name = arguments[0];
     gnuopt = arguments[1];
     desc = arguments[2];
@@ -651,11 +654,8 @@ task('tooling', 'Prepare build environment', [], function tooling() {
     let list = maker.tasks[name];
     list.forEach(t => {
       var [gnuopt, desc, dep, f] = t;
-      if ( ! f || ! f.name ) {
+      if ( ! f ) {
         error(`[build] task missing function ${name} ${t}`);
-      }
-      if ( f.name !== name ) {
-        warning(`[build] tooling name: ${name} != f.name ${f.name}`);
       }
       task(name, gnuopt, desc, dep, f, t.pom);
     });


### PR DESCRIPTION
Was a holder over from the move from build.js into the tooling poms. Tooling tasks are now described in a {} and each has a name, which was duplicating the function name.