### PR TITLE
Add renderMenuItem method to AbstractMenu 

### DIFF
--- a/src/foam/core/menu/AbstractMenu.js
+++ b/src/foam/core/menu/AbstractMenu.js
@@ -28,6 +28,10 @@ foam.CLASS({
   ],
 
   methods: [
+    function renderMenuItem(element, menu) {
+      element.translate(menu.id + ".label", menu.label);
+      if (menu.tooltip) element.tooltip = menu.tooltip;
+    },
     function select(X, menu) {
       if ( this.popup ) {
         X.pushMenu(menu.id);


### PR DESCRIPTION
In this commit https://github.com/kgrgreer/foam3/commit/0896d56f15c69ae92b689558b8361597a4a1a74a the abstract menu function was missed i think.

@kgrgreer 