### PR TITLE
CachingAuthService reset on permission changes

### DIFF
--- a/src/foam/core/auth/CachingAuthService.java
+++ b/src/foam/core/auth/CachingAuthService.java
@@ -138,22 +138,8 @@ public class CachingAuthService
     } else if ( obj instanceof UserCapabilityJunction ) {
       userId = ((UserCapabilityJunction) obj).getSourceId();
     } else if ( obj instanceof GroupPermissionJunction ) {
-      GroupPermissionJunction gpj = (GroupPermissionJunction) obj;
       // Reset permission cache
       userPermissionCache_.clear();
-//      for ( Object o  : userPermissionCache_.values() ) {
-//        Map m = (Map) o;
-//        String p = gpj.getTargetId();
-//        if ( p.endsWith(".*") ) {
-//          p = p.substring(0, p.length()-2);
-//          for ( Object o2 : m.keySet() ) {
-//            String p2 = (String) o2;
-//            if ( p2.startsWith(p) )
-//              m.remove(p2);
-//          }
-//        }
-//        m.remove(p);
-//      }
       return;
     }
 

--- a/src/foam/core/auth/CachingAuthService.java
+++ b/src/foam/core/auth/CachingAuthService.java
@@ -119,9 +119,6 @@ public class CachingAuthService
     DAO groupPermissionJunctionDAO = (DAO) getX().get("groupPermissionJunctionDAO");
     if ( groupPermissionJunctionDAO != null ) groupPermissionJunctionDAO.listen(purgeSink, TRUE);
 
-    DAO prerequisiteCapabilityJunctionDAO = (DAO) getX().get("prerequisiteCapabilityJunctionDAO");
-    if (prerequisiteCapabilityJunctionDAO != null)
-      prerequisiteCapabilityJunctionDAO.listen(purgeSink, TRUE);
     // Configure listeners for additional permission DAOs
     if ( extraDAOsToListenTo_ != null ) {
       for ( String daoName : extraDAOsToListenTo_ ) {
@@ -142,19 +139,21 @@ public class CachingAuthService
       userId = ((UserCapabilityJunction) obj).getSourceId();
     } else if ( obj instanceof GroupPermissionJunction ) {
       GroupPermissionJunction gpj = (GroupPermissionJunction) obj;
-      for ( Object o  : userPermissionCache_.values() ) {
-        Map m = (Map) o;
-        String p = gpj.getTargetId();
-        if ( p.endsWith(".*") ) {
-          p = p.substring(0, p.length()-2);
-          for ( Object o2 : m.keySet() ) {
-            String p2 = (String) o2;
-            if ( p2.startsWith(p) )
-              m.remove(p2);
-          }
-        }
-        m.remove(p);
-      }
+      // Reset permission cache
+      userPermissionCache_.clear();
+//      for ( Object o  : userPermissionCache_.values() ) {
+//        Map m = (Map) o;
+//        String p = gpj.getTargetId();
+//        if ( p.endsWith(".*") ) {
+//          p = p.substring(0, p.length()-2);
+//          for ( Object o2 : m.keySet() ) {
+//            String p2 = (String) o2;
+//            if ( p2.startsWith(p) )
+//              m.remove(p2);
+//          }
+//        }
+//        m.remove(p);
+//      }
       return;
     }
 

--- a/src/foam/core/auth/CachingAuthService.java
+++ b/src/foam/core/auth/CachingAuthService.java
@@ -119,6 +119,9 @@ public class CachingAuthService
     DAO groupPermissionJunctionDAO = (DAO) getX().get("groupPermissionJunctionDAO");
     if ( groupPermissionJunctionDAO != null ) groupPermissionJunctionDAO.listen(purgeSink, TRUE);
 
+    DAO prerequisiteCapabilityJunctionDAO = (DAO) getX().get("prerequisiteCapabilityJunctionDAO");
+    if (prerequisiteCapabilityJunctionDAO != null)
+      prerequisiteCapabilityJunctionDAO.listen(purgeSink, TRUE);
     // Configure listeners for additional permission DAOs
     if ( extraDAOsToListenTo_ != null ) {
       for ( String daoName : extraDAOsToListenTo_ ) {


### PR DESCRIPTION
Fixing cache invalidation when changing permissions
since it was incorrect.

@kgrgreer should we go for a full rewrite for it, or the current reset is good enough, from my testing its 200 instances so reseting  them  should not be a problem?