### PR TITLE
Fix file preview when presented file array property

### DIFF
--- a/src/foam/core/fs/File.js
+++ b/src/foam/core/fs/File.js
@@ -157,13 +157,11 @@ foam.CLASS({
       expression: function () {
         return [this];
       },
-      view: function() {
-        let dataSlot = foam.lang.SimpleSlot.create({value: [this]});
-        let selectSlot = foam.lang.SimpleSlot.create({value: 0});
-        return foam.core.fs.fileDropZone.FilePreview.create({
-          data$: dataSlot,
-          selected$: selectSlot
-        });
+      view: function(_, X) {
+        return {
+          class: 'foam.core.fs.fileDropZone.FilePreview',
+          id: X.data.id
+        };
       },
       comparePropertyValues: function(o1, o2) { return 0; }
     },


### PR DESCRIPTION
## Issues
- FilePreview needs `id` to properly render each file preview in file array but wasn't provided
- The result is the first file preview content is being overridden by the subsequent files in the array