### PR TITLE
User - group now required

### DIFF
--- a/src/foam/core/auth/User.js
+++ b/src/foam/core/auth/User.js
@@ -1237,7 +1237,7 @@ foam.RELATIONSHIP({
   },
   targetProperty: {
     hidden: false,
-    // required: true,
+    required: true,
     section: 'systemInformation',
     order: 30,
     gridColumns: 6,

--- a/src/foam/core/auth/services.jrl
+++ b/src/foam/core/auth/services.jrl
@@ -488,7 +488,6 @@ p({
       .setAuthorize(false)
       .setRuler(true)
       .setPm(true)
-      .setValidated(true)
       .setEnableInterfaceDecorators(false)
       .build();
   """,


### PR DESCRIPTION
Also, remove EasyDAO.validate(true) on userRegistrationDAO, as userRegistrationDAO builds it's own DAO stack and inserts ValidatingDAO after UserRegistrationDAO. When installed before user registration fails as validation runs before group is set by UserRegistrationDAO.