### PR TITLE
pom - change order of default loading when root not specified.

### DIFF
--- a/pom.js
+++ b/pom.js
@@ -7,9 +7,6 @@
 foam.POM({
   name: 'foam-full',
   version: 3,
-  envs: {
-    APP_NAME: 'foam',
-  },
   excludes: [ 'build', 'deployment', 'foam3', 'node_modules' ],
   projects: [
     { name: 'src/pom' },

--- a/tools/EnvMaker.js
+++ b/tools/EnvMaker.js
@@ -6,6 +6,7 @@
 
 const { warning } = require('./buildlib');
 const envs = {};
+var rootPOM;
 
 exports.description = `Capture POM values for environment variables or options,
 and translate top level POM keys to build variables ( ex: pom.name -> appName )
@@ -25,8 +26,9 @@ exports.init = function() {
 };
 
 exports.visitPOM = function(pom) {
+  if ( ! rootPOM ) rootPOM = pom;
   pom.envs && Object.keys(pom.envs).forEach(e => {
-    this.verbose(`[Env] pom ${pom.name} testing ${e}`);
+    this.verbose(`[Env] pom ${pom.name} testing ${e}, currently envs[${e}]: ${envs[e]}`);
     if ( envs[e] ) { // envs['APP_NAME']
       this.verbose(`[Env] pom ${pom.name} ignoring change of ${e} from ${envs[e]} to ${pom.envs[e]}`);
       return;
@@ -42,7 +44,7 @@ exports.visitPOM = function(pom) {
       return;
     }
 
-    this.verbose(`[Env] pom ${pom.name} testing ${k}`);
+    this.verbose(`[Env] pom ${pom.name} testing ${k}, currently pom[${k}]: ${pom[k]}`);
     var v = pom[k];
     if ( v ) {
       this.verbose(`[Env] pom ${pom.name} recording ${envs[k]} = ${v}`);
@@ -62,6 +64,15 @@ exports.end = function() {
       delete envs[kv[1]];
     }
   });
+  // Determining app name is a special case.  Historically, this was
+  // taken from the root pom.name, but this makes it difficult to
+  // override in other configuration poms.
+  if ( ! envs['APP_NAME'] ||
+       ! envs['appName'] ||
+       ! envs['app-name'] ) {
+    this.verbose(`[Env] setting APP_NAME to root pom name: ${rootPOM.name}`);
+    envs['APP_NAME'] = rootPOM.name;
+  }
 };
 
 exports.envs = envs;

--- a/tools/RemoteInstallTooling.js
+++ b/tools/RemoteInstallTooling.js
@@ -55,7 +55,9 @@ foam.POM({
 
       try {
         this.log(`[RemoteInstall] uploading ${TARBALL_PATH} to ${REMOTE_URL}:${REMOTE_OUTPUT}/${TARBALL}`);
-        this.execSync(`scp ${SSH_OPT} ${TARBALL_PATH} ${REMOTE_URL}:${REMOTE_OUTPUT}/${TARBALL}`);
+        if ( ! DRY_RUN ) {
+          this.execSync(`scp ${SSH_OPT} ${TARBALL_PATH} ${REMOTE_URL}:${REMOTE_OUTPUT}/${TARBALL}`);
+        }
         this.log(`[RemoteInstall] upload to ${REMOTE_HOSTNAME} complete.`);
       } catch (e) {
         this.error(`[RemoteInstall] upload to ${REMOTE_HOSTNAME} failed.\n`, e);
@@ -69,7 +71,9 @@ foam.POM({
       if ( REMOTE_INSTALL_SCRIPT ) {
         try {
           this.log(`[RemoteInstall] installing to ${REMOTE_HOSTNAME} with ${INSTALL_OPTS}.`);
-          this.execSync(`ssh ${SSH_OPT} ${REMOTE_URL} 'sudo bash -s -- -T${REMOTE_OUTPUT}/${TARBALL} ${INSTALL_OPTS}' < ${REMOTE_INSTALL_SCRIPT}`);
+          if ( ! DRY_RUN ) {
+            this.execSync(`ssh ${SSH_OPT} ${REMOTE_URL} 'sudo bash -s -- -T${REMOTE_OUTPUT}/${TARBALL} ${INSTALL_OPTS}' < ${REMOTE_INSTALL_SCRIPT}`);
+          }
           this.log(`[RemoteInstall] installation to ${REMOTE_HOSTNAME} complete.`);
         } catch (e) {
           this.warning(`[RemoteInstall] installation to ${REMOTE_HOSTNAME} failed.\n`, e);

--- a/tools/build.js
+++ b/tools/build.js
@@ -396,7 +396,7 @@ function moreUsage(arg) {
 var ENVS = {
   EXPORTS:           ['Build environment variables which will be exported to pom tasks.', {}],
   OPTIONS:           ['Build options determined during tooling which can be configured to by CLI and POM arguments to control the build', {}],
-  POM_ENVS:          ['Supports translating top level POM parameters to build parameters, such as pom.name -> APP_NAME, pom.version -> VERSION.  Also provides legacy support to POMs still using top level POM parametes for Java Manifest and Javac Parameters. Java Manifest property \'vendor\' should be set in POM task \'javaManifest\' and \'java\' should be set in POM task \'javacParameters\'.', 'APP_NAME=name,VERSION=version,JAVA_RELEASE=java,JAVA_MANIFEST_VENDOR=vendor'],
+  POM_ENVS:          ['Supports translating top level POM parameters to build parameters, such as pom.version -> VERSION.  Also provides legacy support to POMs still using top level POM parametes for Java Manifest and Javac Parameters. Java Manifest property \'vendor\' should be set in POM task \'javaManifest\' and \'java\' should be set in POM task \'javacParameters\'.', 'VERSION=version,JAVA_RELEASE=java,JAVA_MANIFEST_VENDOR=vendor'],
   POM_TASKS:         ['Map of named tasks captured from build POMs. Will be executed when same named build task is executed.', {}],
   PROJECT:           ['Top-Level Loaded POM Object, not be be confused with variable \'POMS\', which is the name of the POM(s) to be processed by the build'],
   TOOLING_OPTIONS:   ['Options which control the tooling phase of the build', {}],
@@ -602,12 +602,8 @@ function pom() {
       poms.push(fn);
   };
 
-  if ( ! POMS ) {
-    POMS = 'pom';
-  }
-
   var root = false;
-  POMS.split(',').forEach(c => {
+  POMS && POMS.split(',').forEach(c => {
     addPom(c && `${PROJECT_HOME}/${c}`);
     root = root || c == 'pom';
   });
@@ -617,8 +613,11 @@ function pom() {
   // pom will most likely be set to a deployment pom via -J. The build
   // will fail if the foam pom is not specified.
   if ( ! root ) {
-    poms.unshift('pom');
-    POMS = comma('pom', POMS);
+    if ( poms.length > 0 ) {
+      poms.splice(1, 0, 'pom');
+    } else {
+      poms.push('pom');
+    }
     warning('Added /pom');
   }
 

--- a/tools/setup/rootPOM.js
+++ b/tools/setup/rootPOM.js
@@ -10,7 +10,7 @@ foam.POM({
     // Add your license header here
   `,
   envs: {
-    VERSION: '1.0.0',
+    version: '1.0.0',
     // javaMainArgs: 'spid:{spid}'
   },
   tasks: [


### PR DESCRIPTION
Changed order of root pom injection when not specified to ensure the configuration of the specified pom supercedes the root. Remove foam's root pom envs:appName, as this makes it difficult for application level poms to supercede, given how 'name' is determined.
Update EnvMaker to delay setting APP_NAME as long as possible.