### PR TITLE
Do not retry on validation exception

### DIFF
--- a/src/foam/box/RetryBox.js
+++ b/src/foam/box/RetryBox.js
@@ -59,7 +59,8 @@ foam.CLASS({
   extends: 'foam.box.ProxyBox',
 
   requires: [
-    'foam.lang.Exception'
+    'foam.lang.Exception',
+    'foam.lang.ValidationException'
   ],
 
   properties: [
@@ -83,9 +84,11 @@ foam.CLASS({
       code: function send(msg) {
         if ( this.Exception.isInstance(msg.object) && ( this.maxAttempts == -1 || this.attempt < this.maxAttempts ) ) {
           // console.log('********************************************* ATTEMPT', this.attempt);
-          this.attempt++;
-          this.destination.send(this.message);
-          return;
+          if ( ! this.ValidationException.isInstance(msg.object.data.exception) ) {
+            this.attempt++;
+            this.destination.send(this.message);
+            return;
+          }
         }
 
         this.delegate && this.delegate.send(msg);


### PR DESCRIPTION
When server throws validation exception there's no need to retry from the client box since it will end up with the same validation exception.