### PR TITLE
Add viewMoreMenuItem to alarming, cron, er, and logger menus

### DIFF
--- a/src/foam/core/alarming/menus.jrl
+++ b/src/foam/core/alarming/menus.jrl
@@ -17,7 +17,6 @@ p({
         limit: 4,
         citationView: "foam.core.alarming.AlarmCitationView",
         viewMore: true,
-        viewMoreMenuItem: "admin.alarms",
         emptyTitle: "No activity"
       },
       mode: "config"

--- a/src/foam/core/alarming/menus.jrl
+++ b/src/foam/core/alarming/menus.jrl
@@ -17,6 +17,7 @@ p({
         limit: 4,
         citationView: "foam.core.alarming.AlarmCitationView",
         viewMore: true,
+        viewMoreMenuItem: "admin.alarms",
         emptyTitle: "No activity"
       },
       mode: "config"

--- a/src/foam/core/cron/menus.jrl
+++ b/src/foam/core/cron/menus.jrl
@@ -51,6 +51,7 @@ p({
         limit: 4,
         citationView: "foam.core.cron.CronCitationView",
         viewMore: true,
+        viewMoreMenuItem: "admin.cronjobs",
         emptyTitle: "No activity"
       },
       mode: "config"

--- a/src/foam/core/er/menus.jrl
+++ b/src/foam/core/er/menus.jrl
@@ -34,6 +34,7 @@ p({
         limit: 4,
         citationView: "foam.core.er.EventRecordCitationView",
         viewMore: true,
+        viewMoreMenuItem: "er",
         emptyTitle: "No activity"
       },
       mode: "config"

--- a/src/foam/core/logger/menus.jrl
+++ b/src/foam/core/logger/menus.jrl
@@ -17,6 +17,7 @@ p({
         limit: 4,
         citationView: "foam.core.logger.LogMessageCitationView",
         viewMore: true,
+        viewMoreMenuItem: "admin.logs",
         emptyTitle: "No activity"
       },
       mode: "config"


### PR DESCRIPTION
Introduce viewMoreMenuItem to enhance the menu options for alarming, cron, event records, and logger components.

Reason for the change is to fix the routing of the view more button to send user to the right page 