### PR TITLE
Fix missing import and warning in UnstyledTableGroup

### DIFF
--- a/src/foam/u2/table/UnstyledTableGroup.js
+++ b/src/foam/u2/table/UnstyledTableGroup.js
@@ -16,7 +16,6 @@ foam.CLASS({
   ],
 
   imports: [
-    'canBuildObjfromProj',
     'nestedPropsAndIndexes',
     'propertyNamesToQuery',
     'props',

--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -351,8 +351,7 @@ foam.CLASS({
           }
 
           var isEven = (index + 1) % 2 !== 0 ;
-          var rowEl = self.E().tag(self.rowView, args).attr('data-idx', index).attr('data-even', isEven);
-          e.start(rowEl).hide(self.collapsedGroups[self.currGroup_] ?? false);
+          var rowEl = e.start(self.rowView, args).attr('data-idx', index).attr('data-even', isEven).hide(self.collapsedGroups[self.currGroup_] ?? false);
           rowEl.el().then(a => {
             self.rowObserver.observe(a)
           });


### PR DESCRIPTION
Addressed a missing required import and resolved a warning related to the use of a literal View as ViewSpec in the UnstyledTableGroup implementation.

also that improves performance 