### PR TITLE
Build Tooling - Help

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [INSTALL.md](INSTALL.md) for more detailed installation notes.
 
 **NOTE: this will create a parent directory above foam3/**
 
-    ./build.sh -Tsetup/Project --createAdmin --appName:Example --package:com.foamdev --adminPassword:badpassword
+    ./build.sh -T+setup/Project --createAdmin --appName:Example --package:com.foamdev --adminPassword:badpassword
     cd ..
     ./build.sh
 

--- a/deployment/https/pom.js
+++ b/deployment/https/pom.js
@@ -1,5 +1,6 @@
 foam.POM({
   name:'https',
+  help: 'Provide SSL Certificate and port configuration for HTTPS.',
   envs: {
     webPort: '8443'
   },
@@ -8,4 +9,4 @@ foam.POM({
     { source: 'foamdev.jks' },
     { source: 'foamdev.pkcs12' }
   ]
-})
+});

--- a/tools/EnvMaker.js
+++ b/tools/EnvMaker.js
@@ -67,11 +67,13 @@ exports.end = function() {
   // Determining app name is a special case.  Historically, this was
   // taken from the root pom.name, but this makes it difficult to
   // override in other configuration poms.
-  if ( ! envs['APP_NAME'] ||
-       ! envs['appName'] ||
-       ! envs['app-name'] ) {
-    this.verbose(`[Env] setting APP_NAME to root pom name: ${rootPOM.name}`);
-    envs['APP_NAME'] = rootPOM.name;
+  if ( rootPOM ) {
+    if ( ! envs['APP_NAME'] ||
+         ! envs['appName'] ||
+         ! envs['app-name'] ) {
+      this.verbose(`[Env] setting APP_NAME to root pom name: ${rootPOM.name}`);
+      envs['APP_NAME'] = rootPOM.name;
+    }
   }
 };
 

--- a/tools/HelpMaker.js
+++ b/tools/HelpMaker.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+const topics = {};
+
+exports.description = 'Register POM help.';
+
+exports.visitPOM = function(pom) {
+  if ( ! pom.help ) return;
+
+  let help = {
+    name: pom.name,
+    help: pom.help,
+    path: pom.path
+  };
+  var t = topics[pom.name] || [];
+  t.push(help);
+  topics[pom.name] = t;
+};
+
+exports.end = function() {
+  let count = Object.keys(topics).length;
+  this.verbose(`[Help] Registered ${count} help topics`);
+};
+
+exports.topics = topics;

--- a/tools/TaskMaker.js
+++ b/tools/TaskMaker.js
@@ -28,7 +28,7 @@ exports.visitPOM = function(pom) {
 
 exports.end = function() {
   let count = Object.keys(tasks).length;
-  this.log(`[Task] Registered ${count} tasks`);
+  this.verbose(`[Task] Registered ${count} tasks`);
 };
 
 exports.tasks = tasks;

--- a/tools/build.js
+++ b/tools/build.js
@@ -80,6 +80,7 @@ var depth   = 1;
 var running = {};
 var summary = [];
 let TOOLING_TASKS = {};
+let POM_HELP = {}; // additional help topics provided in build
 
 function task() {
   var name, gnuopt, desc = '', dep = [], f, pom = 'build';
@@ -138,7 +139,7 @@ function task() {
     fired = true;
     let tasks = TOOLING_TASKS[name];
     if ( ! tasks ) {
-      error(`Task not found: ${name}`);
+      outputHelp(name, 'Task not found:');
     }
     if ( NOP.split(',').includes(name) ) {
       warning(`Skipping Task :: ${name}`);
@@ -235,24 +236,7 @@ function execute(t, ...args) {
   if ( f ) {
     f.apply(Object.assign({}, EXPORTS), args);
   } else {
-    var extra = '';
-    if ( t.length > 1 ) {
-      let similar = findSimilarTasks(TOOLING_TASKS, t);
-      if ( similar.length > 0 ) {
-        extra += '\n  Possible Task matches: \n';
-      }
-      similar.forEach(task => {
-        extra += '    ' + task.name + ' ' + task.gnuopt + ' - ' + task.desc + '\n';
-      });
-      similar = findSimilarOptions(OPTIONS, t);
-      if ( similar.length > 0 ) {
-        extra += '\n  Possible Option matches: \n';
-      }
-      similar.forEach(option => {
-        extra += '    ' + option.name + ' ' + option.opt + ' ' + option.gnuopt + ' - ' + option.desc + '\n';
-      });
-    }
-    error('Task not found:', t, extra);
+    outputHelp(t, "Task not found:");
   }
 }
 
@@ -493,21 +477,7 @@ OPTIONS = addOptions({
   flags: ['f', 'flags', 'FLAGS', 'Flags passed to pmake. Explicitly set with --flags:test, for example.', '', arg => FLAGS = arg ],
   help: [ 'h', 'help', 'HELP', 'Print usage information for environment variables (envs), options, and tasks.  Narrow output with --help:tasks, for example. Or show help for a particular topic with --help:foo where foo is the name of an option or task.', '', arg => {
     HELP = true;
-    if ( ! arg ) {
-      moreUsage(arg);
-    } else if ( typeof arg === "string" ) {
-      if ( arg === 'envs' ||
-           arg === 'options' ||
-           arg === 'tasks' ) {
-        moreUsage(arg);
-      } else {
-        execute('topic', arg);
-      }
-    } else if ( arg instanceof Function ) {
-      moreUsage();
-      arg();
-    }
-    process.exit(0);
+    TOPIC_HELP = arg;
   }],
   hostname: ['', 'hostname', 'HOST_NAME', 'Hostname to set in JVM', () => os.hostname(), arg => HOST_NAME = org ],
   nop: ['', 'nop', 'NOP', 'List of task NOT to run. ex: --nop:genJS,genJava', '', arg => NOP = comma(NOP, arg) ],
@@ -523,61 +493,6 @@ OPTIONS = addOptions({
              TASKS = TASKS ? TASKS + TASK_SEPERATOR + t : t;
            } ],
   timestamp: ['', 'timestamp', 'TIMESTAMP', 'Date/time string to timestamp files', () => TIMESTAMP = new Date().toISOString().substring(0, 19).replaceAll('-','').replaceAll(':','').replaceAll('T',''), arg => TIMESTAMP = arg],
-  topic: [ 'H', 'topic-help', '', 'Help on a particular environment variable, option, or task', '', arg => {
-    HELP = true;
-    if ( arg.startsWith(':') ||
-         arg.startsWith('=') ) {
-      arg = arg.substring(1);
-    }
-    info(`Help for \'${arg}\'`);
-    var option = findOption(OPTIONS, arg);
-    if ( option ) {
-      let opts = option.opt ? '-'+option.opt+', ' : '';
-      opts += '--'+option.name;
-      if ( option.name !== option.gnuopt ) {
-        opts += ', --'+option.gnuopt;
-      }
-      var def = option.env && globalThis[option.env];
-      if ( ! def ) {
-        def = option.def ? option.def : '';
-        if ( def instanceof Function ) {
-          def = def();
-        }
-      }
-      let desc = option.desc;
-      log('(OPTION)', ''.padStart(0), opts+':', '\x1b[0;35m', def,'\x1b[0;0m', desc);
-    } else {
-      let t = findTask(TOOLING_TASKS, arg); // first will do
-      if ( t ) {
-        var msg = arg;
-        if ( arg !== t.name ) msg += ' '+t.name;
-        log('(TASK)', msg, t.desc);
-      } else {
-        let e = ENVS[arg];
-        if ( e ) {
-          log('(ENV)', arg,': ',e[0]);
-        } else {
-          var extra = '';
-          let similar = findSimilarTasks(TOOLING_TASKS, arg);
-          if ( similar.length > 0 ) {
-            extra += '\n  Possible Task matches: \n';
-          }
-          similar.forEach(task => {
-            extra += '    ' + task.name + ' ' + task.gnuopt + ' - ' + task.desc + '\n';
-          });
-          similar = findSimilarOptions(OPTIONS, arg);
-          if ( similar.length > 0 ) {
-            extra += '\n  Possible Option matches: \n';
-          }
-          similar.forEach(option => {
-            extra += '    ' + option.name + ' ' + option.opt + ' ' + option.gnuopt + ' - ' + option.desc + '\n';
-          });
-          error('Topic not found - ', arg, extra);
-        }
-      }
-    }
-    process.exit(0);
-  } ],
   verbose: ['', 'verbose', 'VERBOSE', 'Enable VerboseMaker to log additional info during build. ', false, function(arg) { VERBOSE = arg ? bool(arg) : true; }]
 
 }, OPTIONS);
@@ -585,11 +500,18 @@ OPTIONS = addOptions({
 // explicitly add journal to POM list, intented to be called
 // after pom() has setup the initial list
 function addJournal(name) {
-  let pom = name && `${PROJECT_HOME}/deployment/${name}/pom`;
-  if ( ! existsSync(pom + '.js') )
-    error('POM file not found ' + pom + '.js');
-  else
-    POMS = comma(POMS, pom);
+  let fn = name && `${PROJECT_HOME}/deployment/${name}/pom`;
+  if ( ! existsSync(fn + '.js') ) {
+    let fn2 = `${PROJECT_HOME}/foam3/deployment/${name}/pom`;
+    if ( ! existsSync(fn2 + '.js') ) {
+      error('POM not found ' + fn + '.js');
+      fn = null;
+    } else {
+      fn = fn2;
+    }
+  }
+  if ( fn )
+    POMS = comma(POMS, fn);
 }
 
 // build pom map and ensure the POMS list is viable
@@ -597,7 +519,7 @@ function pom() {
   var poms   = [];
   function addPom(fn) {
     if ( ! existsSync(fn + '.js') )
-      warning('File not found ' + fn + '.js');
+      warning('POM not found ' + fn + '.js');
     else
       poms.push(fn);
   };
@@ -626,9 +548,9 @@ function pom() {
       if ( ! c ) return;
       let fn = `${PROJECT_HOME}/deployment/${c}/pom`;
       if ( ! existsSync(fn + '.js') ) {
-        let fn2 = `foam3/deployment/${c}/pom`;
+        let fn2 = `${PROJECT_HOME}/foam3/deployment/${c}/pom`;
         if ( ! existsSync(fn2 + '.js') ) {
-          warning('File not found ' + fn + '.js');
+          error('POM not found ' + fn + '.js');
           fn = null;
         } else {
           fn = fn2;
@@ -640,6 +562,105 @@ function pom() {
 
   POMS = poms.join(',');
 }
+
+function outputHelp(arg, msg) {
+  var found = false;
+
+  pom();
+  execute('pomEnvs');
+
+  if ( ! msg ) {
+    if ( ! arg ||
+         ( arg === 'envs' ||
+           arg === 'options' ||
+           arg === 'tasks' ) ) {
+      found = true;
+      moreUsage(arg);
+    }
+
+    if ( ! found ) {
+      if ( arg.startsWith(':') ||
+           arg.startsWith('=') ) {
+        arg = arg.substring(1);
+      }
+      info(`Help for \'${arg}\'`);
+      var option = findOption(OPTIONS, arg);
+      if ( option ) {
+        found = true;
+        let opts = option.opt ? '-'+option.opt+', ' : '';
+        opts += '--'+option.name;
+        if ( option.name !== option.gnuopt ) {
+          opts += ', --'+option.gnuopt;
+        }
+        var def = option.env && globalThis[option.env];
+        if ( ! def ) {
+          def = option.def ? option.def : '';
+          if ( def instanceof Function ) {
+            def = def();
+          }
+        }
+        let desc = option.desc;
+        log('(OPTION)', ''.padStart(0), opts+':', '\x1b[0;35m', def,'\x1b[0;0m', desc);
+      }
+      if ( ! found ) {
+        let t = findTask(TOOLING_TASKS, arg); // first will do
+        if ( t ) {
+          found = true;
+          var m = arg;
+          if ( arg !== t.name ) m += ' '+t.name;
+          log('(TASK)', m, t.desc);
+        }
+      }
+      if ( ! found ) {
+        let e = ENVS[arg];
+        if ( e ) {
+          found = true;
+          log('(ENV)', arg,': ',e[0]);
+        }
+      }
+    }
+  }
+  if ( ! found ) {
+    var extra = '';
+    if ( arg && arg.length > 1 ) {
+      let similar = findSimilarTasks(TOOLING_TASKS, arg);
+      if ( similar.length > 0 ) {
+        extra += '\n  Possible Task matches: \n';
+      }
+      similar.forEach(task => {
+        extra += '    ' + task.name + ' ' + task.gnuopt + ' - ' + task.desc + '\n';
+      });
+      similar = findSimilarOptions(OPTIONS, arg);
+      if ( similar.length > 0 ) {
+        extra += '\n  Possible Option matches: \n';
+      }
+      similar.forEach(option => {
+        extra += '    ' + option.name + ' ' + option.opt + ' ' + option.gnuopt + ' - ' + option.desc + '\n';
+      });
+      var title = false;
+      Object.keys(POM_HELP).forEach(name => {
+        let pomHelp = POM_HELP[name];
+        pomHelp.forEach(h => {
+          if ( name.startsWith(arg) ||
+               pomHelp.help.indexOf(arg) ) {
+            if ( ! title ) {
+              title = true;
+              extra += '\n  Possible POM matches: \n';
+            }
+            extra += '    '+name+': '+h.help;
+            extra += '\n     '+h.path+ '\n';
+          }
+        });
+      });
+    }
+    if ( ! msg )
+      msg = 'Topic not found:';
+    error(msg, arg, extra);
+  }
+
+  process.exit(0);
+}
+
 
 // ############################
 // # Build tasks
@@ -690,7 +711,10 @@ task('tooling', 'Prepare build environment', [], function tooling() {
 });
 
 task('pom-envs', 'Capture POM arguments to environment values or options, and register POM tasks for later execution when the corresponding build tasks is executed.', [], function pomEnvs() {
-  let makers = pmake.bind(Object.assign({}, EXPORTS), `-makers=Env,Task -flags=${flag()} -pom=${POMS} -builddir=${BUILD_DIR} -envs=${POM_ENVS} -tasks=${TOOLING_TASKS} -options=${Object.assign({}, OPTIONS)}`)();
+  let makers = pmake.bind(Object.assign({}, EXPORTS), `-makers=Help,Env,Task -flags=${flag()} -pom=${POMS} -builddir=${BUILD_DIR} -envs=${POM_ENVS} -tasks=${TOOLING_TASKS} -options=${Object.assign({}, OPTIONS)}`)();
+  let helpMaker = makers.get('Help');
+  Object.assign(POM_HELP, helpMaker.topics);
+
   let envMaker = makers.get('Env');
   Object.keys(envMaker.envs).forEach(e => {
     let option = findOption(OPTIONS, e);
@@ -742,11 +766,14 @@ task('show-poms', 'Show POM structure.', [], function showPOMs() {
 task('get-env', 'Return value of arg. Called from installation scripts', ['pomEnvs'], function getEnv(arg) { console.log(`${arg}=${globalThis[arg]}`); });
 
 // Phase I - process tooling poms
-processToolingArgs.bind(Object.assign({}, EXPORTS), TOOLING_OPTIONS, moreUsage)();
+processToolingArgs.bind(Object.assign({}, EXPORTS), TOOLING_OPTIONS)();
 execute('tooling');
 
 // Phase II - process command line args,
-processBuildArgs.bind(Object.assign({}, EXPORTS), OPTIONS, moreUsage)();
+processBuildArgs.bind(Object.assign({}, EXPORTS), OPTIONS, outputHelp)();
+
+if ( HELP )
+  outputHelp(TOPIC_HELP);
 
 // build pom map for POM_TASKS, and ensure POMS list is viable
 pom();
@@ -757,9 +784,8 @@ pom();
 // execute('pomEnvs');
 
 // Phase III - execute build tasks
-if ( SHOW_ENVS ) {
+if ( SHOW_ENVS )
   moreUsage();
-}
 
 TASKS.split(TASK_SEPERATOR).forEach(t => {
   var s = t.split(':');

--- a/tools/buildlib.js
+++ b/tools/buildlib.js
@@ -359,7 +359,7 @@ function findSimilarOptions(options, o) {
   return similar;
 }
 
-function processToolingArgs(options, moreUsage) {
+function processToolingArgs(options) {
   const args = process.argv.slice(2);
   for ( var i = 0 ; i < args.length ; i++ ) {
     var arg = args[0];
@@ -391,7 +391,7 @@ function processToolingArgs(options, moreUsage) {
   }
 }
 
-function processBuildArgs(options, moreUsage) {
+function processBuildArgs(options, help) {
   const args = process.argv.slice(2);
   for ( var i = 0 ; i < args.length ; i++ ) {
     var arg = args[i];
@@ -402,15 +402,11 @@ function processBuildArgs(options, moreUsage) {
       for ( var k = 0; k < as.length; k++ ) {
         arg = as[k];
         var [opt, val] = arg.split(':');
-        if ( opt === 'help' ) {
-          options['help'].f(val);
+        let option = findOption(options, opt);
+        if ( option ) {
+          option.f.bind(this, val)();
         } else {
-          let option = findOption(options, opt);
-          if ( option ) {
-            option.f.bind(this, val)();
-          } else {
-            options['tasks'].f.bind(this, arg)();
-          }
+          options['tasks'].f.bind(this, arg)();
         }
       }
     } else if ( arg.startsWith('-') ) {
@@ -427,12 +423,13 @@ function processBuildArgs(options, moreUsage) {
             option.f.bind(this, null)();
           }
         } else {
-          let msg = 'Unknown argument "' + a + '"';
-          // output warning message after usage as the usage is so long
-          // the user will have to scroll pages up to see the issue.
-          options['help'].f(() => warning(msg));
+          help && help(a, 'Unknown argument:') ||
+            error('Unknown argument:', a);
         }
       }
+    } else {
+      help && help(arg, 'Unknown argument:') ||
+        error('Unknown argument:', a);
     }
   }
 }

--- a/tools/setup/ProjectTooling.js
+++ b/tools/setup/ProjectTooling.js
@@ -6,7 +6,7 @@
 
 /**
    Support for creating new FOAM based projects.
-   usage: node tools/build.js -Tsetup/Project --appName:Recipe --package:com.foamdev.com --adminPassword:badpassword
+   usage: node tools/build.js -T+setup/Project --appName:Recipe --package:com.foamdev.com --adminPassword:badpassword
 */
 foam.POM({
   name: 'project',
@@ -184,13 +184,13 @@ foam.POM({
     usage: ['usage', 'Example usage', [], function() {
       this.log('Project creation examples:');
       this.warning('must be run from foam3/ directory)');
-      this.log('  node tools/build.js -Tsetup/Project --appName:Recipe --package:com.foamdev.cook --adminPassword:badpassword');
+      this.log('  node tools/build.js -T+setup/Project --appName:Recipe --package:com.foamdev.cook --adminPassword:badpassword');
       this.log('      Generate a project matchin the FOAM-Recipes tutorial');
-      this.log('  node tools/build.js -Tsetup/Project --appName:Simple --package:com.foamdev --adminPassword:badpassword');
+      this.log('  node tools/build.js -T+setup/Project --appName:Simple --package:com.foamdev --adminPassword:badpassword');
       this.log('      Generate a project with a very simple model.');
-      this.log('  node tools/build.js -Tsetup/Project --type:demo --appName:Example --package:com.foamdev --adminPassword:badpassword');
+      this.log('  node tools/build.js -T+setup/Project --type:demo --appName:Example --package:com.foamdev --adminPassword:badpassword');
       this.log('      Generate a project with a more elaborate model demonstrating more FOAM features..');
-      this.log('  node tools/build.js -Tsetup/Project --createAdmin --appName:Example --package:com.foamdev --adminPassword:badpassword');
+      this.log('  node tools/build.js -T+setup/Project --createAdmin --appName:Example --package:com.foamdev --adminPassword:badpassword');
       this.log('      Generate an admin user for existing projects which were previously relying on the, now removed, foam-admin user provided by the baseline FOAM repo.');
       this.log();
     }],


### PR DESCRIPTION
Move help out of processBuildArgs so it can be run after poms are loaded so that it can provide help on poms themselves. For example,  -Jhttps --help:https  in this case adding help to an existing build sequence will also search the poms for the help string if no matching option or tasks is found