### PR TITLE
Add console buttons

### DIFF
--- a/src/foam/comics/v3/DetailView.js
+++ b/src/foam/comics/v3/DetailView.js
@@ -82,6 +82,9 @@ foam.CLASS({
   ],
 
   css: `
+    ^buttonGroup {
+      justify-content: flex-end;
+    }
   `,
 
   properties: [
@@ -223,7 +226,7 @@ foam.CLASS({
               // overrides: { size: 'SMALL' },
               overlaySpec: { obj: self, icon: '/images/Icon_More_Resting.svg', showDropdownIcon: false  }
             }, this.buttonGroup_$)
-            .addClass(this.myClass('buttonGroup'))
+            .addClass(self.myClass('buttonGroup'))
             .add(self.slot(function(primary) {
               if ( ! primary ) return;
               return this.E()

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -493,7 +493,12 @@ foam.CLASS({
       }
     },
     [ 'togglerPosition', 'left' ],
-    [ 'expanded', true ]
+    [ 'expanded', true ],
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'configViewSpec',
+      documentation: `Passed on to the ReactiveSectionedDetailView as config, see AbstractSectionedDetailView to learn more about configuring detail views`
+    }
   ],
 
   methods: [
@@ -1034,8 +1039,14 @@ foam.CLASS({
       layout.isMenuOpen$ = flowableTree.isMenuOpen$;
       layout.left.tag(flowableTree);
       layout.middle.call(this.renderSelf, [this]);
-      layout.right.add(this.dynamic(function(selectedValue) {
-        this.tag(self.ReactiveSectionedDetailView, {data: selectedValue, showActions: true, showHeader: true});
+      layout.right.add(this.dynamic(function(selectedValue, selected$configViewSpec) {
+        this.tag(self.ReactiveSectionedDetailView, {
+          of: selectedValue?.cls_.id ?? '', 
+          ...(selected$configViewSpec || {}),  
+          data: selectedValue, 
+          showActions: true, 
+          showHeader: true
+        });
       }));
 
       layout.header.add(this.dynamic(function(showPrompts) {

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -711,7 +711,152 @@ foam.CLASS({
       var p = this.LoginView.create({mode_: 0});
 
       this.out.tag(p);
-      this.currentBlock.obj = p;
+      this.currentBlock.value = p;
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.core.reflow.cmd',
+  name: 'Button',
+  extends: 'foam.core.reflow.cmd.Command',
+
+  classes: [
+    {
+      name: 'FlowAction',
+      extends: 'foam.lang.Action',
+      documentation: 'Small inner class to set up some basic view and configuration settings to make actions easier to use in console, might want to move this out if we ever want to use them outside these commands',
+      sections: [
+        {
+          name: 'config',
+          title: '',
+          properties: [
+            { name: 'label', onKey: true },
+            { name: 'script' },
+            { name: 'buttonStyle' },
+            { name: 'size' },
+            { name: 'icon' },
+            { name: 'themeIcon' },
+            // These need more work to be integrated here, they need proper data setting, we would probably want to switch to ActionReferneces for this
+            // { name: 'isEnabled' },
+            // { name: 'isAvailable' }
+          ]
+        }
+      ],
+      properties: [
+        {
+          class: 'String',
+          name: 'script',
+          supportingLabel: 'By default this button will insert the text "Hello World" as the next command when clicked. Change this script to modify this behaviour',
+          value: `'Hello World'`,
+          view: {
+            class: 'foam.u2.tag.TextArea',
+            rows: 5
+          }
+        },
+        {
+          name: 'code',
+          expression: function(script) {
+            if ( ! script ) return () => {};
+            return function(X) {
+              X.eval_(script);
+            }
+          }
+        },
+        {
+          name: 'name',
+          factory: function() { return 'flowButton_' + foam.next$UID(); }
+        },
+        ['label', 'Button']
+      ],
+      methods: [
+        function toE(args, X) {
+          var view = foam.u2.ViewSpec.createView(this.view, {
+            ...(args || {}),
+            action: this,
+            label$: this.label$,
+            buttonStyle$: this.buttonStyle$,
+            size$: this.size$,
+            icon$: this.icon$,
+            themeIcon$: this.themeIcon$
+          }, this, X);
+
+          if ( X.data$ && ! ( args && ( args.data || args.data$ ) ) ) {
+            view.data$ = X.data$;
+          }
+
+          return view;
+        }
+      ]
+    }
+  ],
+
+  properties: [
+    [ 'description', 'Create a button with custom logic' ]
+  ],
+
+  methods: [
+    function execute(label, script) {
+      var action = this.FlowAction.create({
+        label: label,
+        script: script
+      });
+      this.currentBlock.value = action;
+      this.currentBlock.configViewSpec = {
+        useSections: ['config']
+      }
+      this.out.tag(action);
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow.cmd',
+  name: 'Buttons',
+  extends: 'foam.core.reflow.cmd.Command',
+
+    classes: [
+    {
+      name: 'FlowActionArrayHolder',
+      properties: [
+        {
+          class: 'FObjectArray',
+          of: 'foam.core.reflow.cmd.Button.FlowAction',
+          name: 'actions',
+          factory: function() {
+            return [{class: 'foam.core.reflow.cmd.Button.FlowAction'}]
+          },
+          view: {
+            class: 'foam.u2.view.TitledArrayView',
+            valueView: {
+              class: 'foam.u2.detail.VerticalDetailView',
+              useSections: ['config']
+            }
+          }
+        }
+      ]
+    }
+  ],
+
+  properties: [
+    [ 'description', 'Create multiple buttons with custom logic' ],
+    'holder_'
+  ],
+
+  methods: [
+    function execute() {
+      this.holder_ = this.FlowActionArrayHolder.create();
+      this.currentBlock.value = this.holder_;
+      // This is not the most efficient way to do this, if this is slow or causing too many refreshes, this should be adjusted to
+      // do a diff and only add new actions and remove old ones rather than re-rendering the group every time
+      this.out.add(this.dynamic(function(holder_$actions) {
+        this.start(foam.u2.ButtonGroup)
+          .forEach(holder_$actions, function(v) {
+            this.tag(v)
+          })
+        .end();
+      }))
     }
   ]
 });

--- a/src/foam/core/reflow/cmd/cmds.jrl
+++ b/src/foam/core/reflow/cmd/cmds.jrl
@@ -100,3 +100,13 @@ p({
   """,
   permissionRequired: true
 })
+p({
+  "class":"foam.core.reflow.cmd.Button",
+  "id": "button",
+  "description": "Create a button with custom logic"
+})
+p({
+  "class":"foam.core.reflow.cmd.Buttons",
+  "id": "buttons",
+  "description": "Create multiple buttons with custom logic"
+})

--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -25,12 +25,14 @@ foam.CLASS({
       class:'Enum',
       of: 'foam.u2.ButtonStyle',
       name: 'buttonStyle',
+      generateJava: false,
       value: 'SECONDARY'
     },
     {
       class:'Enum',
       of: 'foam.u2.ButtonSize',
       name: 'size',
+      generateJava: false,
       value: 'MEDIUM'
     }
   ]

--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -17,6 +17,27 @@
 
 foam.CLASS({
   package: 'foam.u2',
+  name: 'ActionEnumRefinement',
+  refines: 'foam.lang.Action',
+
+  properties: [
+    {
+      class:'Enum',
+      of: 'foam.u2.ButtonStyle',
+      name: 'buttonStyle',
+      value: 'SECONDARY'
+    },
+    {
+      class:'Enum',
+      of: 'foam.u2.ButtonSize',
+      name: 'size',
+      value: 'MEDIUM'
+    }
+  ]
+})
+
+foam.CLASS({
+  package: 'foam.u2',
   name: 'ActionView',
   extends: 'foam.u2.tag.Button',
 

--- a/src/foam/u2/ButtonGroup.js
+++ b/src/foam/u2/ButtonGroup.js
@@ -24,7 +24,6 @@ foam.CLASS({
       align-items: center;
       flex-wrap: wrap;
       flex: 2 0 fit-content;
-      justify-content: flex-end;
     }
     ^vertical {
       flex-direction: column;

--- a/src/foam/u2/tag/Button.js
+++ b/src/foam/u2/tag/Button.js
@@ -491,7 +491,7 @@ foam.CLASS({
         return this.myClass(styleClass_);
       }));
 
-      this.addClass(this.myClass(this.size.label.toLowerCase()));
+      this.addClass(this.slot(function(size) { return this.myClass(size.label.toLowerCase()) }));
       this.enableClass(this.myClass('iconOnly'), ! (this.contents || this.label));
       this.enableClass(this.myClass('iconAfter'), this.isIconAfter$);
       this.enableClass('destructive', this.isDestructive$);
@@ -504,24 +504,27 @@ foam.CLASS({
     async function addContent() {
       /** Add text or icon to button. **/
       var self = this;
-      if ( ( this.themeIcon && this.theme ) ) {
-        this
-          .start({ class: 'foam.u2.tag.Image', glyph: this.themeIcon, role: 'presentation' })
-            .addClass(this.myClass('SVGIcon'))
-          .end();
-      } else if ( this.icon ) {
-        this
-          .start({ class: 'foam.u2.tag.Image', data: this.icon, role: 'presentation', embedSVG: true })
-            .addClass(this.myClass('SVGIcon'), this.myClass('imgSVGIcon'))
-          .end();
-      } else if ( this.iconFontName ) {
-        this.nodeName = 'i';
-        this.addClass(this.action.name);
-        this.addClass(this.iconFontClass); // required by font package
-        this.attr(role, 'presentation')
-        this.style({ 'font-family': this.iconFontFamily });
-        this.add(this.iconFontName);
-      }
+      this.add(this.dynamic(function(themeIcon, icon) {
+        if ( ( themeIcon && self.theme ) ) {
+          this
+            .start({ class: 'foam.u2.tag.Image', glyph: themeIcon, role: 'presentation' })
+              .addClass(self.myClass('SVGIcon'))
+            .end();
+        } else if ( icon ) {
+          this
+            .start({ class: 'foam.u2.tag.Image', data: icon, role: 'presentation', embedSVG: true })
+              .addClass(self.myClass('SVGIcon'), self.myClass('imgSVGIcon'))
+            .end();
+        // TODO: Maybe deprecate, not really used
+        } else if ( self.iconFontName ) {
+          this.nodeName = 'i';
+          this.addClass(self.action.name);
+          this.addClass(self.iconFontClass); // required by font package
+          this.attr(role, 'presentation')
+          this.style({ 'font-family': self.iconFontFamily });
+          this.add(self.iconFontName);
+        }
+      }))
       this.add(this.slot(function(label) {
         let e = this.E().show(!! label).style({ display: 'contents' });
         if ( foam.String.isInstance(this.label)  ) {


### PR DESCRIPTION
Replaces: https://github.com/kgrgreer/foam3/pull/4034

I was hoping i wouldnt need to subclass Action but it turned out to be easier for configuration and extensibility inside FLOW.

Also adds the ability to configure the detailView that shows up on the right side for blocks now, removing the need for making flow specific models for existing models. Can just add a section in a refinement and that should be plenty. 