### PR TITLE
Fixes GroupByDao since It was breaking after the first run

### DIFF
--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -379,7 +379,7 @@ foam.CLASS({
   name: 'GroupByDAOAgent',
   extends: 'foam.core.reflow.AbstractDAOAgent',
 
-  imports: [ 'currentBlock as block', 'eval_' ],
+  imports: [ 'selected as block', 'eval_' ],
 
   properties: [
     {


### PR DESCRIPTION
Changed 'currentBlock' to 'selected'.