### PR TITLE
Remove collapsed state management from table group view

### DIFF
--- a/src/foam/u2/table/UnstyledTableGroup.js
+++ b/src/foam/u2/table/UnstyledTableGroup.js
@@ -28,10 +28,6 @@ foam.CLASS({
 
   properties: [
     'projection',
-    {
-      class: 'Boolean',
-      name: 'collapsed'
-    }
   ],
 
   methods: [
@@ -79,12 +75,6 @@ foam.CLASS({
       style({ 'min-width': this.table.tableWidth_$ });
       [prop, objReturned] = this.getCellData(objForCurrentProperty, this.table.groupBy, nestedPropertiesObjsMap);
       this.start().addClass(self.table.myClass('group-content'),'h500')
-        .startContext({data: self})
-          .start(self.EXPAND)
-            .addClass(self.table.myClass('expand-icon'))
-            .enableClass(self.table.myClass('collapsed'), self.collapsed$)
-          .end()
-        .endContext()
         .start('span')
           .style({ flex: '3 0 0' })
           .add(prop.columnLabel + ': ')
@@ -105,16 +95,4 @@ foam.CLASS({
     }
   ],
 
-  actions: [
-    {
-      name: 'expand',
-      label: '',
-      size: 'SMALL',
-      themeIcon: 'next',
-      buttonStyle: foam.u2.ButtonStyle.TERTIARY,
-      code: function() {
-        this.collapsed = ! this.collapsed;
-      }
-    }
-  ]
 });

--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -340,17 +340,12 @@ foam.CLASS({
             
             // Show header if this is a new group (different from last rendered group)
             if ( ! foam.util.equals(group, self.currGroup_) ) {
-              // Create or reuse collapse state
-              if ( ! self.collapsedGroups[group] ) {
-                let isGroupCollapsed$ = foam.lang.SimpleSlot.create({value: false});
-                self.collapsedGroups[group] = isGroupCollapsed$;
-              }
+      
               
               e.tag(self.groupHeaderView,
                 { ...args,
                   groupLabel: group,
                   groupBy: self.groupBy,
-                  collapsed$: self.collapsedGroups[group]
               }
               );
               
@@ -359,7 +354,7 @@ foam.CLASS({
           }
 
           var isEven = (index + 1) % 2 !== 0 ;
-          var rowEl = e.start(self.rowView, args).attr('data-idx', index).attr('data-even', isEven).hide(self.collapsedGroups[self.currGroup_] ?? false);
+          var rowEl = e.start(self.rowView, args).attr('data-idx', index).attr('data-even', isEven);
           rowEl.el().then(a => {
             self.rowObserver.observe(a)
           });


### PR DESCRIPTION
Because the grouping shows groups per page not groups over all, so the user sees one group instead of 5 in the table for example