### PR TITLE
gui-shows property label(My Prop) instead of name

### DIFF
--- a/src/foam/core/reflow/ComparatorView.js
+++ b/src/foam/core/reflow/ComparatorView.js
@@ -28,8 +28,11 @@ foam.CLASS({
         var choices = [ '--' ];
         of.getAxiomsByClass(foam.lang.Property).forEach(p => {
           if ( p.hidden || p.networkTransient ) return;
-          choices.push(p.name);
-          choices.push('-' + p.name);
+          // instead of pushing [p, p.label] into choices, 
+          // we're pushing `[ '-' + p.name, '-' + p.label]` because what gets shown in gui is '-id vs id',
+          // '-' sign, it's being used to denote ordering, so pushing `[p, '-' + p.label]` does not preserve that behavior
+          choices.push([p.name, p.label]);    
+          choices.push(['-' + p.name, '-' + p.label]);
         });
         return { class: 'foam.u2.view.ChoiceView', choices: choices };
       },

--- a/src/foam/core/reflow/PredicateView.js
+++ b/src/foam/core/reflow/PredicateView.js
@@ -36,10 +36,14 @@ foam.CLASS({
         of.getAxiomsByClass(foam.lang.Property).forEach(p => {
           if ( ! p.searchable && ( p.hidden || p.networkTransient ) ) return;
           if ( foam.lang.Boolean.isInstance(p) ) {
-            choices.push('is:'  + p.name);
-            choices.push('-is:' + p.name);
+            // insted of pushing 
+            // choices.push([p, 'is:'  + p.name]); 
+            // we're pushing `[ 'is:' + p.name, 'is:' + p.label]`
+            // reason provided in ComparatorView ~ same logic
+            choices.push([ 'is:' + p.name, 'is:' + p.label]);
+            choices.push([ '-is:' + p.name, '-is:' + p.label]);
           } else {
-            choices.push(p.name);
+            choices.push([p.name, p.label]);
           }
         });
         return { class: 'foam.u2.view.ChoiceView', choices: choices, type: 'search' };


### PR DESCRIPTION
(e.g. label: 'My Prop', name: 'myProp')
### little explanation for changes 

- ComparatorView is being used for filtering (where clause), so the (`-`) is being used to say "is present" vs "is not present"(-).
- PredicateView is being used for sorting (order clause), so the (`-`) is being used to say "ascending" vs "descending".