### PR TITLE
Fix infinite loop on object deletion by using proper route clearing

### DIFF
--- a/src/foam/comics/v3/DetailView.js
+++ b/src/foam/comics/v3/DetailView.js
@@ -351,7 +351,7 @@ foam.CLASS({
         let id   = this.data?.id ?? this.idOfRecord;
         self.config.unfilteredDAO.inX(self.__subContext__).find(id).then(d => {
           if ( ! d ) {
-            this.daoController.route = '';
+            this.daoController.routeToMe();
             return;
           }
           self.data = d;
@@ -539,7 +539,7 @@ foam.CLASS({
           dao: this.config.dao,
           onDelete: () => {
             this.finished.pub();
-            this.daoController.route = '';
+            this.daoController.routeToMe();
           },
           data: this.data
         }));


### PR DESCRIPTION
Replace direct route assignments with routeToMe() calls to ensure browser URL stays synchronized with internal route state, preventing loops caused by URL/route desynchronization.


example: note it happens every two tries 
  When deleting objects from foam detailed views, an infinite loop occurred due to:
  1. Direct route assignment (`this.daoController.route = ''`) only updating internal state
  2. Browser URL remaining unchanged with deleted object ID
  3. System attempting to reload deleted object from stale URL
  4. Creating feedback loop between route clearing and object loading
  
  @sarthak-marwaha these changes are related to your work so please review to make sure I didnt break something else