### PR TITLE
Remove label for 'spid' property in Flow.js to streamline the code

### DIFF
--- a/src/foam/core/reflow/Flow.js
+++ b/src/foam/core/reflow/Flow.js
@@ -147,10 +147,8 @@ foam.CLASS({
       class: 'Reference',
       of: 'foam.core.auth.ServiceProvider',
       name: 'spid',
-      label: 'Client',
       readPermissionRequired: true,
       writePermissionRequired: true
-      // todo make choice view section & placeholder say client
     },
     {
       class: 'Int',


### PR DESCRIPTION
My bad - thx @jlhughes for the catch