### PR TITLE
SafetyUtil - add compare(date, date) 

### DIFF
--- a/src/foam/lang/AbstractDatePropertyInfo.java
+++ b/src/foam/lang/AbstractDatePropertyInfo.java
@@ -33,8 +33,7 @@ public abstract class AbstractDatePropertyInfo
   };
 
   public int compareValues(java.lang.Object o1, java.lang.Object o2) {
-    // Remove time component of Date
-    return foam.util.SafetyUtil.compare(((Date) o1).getTime() / 100000, ((Date) o2).getTime() / 100000);
+    return foam.util.SafetyUtil.compare((Date) o1, (Date) o2);
   }
 
   public Object fromString(String value) {

--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -101,6 +101,10 @@ public class SafetyUtil {
       return -1;
     }
 
+    if ( o1 instanceof java.util.Date && o2 instanceof java.util.Date ) {
+      return compare((java.util.Date) o1, (java.util.Date) o2);
+    }
+
     // Compare classes if the classes are different
     if ( o1.getClass() != o2.getClass() ) {
       compare(o1.getClass().getName(), o2.getClass().getName());
@@ -313,6 +317,18 @@ public class SafetyUtil {
 
   public static int compare(double o1, double o2) {
     return o1 == o2 ? 0 : o1 < o2 ? -1 : 1;
+  }
+
+  public static int compare(java.util.Date o1, java.util.Date o2) {
+    if ( o1 == null && o2 == null ) return 0;
+    if ( o1 == null ) return -1;
+    if ( o2 == null ) return 1;
+
+    // Zero out sub day milliseconds as FOAM Date comparisons should
+    // only be concerned with year month day.
+    long m1 = o1.getTime();
+    long m2 = o2.getTime();
+    return compare(m1 - (m1 % 86400000), m2 - (m2 % 86400000));
   }
 
   public static int hashCode(Object o1) {

--- a/src/foam/util/test/SafetyUtilTest.js
+++ b/src/foam/util/test/SafetyUtilTest.js
@@ -12,6 +12,8 @@ foam.CLASS({
   javaImports: [
     'foam.core.auth.User',
     'foam.util.SafetyUtil',
+    'java.util.Calendar',
+    'java.util.Date'
   ],
   documentation: 'test utility functions',
 
@@ -23,6 +25,7 @@ foam.CLASS({
       SafetyUtilTest_compare_primitive_array();
       SafetyUtilTest_compare_object_array();
       SafetyUtilTest_compare_fobject_array();
+      SafetyUtilTest_compare_date();
     `,
     },
     {
@@ -96,6 +99,29 @@ foam.CLASS({
         test(SafetyUtil.compare(arr1, arr2) ==  0, "Compare fobject array, arr1 == arr2");
         test(SafetyUtil.compare(arr1, arr3) == -1, "Compare fobject array, arr1 < arr3");
         test(SafetyUtil.compare(arr3, arr2) ==  1, "Compare fobject array, arr3 > arr2");
+      `
+    },
+    {
+      name: 'SafetyUtilTest_compare_date',
+      javaCode: `
+        var d1 = new Date();
+        var d2 = new Date();
+        d2.setHours(d2.getHours() +1);
+        test ( SafetyUtil.compare(d1, d2) == 0, "Compare date differing in time only");
+        d2.setHours(d2.getHours() -1);
+
+        d1.setYear(d1.getYear() + 1);
+        test ( SafetyUtil.compare(d1, d2) == 1, "Compare date differing in year");
+
+        Calendar cal = Calendar.getInstance();
+        d1.setYear(d1.getYear() -1);
+        cal.setTime(d1);
+        cal.set(Calendar.MONTH, 1);
+        d1 = cal.getTime();
+        cal.setTime(d2);
+        cal.set(Calendar.MONTH, 2);
+        d2 = cal.getTime();
+        test(SafetyUtil.compare(d1, d2) ==  -1, "Compare date differing in month");
       `
     }
   ]


### PR DESCRIPTION
Add compare(date, date) which only compares the year-month-day part of Date.

### Failing Test Cases

- [ ] CoreTypesValidationTest fails maxDate test.  
- [ ] EventRecordsSystemOutageTest
- [ ] HistoryRecordServiceTest
- [ ] QueryParserUserTest 