### PR TITLE
fix: update sink view choice to 'Count' in AbstractDAOAgent

### DIFF
--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -388,7 +388,7 @@ foam.CLASS({
        return { class: 'foam.core.reflow.PropertyChoiceView', of: X.data.of };
       }
     },
-    { name: 'sink', view: 'foam.core.reflow.SinkView', choice: 'COUNT' } // TODO: why doesn't choice work?
+    { name: 'sink', view: { class: 'foam.core.reflow.SinkView', choice: 'Count' } }
   ],
 
   methods: [


### PR DESCRIPTION
fixing 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8dcdf8ca-1937-4f44-b05a-73c83872ec81" />
to show count as default.