### PR TITLE
Fix demo examples navigation broken by symlink removal

### DIFF
--- a/src/foam/demos/examples/pom.js
+++ b/src/foam/demos/examples/pom.js
@@ -7,9 +7,9 @@
 foam.POM({
   name: "fbe",
   projects: [
-    { name: '../../../../foam3/src/pom' },
-    { name: '../../../../foam3/src/io/c9/ace/pom' },
-    { name: '../../../../foam3/src/foam/core/pom' }
+    { name: '../../../pom' },
+    { name: '../../../io/c9/ace/pom' },
+    { name: '../../../foam/core/pom' }
   ],
   files: [
     { name: 'FBE' },


### PR DESCRIPTION
## Problem
The foam3 demo examples page (`/foam3/src/foam/demos/examples/index.html`) was broken with 404 errors:
```
GET http://localhost:8080/foam3/foam3/src/pom.js net::ERR_ABORTED 404 (Not Found)
foam.CLASS is not a function
```

## Root Cause
Commit `32d3d9e9da` accidentally removed the `foam3` symlink while moving `agents.jrl`. This symlink was critical for path resolution in demo pages.

**Before (with symlink):**
- `foam3` → `.` (symlink to root)
- Path `../../../../foam3/src/pom` resolved to `../../../src/pom` ✅

**After (symlink removed):**
- `foam3` is now a subdirectory
- Same path creates `foam3/foam3/src/pom.js` ❌

## Solution
Fixed the relative paths in `/src/foam/demos/examples/pom.js`:
- `../../../../foam3/src/pom` → `../../../pom`
- `../../../../foam3/src/io/c9/ace/pom` → `../../../io/c9/ace/pom`  
- `../../../../foam3/src/foam/core/pom` → `../../../foam/core/pom`

## Testing
- Demo examples page now loads without 404 errors
- `foam.CLASS` is available and functional