### PR TITLE
fix(FileDropZone): deduplicate format labels for readable display

### DIFF
--- a/src/foam/core/fs/fileDropZone/FileDropZone.js
+++ b/src/foam/core/fs/fileDropZone/FileDropZone.js
@@ -274,9 +274,21 @@ foam.CLASS({
       var constructedString = '';
 
       if ( readable ) {
-        supportedTypes.forEach((type, index) => {
-          constructedString += this.supportedFormats[type];
-          if ( index < supportedTypes.length - 1 ) {
+        // Deduplicate format labels for readable display
+        var uniqueLabels = [];
+        var seenLabels = {};
+        
+        supportedTypes.forEach(type => {
+          var label = this.supportedFormats[type];
+          if ( !seenLabels[label] ) {
+            seenLabels[label] = true;
+            uniqueLabels.push(label);
+          }
+        });
+        
+        uniqueLabels.forEach((label, index) => {
+          constructedString += label;
+          if ( index < uniqueLabels.length - 1 ) {
             constructedString += ', ';
           }
         });

--- a/src/foam/core/fs/fileDropZone/FileDropZone.js
+++ b/src/foam/core/fs/fileDropZone/FileDropZone.js
@@ -285,7 +285,6 @@ foam.CLASS({
           }
           index++;
         });
-        
       } else {
         supportedTypes.forEach((type, index) => {
           constructedString += type;

--- a/src/foam/core/fs/fileDropZone/FileDropZone.js
+++ b/src/foam/core/fs/fileDropZone/FileDropZone.js
@@ -276,7 +276,6 @@ foam.CLASS({
       if ( readable ) {
         // Deduplicate format labels for readable display
         let uniqueLabels = new Set(Object.values(this.supportedFormats));
-        console.log('Unique labels:', uniqueLabels);
         let index = 0;
         uniqueLabels.forEach((label) => {
           constructedString += label;

--- a/src/foam/core/fs/fileDropZone/FileDropZone.js
+++ b/src/foam/core/fs/fileDropZone/FileDropZone.js
@@ -275,22 +275,15 @@ foam.CLASS({
 
       if ( readable ) {
         // Deduplicate format labels for readable display
-        var uniqueLabels = [];
-        var seenLabels = {};
-        
-        supportedTypes.forEach(type => {
-          var label = this.supportedFormats[type];
-          if ( !seenLabels[label] ) {
-            seenLabels[label] = true;
-            uniqueLabels.push(label);
-          }
-        });
-        
-        uniqueLabels.forEach((label, index) => {
+        let uniqueLabels = new Set(Object.values(this.supportedFormats));
+        console.log('Unique labels:', uniqueLabels);
+        let index = 0;
+        uniqueLabels.forEach((label) => {
           constructedString += label;
-          if ( index < uniqueLabels.length - 1 ) {
+          if ( index < uniqueLabels.size - 1 ) {
             constructedString += ', ';
           }
+          index++;
         });
       } else {
         supportedTypes.forEach((type, index) => {

--- a/src/foam/core/fs/fileDropZone/FileDropZone.js
+++ b/src/foam/core/fs/fileDropZone/FileDropZone.js
@@ -280,7 +280,7 @@ foam.CLASS({
         
         supportedTypes.forEach(type => {
           var label = this.supportedFormats[type];
-          if ( !seenLabels[label] ) {
+          if (  ! seenLabels[label] ) {
             seenLabels[label] = true;
             uniqueLabels.push(label);
           }


### PR DESCRIPTION
just in the case of more than format having same name like both will show `Excel`
<img width="684" alt="image" src="https://github.com/user-attachments/assets/d5aefa80-266a-4523-a9ee-65bedf4b409b" />
