### PR TITLE
Use existing mappings for CSV header parsing

### DIFF
--- a/src/foam/core/reflow/Upload.js
+++ b/src/foam/core/reflow/Upload.js
@@ -461,7 +461,10 @@ foam.CLASS({
       this.rows = a.length-1;
 
       try {
-        var props  = this.parseColumns(a[0]);
+        // Use existing mappings if available, otherwise parse from CSV headers
+        var props = this.mappings && this.mappings.length > 0 ? 
+          this.mappings : 
+          this.parseColumns(a[0]);
         var parser = this.CSVParser.create({});
         var agent;
 


### PR DESCRIPTION
Utilize existing mappings when available to improve CSV header parsing efficiency. If no mappings are present, fallback to parsing headers from the CSV.

since it was overriding my mappings when I pass to it.