### PR TITLE
Fix arguments for addValue and update README tag reference

### DIFF
--- a/src/foam/core/reflow/README.md
+++ b/src/foam/core/reflow/README.md
@@ -6,8 +6,8 @@ addValue(foam.audio.Speak.create({}, this));
 which will add to both the document itself and the PropertySheet, or if you only want to add
 to the PropertySheet, do:
 
-addValue(foam.audio.Speak.create({}, this), false);
+addValue(foam.audio.Speak.create({}, this), true);
 
 To add to just the document, you can do:
 
-this.currentBlock.tag(foam.audio.Speak)
+this.out.tag(foam.audio.Speak)


### PR DESCRIPTION
Correct the arguments for the `addValue` function and update the README to reflect the proper usage of the tag method.