### PR TITLE
Improve handler view class reference resolution in Mapping

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -17,7 +17,16 @@ foam.CLASS({
       class: "foam.mlang.ExprProperty",
       name: 'handler',
       view: function(_, X) {
-        return { class: 'foam.core.reflow.PropertyChoiceView', forCls: X.data.of };
+        // Try multiple ways to get the class reference
+        var cls = X.data.of;
+        
+        // Workaround: When loading from DAO, 'of' is not serialized but handler maintains sourceCls_
+        // This prevents the view from showing just the default placeholder
+        if ( ! cls && X.data.handler && X.data.handler.sourceCls_ ) {
+          cls = X.data.handler.sourceCls_;
+        }
+        
+        return { class: 'foam.core.reflow.PropertyChoiceView', forCls: cls };
       }
     },
     {


### PR DESCRIPTION
Enhance the resolution of class references for the handler view to ensure proper display, especially when loading from DAO.

before fix
<img width="625" height="188" alt="image" src="https://github.com/user-attachments/assets/1d3e90fd-e170-4d7e-b523-ede5cb3e024e" />


after fix 
<img width="874" height="175" alt="image" src="https://github.com/user-attachments/assets/9e78f573-c3b7-4e8f-9849-1e41ca0c60b7" />
