### PR TITLE
Fix crunch security loophole

### DIFF
--- a/src/foam/core/crunch/Capability.js
+++ b/src/foam/core/crunch/Capability.js
@@ -465,7 +465,7 @@ foam.CLASS({
         CapabilityJunctionStatus status = ucj.getStatus();
 
         if ( prereq.getStatus() == CapabilityJunctionStatus.AVAILABLE && getAutoGrantPrereqs() )
-          prereq = ((CrunchService) x.get("crunchService")).updateUserJunction(x, subject, prereq.getTargetId(), null, null);
+          prereq = ((CrunchService) x.get("crunchService")).updateJunctionFor(x, prereq.getTargetId(), null, null, subject.getUser(), subject.getRealUser());
 
         boolean reviewRequired = getReviewRequired();
         CapabilityJunctionStatus prereqStatus = prereq.getStatus();

--- a/src/foam/core/crunch/ServerCrunchService.java
+++ b/src/foam/core/crunch/ServerCrunchService.java
@@ -466,6 +466,8 @@ public class ServerCrunchService
     return this.updateUserJunction(x, (Subject) x.get("subject"), capabilityId, data, status);
   }
 
+  // Update UCJ without switching to user context
+  // Useful for granting grantMode: MANUAL capabilities
   public UserCapabilityJunction updateUserJunction(
     X x, Subject subject, String capabilityId, FObject data,
     CapabilityJunctionStatus status
@@ -478,10 +480,6 @@ public class ServerCrunchService
     }
     if ( status != null ) {
       ucj.setStatus(status);
-    }
-    AuthService auth = (AuthService) x.get("auth");
-    if ( auth.check(x, "service.crunchService.updateUserContext") ) {
-      x = Auth.sudo(x, subject.getUser(), subject.getRealUser());
     }
     DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
     return (UserCapabilityJunction) userCapabilityJunctionDAO.inX(x).put(ucj);

--- a/src/foam/core/crunch/ruler/UserCapabilityTicketRuleAction.js
+++ b/src/foam/core/crunch/ruler/UserCapabilityTicketRuleAction.js
@@ -18,6 +18,7 @@ foam.CLASS({
     'foam.lang.X',
     'foam.dao.DAO',
     'foam.core.auth.User',
+    'foam.core.auth.Subject',
     'foam.core.crunch.CapabilityJunctionStatus',
     'foam.core.crunch.UserCapabilityTicket',
     'foam.core.crunch.CrunchService'
@@ -36,7 +37,8 @@ foam.CLASS({
 
             for ( var id : ticket.getCreatedForUsers() ) {
               User user = (User) dao.find(id);
-              crunchService.updateJunctionFor(x, ticket.getCapability(), null, CapabilityJunctionStatus.GRANTED, user, user);
+              Subject sub = new Subject(user);
+              crunchService.updateUserJunction(x, sub, ticket.getCapability(), null, CapabilityJunctionStatus.GRANTED);
             }
 
             ticket.setStatus("CLOSED");

--- a/src/groupPermissionJunctions.jrl
+++ b/src/groupPermissionJunctions.jrl
@@ -60,7 +60,6 @@ p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.capabilityDAO"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.userCapabilityJunctionDAO"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.crunchService"})
-p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.crunchService.*"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"capability.read.*"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.capabilityCategoryDAO"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"capabilitycategory.read.*"})


### PR DESCRIPTION
Removes the service.crunchService.* permission from basic users, as it allowed all users access to elevated Crunch permissions—such as granting themselves arbitrary capabilities without proper validation, and altering the capabilities of other users.

As a result of this removal, we now require a method in crunchService to pass a different user in context (one with elevated permissions) to perform these operations when expected—for example, when the system or ops user grants a grantMode: MANUAL capability to a basic user. The updateUserJunction method has been updated accordingly: it no longer uses Auth.sudo to switch into the UCJ source user's context, and instead maintains the context of the user requesting the action from the Crunch service. The updateJunctionFor method should now be used when Auth.sudo behavior is required for operations on ucjDAO.