### PR TITLE
MaterializedDAO - support direct delegate loading (JDAO for example).

### DIFF
--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -113,6 +113,13 @@ public class MDAO
     }
   }
 
+  // Add Index which skips bulkload
+  public void addStoreIndex(Index index) {
+    synchronized ( writeLock_ ) {
+      setState(index_.addStoreIndex(state_, index));
+    }
+  }
+
   /** Add an Index which is for a unique value. Use addIndex() if the index is not unique. **/
   public void addUniqueIndex(Indexer... props) {
     Index idx = ValueIndex.instance();
@@ -277,7 +284,9 @@ public class MDAO
     }
     if ( cmd instanceof AddIndexCommand ) {
       AddIndexCommand indexCmd = (AddIndexCommand) cmd;
-      if ( indexCmd.getIndex() != null ) {
+      if ( indexCmd.getStore() ) {
+        addStoreIndex((Index) indexCmd.getIndex());
+      } else if ( indexCmd.getIndex() != null ) {
          addIndex((Index) indexCmd.getIndex());
       } else {
         if ( indexCmd.getUnique() ) {

--- a/src/foam/dao/MaterializedDAO.js
+++ b/src/foam/dao/MaterializedDAO.js
@@ -155,7 +155,8 @@ foam.CLASS({
         if ( getPm() )
           val = new foam.dao.PMDAO.Builder(getX()).setCSpec(getCSpec()).setDelegate(val).build();
         */
-      `
+      `,
+      javaFactory: 'return new foam.dao.MDAO(getOf());'
     },
     {
       class: 'Array',

--- a/src/foam/dao/MaterializedDAO.js
+++ b/src/foam/dao/MaterializedDAO.js
@@ -24,6 +24,7 @@ foam.CLASS({
     'foam.lang.Detachable',
     'foam.lang.FObject',
     'foam.dao.index.AddIndexCommand',
+    'static foam.mlang.MLang.COUNT',
     'foam.mlang.sink.Count',
     'foam.mlang.predicate.Predicate',
     'foam.mlang.predicate.True',
@@ -154,8 +155,7 @@ foam.CLASS({
         if ( getPm() )
           val = new foam.dao.PMDAO.Builder(getX()).setCSpec(getCSpec()).setDelegate(val).build();
         */
-      `,
-      javaFactory: 'return new foam.dao.MDAO(getOf());'
+      `
     },
     {
       class: 'Array',
@@ -182,7 +182,8 @@ foam.CLASS({
       javaType: 'void',
       synchronized: true,
       javaCode: `
-        if ( getInitialized() ) return;
+        if ( getInitialized() )
+          return;
 
         Logger logger = Loggers.logger(getX(), this, getInstanceName());
         logger.info("initializing");
@@ -193,9 +194,18 @@ foam.CLASS({
 
         // Could take a long time
         PM pm = new PM("MaterializedDAO", "initializing", getSourceDAO().getOf().getSimpleName());
+
         AddIndexCommand cmd = new AddIndexCommand();
+        Count count = (Count) getDelegate().select(COUNT());
+        logger.info("maybeInit, count", count.getValue());
+        if ( count.getValue() > 0 ) {
+          // If delegate is already populated then skip bulkloading
+          // on index creation.
+          cmd.setStore(true);
+        }
         cmd.setIndex(new MaterializedDAOIndex(this));
         getSourceDAO().cmd(cmd);
+
         pm.log(getX());
         logger.info("initialized");
 
@@ -242,7 +252,6 @@ foam.CLASS({
         return this;
       `
     },
-
     {
       name: 'indexRemove',
       type: 'Object',

--- a/src/foam/dao/index/AddIndexCommand.js
+++ b/src/foam/dao/index/AddIndexCommand.js
@@ -14,6 +14,10 @@ foam.CLASS({
       name: 'unique'
     },
     {
+      class: 'Boolean',
+      name: 'store'
+    },
+    {
       class: 'FObjectArray',
       of: 'foam.lang.Indexer',
       name: 'indexers'

--- a/src/foam/dao/index/AltIndex.java
+++ b/src/foam/dao/index/AltIndex.java
@@ -57,6 +57,12 @@ public class AltIndex
     return sa;
   }
 
+  // Add Index which skips bulkload
+  public Object addStoreIndex(Object state, Index i) {
+    delegates_.add(i);
+    return state;
+  }
+
   protected Object[] cloneState(Object state) {
     Object[] s2 = new Object[delegates_.size()];
 


### PR DESCRIPTION
If the delegate is already populated at time of maybeInit, then skip bulkloading when adding the MaterializedDAOIndex to the SourceDAO.