### PR TITLE
DOS-373-DOS-429-make-all-select-views-consistent (where, order, columns - views)

### DIFF
--- a/src/foam/core/reflow/ComparatorView.js
+++ b/src/foam/core/reflow/ComparatorView.js
@@ -6,11 +6,50 @@
 
 foam.CLASS({
   package: 'foam.core.reflow',
+  name: 'ComparatorOption',
+  
+  documentation: 'Model for comparator dropdown options',
+  
+  properties: [
+    {
+      class: 'String',
+      name: 'id',
+      factory: function() { return this.value; }
+    },
+    {
+      class: 'String',
+      name: 'value',
+      documentation: 'The actual string value to insert (e.g., "name", "-createdDate")'
+    },
+    {
+      class: 'String',
+      name: 'label',
+      documentation: 'Display label for the option'
+    },
+    {
+      class: 'String',
+      name: 'direction',
+      documentation: 'Sort direction: ASC or DESC',
+      value: 'ASC'
+    },
+    {
+      name: 'property',
+      documentation: 'Optional reference to the property object'
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
   name: 'ComparatorView',
   extends: 'foam.u2.View',
 
   requires: [
-    'foam.u2.TextField'
+    'foam.u2.TextField',
+    'foam.u2.view.RichChoiceIconView',
+    'foam.core.reflow.ComparatorOption',
+    'foam.core.reflow.PropertyOptionCitationView'
   ],
 
   imports: [
@@ -23,26 +62,70 @@ foam.CLASS({
       align-items: center;
       gap: 8px;
     }
+    ^ .foam-u2-TextField {
+      z-index: 10;
+    }
   `,
 
   properties: [
     {
       name: 'choices',
       view: function(_, X) {
+        var ComparatorOption = foam.core.reflow.ComparatorOption;
         var of = X.objData.dao.of;
-        var choices = [ '--' ];
+        var options = [];
+        
+        // Add separator option
+        options.push(ComparatorOption.create({
+          value: '--',
+          label: 'Choose Property'
+        }));
+        
+        // Process properties
         of.getAxiomsByClass(foam.lang.Property).forEach(p => {
           if ( p.hidden || p.networkTransient ) return;
-          // instead of pushing [p, p.label] into choices,
-          // we're pushing `[ '-' + p.name, '-' + p.label]` because what gets shown in gui is '-id vs id',
-          // '-' sign, it's being used to denote ordering, so pushing `[p, '-' + p.label]` does not preserve that behavior
-          choices.push([p.name, p.name]);
-          choices.push(['-' + p.name, '-' + p.name]);
+          
+          // Ascending option
+          options.push(ComparatorOption.create({
+            value: p.name,
+            label: '↑ ' + (p.label || p.name),
+            direction: 'ASC',
+            property: p
+          }));
+          
+          // Descending option
+          options.push(ComparatorOption.create({
+            value: '-' + p.name,
+            label: '↓ ' + (p.label || p.name),
+            direction: 'DESC',
+            property: p
+          }));
         });
-        return { class: 'foam.u2.view.ChoiceIconView', choices: choices, themeIcon: 'plus' };
+        
+        // Create DAO from options
+        var dao = foam.dao.ArrayDAO.create({
+          of: ComparatorOption,
+          array: options
+        });
+        
+        return {
+          class: 'foam.u2.view.RichChoiceIconView',
+          themeIcon: 'plus',
+          search: true,
+          searchPlaceholder: 'Search properties...',
+          idProperty: 'value',
+          rowView: { class: 'foam.core.reflow.PropertyOptionCitationView' },
+          sections: [
+            {
+              heading: 'Sort By',
+              dao: dao,
+              searchBy: [ ComparatorOption.LABEL, ComparatorOption.VALUE ]
+            }
+          ]
+        };
       },
       preSet: function(o, n) {
-        if ( n == '--' ) return;
+        if ( n == '--' || ! n ) return;
         if ( this.objData.order ) this.objData.order += ',';
         this.objData.order += n;
         return '--';
@@ -60,6 +143,6 @@ foam.CLASS({
   ],
 
   listeners: [
-  ],
+  ]
 
 });

--- a/src/foam/core/reflow/ComparatorView.js
+++ b/src/foam/core/reflow/ComparatorView.js
@@ -54,8 +54,8 @@ foam.CLASS({
     function render() {
       this.
         addClass().
-        tag(this.TextField, {data$: this.data$, size: 40, type: 'search'}).
-        startContext({data: this}).add(this.CHOICES).endContext();
+        startContext({data: this}).add(this.CHOICES).endContext().
+        tag(this.TextField, {data$: this.data$, size: 40, type: 'search'});
     }
   ],
 

--- a/src/foam/core/reflow/ComparatorView.js
+++ b/src/foam/core/reflow/ComparatorView.js
@@ -138,7 +138,7 @@ foam.CLASS({
       this.
         addClass().
         startContext({data: this}).add(this.CHOICES).endContext().
-        tag(this.TextField, {data$: this.data$, size: 40, type: 'search'});
+        tag(this.TextField, {data$: this.data$, size: 40});
     }
   ],
 

--- a/src/foam/core/reflow/DAOPrompt.js
+++ b/src/foam/core/reflow/DAOPrompt.js
@@ -265,7 +265,6 @@ foam.CLASS({
       section: 'filter',
       displayWidth: 60,
       view: { class: 'foam.core.reflow.PredicateView' }
-//      view: { class: 'foam.u2.TextField', type: 'search' } // adds 'x' to clear field
     },
     {
       class: 'String',
@@ -273,7 +272,6 @@ foam.CLASS({
       section: 'filter',
       displayWidth: 60,
       view: { class: 'foam.core.reflow.ComparatorView' }
-//      view: { class: 'foam.u2.TextField', type: 'search' } // adds 'x' to clear field
     },
     {
       class: 'String',

--- a/src/foam/core/reflow/PredicateView.js
+++ b/src/foam/core/reflow/PredicateView.js
@@ -142,7 +142,7 @@ foam.CLASS({
       this.
         addClass().
         startContext({data: this}).add(this.CHOICES).endContext().
-        tag(this.TextField, {data$: this.data$, size: 40, type: 'search'});
+        tag(this.TextField, {data$: this.data$, size: 40});
     }
   ],
 

--- a/src/foam/core/reflow/PredicateView.js
+++ b/src/foam/core/reflow/PredicateView.js
@@ -63,8 +63,8 @@ foam.CLASS({
     function render() {
       this.
         addClass().
-        tag(this.TextField, {data$: this.data$, size: 40, type: 'search'}).
-        startContext({data: this}).add(this.CHOICES).endContext();
+        startContext({data: this}).add(this.CHOICES).endContext().
+        tag(this.TextField, {data$: this.data$, size: 40, type: 'search'});
     }
   ],
 

--- a/src/foam/core/reflow/PredicateView.js
+++ b/src/foam/core/reflow/PredicateView.js
@@ -6,11 +6,45 @@
 
 foam.CLASS({
   package: 'foam.core.reflow',
+  name: 'PredicateOption',
+  
+  documentation: 'Model for predicate dropdown options',
+  
+  properties: [
+    {
+      class: 'String',
+      name: 'id',
+      factory: function() { return this.value; }
+    },
+    {
+      class: 'String',
+      name: 'value',
+      documentation: 'The actual string value to insert (e.g., "is:active", "name")'
+    },
+    {
+      class: 'String',
+      name: 'label',
+      documentation: 'Display label for the option'
+    },
+
+    {
+      name: 'property',
+      documentation: 'Optional reference to the property object'
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
   name: 'PredicateView',
   extends: 'foam.u2.View',
 
   requires: [
-    'foam.u2.TextField'
+    'foam.u2.TextField',
+    'foam.u2.view.RichChoiceIconView',
+    'foam.core.reflow.PredicateOption',
+    'foam.core.reflow.PropertyOptionCitationView'
   ],
 
   imports: [
@@ -26,31 +60,75 @@ foam.CLASS({
     }
     ^helper-icon svg { fill: currentColor; }
     ^helper-icon { vertical-align: sub; padding: 6px; }
+    ^ .foam-u2-TextField {
+      z-index: 10;
+    }
   `,
 
   properties: [
     {
       name: 'choices',
       view: function(_, X) {
+        var PredicateOption = foam.core.reflow.PredicateOption;
         var of = X.objData.dao.of;
-        var choices = [ '--' ];
+        var options = [];
+        
+        // Add separator option
+        options.push(PredicateOption.create({
+          value: '--',
+          label: '-- Choose Property --'
+        }));
+        
+        // Process properties
         of.getAxiomsByClass(foam.lang.Property).forEach(p => {
           if ( ! p.searchable && ( p.hidden || p.networkTransient ) ) return;
+          
           if ( foam.lang.Boolean.isInstance(p) ) {
-            // insted of pushing
-            // choices.push([p, 'is:'  + p.name]);
-            // we're pushing `[ 'is:' + p.name, 'is:' + p.label]`
-            // reason provided in ComparatorView ~ same logic
-            choices.push([ 'is:' + p.name, 'is:' + p.name]);
-            choices.push([ '-is:' + p.name, '-is:' + p.name]);
+            // Boolean predicates
+            options.push(PredicateOption.create({
+              value: 'is:' + p.name,
+              label: 'is: ' + (p.label || p.name),
+              property: p
+            }));
+            options.push(PredicateOption.create({
+              value: '-is:' + p.name,
+              label: 'isNot: ' + (p.label || p.name),
+              property: p
+            }));
           } else {
-            choices.push([p.name, p.name]);
+            // Other property types
+            options.push(PredicateOption.create({
+              value: p.name,
+              label: p.label || p.name,
+              property: p
+            }));
           }
         });
-        return { class: 'foam.u2.view.ChoiceIconView', choices: choices, type: 'search', themeIcon: 'plus' };
+        
+        // Create DAO from options
+        var dao = foam.dao.ArrayDAO.create({
+          of: PredicateOption,
+          array: options
+        });
+        
+        return {
+          class: 'foam.u2.view.RichChoiceIconView',
+          themeIcon: 'plus',
+          search: true,
+          searchPlaceholder: 'Search properties...',
+          idProperty: 'value',
+          rowView: { class: 'foam.core.reflow.PropertyOptionCitationView' },
+          sections: [
+            {
+              heading: 'Properties',
+              dao: dao,
+              searchBy: [ PredicateOption.LABEL, PredicateOption.VALUE ]
+            }
+          ]
+        };
       },
       preSet: function(o, n) {
-        if ( n == '--' ) return;
+        if ( n == '--' || ! n ) return;
         if ( this.objData.where ) this.objData.where += ' ';
         this.objData.where += n;
         return '--';

--- a/src/foam/core/reflow/PropertyChoiceView.js
+++ b/src/foam/core/reflow/PropertyChoiceView.js
@@ -137,6 +137,71 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.core.reflow',
+  name: 'PropertyChoiceIconView_',
+  extends: 'foam.u2.view.RichChoiceIconView',
+
+  properties: [
+    {
+      name: 'forCls',
+      postSet: function(_, value) {
+        this.rebuildSections();
+      }
+    },
+    'predicate',
+    {
+      name: 'search',
+      value: true
+    },
+    {
+      name: 'idProperty',
+      value: 'name'
+    },
+    {
+      name: 'choosePlaceholder',
+      value: 'Choose Property'
+    },
+    {
+      name: 'rowView',
+      factory: function() {
+        return { class: 'foam.core.reflow.PropertyCitationView' };
+      }
+    },
+    {
+      name: 'sections',
+      factory: function() {
+        if ( ! this.forCls ) return [
+          {
+            heading: 'Properties',
+            dao: foam.dao.ArrayDAO.create({ of: foam.lang.Property, array: [] }),
+            searchBy: [ foam.lang.Property.NAME ]
+          }
+        ];
+        let arr = this.forCls.getAxiomsByClass(foam.lang.Property)
+          .filter(p => p.showInPropertyChoice)
+          .filter(p => ! this.predicate || this.predicate(p))
+          .sort(foam.lang.Property.NAME.compare);
+
+        return [
+          {
+            heading: 'Properties',
+            dao: foam.dao.ArrayDAO.create({ of: foam.lang.Property, array: arr }),
+            searchBy: [ foam.lang.Property.NAME ]
+          }
+        ];
+      }
+    }
+  ],
+
+  methods: [
+    function rebuildSections() {
+      this.clearProperty('sections');
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
   name: 'PropertyChoiceView',
   extends: 'foam.u2.View',
 
@@ -160,6 +225,37 @@ foam.CLASS({
       );
 
       this.start(this.PropertyChoiceView_, {forCls: this.forCls, data$: this.propName$});
+    }
+  ]
+
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'PropertyChoiceIconView',
+  extends: 'foam.u2.View',
+
+  requires: [ 'foam.core.reflow.PropertyChoiceIconView_' ],
+
+  properties: [
+    'forCls',
+    'propName'
+  ],
+
+  methods: [
+    function render() {
+      this.SUPER();
+
+      var self = this;
+
+      this.data$.relateTo(
+        this.propName$,
+        function propToName(p) { return p ? p.name : ''; },
+        function nameToProp(n) { return n ? self.forCls.getAxiomByName(n) : ''; }
+      );
+
+      this.start(this.PropertyChoiceIconView_, {forCls: this.forCls, data$: this.propName$});
     }
   ]
 

--- a/src/foam/core/reflow/PropertyChoiceView.js
+++ b/src/foam/core/reflow/PropertyChoiceView.js
@@ -63,8 +63,93 @@ foam.CLASS({
       this.SUPER();
       // Clear the default summary content and add our custom layout
       this
-        .start('div').addClass(this.myClass('label')).add(this.data.label || this.data.name).end()
-        .start('div').addClass(this.myClass('name')).add(this.data.name).end();
+        .start('div')
+          .addClass(this.myClass('label'))
+          .add(this.data.label || this.data.name)
+        .end()
+        .start('div')
+          .addClass(this.myClass('name'))
+          .add(this.data.name)
+        .end();
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'PropertyChoiceMixin',
+  
+  documentation: `
+    Mixin that extracts common property selection logic to eliminate duplication
+    between PropertyChoiceView_ (standard dropdown) and PropertyChoiceIconView_ 
+    (icon-based dropdown). This pattern allows both views to share the same
+    property filtering and section building logic while maintaining different
+    visual representations through their parent classes (RichChoiceView vs 
+    RichChoiceIconView).
+  `,
+
+  properties: [
+    {
+      name: 'forCls',
+      postSet: function(_, value) {
+        this.rebuildSections();
+      }
+    },
+    'predicate',
+    {
+      name: 'search',
+      value: true
+    },
+    {
+      name: 'idProperty',
+      value: 'name'
+    },
+    {
+      name: 'choosePlaceholder',
+      value: 'Choose Property'
+    },
+    {
+      name: 'rowView',
+      factory: function() {
+        return { class: 'foam.core.reflow.PropertyCitationView' };
+      }
+    },
+    {
+      name: 'sections',
+      factory: function() {
+        if ( ! this.forCls ) return [
+          {
+            heading: 'Properties',
+            dao: foam.dao.ArrayDAO.create({ 
+              of: foam.lang.Property, 
+              array: [] 
+            }),
+            searchBy: [ foam.lang.Property.NAME ]
+          }
+        ];
+        let arr = this.forCls.getAxiomsByClass(foam.lang.Property)
+          .filter(p => p.showInPropertyChoice)
+          .filter(p => ! this.predicate || this.predicate(p))
+          .sort(foam.lang.Property.NAME.compare);
+
+        return [
+          {
+            heading: 'Properties',
+            dao: foam.dao.ArrayDAO.create({ 
+              of: foam.lang.Property, 
+              array: arr 
+            }),
+            searchBy: [ foam.lang.Property.NAME ]
+          }
+        ];
+      }
+    }
+  ],
+
+  methods: [
+    function rebuildSections() {
+      this.clearProperty('sections');
     }
   ]
 });
@@ -74,64 +159,7 @@ foam.CLASS({
   package: 'foam.core.reflow',
   name: 'PropertyChoiceView_',
   extends: 'foam.u2.view.RichChoiceView',
-
-  properties: [
-    {
-      name: 'forCls',
-      postSet: function(_, value) {
-        this.rebuildSections();
-      }
-    },
-    'predicate',
-    {
-      name: 'search',
-      value: true
-    },
-    {
-      name: 'idProperty',
-      value: 'name'
-    },
-    {
-      name: 'choosePlaceholder',
-      value: 'Choose Property'
-    },
-    {
-      name: 'rowView',
-      factory: function() {
-        return { class: 'foam.core.reflow.PropertyCitationView' };
-      }
-    },
-    {
-      name: 'sections',
-      factory: function() {
-        if ( ! this.forCls ) return [
-          {
-            heading: 'Properties',
-            dao: foam.dao.ArrayDAO.create({ of: foam.lang.Property, array: [] }),
-            searchBy: [ foam.lang.Property.NAME ]
-          }
-        ];
-        let arr = this.forCls.getAxiomsByClass(foam.lang.Property)
-          .filter(p => p.showInPropertyChoice)
-          .filter(p => ! this.predicate || this.predicate(p))
-          .sort(foam.lang.Property.NAME.compare);
-
-        return [
-          {
-            heading: 'Properties',
-            dao: foam.dao.ArrayDAO.create({ of: foam.lang.Property, array: arr }),
-            searchBy: [ foam.lang.Property.NAME ]
-          }
-        ];
-      }
-    }
-  ],
-
-  methods: [
-    function rebuildSections() {
-      this.clearProperty('sections');
-    }
-  ]
+  mixins: ['foam.core.reflow.PropertyChoiceMixin']
 });
 
 
@@ -139,64 +167,7 @@ foam.CLASS({
   package: 'foam.core.reflow',
   name: 'PropertyChoiceIconView_',
   extends: 'foam.u2.view.RichChoiceIconView',
-
-  properties: [
-    {
-      name: 'forCls',
-      postSet: function(_, value) {
-        this.rebuildSections();
-      }
-    },
-    'predicate',
-    {
-      name: 'search',
-      value: true
-    },
-    {
-      name: 'idProperty',
-      value: 'name'
-    },
-    {
-      name: 'choosePlaceholder',
-      value: 'Choose Property'
-    },
-    {
-      name: 'rowView',
-      factory: function() {
-        return { class: 'foam.core.reflow.PropertyCitationView' };
-      }
-    },
-    {
-      name: 'sections',
-      factory: function() {
-        if ( ! this.forCls ) return [
-          {
-            heading: 'Properties',
-            dao: foam.dao.ArrayDAO.create({ of: foam.lang.Property, array: [] }),
-            searchBy: [ foam.lang.Property.NAME ]
-          }
-        ];
-        let arr = this.forCls.getAxiomsByClass(foam.lang.Property)
-          .filter(p => p.showInPropertyChoice)
-          .filter(p => ! this.predicate || this.predicate(p))
-          .sort(foam.lang.Property.NAME.compare);
-
-        return [
-          {
-            heading: 'Properties',
-            dao: foam.dao.ArrayDAO.create({ of: foam.lang.Property, array: arr }),
-            searchBy: [ foam.lang.Property.NAME ]
-          }
-        ];
-      }
-    }
-  ],
-
-  methods: [
-    function rebuildSections() {
-      this.clearProperty('sections');
-    }
-  ]
+  mixins: ['foam.core.reflow.PropertyChoiceMixin']
 });
 
 
@@ -204,6 +175,14 @@ foam.CLASS({
   package: 'foam.core.reflow',
   name: 'PropertyChoiceView',
   extends: 'foam.u2.View',
+  
+  documentation: `
+    Wrapper view that handles the data binding between a Property object and its
+    string name representation. This is necessary because the underlying 
+    RichChoiceView expects string IDs, but we want to work with Property objects.
+    The relateTo() method creates a bidirectional binding that converts between
+    Property objects and their names.
+  `,
 
   requires: [ 'foam.core.reflow.PropertyChoiceView_' ],
 
@@ -221,10 +200,15 @@ foam.CLASS({
       this.data$.relateTo(
         this.propName$,
         function propToName(p) { return p ? p.name : ''; },
-        function nameToProp(n) { return n ? self.forCls.getAxiomByName(n) : ''; }
+        function nameToProp(n) { 
+          return n ? self.forCls.getAxiomByName(n) : ''; 
+        }
       );
 
-      this.start(this.PropertyChoiceView_, {forCls: this.forCls, data$: this.propName$});
+      this.start(this.PropertyChoiceView_, {
+        forCls: this.forCls, 
+        data$: this.propName$
+      });
     }
   ]
 
@@ -235,6 +219,13 @@ foam.CLASS({
   package: 'foam.core.reflow',
   name: 'PropertyChoiceIconView',
   extends: 'foam.u2.View',
+  
+  documentation: `
+    Icon-based variant of PropertyChoiceView. Provides the same Property<->name
+    binding functionality but renders as an icon button (typically a plus icon)
+    instead of a traditional dropdown. Used in space-constrained UIs where a
+    full dropdown would be too large.
+  `,
 
   requires: [ 'foam.core.reflow.PropertyChoiceIconView_' ],
 
@@ -252,10 +243,15 @@ foam.CLASS({
       this.data$.relateTo(
         this.propName$,
         function propToName(p) { return p ? p.name : ''; },
-        function nameToProp(n) { return n ? self.forCls.getAxiomByName(n) : ''; }
+        function nameToProp(n) { 
+          return n ? self.forCls.getAxiomByName(n) : ''; 
+        }
       );
 
-      this.start(this.PropertyChoiceIconView_, {forCls: this.forCls, data$: this.propName$});
+      this.start(this.PropertyChoiceIconView_, {
+        forCls: this.forCls, 
+        data$: this.propName$
+      });
     }
   ]
 

--- a/src/foam/core/reflow/PropertyListView.js
+++ b/src/foam/core/reflow/PropertyListView.js
@@ -33,7 +33,7 @@ foam.CLASS({
       name: 'choice',
       view: function(_, X) {
         // X.data is actually 'this' because PropertyListView is a Controller, not a View
-        return { class: 'foam.core.reflow.PropertyChoiceView_', forCls: X.data.forCls };
+        return { class: 'foam.core.reflow.PropertyChoiceIconView_', forCls: X.data.forCls };
       },
       preSet: function(o, n) {
         if ( n == '*' ) {

--- a/src/foam/core/reflow/PropertyListView.js
+++ b/src/foam/core/reflow/PropertyListView.js
@@ -55,7 +55,7 @@ foam.CLASS({
       this.SUPER();
       this.addClass();
       this.add(function(forCls) {
-        this.tag(self.DATA, { type: 'search' }).add(' ', self.CHOICE);
+        this.add(' ', self.CHOICE).tag(self.DATA, { type: 'search' });
       });
     }
   ],

--- a/src/foam/core/reflow/PropertyListView.js
+++ b/src/foam/core/reflow/PropertyListView.js
@@ -13,8 +13,13 @@ foam.CLASS({
     ^ {
       display: inline-flex;
       width: 100%;
-      gap: 5px;
+      gap: $inputHorizontalPadding;
+      align-items: center;
     }
+    ^ .property-data {
+      width: 100%;
+    }
+
     ^ .property-choice {
       width: 100%;
       overflow-x: hidden;

--- a/src/foam/core/reflow/PropertyOptionCitationView.js
+++ b/src/foam/core/reflow/PropertyOptionCitationView.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'PropertyOptionCitationView',
+  extends: 'foam.u2.CitationView',
+  
+  documentation: 'Simple citation view for property dropdown options in PredicateView and ComparatorView',
+  
+  css: `
+    ^row {
+      display: flex;
+      overflow-x: hidden;
+      width: 100%;
+      flex-direction: column;
+      gap: 2px;
+      border-bottom: 1px solid $borderXLight;
+    }
+    
+    ^row:last-child {
+      border-bottom: none;
+    }
+    
+    ^label {
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 1.2;
+    }
+    
+    ^value {
+      font-family: monospace;
+      font-size: 12px;
+      color: $textSecondary;
+      line-height: 1.2;
+    }
+  `,
+  
+  methods: [
+    function getSummary(data) {
+      return '';
+    },
+    
+    function render() {
+      this.SUPER();
+      if ( ! this.data ) return;
+      
+      this
+        .start('div')
+          .addClass(this.myClass('label'))
+          .add(this.data.label || this.data.value)
+        .end()
+        .start('div')
+          .addClass(this.myClass('value'))
+          .add(this.data.value)
+        .end();
+    }
+  ]
+});

--- a/src/foam/core/reflow/pom.js
+++ b/src/foam/core/reflow/pom.js
@@ -54,8 +54,9 @@ foam.POM({
     { name: 'Mapping',                 flags: 'js|java' },
     { name: 'ToolbarControl',          flags: 'js|java' },
     { name: 'control/HelpControl',     flags: 'js' },
-    { name: 'control/CollectionsControl', flags: 'js' },
-    { name: 'control/FlowsControl',     flags: 'js' },
-    { name: 'control/ComponentsControl', flags: 'js' }
+    { name: 'PropertyOptionCitationView',   flags: 'js' },
+    { name: 'control/CollectionsControl',   flags: 'js' },
+    { name: 'control/FlowsControl',         flags: 'js' },
+    { name: 'control/ComponentsControl',    flags: 'js' }
   ]
 });

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -863,3 +863,213 @@ foam.CLASS({
     }
   ]
 });
+
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'RichChoiceIconView',
+  extends: 'foam.u2.view.RichChoiceView',
+
+  documentation: `
+    A RichChoiceView that renders as an icon button instead of a traditional dropdown.
+    Similar to ChoiceIconView but for rich choice dropdowns.
+  `,
+
+  css: `
+    ^ {
+      position: relative;
+      display: inline-block;
+    }
+
+    ^icon-wrapper {
+      position: relative;
+      display: inline-block;
+    }
+
+    ^.property-choice {
+      width: 100%;
+      max-width: fit-content;
+      overflow-x: hidden;
+    }
+
+    ^selection-view {
+      position: absolute;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      cursor: pointer;
+      z-index: 2;
+      border: none !important;
+      background: transparent !important;
+    }
+
+    ^selection-view:hover,
+    ^selection-view:focus {
+      border: none !important;
+      background: transparent !important;
+    }
+  `,
+
+  properties: [
+    {
+      class: 'GlyphProperty',
+      name: 'themeIcon',
+      value: 'plus',
+      documentation: 'The glyph to display in the icon button'
+    }
+  ],
+
+  actions: [
+    {
+      name: 'iconButton',
+      label: '',
+      isAvailable: function() { return true; },
+      code: function() {
+        // This action does nothing - it's just for the button UI
+        // The actual functionality comes from the overlaid selection view
+      }
+    }
+  ],
+
+  methods: [
+    function render() {
+      var self = this;
+
+      if ( ! Array.isArray(this.sections) || this.sections.length === 0 ) {
+        throw new Error(`You must provide an array of sections. See documentation on the 'sections' property in RichTextView.js.`);
+      }
+
+      // Set up data binding and dropdown
+      this.onDetach(this.data$.sub(this.onDataUpdate));
+      this.onDataUpdate();
+
+      this.onDetach(() => this.dropdown_.remove());
+      this.attrs({
+        name: self.prop$.map(v => v?.name),
+        'data-value': self.data$,
+        'role': 'combobox',
+        'aria-controls': 'listbox',
+        'aria-haspopup': 'listbox',
+        'aria-expanded': self.isOpen_$.map(v => v ? 'true' : 'false')
+      });
+      self.isOpen_$.follow(this.dropdown_.opened$);
+      self.dropdown_.add(self.slot(function(hasBeenOpenedYet_) {
+        if ( ! hasBeenOpenedYet_ ) return this.E();
+        return this.E()
+          .addClass(self.myClass('container'))
+          .add(self.search$.map(searchEnabled => {
+            if ( ! searchEnabled ) return null;
+            return this.E()
+              .start()
+                .start('img')
+                  .attrs({ src: '/images/ic-search.svg' })
+                .end()
+                .startContext({ data: self })
+                  .addClass(self.myClass('search'))
+                  .tag(self.FILTER_.clone().copyFrom({ view: {
+                    class: 'foam.u2.TextField',
+                    placeholder: this.searchPlaceholder || 'Search... ',
+                    autofocus: true,
+                    onKey: true
+                  } }), {}, self.inputField$)
+                .endContext()
+              .end();
+          }))
+          .add(self.slot(function(sections) {
+            var promiseArray = [];
+            sections.forEach(function(section) {
+              promiseArray.push(section.dao.select(self.COUNT()));
+            });
+            return Promise.all(promiseArray).then(resp => {
+              var index = 0;
+              return this.E().forEach(sections, function(section) {
+                if ( section.hideIfEmpty && resp[index].value <= 0 ) return;
+                section.refineInput_ = resp[index].value > section.choicesLimit;
+                this.addClass(self.myClass('setAbove'))
+                  .start().addClass(self.myClass('section'))
+                  .start().hide(! section.heading)
+                    .addClass('h600', self.myClass('heading'))
+                    .translate(section.heading$)
+                  .end()
+                  .start()
+                    .select( section.choicesLimit ? section.filteredDAO$proxy.limit(section.choicesLimit) : section.filteredDAO$proxy, function(obj) {
+                      let addRow = function() {
+                        this.start(self.rowView, { data: obj })
+                          .attr('disabled', section.disabled)
+                          .attr('role', 'option')
+                          .enableClass('disabled', section.disabled)
+                          .callIf(! section.disabled, function() {
+                            this.on('click', () => {
+                              self.onSelect(obj);
+                              self.dropdown_.close();
+                            });
+                          })
+                        .end();
+                      }
+                      if ( this.U3 ) {
+                        this.call(addRow);
+                      } else {
+                        return this.E().call(addRow);
+                      }
+                    }, false, self.comparator)
+                  .end()
+                  .callIf(section.choicesLimit, function() {
+                    this.start()
+                      .addClass(self.myClass('moreChoices'))
+                      .add(section.refineInput_$.map(v => v ? self.MORE_CHOICES : ''))
+                    .end();
+                  })
+                  .end();
+                  index++;
+              });
+            });
+          }))
+          .add(this.slot(self.addAction));
+      }));
+
+      // Render the icon button with invisible overlay
+      this
+        .addClass(this.myClass())
+        .add(this.slot(function(mode) {
+          if ( mode !== foam.u2.DisplayMode.RO && mode !== foam.u2.DisplayMode.HIDDEN ) {
+            if ( self.ctrl ) {
+              self.ctrl.add(this.dropdown_);
+            } else {
+              this.dropdown_.write();
+            }
+            return self.E()
+              .addClass(this.myClass('icon-wrapper'))
+              .tag(self.ICON_BUTTON, {
+                data: self,
+                themeIcon$: self.themeIcon$
+              })
+              .start('', {}, this.selectionEl_$)
+                .addClass(this.myClass('selection-view'))
+                .enableClass('disabled', this.mode$.map((mode) => mode === foam.u2.DisplayMode.DISABLED))
+                .on('click', function(e) {
+                  var x = e.clientX || this.getBoundingClientRect().x;
+                  var y = e.clientY || this.getBoundingClientRect().y;
+                  if ( self.mode === foam.u2.DisplayMode.RW ) {
+                    self.dropdown_.parentEl = self.selectionEl_.el_();
+                    self.dropdown_.open(x, y);
+                    if ( self.inputField ) self.inputField.focused = true;
+                  }
+                  e.preventDefault();
+                  e.stopPropagation();
+                })
+              .end();
+          } else {
+            return self.E()
+              .addClass(this.myClass())
+              .tag(self.ICON_BUTTON, {
+                data: self,
+                themeIcon$: self.themeIcon$,
+                mode$: self.mode$
+              });
+          }
+        }));
+    }
+  ]
+});

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -901,6 +901,7 @@ foam.CLASS({
       left: 0;
       cursor: pointer;
       z-index: 2;
+      min-width: 250px;
       border: none !important;
       background: transparent !important;
     }

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -405,7 +405,9 @@ foam.CLASS({
         this.sections.forEach((section) => {
           if ( newValue ) {
             if ( section.searchBy.length > 0 ) {
-              var arrOfExpressions = section.searchBy.map((prop) => this.CONTAINS_IC(prop, newValue));
+              var arrOfExpressions = section.searchBy.map((prop) => 
+                this.CONTAINS_IC(prop, newValue)
+              );
               var pred = this.Or.create({ args: arrOfExpressions });
             }
             else {
@@ -491,15 +493,9 @@ foam.CLASS({
   ],
 
   methods: [
-    function render() {
-      this.SUPER();
-
+    function initializeDropdown() {
       var self = this;
-
-      if ( ! Array.isArray(this.sections) || this.sections.length === 0 ) {
-        throw new Error(`You must provide an array of sections. See documentation on the 'sections' property in RichTextView.js.`);
-      }
-
+      
       // If the property that this view is for already has a value when being
       // rendered, the 'data' property on this model will be set to an id for
       // the object being referenced by the Reference property being rendered.
@@ -558,7 +554,11 @@ foam.CLASS({
                     .translate(section.heading$)
                   .end()
                   .start()
-                    .select( section.choicesLimit ? section.filteredDAO$proxy.limit(section.choicesLimit) : section.filteredDAO$proxy, function(obj) {
+                    .select( 
+                      section.choicesLimit ? 
+                        section.filteredDAO$proxy.limit(section.choicesLimit) : 
+                        section.filteredDAO$proxy, 
+                      function(obj) {
                       let addRow = function() {
                         this.start(self.rowView, { data: obj })
                           .attr('disabled', section.disabled)
@@ -582,7 +582,9 @@ foam.CLASS({
                   .callIf(section.choicesLimit, function() {
                     this.start()
                       .addClass(self.myClass('moreChoices'))
-                      .add(section.refineInput_$.map(v => v ? self.MORE_CHOICES : ''))
+                      .add(section.refineInput_$.map(v => 
+                        v ? self.MORE_CHOICES : ''
+                      ))
                     .end();
                   })
                   .end();
@@ -592,7 +594,11 @@ foam.CLASS({
           }))
           .add(this.slot(self.addAction));
       }));
-
+    },
+    
+    function renderSelectionUI() {
+      var self = this;
+      
       this
         .add(this.slot(function(mode) {
           if ( mode !== foam.u2.DisplayMode.RO && mode !== foam.u2.DisplayMode.HIDDEN ) {
@@ -606,7 +612,9 @@ foam.CLASS({
               .addClass(this.myClass())
               .start('', {}, this.selectionEl_$)
                 .addClass(this.myClass('selection-view'))
-                .enableClass('disabled', this.mode$.map((mode) => mode === foam.u2.DisplayMode.DISABLED))
+                .enableClass('disabled', this.mode$.map((mode) => 
+                  mode === foam.u2.DisplayMode.DISABLED
+                ))
                 .on('click', function(e) {
                   var x = e.clientX || this.getBoundingClientRect().x;
                   var y = e.clientY || this.getBoundingClientRect().y;
@@ -651,6 +659,19 @@ foam.CLASS({
                 .end();
           }
         }));
+    },
+    
+    function render() {
+      this.SUPER();
+
+      var self = this;
+
+      if ( ! Array.isArray(this.sections) || this.sections.length === 0 ) {
+        throw new Error(`You must provide an array of sections. See documentation on the 'sections' property in RichTextView.js.`);
+      }
+
+      this.initializeDropdown();
+      this.renderSelectionUI();
     },
 
     function onSelect(obj) {
@@ -819,7 +840,10 @@ foam.CLASS({
                 .tag((self.rowView || self.CitationView), { data: fullObject })
               .end().endContext();
             } else {
-              this.start().addClass(self.myClass('paddingWrapper')).add(self.defaultSelectionPrompt).end();
+              this.start()
+                .addClass(self.myClass('paddingWrapper'))
+                .add(self.defaultSelectionPrompt)
+              .end();
             }
           }));
         }
@@ -871,8 +895,17 @@ foam.CLASS({
   extends: 'foam.u2.view.RichChoiceView',
 
   documentation: `
-    A RichChoiceView that renders as an icon button instead of a traditional dropdown.
-    Similar to ChoiceIconView but for rich choice dropdowns.
+    Icon-based variant of RichChoiceView that renders as a clickable icon button
+    instead of a traditional dropdown field. The dropdown functionality remains
+    identical - only the trigger element changes from a text field to an icon.
+    
+    Key differences from parent RichChoiceView:
+    - Renders an icon button (default: plus icon) as the trigger
+    - Uses an invisible overlay to capture clicks on the icon
+    - No visible text selection - suitable for space-constrained UIs
+    - Commonly used in table headers or toolbars where space is limited
+    
+    The dropdown content and behavior is inherited unchanged from RichChoiceView.
   `,
 
   css: `
@@ -935,120 +968,31 @@ foam.CLASS({
   ],
 
   methods: [
-    function render() {
+    function renderSelectionUI() {
       var self = this;
-
-      if ( ! Array.isArray(this.sections) || this.sections.length === 0 ) {
-        throw new Error(`You must provide an array of sections. See documentation on the 'sections' property in RichTextView.js.`);
-      }
-
-      // Set up data binding and dropdown
-      this.onDetach(this.data$.sub(this.onDataUpdate));
-      this.onDataUpdate();
-
-      this.onDetach(() => this.dropdown_.remove());
-      this.attrs({
-        name: self.prop$.map(v => v?.name),
-        'data-value': self.data$,
-        'role': 'combobox',
-        'aria-controls': 'listbox',
-        'aria-haspopup': 'listbox',
-        'aria-expanded': self.isOpen_$.map(v => v ? 'true' : 'false')
-      });
-      self.isOpen_$.follow(this.dropdown_.opened$);
-      self.dropdown_.add(self.slot(function(hasBeenOpenedYet_) {
-        if ( ! hasBeenOpenedYet_ ) return this.E();
-        return this.E()
-          .addClass(self.myClass('container'))
-          .add(self.search$.map(searchEnabled => {
-            if ( ! searchEnabled ) return null;
-            return this.E()
-              .start()
-                .start('img')
-                  .attrs({ src: '/images/ic-search.svg' })
-                .end()
-                .startContext({ data: self })
-                  .addClass(self.myClass('search'))
-                  .tag(self.FILTER_.clone().copyFrom({ view: {
-                    class: 'foam.u2.TextField',
-                    placeholder: this.searchPlaceholder || 'Search... ',
-                    autofocus: true,
-                    onKey: true
-                  } }), {}, self.inputField$)
-                .endContext()
-              .end();
-          }))
-          .add(self.slot(function(sections) {
-            var promiseArray = [];
-            sections.forEach(function(section) {
-              promiseArray.push(section.dao.select(self.COUNT()));
-            });
-            return Promise.all(promiseArray).then(resp => {
-              var index = 0;
-              return this.E().forEach(sections, function(section) {
-                if ( section.hideIfEmpty && resp[index].value <= 0 ) return;
-                section.refineInput_ = resp[index].value > section.choicesLimit;
-                this.addClass(self.myClass('setAbove'))
-                  .start().addClass(self.myClass('section'))
-                  .start().hide(! section.heading)
-                    .addClass('h600', self.myClass('heading'))
-                    .translate(section.heading$)
-                  .end()
-                  .start()
-                    .select( section.choicesLimit ? section.filteredDAO$proxy.limit(section.choicesLimit) : section.filteredDAO$proxy, function(obj) {
-                      let addRow = function() {
-                        this.start(self.rowView, { data: obj })
-                          .attr('disabled', section.disabled)
-                          .attr('role', 'option')
-                          .enableClass('disabled', section.disabled)
-                          .callIf(! section.disabled, function() {
-                            this.on('click', () => {
-                              self.onSelect(obj);
-                              self.dropdown_.close();
-                            });
-                          })
-                        .end();
-                      }
-                      if ( this.U3 ) {
-                        this.call(addRow);
-                      } else {
-                        return this.E().call(addRow);
-                      }
-                    }, false, self.comparator)
-                  .end()
-                  .callIf(section.choicesLimit, function() {
-                    this.start()
-                      .addClass(self.myClass('moreChoices'))
-                      .add(section.refineInput_$.map(v => v ? self.MORE_CHOICES : ''))
-                    .end();
-                  })
-                  .end();
-                  index++;
-              });
-            });
-          }))
-          .add(this.slot(self.addAction));
-      }));
-
-      // Render the icon button with invisible overlay
+      
+      // Override parent to render icon button instead of dropdown field
       this
         .addClass(this.myClass())
         .add(this.slot(function(mode) {
           if ( mode !== foam.u2.DisplayMode.RO && mode !== foam.u2.DisplayMode.HIDDEN ) {
             if ( self.ctrl ) {
-              self.ctrl.add(this.dropdown_);
+              self.ctrl.add(self.dropdown_);
             } else {
-              this.dropdown_.write();
+              self.dropdown_.write();
             }
             return self.E()
-              .addClass(this.myClass('icon-wrapper'))
+              .addClass(self.myClass('icon-wrapper'))
               .tag(self.ICON_BUTTON, {
                 data: self,
                 themeIcon$: self.themeIcon$
               })
-              .start('', {}, this.selectionEl_$)
-                .addClass(this.myClass('selection-view'))
-                .enableClass('disabled', this.mode$.map((mode) => mode === foam.u2.DisplayMode.DISABLED))
+              // Invisible overlay captures clicks on the icon to open dropdown
+              .start('', {}, self.selectionEl_$)
+                .addClass(self.myClass('selection-view'))
+                .enableClass('disabled', self.mode$.map((mode) => 
+                  mode === foam.u2.DisplayMode.DISABLED
+                ))
                 .on('click', function(e) {
                   var x = e.clientX || this.getBoundingClientRect().x;
                   var y = e.clientY || this.getBoundingClientRect().y;
@@ -1063,7 +1007,7 @@ foam.CLASS({
               .end();
           } else {
             return self.E()
-              .addClass(this.myClass())
+              .addClass(self.myClass())
               .tag(self.ICON_BUTTON, {
                 data: self,
                 themeIcon$: self.themeIcon$,


### PR DESCRIPTION
- Refactor PropertyChoiceView_ and PropertyChoiceIconView_ to use extracted mixin
- Refactor RichChoiceIconView to share dropdown initialization with parent reducing code duplication

- Add ComparatorOption/PredicateOption model for sort-direction/predicate options

- Add PropertyOptionCitationView for consistent dropdown row rendering