### PR TITLE
fix: simplify expression evaluation by removing unnecessary scope

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -159,10 +159,8 @@ foam.CLASS({
       var result;
       try {
         with ( foam.core.reflow.lib ) {
-          with ( this.scope ) {
-            with ( rowData ) {
-              result = eval(expression);
-            }
+          with ( rowData ) {
+            result = eval(expression);
           }
         }
       } catch (x) {


### PR DESCRIPTION
to allow migration to fscript in the future