### PR TITLE
DAO Compaction - refactor medusa compaction for single dao compaction

### DIFF
--- a/deployment/compaction/Compaction.flow
+++ b/deployment/compaction/Compaction.flow
@@ -1,0 +1,57 @@
+<title>DAO Compaction</title>
+<h1>Compaction</h1>
+<h2>Overview</h2>
+
+Compaction dumps a DAO out to new journal file, in a effort to reduce replay time.  Each DAO operation on the same object generates a journal entry containing just the change on the object.  In time there are many entries for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple entries to just one.
+
+<h2>Considerations</h2>
+<ul>
+  <li>Compaction can be run concurrently with live traffic, but it is recommended to run compaction at a low traffic period.  Also, compaction can fail requiring system halt and manual intervention, so a Maintenance Window should be scheduled</li>
+  <li>Compaction filters out many archive or history operations. See deployment/compaction/compactions.jrl</li>
+</ul>
+
+<h2>Invocation</h2>
+Compaction is controlled by script <b>DAOCompaction</b> and scriptParameter <b>DAOCompaction</b>.
+
+<p>Once script execution reports completion, check:</p>
+<ol>
+<li>ScriptEvents for an 'OK' message.</li>
+<li>EventRecords for a compaction summary.  Open the reponse message to see the statistics.</li>
+</ol>
+
+<p>Compaction is accomplished by running the script <b>DAOCompaction</b>.</p>
+<h2>Compaction, Major steps in the process</h2>
+<ol>
+<li>Start blocking DAO operations</li>
+<li>Roll the journal.  journal becomes journal.1 on the first invocation. Next will rename journal to journal.2</li>
+<li>Unblock DAO operations. At this point live traffic is processed during compaction.</li>
+<li>Start compating.</li>
+<li>End</li>
+</ol>
+
+<h2>Rollback</h2>
+Should compaction fail for any reason, a rollback is required.
+When compaction fails the system should be considered invalid. Live traffic must be halted immediately.  Any operations which occured during compaction will be lost on rollback.
+
+<p>To rollback:</p>
+<ol>
+<li>halt the system</li>
+<li>undo the rolled journal.  Discard the unnumbered journal file and remove the number postfix from the highest number journal.  journal.1 -> journal</li>
+<li>start the system</li>
+</ol>
+
+
+<h2>Controlling Compaction via the Compaction model</h2>
+<foam class="foam.flow.widgets.TabbedModelDocumentation" defaultTab="properties" of="foam.dao.compaction.Compaction" />
+
+<h3>compactable</h3>
+By default a DAO is compactable, meaning it's entries will be reduced. If compaction is disabled (false), then the DAO's entries will be discarded - they will not be compacted into a new journal.
+<h3>reducible</h3>
+By default a DAO is reducible, meaning multiple CRUD operations are reduced to one. If <i>reducible</i> is false, then all entries are transfered the new ledger.
+<h3>compactLifecycleDeleted</h3>
+LifecycleAware objects which are deleted/removed are set to state DELETED, an r() journal entry is not created.  This option allows to compact DELETED entries.
+<h3>clearable</h3>
+Not used outside of Medusa.
+<h3>sink</h3>
+Custom sinks can be registered for per entry control during compaction.
+See localTicketCommentDAO for an example of inline sink Predicate controlling Ticket Comment compaction based on Ticket Status.

--- a/deployment/compaction/Compaction.flow
+++ b/deployment/compaction/Compaction.flow
@@ -2,7 +2,9 @@
 <h1>Compaction</h1>
 <h2>Overview</h2>
 
-Compaction dumps a DAO out to new journal file, in a effort to reduce replay time.  Each DAO operation on the same object generates a journal entry containing just the change on the object.  In time there are many entries for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple entries to just one.
+<p>Compaction dumps a DAO out to new journal file, in a effort to reduce replay time.  Each DAO operation on the same object generates a journal entry containing just the change on the object.  In time there are many entries for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple entries to just one.</p>
+<p>Used in conjuction with a custom compaction sink, the compaction process can facilitate archiving with only recent or active objects written to the new journal.</p>
+
 
 <h2>Considerations</h2>
 <ul>

--- a/deployment/compaction/Compaction.flow
+++ b/deployment/compaction/Compaction.flow
@@ -4,7 +4,7 @@
 
 <p>Compaction dumps a DAO out to new journal file, in a effort to reduce replay time.  Each DAO operation on the same object generates a journal entry containing just the change on the object.  In time there are many entries for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple entries to just one.</p>
 <p>Used in conjuction with a custom compaction sink, the compaction process can facilitate archiving with only recent or active objects written to the new journal.</p>
-
+<p>Following on the idea of archiving, the <b>select</b> for compaction is performed on the DAO returned from the context using CSpecname. If the DAO stack contains a FixedSizedDAO then only those records retained by the FixedSizedDAO will be compacted into the new journal.</p>
 
 <h2>Considerations</h2>
 <ul>

--- a/deployment/compaction/compactions.jrl
+++ b/deployment/compaction/compactions.jrl
@@ -1,0 +1,171 @@
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "bootstrap"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "alarmDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localAlarmDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localAnalyticEventDAO",
+  loadable: true
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "analyticEventDAO",
+  loadable: true
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "benchmarkResultDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localBenchmarkResultDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "capabilityPayloadDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "capabilityPayloadRecordDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "cronJobEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec:  "localCronJobEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "CSPViolationsDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "counterDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localEmailMessageDAO",
+  loadable: true
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "emailMessageDAO",
+  loadable: true
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "eventRecordDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localEventRecordDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "monitorReportDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localNotificationDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "notificationDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "omNameDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "bareOmNameDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "ruleHistoryDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "scriptEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localScriptEventDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localSessionDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "sessionDAO",
+  loadable: false
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localTicketDAO",
+  compactible: true,
+  sink: {
+    class: "foam.core.ticket.TicketCompactionSink",
+    predicate: {
+      class: "foam.mlang.predicate.FScriptPredicate",
+      query: 'status != "CLOSED"'
+    }
+  }
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localTicketCommentDAO",
+  compactible: true,
+  sink: {
+    class: "foam.core.ticket.TicketCommentCompactionSink",
+    predicate: {
+      class: "foam.mlang.predicate.FScriptPredicate",
+      query: 'status != "CLOSED"'
+    }
+  }
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localTicketHistoryDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "ticketHistoryDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "localTicketCommentHistoryDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "ticketCommentHistoryDAO"
+})
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "userCapabilityJunctionHistoryDAO"
+})

--- a/deployment/compaction/pom.js
+++ b/deployment/compaction/pom.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.POM({
+  name: "compaction",
+  projects: [
+    { name: '../../src/pom' },
+    { name: '../../src/foam/dao/compaction/pom' }
+  ],
+  files: [
+    { name: "../../src/foam/core/ticket/TicketCommentCompactionSink", flags: "js|java" },
+    { name: "../../src/foam/core/ticket/TicketCompactionSink",        flags: "js|java" }
+  ]
+});

--- a/deployment/compaction/scriptparameters.jrl
+++ b/deployment/compaction/scriptparameters.jrl
@@ -1,0 +1,7 @@
+p({
+  class:"foam.core.script.ScriptParameter",
+  id:"DAOCompaction",
+  name:"DAOCompaction",
+  parameters:{"daos":"userDAO"},
+  enabled:false
+})

--- a/deployment/compaction/scripts.jrl
+++ b/deployment/compaction/scripts.jrl
@@ -4,7 +4,6 @@ p({
   code:"""
 /**
  * Configuration (via scriptParameter):
- * dryRun: true | false
  * daos: 'userDAO,accountDAO'
  */
 

--- a/deployment/compaction/scripts.jrl
+++ b/deployment/compaction/scripts.jrl
@@ -1,0 +1,59 @@
+p({
+  class:"foam.core.script.Script",
+  id:"DAOCompaction",
+  code:"""
+/**
+ * Configuration (via scriptParameter):
+ * dryRun: true | false
+ * daos: 'userDAO,accountDAO'
+ */
+
+import foam.dao.compaction.*;
+import foam.dao.DAO;
+import foam.dao.ProxyDAO;
+
+String[] daos = null;
+sp = scriptParameter;
+if ( sp != null ) {
+  p = sp.getParameters();
+  if ( p != null ) {
+    if ( p.get("daos") != null ) {
+      daos = String.valueOf(p.get("daos").toString()).split(",");
+    }
+  }
+}
+if ( daos == null || daos.length == 0 ) {
+    print("No dao(s) specified");
+    return;
+}
+for ( n : daos ) {
+    d = x.get(n);
+    if ( n == null ) {
+        print("ERROR: DAO not found: "+n);
+        break;
+    }
+    if ( ! ( d instanceof DAO ) ) {
+        print("ERROR: Not DAO: "+n);
+        break;
+    }
+
+    try {
+        c = new CompactionDAO(x, n);
+        print("INFO: Compacting: "+n);
+        c.execute(x);
+        print("INFO: Compaction complete: "+n+", System OK");
+    } catch (IllegalStateException e) {
+        print(e.getMessage());
+        print("WARNING: Compaction aborted: "+n+", System OK");
+        break;
+    } catch (Throwable t) {
+        print(t.getMessage());
+        print("ERROR: Compaction failed: "+n+", System state unknown. Intervention required.");
+        break;
+    }
+}
+
+print("DONE");
+""",
+  lastModified:1753810864645
+})

--- a/deployment/compaction/services.jrl
+++ b/deployment/compaction/services.jrl
@@ -1,0 +1,15 @@
+p({
+  "class": "foam.core.boot.CSpec",
+  "name": "compactionDAO",
+  "serve": true,
+  "serviceScript": """
+    return new foam.dao.EasyDAO.Builder(x)
+      .setOf(foam.dao.compaction.Compaction.getOwnClassInfo())
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName("compactions")
+      .setRuler(false)
+      .build()
+      .orderBy(foam.mlang.MLang.DESC(foam.dao.compaction.Compaction.ID));
+  """,
+  "client": "{\"of\":\"foam.dao.compaction.Compaction\"}"
+})

--- a/src/foam/core/ticket/TicketCommentCompactionSink.js
+++ b/src/foam/core/ticket/TicketCommentCompactionSink.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.ticket',
+  name: 'TicketCommentCompactionSink',
+  extends: 'foam.dao.ProxySink',
+  implements: ['foam.lang.ContextAware'],
+
+  documentation: `Sink which controls which Tickets comments can be compacted. Predicate is evaluated on owning Ticket.`,
+
+  javaImports: [
+    'foam.lang.X'
+  ],
+
+  properties: [
+    {
+      documentation: `Compact (keep) tickets comments which satisfy this predicate`,
+      name: 'predicate',
+      class: 'FObjectProperty',
+      of: 'foam.mlang.predicate.Predicate',
+      view: { class: 'foam.u2.view.JSONTextView' },
+      javaFactory: `
+      return foam.mlang.MLang.TRUE;
+      `
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      args: 'Any obj, foam.lang.Detachable sub',
+      javaCode: `
+      X x = getX();
+      TicketComment comment = (TicketComment) obj;
+      if ( comment != null ) {
+        Ticket ticket = comment.findTicket(x);
+        if ( getPredicate().f(ticket) ) {
+          getDelegate().put(obj, sub);
+        } else {
+          ((foam.core.logger.Logger) x.get("logger")).info("TicketCommentCompactionSink,discard", comment.getId(), ticket.getId());
+        }
+      }
+      `
+    }
+  ]
+});

--- a/src/foam/core/ticket/TicketCompactionSink.js
+++ b/src/foam/core/ticket/TicketCompactionSink.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.ticket',
+  name: 'TicketCompactionSink',
+  extends: 'foam.dao.ProxySink',
+  implements: ['foam.lang.ContextAware'],
+
+  documentation: `Sink which controls which Tickets can be compacted. `,
+
+  javaImports: [
+    'foam.lang.X'
+  ],
+
+  properties: [
+    {
+      documentation: `Compact (keep) tickets which satisfy this predicate`,
+      name: 'predicate',
+      class: 'FObjectProperty',
+      of: 'foam.mlang.predicate.Predicate',
+      view: { class: 'foam.u2.view.JSONTextView' },
+      javaFactory: `
+      return foam.mlang.MLang.TRUE;
+      `
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      args: 'Any obj, foam.lang.Detachable sub',
+      javaCode: `
+      X x = getX();
+      Ticket ticket = (Ticket) obj;
+      if ( ticket != null ) {
+        ((foam.core.logger.Logger) x.get("logger")).info("TicketCompactionSink", ticket.getId(), ticket.getStatus());
+        if ( getPredicate().f(ticket) ) {
+          getDelegate().put(obj, sub);
+        } else {
+          ((foam.core.logger.Logger) x.get("logger")).info("TicketCompactionSink,discard", ticket.getId(), ticket.getStatus());
+        }
+      }
+      `
+    }
+  ]
+});

--- a/src/foam/dao/compaction/BlockingDAO.js
+++ b/src/foam/dao/compaction/BlockingDAO.js
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.compaction',
+  name: 'BlockingDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  abstract: true,
+  
+  documentation: `All DAO operations will blocked while condition is true, and unblocked when a particular CMD is received.`,
+
+  javaImports: [
+    'foam.dao.DAO',
+    'foam.core.pm.PM',
+    'foam.core.logger.Logger',
+    'foam.core.logger.Loggers',
+    'java.util.concurrent.atomic.AtomicLong'
+  ],
+
+  javaCode: `
+    private Object lock_ = new Object();
+    private AtomicLong blocked_ = new AtomicLong();
+  `,
+
+  constants: [
+    {
+      documentation: 'Return number of threads currently blocked',
+      name: 'BLOCKED_CMD',
+      type: 'String',
+      value: 'BLOCKED_CMD'
+    },
+    {
+      documentation: 'Notify all threads',
+      name: 'UNBLOCK_CMD',
+      type: 'String',
+      value: 'UNBLOCK_CMD'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'find_',
+      javaCode: `
+      // Loggers.logger(x, this).debug("find");
+      block(x);
+      return getDelegate().find_(x, id);
+      `
+    },
+    {
+      name: 'select_',
+      javaCode: `
+      // Loggers.logger(x, this).debug("select");
+      block(x);
+      return getDelegate().select_(x, sink, skip, limit, order, predicate);
+      `
+    },
+    {
+      name: 'put_',
+      javaCode: `
+      // Loggers.logger(x, this).debug("put");
+      block(x);
+      return getDelegate().put_(x, obj);
+      `
+    },
+    {
+      name: 'remove_',
+      javaCode: `
+      // Loggers.logger(x, this).debug("remove");
+      block(x);
+      return getDelegate().remove_(x, obj);
+      `
+    },
+    {
+      name: 'removeAll_',
+      javaCode: `
+      // Loggers.logger(x, this).debug("removeAll");
+      block(x);
+      getDelegate().removeAll_(x, skip, limit, order, predicate);
+      `
+    },
+    {
+      name: 'cmd_',
+      javaCode: `
+      if ( obj != null ) {
+        if ( UNBLOCK_CMD.equals(obj) ) {
+           /* obj.equals(getUnblockCmd()) ||*/
+          ((foam.core.om.OMLogger) x.get("OMLogger")).log(obj.toString());
+          Loggers.logger(x, this).info("cmd", "unblock", "received", "blocked", blocked_.get());
+          unblock(x);
+        }
+        if ( BLOCKED_CMD.equals(obj) ) {
+          ((foam.core.om.OMLogger) x.get("OMLogger")).log(obj.toString());
+          return blocked_.get();
+        }
+      }
+      return getDelegate().cmd_(x, obj);
+      `
+    },
+    {
+      name: 'block',
+      args: 'Context x',
+      javaCode: `
+      if ( ! maybeBlock(x) ) {
+        return;
+      }
+
+      synchronized ( lock_ ) {
+        while ( maybeBlock(x) ) {
+          PM pm = PM.create(x, this.getClass().getSimpleName(), "block", "wait");
+          try {
+            Logger logger = Loggers.logger(x, this);
+            logger.debug("wait", blocked_.get());
+            blocked_.getAndIncrement();
+            lock_.wait();
+            logger.debug("wake", blocked_.get());
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          } finally {
+            pm.log(x);
+            blocked_.getAndDecrement();
+          }
+        }
+      }
+      `
+    },
+    {
+      name: 'unblock',
+      args: 'Context x',
+      javaCode: `
+      if ( ! maybeBlock(x) ) {
+        synchronized ( lock_ ) {
+          lock_.notifyAll();
+        }
+      }
+      `
+    },
+    {
+      name: 'maybeBlock',
+      args: 'Context x',
+      type: 'Boolean',
+      javaCode: `
+      return false;
+      `
+    },
+    {
+      name: 'getBlockedCount',
+      type: 'Long',
+      javaCode: `
+      return blocked_.get();
+      `
+    }
+  ]
+});

--- a/src/foam/dao/compaction/Compaction.js
+++ b/src/foam/dao/compaction/Compaction.js
@@ -8,6 +8,7 @@ foam.CLASS({
   package: 'foam.dao.compaction',
   name: 'Compaction',
   documentation: `Compaction dumps an MDAO out to a new journal file, in a effort to reduce replay time.  Each DAO operation on the same object generates an entry  containing just the change on the object.  In time there are multiple entries for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple entry to just one, and reducing replay time.
+Used in conjuction with a custom compaction sink, the compaction process can facilitate archiving with only recent or active objects written to the new journal.
 `,
 
   ids: ['cSpec'],

--- a/src/foam/dao/compaction/Compaction.js
+++ b/src/foam/dao/compaction/Compaction.js
@@ -7,7 +7,7 @@
 foam.CLASS({
   package: 'foam.dao.compaction',
   name: 'Compaction',
-  documentation: `Compaction dumps the current system out to new ledger files, in a effort to reduce replay time.  Each DAO operation on the same object generates a unique MedusaEntry containing just the change on the object.  In time there are multiple MedusaEntry's for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple MedusaEntry's to just one.
+  documentation: `Compaction dumps an MDAO out to a new journal file, in a effort to reduce replay time.  Each DAO operation on the same object generates an entry  containing just the change on the object.  In time there are multiple entries for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple entry to just one, and reducing replay time.
 `,
 
   ids: ['cSpec'],

--- a/src/foam/dao/compaction/Compaction.js
+++ b/src/foam/dao/compaction/Compaction.js
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.compaction',
+  name: 'Compaction',
+  documentation: `Compaction dumps the current system out to new ledger files, in a effort to reduce replay time.  Each DAO operation on the same object generates a unique MedusaEntry containing just the change on the object.  In time there are multiple MedusaEntry's for the same object.  Compaction writes out each object in entirety once, thus reducing the multiple MedusaEntry's to just one.
+`,
+
+  ids: ['cSpec'],
+
+  properties: [
+    {
+      class: 'Reference',
+      of: 'foam.core.boot.CSpec',
+      name: 'cSpec',
+      label: 'CSpec',
+      tableWidth: 225,
+      view: function(_, X) {
+        var E = foam.mlang.Expressions.create();
+        return {
+          class: 'foam.u2.view.RichChoiceView',
+          search: true,
+          sections: [
+            {
+              heading: 'DAO',
+              dao: X.cSpecDAO
+                .where(E.ENDS_WITH(foam.core.boot.CSpec.ID, 'DAO'))
+                .orderBy(foam.core.boot.CSpec.ID)
+            }
+          ]
+        };
+      }
+    },
+    {
+      documentation: `DAO is eligible for compaction, meaning it's entries will be reduced. If compaction is disabled (false), then the DAO's entries will be discarded - they will not be compacted into a new ledger.`,
+      name: 'compactible',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      documentation: 'An entry eligible for compaction is normally output only once, but if not reducible, then all copies are output',
+      name: 'reducible',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      documentation: 'LifecycleAware objects which are deleted/removed are set to state DELETED, an r() journal entry is not created.  This option allows to compact DELETED entries.',
+      name: 'compactLifecycleDeleted',
+      class: 'Boolean',
+      value: false
+    },
+    {
+      documentation: 'Entry data can be clear after compaction',
+      name: 'clearable',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      documentation: 'DAO specific Sink to control compaction. When null/undefined, a test for a facetted sink will occur',
+      name: 'sink',
+      class: 'FObjectProperty',
+      of: 'foam.dao.Sink',
+      view: { class: 'foam.u2.view.JSONTextView' }
+    },
+    {
+      documentation: 'An nspec is eligible for reading into a medusa system for bootstrapping.',
+      name: 'loadable',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      documentation: 'Name for JDAO creation during loading. Default is best gues. Required when nspec has JDAO setup outside of EasyDAO.',
+      name: 'journalName',
+      class: 'String',
+      javaFactory: `
+      var name = getCSpec();
+      name = name.replace("DAO", "");
+      name = name.replace("local", "");
+      name = name.toLowerCase();
+      name = name + "s";
+      return name;
+      `
+    }
+  ]
+});

--- a/src/foam/dao/compaction/CompactionDAO.js
+++ b/src/foam/dao/compaction/CompactionDAO.js
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.compaction',
+  name: 'CompactionDAO',
+  extends: 'foam.dao.compaction.BlockingDAO',
+
+  documentation: `
+Re-writes DAO with a single full copy of each Object.
+
+Run from script 'DAOCompaction'
+
+process:
+block dao operations
+roll journal file
+unblock dao
+select from mdao and write full records to new empty journal
+  `,
+
+  javaImports: [
+    'foam.core.logger.Loggers',
+    'foam.core.logger.Logger',
+    'foam.core.er.EventRecord',
+    'foam.lang.Agency',
+    'foam.lang.ContextAgent',
+    'foam.lang.FObject',
+    'foam.lang.X',
+    'foam.dao.DAO',
+    'foam.dao.FileRollCmd',
+    'foam.dao.Journal',
+    'foam.dao.MDAO',
+    'foam.dao.ProxyDAO',
+    'foam.dao.ProxySink',
+    'foam.dao.Sink',
+    'foam.dao.java.JDAO',
+    'foam.log.LogLevel',
+    'foam.mlang.sink.Count',
+    'foam.mlang.sink.Sequence',
+    'java.time.Duration'
+  ],
+
+  constants: [
+    {
+      documentation: 'Initiate Compaction process',
+      name: 'COMPACTION_CMD',
+      type: 'String',
+      value: 'COMPACTION_CMD'
+    }
+  ],
+
+  properties: [
+    {
+      name: 'serviceName',
+      class: 'String'
+    },
+    {
+      documentation: 'true when blocking for setup',
+      name: 'blocking',
+      class: 'Boolean',
+      visibility: 'HIDDEN'
+    },
+    {
+      name: 'eventRecord',
+      class: 'FObjectProperty',
+      of: 'foam.core.er.EventRecord'
+    }
+  ],
+
+  javaCode: `
+  public CompactionDAO(X x, String serviceName) {
+    setX(x);
+    setServiceName(serviceName);
+    setDelegate(new foam.dao.NullDAO(x, this.getOwnClassInfo()));
+  }
+  `,
+
+  methods: [
+    {
+      name: 'cmd_',
+      javaCode: `
+      if ( COMPACTION_CMD.equals(obj) ) {
+        ((foam.core.om.OMLogger) x.get("OMLogger")).log(obj.toString());
+        execute(x);
+        return obj;
+      }
+      return getDelegate().cmd_(x, obj);
+      `
+    },
+    {
+      name: 'maybeBlock',
+      args: 'X x',
+      javaCode: `
+      return getBlocking();
+      `
+    },
+    {
+      name: 'execute',
+      args: 'X x',
+      javaCode: `
+      Logger logger = Loggers.logger(x, this, "execute");
+      long startTime = System.currentTimeMillis();
+      logger.info("start");
+      EventRecord er = (EventRecord) ((DAO) x.get("eventRecordDAO")).put(new EventRecord(x, getServiceName(), "compaction", "start")).fclone();
+      er.clearId();
+      setEventRecord(er);
+
+      try {
+        roll(x);
+        compaction(x);
+
+        logger.info("end");
+        er = getEventRecord();
+        er.setMessage("complete");
+        ((DAO) x.get("eventRecordDAO")).put(er);
+       } catch (Throwable t) {
+        er = getEventRecord();
+        er.setMessage(t.getMessage());
+        er.setSeverity(LogLevel.ERROR);
+        er.setException(t);
+        ((DAO) x.get("eventRecordDAO")).put(er);
+        throw t;
+      } finally {
+        logger.info("end", "duration", Duration.ofMillis(System.currentTimeMillis() - startTime));
+      }
+      `
+    },
+    {
+      documentation: 'Copy the current journal to journal.1 and create a new empty journal.',
+      name: 'roll',
+      args: 'X x',
+      javaCode: `
+      Logger logger = Loggers.logger(x, this, "roll", getServiceName());
+      ProxyDAO dao = (ProxyDAO) x.get(getServiceName());
+      DAO savedDelegate = dao.getDelegate();
+
+      try {
+        this.setDelegate(savedDelegate);
+        dao.setDelegate(this);
+        setBlocking(true);
+
+        FileRollCmd cmd = new FileRollCmd();
+        cmd = (FileRollCmd) getDelegate().cmd_(x, new FileRollCmd());
+        if ( ! foam.util.SafetyUtil.isEmpty(cmd.getError()) ) {
+          logger.error("failed", cmd.getError());
+          throw new CompactionException("roll");
+        } else {
+          logger.info("complete", cmd.getRolledFilename());
+        }
+      } catch (RuntimeException e) {
+        logger.error("failed", e.getMessage());
+        throw new CompactionException("roll", e);
+      } finally {
+        setBlocking(false);
+        super.unblock(x);
+        dao.setDelegate(savedDelegate);
+      }
+      `
+    },
+    {
+      documentation: 'Dump data to new journal file',
+      name: 'compaction',
+      args: 'X x',
+      javaCode: `
+      final Logger logger = Loggers.logger(x, this, "compaction", getServiceName());
+
+      DAO dao = (DAO) x.get(getServiceName());
+      MDAO mdao = null;
+      JDAO jdao = null;
+      while ( dao != null ) {
+        if ( dao instanceof MDAO ) {
+          mdao = (MDAO) dao;
+          break;
+        }
+        if ( dao instanceof JDAO ) {
+          jdao = (JDAO) dao;
+        }
+        if ( dao instanceof ProxyDAO ) {
+          dao = (DAO) ((ProxyDAO) dao).getDelegate();
+        } else {
+          break;
+        }
+      }
+      if ( mdao == null ) {
+        logger.error("mdao not found");
+        throw new CompactionException("mdao not found");
+      }
+      if ( jdao == null ) {
+        logger.error("jdao not found");
+        throw new CompactionException("jdao not found");
+      }
+
+      final DAO sourceDAO = (MDAO) mdao;
+
+      final Count total = (Count) dao.select(new Count());
+      final Count processed = new Count();
+      final CompactionSink compactionSink = new CompactionSink(x, getServiceName(),
+        new JournalSink(x, jdao.getJournal()));
+      final Sink sink = new Sequence.Builder(x)
+                     .setArgs(new Sink[] {
+                       processed,
+                       compactionSink
+                     })
+                     .build();
+
+      final long startTime = System.currentTimeMillis();
+      Agency agency = (Agency) x.get("threadPool");
+      agency.submit(x, new ContextAgent() {
+        public void execute(X x) {
+          logger.info("start");
+          sourceDAO.select(sink);
+          long compactionTime = System.currentTimeMillis() - startTime;
+          logger.info("agency", "end", "duration", Duration.ofMillis(compactionTime));
+        }
+      }, this.getClass().getSimpleName()+".compaction");
+
+      // wait for eof
+      while ( ! compactionSink.getIsEof() &&
+              ((Long) processed.getValue()) < ((Long) total.getValue()) ) {
+        long percentComplete = (long) ((((Long) processed.getValue()) / ((Long) total.getValue()).doubleValue()) * 100.0);
+        logger.info("progress", "processed", processed.getValue(), percentComplete, "%");
+        try {
+          Thread.currentThread().sleep(5000);
+        } catch (InterruptedException e) {
+          break;
+        }
+      }
+      long compactionTime = System.currentTimeMillis() - startTime;
+      double seconds = compactionTime / 1000.0;
+      double minutes = compactionTime / 60;
+      double min100K = minutes / ( (Long) processed.getValue() / 100000.0 );
+      StringBuilder report = new StringBuilder();
+      report.append("instance,processed,duration s,date");
+      report.append("\\n");
+      report.append(System.getProperty("hostname", "loalhost"));
+      report.append(",");
+      report.append(processed.getValue());
+      report.append(",");
+      report.append(Math.round(seconds));
+      report.append(",");
+      report.append(new java.util.Date(startTime));
+
+      logger.info("compactionComplete", "report", "\\n"+report.toString());
+
+      EventRecord er = getEventRecord();
+      er.setResponseMessage(report.toString());
+      `
+    }
+  ],
+  classes: [
+    {
+      name: 'JournalSink',
+      extends: 'foam.dao.AbstractSink',
+
+      documentation: 'put to Journal',
+
+      javaCode: `
+        public JournalSink(X x, Journal journal) {
+          setX(x);
+          setJournal(journal);
+        }
+      `,
+
+      properties: [
+        {
+          class: 'Object',
+          name: 'journal'
+        },
+        {
+          class: 'foam.dao.DAOProperty',
+          of: 'foam.dao.NullDAO',
+          name: 'nullDAO',
+          javaFactory: 'return new foam.dao.NullDAO(getX(), this.getOwnClassInfo());'
+        },
+        {
+          name: 'isEof',
+          class: 'Boolean'
+        }
+      ],
+
+      methods: [
+        {
+          name: 'put',
+          javaCode: `
+          ((Journal) getJournal()).put(getX(), "", getNullDAO(), (FObject) obj);
+          `
+        },
+        {
+          name: 'eof',
+          javaCode: 'setIsEof(true);'
+        }
+      ]
+    }
+  ]
+});

--- a/src/foam/dao/compaction/CompactionException.js
+++ b/src/foam/dao/compaction/CompactionException.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  name: 'CompactionException',
+  package: 'foam.dao.compaction',
+  extends: 'foam.lang.FOAMException',
+
+  javaCode: `
+    public CompactionException(String message) {
+      super(message);
+    }
+
+    public CompactionException(Throwable cause) {
+      super(cause.getMessage(), cause);
+    }
+
+    public CompactionException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  `
+});

--- a/src/foam/dao/compaction/CompactionSink.js
+++ b/src/foam/dao/compaction/CompactionSink.js
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.compaction',
+  name: 'CompactionSink',
+  extends: 'foam.dao.ProxySink',
+
+  documentation: 'Find CompactionSink Facet for nspec dao of',
+
+  javaImports: [
+    'foam.lang.ClassInfo',
+    'foam.lang.ContextAware',
+    'foam.lang.X',
+    'foam.lang.FacetManager',
+    'foam.dao.DAO',
+    'foam.dao.ProxySink',
+    'foam.dao.Sink',
+    'foam.core.logger.Logger',
+    'foam.core.logger.Loggers'
+  ],
+
+  javaCode: `
+    public CompactionSink(X x, String serviceName, Sink delegate) {
+      super(x, delegate);
+      setServiceName(serviceName);
+      setSink(getFacetedSink(x));
+    }
+  `,
+
+  properties: [
+    {
+      name: 'serviceName',
+      class: 'String'
+    },
+    {
+      name: 'sink',
+      class: 'Object'
+    },
+    {
+      name: 'isEof',
+      class: 'Boolean'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      javaCode: `
+      ((Sink) getSink()).put(obj, sub);
+      `
+    },
+    {
+      name: 'getFacetedSink',
+      args: 'X x',
+      type: 'Sink',
+      javaCode: `
+      DAO dao = (DAO) x.get(getServiceName());
+      Compaction compaction = (Compaction) ((DAO) getX().get("compactionDAO")).find(getServiceName());
+      Sink sink = null;
+      if ( compaction != null ) {
+        sink = (Sink) compaction.getSink();
+      }
+      if ( sink == null ) {
+        try {
+          FacetManager fm = (FacetManager) x.get("facetManager");
+          sink = (Sink) fm.create(dao.getOf().getId()+"CompactionSink", x);
+        } catch (Throwable t) {
+          // nop
+        }
+      }
+      if ( sink != null ) {
+        if ( sink instanceof ContextAware ) {
+          ((ContextAware) sink).setX(x);
+        }
+        ((ProxySink) sink).setDelegate(getDelegate());
+      } else {
+        sink = getDelegate();
+      }
+
+      ((Logger) x.get("logger")).info("CompactionSink",getServiceName(), "sink",sink.getClass().getName());
+      return sink;
+      `
+    },
+    {
+      name: 'eof',
+      javaCode: 'setIsEof(true);'
+    }
+  ]
+});

--- a/src/foam/dao/compaction/pom.js
+++ b/src/foam/dao/compaction/pom.js
@@ -1,0 +1,11 @@
+foam.POM({
+  name: "compaction",
+
+  files: [
+    { name: 'BlockingDAO',                                       flags: 'js|java'},
+    { name: 'Compaction',                                        flags: 'js|java'},
+    { name: 'CompactionDAO',                                     flags: 'js|java'},
+    { name: 'CompactionException',                               flags: 'js|java'},
+    { name: 'CompactionSink',                                    flags: 'js|java'}
+  ]
+});


### PR DESCRIPTION
Compaction dumps an MDAO to a new journal, writing each record in entirety, replacing the original journal which may have a long history of partial entries as a result of object updates.
Journal replay parsing time is relative to lines parsed, the less lines, the less time replay takes.
The process supports faceted Sinks to control the compaction of individual models.