### PR TITLE
Add clone method to create shallow copies of Memento instances

### DIFF
--- a/src/foam/u2/memento/Memento.js
+++ b/src/foam/u2/memento/Memento.js
@@ -411,6 +411,17 @@ foam.CLASS({
       this.memento_;
       // Copy args again cause context was needed for mementos
       this.SUPER(args);
-    }
+    },
+    function clone(opt_X) {
+      /** Create a shallow copy of this object. **/
+      var m = {};
+      for ( var key in this.instance_ ) {
+        if ( this.instance_[key] === undefined ) continue; // Skip previously cleared keys.
+
+        var value = this.instance_[key];
+        m[key] = value;
+      }
+      return this.cls_.create(m, opt_X || this.__context__);
+    },
   ]
 });


### PR DESCRIPTION
Consider:
https://github.com/kgrgreer/foam3/blob/c8ddbe55857f58511f3ca5e2e4acdbdcec81a6d1/src/foam/core/reflow/Console.js#L680-L685

Memorable has a property:
https://github.com/kgrgreer/foam3/blob/c8ddbe55857f58511f3ca5e2e4acdbdcec81a6d1/src/foam/u2/memento/Memento.js#L392-L406

And default FObject clone functions are:
https://github.com/kgrgreer/foam3/blob/c8ddbe55857f58511f3ca5e2e4acdbdcec81a6d1/src/foam/lang/FObject.js#L935-L957

Issue is foam.u2.memento.Memento also has property obj which is the object itself. So here it would be Console.
So a deep clone runs into an infinite loop - console obj is cloned and when it reaches memento_ it clones that property which then goes to clone obj property which leads us back to console obj is cloned... then memento... then obj ... and so on.

This pr fixes the issue by setting a shallowClone onto Memorable.clone()