### PR TITLE
PT-FIXES:DOS-504 Make execute and execute_ methods async for promise handling

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -999,9 +999,9 @@ foam.CLASS({
       var cmds = await this.commandDAO.select();
 
       cmds.array.forEach(c => {
-        this.localScope[c.id] = (...args) => {
+        this.localScope[c.id] = async (...args) => {
           var cmd = c.clone(this.currentBlock);
-          return cmd.execute.apply(cmd, args);
+          return await cmd.execute.apply(cmd, args);
         }
       });
 

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -36,13 +36,16 @@ foam.CLASS({
       return Promise.resolve();
     },
 
-    function execute(...args) {
+    async function execute(...args) {
       with ( this ) {
         with ( { args: args, addValue: this.addValue.bind(this) } ) {
           try {
-            eval(this.script);
+            // Use arrow function to preserve this binding and with context
+            var result = await eval('(async () => { ' + this.script + ' })()');
+            return result;
           } catch (x) {
             console.log('Error:', x, 'in:', this.script);
+            throw x; // Re-throw to propagate the error
           }
         }
       }
@@ -97,7 +100,7 @@ foam.CLASS({
       name: 'execute_',
       label: 'execute',
       isAvailable: function() { return this.linkable; },
-      code: function() { this.execute(); }
+      code: async function() { await this.execute(); }
     }
   ]
 });


### PR DESCRIPTION
Convert the `execute` and `execute_` methods to async functions to properly handle promises and ensure correct execution flow.