### PR TITLE
Add layout Command and WrapperNode

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-with */
 /**
  * @license
  * Copyright 2024 The FOAM Authors. All Rights Reserved.
@@ -18,21 +19,24 @@ foam.CLASS({
   properties: [
     {
       name: 'flowParent',
+      hidden: true,
       transient: true
     },
     {
       class: 'String',
-      name: 'flowName'
+      name: 'flowName',
+      onKey: true
     },
     {
-      class: 'List',
+      class: 'Array',
       name: 'flowChildren',
-      transient: true
+      hidden: true
     },
-    { name: 'value' },
+    { name: 'value', hidden: true },
     {
       name: 'treeRowRenderer',
-      value: function(e) { e.add(this.flowName); }
+      hidden: true,
+      value: function(e) { e.add(this.flowName$); }
     }
   ],
 
@@ -45,12 +49,15 @@ foam.CLASS({
     },
 
     function findFlowChildByName(n) {
-      return this.flowChildren.find(c => c.flowName === n);
+      return this.flowChildren.find(c => {
+        if ( c.flowName === n || (c.flowChildren?.length && c.findFlowChildByName(n)) ) 
+          return true;
+      });
     },
 
     function addFlowChild(f) {
       if ( f.deleted_ ) return;
-      this.flowChildren = this.flowChildren.concat([f]);
+      this.flowChildren$push(f);
       this.addFlowChild_ && this.addFlowChild_(f);
     },
 
@@ -345,9 +352,9 @@ foam.CLASS({
   name: 'Block',
   extends: 'foam.u2.Accordion',
 
-  mixins: [ 'foam.core.reflow.Flowable' ],
+  implements: [ 'foam.core.reflow.Flowable' ],
 
-  imports: [ 'data', 'showPrompts' ],
+  imports: [ 'data', 'showPrompts', 'addToScope', 'selected' ],
 
   exports: [ 'addValue', 'log', 'out', 'as block' ],
 
@@ -357,7 +364,6 @@ foam.CLASS({
     }
     ^:not(^hidePrompts) {
       border-bottom: 1px solid $borderLight;
-      padding: 8px 16px;
     }
     ^output {
       overflow-x: auto;
@@ -376,7 +382,7 @@ foam.CLASS({
       border: none;
       height: 20px;
     }
-    ^:hover { background: $backgroundSecondary; }
+    ^.block:hover:not(:has(.block:hover)) { background: $backgroundSecondary; }
     ^ .foam-u2-ReadWriteView { padding-right: 8px; }
     ^content {
       overflow-x: auto;
@@ -386,39 +392,83 @@ foam.CLASS({
 
   properties: [
     {
+      name: 'flowName',
+      label: 'Block Name',
+      supportingLabel: 'Used to as the name for this block and as the variable name in the scope'
+    },
+    {
       class: 'String',
       name: 'cmd',
+      visibility: 'RO',
       displayWidth: 80
     },
     [ 'value', null ],
     {
       name: 'out',
-      getter: function() {
-        return this.content;
+      hidden: true
+    },
+    {
+      class: 'Class',
+      name: 'borderClass',
+      label: 'Border Type',
+      factory: function() { return foam.u2.borders.NullBorder; },
+      view: function(_,X) {
+        // TODO: replace with strategizer
+        // TODO: add a new card with title border that uses the foam.u2.borders.CardBorder 
+        // rather than foam.dashboard.view.Card
+        return {
+          class: 'foam.u2.view.ChoiceView',
+          choices: [
+            [foam.u2.borders.NullBorder, 'None'],
+            [foam.u2.borders.CardBorder, 'Card'],
+            [foam.u2.borders.BackgroundCard, 'Background'],
+            [foam.u2.borders.SpacingBorder, 'Padding'],
+            [foam.dashboard.view.CardWrapper, 'Card with Title']
+          ]
+        };
       }
     },
-    [ 'togglerPosition', 'left' ],
-    [ 'expanded', true ],
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'border',
+      label: 'Border Properties',
+      value: { class: 'foam.u2.borders.NullBorder'},
+      view: function (_, X) {
+        return {
+          class: 'foam.u2.view.ViewConfiguratorView',
+          data_$: X.data$.dot('borderEl_'),
+          allowClassChange: false
+        };
+      }
+    },
+    {
+      name: 'borderEl_',
+      hidden: true
+    },
+    { name: 'togglerPosition', value: 'right', hidden: true },
+    { name: 'expanded', value: true, hidden: true },
     {
       class: 'foam.u2.ViewSpec',
       name: 'configViewSpec',
+      hidden: true,
       documentation: `Passed on to the ReactiveSectionedDetailView as config, see AbstractSectionedDetailView to learn more about configuring detail views`
     }
   ],
 
   methods: [
+    function init() {
+      let self = this;
+      this.SUPER();
+      this.content.tag(this.borderClass, {}, self.borderEl_$);
+      this.out = foam.u2.WrapperNode.create({ parentNode: this.content }, this);
+      self.borderEl_.add(this.out);
+    },
     function render() {
       this.on('click', this.onClick);
+      this.addClass('block');
       this.enableClass(this.myClass('hidePrompts'), this.showPrompts$.not());
-      this.title.
-        on('click', (e) => { e.stopPropagation();  e.preventDefault(); }).
-        on('dblclick', (e) => { e.stopPropagation();  e.preventDefault(); }).
-        start('span')
-          .addClass(this.myClass('prompt')).start(foam.u2.ReadWriteView, {data$: this.flowName$})
-        .end()
-        .add(' = ')
-        .add(this.CMD);
-      this.rightSection.tag(this.DEL);
+      this.title.add(this.flowName$);
+      this.rightSection.tag(this.DEL, { label: ''});
       this.SUPER();
     },
 
@@ -427,6 +477,14 @@ foam.CLASS({
       this.value = o;
     },
 
+    function addFlowChild_(c) {
+      this.addToScope(c);
+      this.out.add(c);
+    },
+
+    function removeFlowChild_(c) {
+      c.remove();
+    },
     function log(...args) {
       if ( args.length == 0 ) return;
       if ( this.seen ) this.out.tag('br');
@@ -435,14 +493,14 @@ foam.CLASS({
     },
 
     function outputJSON(json) {
-      json.outputFObject_(this, this.cls_, [ this.FLOW_NAME, this.CMD, this.VALUE ]);
+      json.outputFObject_(this, this.cls_, [ this.FLOW_NAME, this.CMD, this.VALUE, this.FLOW_CHILDREN, this.REACTIONS_ ]);
     }
   ],
 
   actions: [
     {
       name: 'del',
-      label: '',
+      label: 'Delete',
       themeIcon: 'close',
       buttonStyle: 'TERTIARY',
       size: 'SMALL',
@@ -455,9 +513,22 @@ foam.CLASS({
 
   listeners: [
     {
-      name: 'onClick',
+      name: 'replaceBorder',
+      on: ['this.propertyChange.borderClass'],
       code: function() {
-        this.data.selected = this;
+          let el = this.borderClass.create({}, this);
+          this.out.moveTo(el);
+          el.replaceElement_(this.borderEl_);
+          this.borderEl_ = el;
+      }
+    },
+    {
+      name: 'onClick',
+      code: function(e) {
+        if ( e.srcElement.nodeName == 'INPUT' ) return;
+        e.stopImmediatePropagation();
+        e.preventDefault();
+        this.selected = this;
       }
     }
   ]
@@ -494,6 +565,7 @@ foam.CLASS({
       width: 15%;
       border-right: 1px solid $borderLight;
       flex: 0 0 auto;
+      overflow-y: auto; 
     }
     ^middle-holder {
       padding: 16px 16px 0 16px;
@@ -637,7 +709,7 @@ foam.CLASS({
         let dragImg_ = document.createElement('img');
         dragImg_.src = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
         evt.dataTransfer.setDragImage(dragImg_, 0, 0);
-        var sidebarName = evt.target.dataset.side + 'Width'
+        var sidebarName = evt.target.dataset.side + 'Width';
         this.oldX_ = evt.clientX;
         this.oldWidth_ = this[sidebarName] || this.MIN_SIDEBAR_WIDTH_FALLBACK;
       }
@@ -646,7 +718,7 @@ foam.CLASS({
       name: 'drag',
       code: function(evt) {
         evt.preventDefault();
-        var sidebarName = evt.target.dataset.side + 'Width'
+        var sidebarName = evt.target.dataset.side + 'Width';
         if ( ! sidebarName || event.clientX == 0 ) return;
         var w = evt.clientX - this.oldX_;
         if ( sidebarName == 'leftWidth' ) {
@@ -685,9 +757,10 @@ foam.CLASS({
   mixins: [ 'foam.u2.memento.Memorable' ],
 
   requires: [
+    'foam.core.reflow.Flowable',
     'foam.core.reflow.ReflowHeader',
     'foam.core.reflow.ReactiveSectionedDetailView',
-    'foam.core.reflow.RightSidebarOutputView',
+    'foam.core.reflow.ReflowConfigView',
     'foam.core.reflow.ReflowToolBar',
     'foam.core.reflow.ToolbarControl',
     'foam.core.reflow.Block',
@@ -711,6 +784,7 @@ foam.CLASS({
   ],
 
   exports: [
+    'addToScope',
     'clearFlow',
     'createFlowChildName',
     'currentBlock',
@@ -741,18 +815,6 @@ foam.CLASS({
       align-items: center;
       justify-content: center;
     }
-    ^input-field {
-      position: relative;
-      margin-block-end: 0;
-      display: inline-flex;
-      width: 100%;
-      align-items: center;
-      position: sticky;
-      justify-content: space-between;
-      bottom: 0;
-      padding: 10px 16px;
-      border-top: 1px solid $borderLight;
-    }
     ^output {
       flex: 1;
       overflow: auto;
@@ -762,22 +824,7 @@ foam.CLASS({
     ^ .foam-u2-view-ValueView {
       min-width: 220px;
     }
-    .foam-core-reflow-Layout-l { overflow-y: auto; }
     ^ .foam-u2-ProgressView { width: 600px; }
-    ^rightBar-title {
-      border-bottom: 1px solid $borderLight;
-      padding: 8px 16px;
-    }
-    ^rightBar {
-      display: flex;
-      flex-direction: column;
-    }
-    ^input-field-container {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      width: 80%;
-    }
     ^error {
       background: $backgroundDestructiveTertiary!important;
       color: $textDestructive;
@@ -834,26 +881,13 @@ foam.CLASS({
       memorable: true
     },
     {
-      class: 'String',
-      name: 'promptMode',
-      value: 'Standard'
-    },
-    {
+      // class: 'Boolean',
       name: 'showPrompts',
       value: true,
       expression: function(flowMode) {
         return flowMode === this.FlowMode.CONSOLE;
       },
       preSet: function(_, n) { return n === 'false' ? '' : n; },
-      // memorable: true
-    },
-    {
-      name: 'showInput',
-      value: true,
-      preSet: function(_, n) { return n === 'false' ? '' : n; },
-      expression: function(flowMode) {
-        return flowMode == this.FlowMode.CONSOLE;
-      },
       memorable: true
     },
     {
@@ -896,15 +930,11 @@ foam.CLASS({
       name: 'selected',
       postSet: function(o, n) {
         if ( o === n ) return;
-        this.selectedValue = n ? n.value : null;
         if (n && n.element_) {
           n.element_.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
       },
       factory: function() { return this; }
-    },
-    {
-      name: 'selectedValue'
     },
     {
       name: 'value',
@@ -931,24 +961,31 @@ foam.CLASS({
       }
     },
 
-    async function includeScript(script) {
+    async function includeScript(script, ctx, skipParse) {
+      ctx = ctx || this.__subContext__;
       if ( ! script ) return;
 
-      var cs = foam.json.parseString(script, this.__subContext__);
+      var cs = skipParse ?
+      script :
+      foam.json.parseString(script, ctx);
 
       for ( var i = 0 ; i < cs.length ; i++ ) {
         var c = cs[i];
 
-        await this.eval_(c.cmd);
+        await ctx.eval_(c.cmd);
 
         this.currentBlock.flowName = c.flowName;
 
         if ( this.currentBlock.value && c.value ) {
-          if ( c.value.clone ) c.value = c.value.clone(this.__subContext__);
+          if ( c.value.clone ) c.value = c.value.clone(ctx);
           this.currentBlock.value.copyFrom(c.value);
         }
 
         await this.currentBlock.value?.onLoad?.();
+
+        if ( c.flowChildren ) {
+          await this.includeScript(c.flowChildren, this.currentBlock.__subContext__, true);
+        }
       }
 
       // Call postLoad after all blocks have executed
@@ -972,16 +1009,10 @@ foam.CLASS({
 
       let oldShowNav = this.showNav;
       this.showNav = false;
-      this.onDetach(() => { this.showNav = oldShowNav;})
+      this.onDetach(() => { this.showNav = oldShowNav;});
       this.SUPER();
 
       var self = this;
-
-      // Add listener to restore navigation when leaving reflow
-      this.onDetach(() => {
-        this.showNav = true;
-      });
-
       this.value.name$.sub(() => this.route = this.value.name);
 
       // Does this ever happen?
@@ -991,10 +1022,6 @@ foam.CLASS({
 
       globalThis.shell = this; // for debugging
 
-      // Doesn't work for some reason. Gets detached when new flow loaded
-      // Replaced with postSet
-      // this.selectedValue$.follow(this.selected$.dot('value'));
-
       // Add commands to localScope
       var cmds = await this.commandDAO.select();
 
@@ -1002,7 +1029,7 @@ foam.CLASS({
         this.localScope[c.id] = (...args) => {
           var cmd = c.clone(this.currentBlock);
           return cmd.execute.apply(cmd, args);
-        }
+        };
       });
 
       // If this.value.script changes
@@ -1023,18 +1050,7 @@ foam.CLASS({
       layout.showHeader = true;
       layout.left.tag(this.FlowableTree, {data: this, selected$: this.selected$, isMenuOpen$: layout.isMenuOpen$});
       layout.middle.call(this.renderSelf, [this]);
-      layout.right.addClass(self.myClass('rightBar')).add(this.dynamic(function(selectedValue, selected$configViewSpec) {
-        this.start().addClass(self.myClass('rightBar-title'), 'h400')
-          .add('Flow Properties')
-        .end()
-        .tag(self.ReactiveSectionedDetailView, {
-          of: selectedValue?.cls_.id ?? '',
-          ...(selected$configViewSpec || {}),
-          data: selectedValue,
-          showActions: true,
-          showHeader: true
-        });
-      }));
+      layout.right.tag(this.ReflowConfigView, { data$: this.selected$});
 
       layout.header.add(this.dynamic(function(showPrompts) {
         this.tag(self.ReflowHeader, {data: self, showPrompts: showPrompts, resetFlow: self.clearFlow});
@@ -1044,39 +1060,13 @@ foam.CLASS({
       await this.eval_('preLoad', null, true);
     },
 
-    function renderToolbar(self) {
-      self.toolbarControlDAO.where(self.EQ(self.ToolbarControl.TOOLBAR, self.promptMode))
-        .select().then(result => {
-          result.array
-            .sort((a, b) => (a.order || 0) - (b.order || 0))
-            .forEach(c => {
-              this.tag({class: c.view, data: self});
-            });
-        });
-    },
-
     function renderSelf(self) {
       this.
         addClass(self.myClass()).
         start('div', null, self.out$)
-          .addClass(self.myClass('output')).end().
-          start('span').
-            show(self.showInput$).
-            addClass(self.myClass('input-field')).
-            add(self.dynamic(function(promptMode) {
-              return this.start().addClass(self.myClass('input-field-container')).
-                        call(self.renderToolbar, [self]).
-                      end()
-            }))
-            .start({
-              class: 'foam.u2.view.ChoiceView',
-              data$: self.promptMode$,
-              choices: ['Standard', 'Advanced'] // TODO: get dynamic from toolbarDAO to create later
-            })
-              .addClass(self.myClass('prompt-mode-choice'))
-            .end().
-          end().
-        end();
+          .addClass(self.myClass('output')).
+        end().
+        tag(self.ReflowToolBar);
 
         // These observers might cause scroll issues later when queries in the console can be edited
         // In that case there should be an explicit flag to only do the scroll when the query is submitted
@@ -1131,7 +1121,7 @@ foam.CLASS({
     },
 
     function refreshFlowScope() {
-      var s = this.flowScope;
+      let s = this.flowScope;
 
       // Remove old bindings
       for ( var x in s )
@@ -1139,25 +1129,28 @@ foam.CLASS({
           delete s[x];
 
       s.flow = this.value;
-
-      // Add shortname bindings for DAO children
-      this.flowChildren.forEach(c => {
-        if ( c.value && c.flowName.endsWith('DAO') ) {
-          s[c.flowName.substring(0, c.flowName.length-3)] = foam.lang.Holder.isInstance(c.value) ? c.value.value : c.value;
-        }
-      });
-
-      // Add bindings for children
-      this.flowChildren.forEach(c => {
-        if ( c.value ) {
-          s[c.flowName] = foam.lang.Holder.isInstance(c.value) ? c.value.value : c.value;
-        }
-      });
+      let addBindings = (flow) => {
+        if ( ! flow.flowChildren.length ) return;
+        flow.flowChildren.forEach(c => {
+          // Add shortname bindings for DAO children
+          if ( c.value && c.flowName.endsWith('DAO') ) {
+            s[c.flowName.substring(0, c.flowName.length-3)] = foam.lang.Holder.isInstance(c.value) ? c.value.value : c.value;
+          }
+          // Add bindings for children
+          if ( c.value ) {
+            s[c.flowName] = foam.lang.Holder.isInstance(c.value) ? c.value.value : c.value;
+          }
+          this.Flowable.isInstance(c) && addBindings(c);
+        });
+      };
+      addBindings(this);
+      this.flowScope = s;
     },
 
-    async function eval_(cmd, opt_ignoreSelect, ignoreHistory) {
+    async function eval_(cmd, opt_ignoreSelect, ignoreHistory, flowParent) {
       /** opt_ignoreSelect if true, causes the evaled cmd to not become the selected block **/
       var self = this;
+      flowParent = flowParent || this;
 
       cmd = cmd.trim();
 
@@ -1167,10 +1160,11 @@ foam.CLASS({
         this.addHistory(cmd);
 
 //      this.out.tag('br').start().show(self.showPrompts$).start('b').add('> ').end().add(cmd);
-      var block = this.currentBlock = this.Block.create({cmd: cmd, flowParent: this});
+      var block = this.currentBlock = this.Block.create({cmd: cmd, flowParent: flowParent}, flowParent);
 
       var innerScope = {
         // shell: this,
+        block: block,
         eval_: this.eval_.bind(this),
         addValue: block.addValue.bind(block),
         log: block.log.bind(block),
@@ -1206,7 +1200,8 @@ foam.CLASS({
             block.value = foam.lang.StringHolder.create({value: x.toString()});
             block.treeRowRenderer = function(e) {
               e.parentNode.addClass(self.myClass('error'));
-              e.add(this.flowName); }
+              e.add(this.flowName);
+            };
           }
         }
 
@@ -1223,7 +1218,10 @@ foam.CLASS({
         }
       }}}
 
-      this.addFlowChild(block);
+      // Re-set block in case the command changed currentBlock
+      // block = this.currentBlock;
+
+      flowParent.addFlowChild(block);
 
       if ( ! opt_ignoreSelect ) this.selected = block;
 
@@ -1251,10 +1249,14 @@ foam.CLASS({
     },
 
     function addFlowChild_(c) {
+      this.addToScope(c);
+      this.out.add(c);
+    },
+
+    function addToScope(c) {
       this.refreshFlowScope();
       c.flowName$.sub(() => this.refreshFlowScope());
       c.value$.sub(() => this.refreshFlowScope());
-      this.out.add(c);
     },
 
     function removeFlowChild_(c) {
@@ -1356,9 +1358,7 @@ foam.CLASS({
     {
       name: 'toggleMode',
       // You can do this.showPrompts = true|false; from flow scripts
-      // You can do this.showInput = true|false; from flow scripts
       code: function() {
-        this.showPrompts = undefined;
         this.flowMode = this.flowMode == this.FlowMode.CONSOLE ?
           this.FlowMode.PRESENTATION :
           this.FlowMode.CONSOLE ;
@@ -1382,21 +1382,6 @@ foam.CLASS({
         this.input = this.history_[this.history_.length - this.historyPosition] ?? '';
       },
       keyboardShortcuts: [ 'arrowdown' ]
-    },
-    {
-      name: 'onInput',
-      label: '',
-      themeIcon: 'next',
-      size: 'SMALL',
-      buttonStyle: 'TEXT',
-      code: function() {
-        var input = this.input;
-        this.input = '';
-        this.eval_(input);
-      },
-      // Using 'enter' keyboard shortcut doesn't work because it prevents newlines in
-      // text areas on the screen.
-      // keyboardShortcuts: [ 'enter' ]
     },
     {
       name: 'clear',
@@ -1428,6 +1413,14 @@ foam.CLASS({
   ],
 
   listeners: [
+    {
+      name: 'onInput',
+      code: function() {
+        var input = this.input;
+        this.input = '';
+        this.eval_(input);
+      }
+    },
     {
       name: 'onClick',
       // TODO: introduce a merge delay so that cut&paste still works

--- a/src/foam/core/reflow/LayoutBlock.js
+++ b/src/foam/core/reflow/LayoutBlock.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'LayoutBlock',
+  extends: 'foam.core.reflow.Block',
+
+  imports: [ 'eval_ as importedEval', 'block', 'data as importedData'],
+  exports: ['out', 'eval_'],
+  requires: [
+    'foam.core.reflow.ReflowToolBar',
+    'foam.u2.layout.Layout'
+  ],
+
+  properties: [
+    {
+      __copyFrom__: 'foam.core.reflow.Console.INPUT',
+      hidden: true
+    },
+    {
+      name: 'cmdHolder',
+      hidden: true
+    },
+    {
+      name: 'out',
+      getter: function() {
+        return this.cmdHolder;
+      }
+    },
+    { name: 'border', hidden: true },
+    { name: 'borderClass', hidden: true }
+  ],
+  methods: [
+    function render() {
+      let self = this;
+      this.SUPER();
+      this.
+        addClass(self.myClass()).
+        tag(this.ReflowToolBar);
+      this.content.tag(this.Layout, {}, this.cmdHolder$);
+      let sub = () => {
+        this.addValue(this.cmdHolder, true);
+      };
+      this.cmdHolder$.sub(sub);
+      sub();
+    },
+    function eval_(...args){
+      if ( ! args[3] || args[3] == this.flowParent )
+        args[3] = this;
+      return this.importedEval(...args);
+    }
+  ],
+  listeners: [
+    {
+      name: 'onInput',
+      code: function() {
+        var input = this.input;
+        this.input = '';
+        this.eval_(input);
+      }
+    }
+  ]
+});

--- a/src/foam/core/reflow/ReactiveDetailView.js
+++ b/src/foam/core/reflow/ReactiveDetailView.js
@@ -198,7 +198,6 @@ foam.CLASS({
           enableClass('reactive', this.reactive$).
           on('click', this.toggleMode).
           add(labelSlot).
-          add(supportingLabelSlot).
           start().
             addClass(this.myClass('switch')).
             add(this.dynamic(function(reactive) {
@@ -214,6 +213,7 @@ foam.CLASS({
             })).
           end().
         end().
+        add(supportingLabelSlot).
         call(this.layoutView, [self, prop, viewSlot]).
         start().
           addClass(this.myClass('propHolder')).

--- a/src/foam/core/reflow/ReflowConfigView.js
+++ b/src/foam/core/reflow/ReflowConfigView.js
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'ReflowConfigView',
+  extends: 'foam.u2.Tabs',
+  //TODO: reactions dont work for block properties
+  requires: [
+    'foam.core.reflow.ReactiveSectionedDetailView',
+    'foam.core.reflow.Block'
+  ],
+  css:` 
+    ^ {
+      gap: 10px;
+    }
+    ^rightBar-title {
+      border-bottom: 1px solid $borderLight;
+      padding: 8px 16px;
+    }
+  `,
+
+  properties: [
+    {
+      name: 'data'
+    },
+    {
+      name: 'selectedValue',
+      expression: function(data) {
+        return this.data?.value;
+      }
+    }
+  ],
+  methods: [
+    function render() {
+      let self = this;
+      this.SUPER();
+      this.start(this.Tab, { label: 'Flow Properties' })
+        .call(function() {
+          self.onDetach(self.data$.sub(() => {
+            self.selected = this;
+          }));
+        })
+        .add(this.dynamic(function(data$configViewSpec, selectedValue) {
+          if ( ! selectedValue ) return;
+          this.tag(self.ReactiveSectionedDetailView, {
+            of: selectedValue.cls_.id ?? '',
+            ...(data$configViewSpec || {}),
+            data: selectedValue,
+            showActions: true,
+            showHeader: true
+          });
+        }))
+      .end()
+      .start(this.Tab, { label: 'Block Properties' })
+        .add(this.dynamic(function(data) {
+          if ( ! data || data.deleted_ || ! self.Block.isInstance(data) ) {
+            this.add('No block selected');
+            return;
+          }
+          this.tag(self.ReactiveSectionedDetailView, {
+            ...(data.configViewSpec || {}),
+            data: data,
+            showActions: true,
+            showHeader: true
+          });
+        }))
+      .end();;
+    }
+  ]
+})

--- a/src/foam/core/reflow/ReflowToolBar.js
+++ b/src/foam/core/reflow/ReflowToolBar.js
@@ -11,153 +11,77 @@ foam.CLASS({
   extends: 'foam.u2.View',
 
   requires: [
-    'foam.core.reflow.DynamicReflowData',
-    'foam.core.reflow.DynamicReflowComponents',
-    'foam.core.reflow.DynamicReflowHelp',
-    'foam.u2.ToggleActionView'
+    'foam.core.reflow.ToolbarControl'
   ],
+
+  imports: ['showPrompts','toolbarControlDAO', 'data as importedData'],
 
   css: `
     ^ {
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      bottom: 64px;
-      z-index: 20;
-    }
-    ^island-holder {
-      display: flex;
-      flex-direction: column;
-      align-items: left;
-      gap: 10px;
-      align-items: center;
-      max-width: 320px;
-    }
-      
-    ^holder {
-      padding: 10px;
-      background-color: $backgroundDefault;
-      border-radius: 4px;
-      border: 1px solid $borderLight;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      position: relative;
+      margin-block-end: 0;
+      display: inline-flex;
       width: 100%;
+      align-items: center;
+      position: sticky;
+      justify-content: space-between;
+      bottom: 0;
+      padding: 10px 16px;
+      border-top: 1px solid $borderLight;
+    }
+    ^ > :lastChild {
+      flex-shrink: 0;
+    }
+    ^input-field-container {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex: 1;
     }
 
-    ^button-group {
-      display: flex;
-      gap: 10px;
-      align-items: center;
-    }
   `,
 
   properties: [
     {
-      name: 'selected',
-      value: null
+      name: 'data',
+      factory: function() {
+        return this.importedData;
+      }
+    },
+    {
+      class: 'String',
+      name: 'promptMode',
+      value: 'Standard',
+      view: {
+        class: 'foam.u2.view.ChoiceView',
+        choices: ['Standard', 'Advanced']
+      }
     }
   ],
 
   methods: [
-    function init() {
-      this.SUPER();
-      this.boundHandleClickOutside = this.handleClickOutside.bind(this);
-      window.addEventListener('mousedown', this.boundHandleClickOutside);
-    },
-
-    function destroy() {
-      window.addEventListener('mousedown', this.boundHandleClickOutside);
-    },
-
-    function handleClickOutside(e) {
-      const islandHolder = document?.querySelector(`.${this.myClass('island-holder')}`);      if (islandHolder && !islandHolder.contains(e.target)) {
-        this.selected = null;
-      }
-    },
-
     function render() {
-      var self = this;
-      const actions = this.cls_.getAxiomsByClass(foam.lang.Action);
-      this.addClass()
-      .start().addClass(this.myClass('island-holder'))
-        .add(this.dynamic(function(selected) {
-          if (selected == 'collections') {
-            this.start().addClass(self.myClass('expanded-island'), self.myClass('holder'))
-              .start(self.DynamicReflowData, { data: self.data })
-            .end();
-          }
-          if (selected == 'components') {
-            this.start().addClass(self.myClass('expanded-island'), self.myClass('holder'))
-              .start(self.DynamicReflowComponents, { data: self.data })
-            .end();
-          }
-          if ( selected == 'help' ) {
-            this.start().addClass(self.myClass('expanded-island'), self.myClass('holder'))
-              .start(self.DynamicReflowHelp, { data: self.data })
-            .end();
-          }
-
-        }))
-        .start().addClass(this.myClass('holder'))
-          .start().addClass(self.myClass('button-group'))
-            .startContext({ data: self })
-              .forEach(actions, function(action) {
-                this.tag(self.ToggleActionView, {
-                  action: action,
-                  data: self,
-                  actionState$: self.selected$.map(function(selected) {
-                    return selected === action.name;
-                  })
-                }).end();
-              })
-            .endContext()
-          .end()
-        .end()
-      .end();
-    }
-  ],
-
-  actions: [
-    {
-      name: 'collections',
-      label: 'Data',
-      buttonStyle: foam.u2.ButtonStyle.TERTIARY,
-      size: 'SMALL',
-      themeIcon: 'file',
-      code: function() {
-        if ( this.selected === 'collections' ) {
-          this.selected = null;
-        } else {
-          this.selected = 'collections';
-        }
-      }
-    },
-    {
-      name: 'components',
-      label: 'Components',
-      buttonStyle: foam.u2.ButtonStyle.TERTIARY,
-      size: 'SMALL',
-      themeIcon: 'plus',
-      code: function() {
-        if ( this.selected === 'components' ) {
-          this.selected = null;
-        } else {
-          this.selected = 'components';
-        }
-      }
-    },
-    {
-      name: 'help',
-      label: 'Help',
-      buttonStyle: foam.u2.ButtonStyle.TERTIARY,
-      themeIcon: 'helpIcon',
-      size: 'SMALL',
-      code: function() {
-        if ( this.selected === 'help' ) {
-          this.selected = null;
-        } else {
-          this.selected = 'help';
-        }
-      }
+      let self = this;
+      this.
+        addClass().
+        show(this.showPrompts$).
+        start().
+        addClass(this.myClass('input-field-container')).
+        add(this.dynamic(function(promptMode) {
+          self.toolbarControlDAO
+            .where(self.EQ(self.ToolbarControl.TOOLBAR, self.promptMode))
+            .select().then(result => {
+              result.array
+                .sort((a, b) => (a.order || 0) - (b.order || 0))
+                .forEach(c => {
+                  this.tag({class: c.view, data: self.data});
+                });
+            });
+        })).
+        end().
+        startContext({ data: this }).
+        add(this.PROMPT_MODE).
+        endContext();
     }
   ]
 });

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -871,3 +871,26 @@ foam.CLASS({
     }
   ]
 });
+
+foam.CLASS({
+  package: 'foam.core.reflow.cmd',
+  name: 'Layout',
+  extends: 'foam.core.reflow.cmd.Command',
+
+  imports: [ 'block', 'currentBlock' ],
+
+  methods: [
+    function execute(...args) {
+      // Take over old block and replace it
+      let b = foam.core.reflow.LayoutBlock.create({
+        cmd: this.block.cmd,
+        flowParent: this.block.flowParent,
+        flowName: this.block.flowName
+      }, this.block.flowParent);
+      this.block.flowParent.addFlowChild(b);
+      this.block.del();
+      this.currentBlock = b;
+      console.log(this.block, this.currentBlock, b);
+    }
+  ]
+});

--- a/src/foam/core/reflow/cmd/DAORowView.js
+++ b/src/foam/core/reflow/cmd/DAORowView.js
@@ -12,6 +12,7 @@ foam.CLASS({
   requires: [
     'foam.u2.tag.Button',
   ],
+  imports: ['eval_'],
 
   css: `
     ^desc-cell {
@@ -58,25 +59,25 @@ foam.CLASS({
     {
       name: 'addFn',
       code: function() {
-        this.data.eval_(`add ${this.shortName}`);
+        this.eval_(`add ${this.shortName}`);
       }
     },
     {
       name: 'uplFn',
       code: function() {
-        this.data.eval_(`upload ${this.shortName}`);
+        this.eval_(`upload ${this.shortName}`);
       }
     },
     {
       name: 'daoFn',
       code: function() {
-        this.data.eval_(`dao ${this.shortName}`);
+        this.eval_(`dao ${this.shortName}`);
       }
     },
     {
       name: 'desFn',
       code: function() {
-        this.data.eval_('describe(' + this.ofId + ')');
+        this.eval_('describe(' + this.ofId + ')');
       }
     }
   ]

--- a/src/foam/core/reflow/cmd/cmds.jrl
+++ b/src/foam/core/reflow/cmd/cmds.jrl
@@ -142,3 +142,10 @@ p({
 """,
   "hidden": true
 })
+
+
+p({
+  "class":"foam.core.reflow.cmd.Layout",
+  "id": "layout",
+  "description": "adds a layout block"
+})

--- a/src/foam/core/reflow/pom.js
+++ b/src/foam/core/reflow/pom.js
@@ -2,6 +2,7 @@ foam.POM({
   name: 'console',
   files: [
     { name: '../../u2/mlang/Table',    flags: 'js|java' },
+    { name: '../../u2/mlang/Pie',    flags: 'js|java' },
     { name: 'AbstractDAOAgent',        flags: 'js' },
     { name: 'CellsSink',               flags: 'js|java' },
     { name: 'Check',                   flags: 'js' },
@@ -26,6 +27,8 @@ foam.POM({
     { name: 'SinkAgent',               flags: 'js|java' },
     { name: 'CommandItemView',         flags: 'js' },
     { name: 'ReflowToolBar',           flags: 'js' },
+    { name: 'ReflowConfigView',        flags: 'web' },
+    { name: 'LayoutBlock',             flags: 'web' },
     { name: 'ModelDAO',                flags: 'js' },
     { name: 'PropertyChoiceView',      flags: 'js' },
     { name: 'PropertySuggestedField',  flags: 'js' },

--- a/src/foam/dashboard/view/Card.js
+++ b/src/foam/dashboard/view/Card.js
@@ -10,7 +10,7 @@ foam.CLASS({
   extends: 'foam.u2.View',
 
   imports: [
-    'dashboardController'
+    'dashboardController?'
   ],
 
   exports: [
@@ -56,15 +56,19 @@ foam.CLASS({
 
   properties: [
     {
+      name: 'size',
+      expression: function(data$size) { return data$size || 'MEDIUM' }
+    },
+    {
       name: 'width',
-      expression: function(data$size) {
-        return this.SIZES[data$size.name][0];
+      expression: function(size) {
+        return this.SIZES[size?.name]?.[0];
       }
     },
     {
       name: 'height',
-      expression: function(data$size) {
-        return this.SIZES[data$size.name][1];
+      expression: function(size) {
+        return this.SIZES[size?.name]?.[1];
       }
     },
     {
@@ -100,6 +104,7 @@ foam.CLASS({
 
   methods: [
     function init() {
+      if ( this.dashboardController )
       this.onDetach(this.dashboardController.sub('dashboard', 'update', function() {
         this.data.update();
       }.bind(this)));
@@ -119,14 +124,14 @@ foam.CLASS({
         addClass(this.myClass()).
         start('div').
         addClass('h500', this.myClass('header')).
-        show(!!this.data.label || !!this.data.configView).
+        show(!!this.data?.label || !!this.data?.configView).
         start().
           style({ float: 'left' }).
-          add(this.data.label$).
+          add(this.data?.label$).
         end().
         start().
           style({ float: 'right' }).
-          tag(this.data.configView).
+          tag(this.data?.configView).
         end().
         end('div').
         start('div').

--- a/src/foam/dashboard/view/CardWrapper.js
+++ b/src/foam/dashboard/view/CardWrapper.js
@@ -15,7 +15,8 @@ foam.CLASS({
 
   requires: [
     'foam.dashboard.model.VisualizationSize',
-    'foam.dashboard.view.Card'
+    'foam.dashboard.view.Card',
+    'foam.u2.borders.CardBorder'
   ],
 
   css: `
@@ -33,39 +34,44 @@ foam.CLASS({
     {
       class: 'foam.u2.ViewSpec',
       name: 'border',
+      hidden: true,
       factory: function () {
         return this.Card;
       }
     },
     'title',
-    'currentView',
-    ['viewTitle', 'Dashboard'],
+    { name: 'currentView', hidden: true },
+    { name: 'viewTitle', value: 'Dashboard', hidden: true },
     {
-      class: 'FObjectProperty',
+      class: 'Enum',
+      of: 'foam.dashboard.model.VisualizationSize',
       name: 'size',
-      factory: function() {
-        return this.VisualizationSize.MEDIUM
+      expression: function(data$size) {
+        return data$size || this.VisualizationSize.MEDIUM;
       }
     },
-    'data',
-    'obj',
-    'mode',
+    { name: 'data', hidden: true },
+    { name: 'obj', hidden: true },
+    { name: 'mode', hidden: true },
     ['aspectRatio', 'auto']
   ],
 
   methods: [
-    function render() {
+    function init() {
+      let self = this;
       this.addClass(this.myClass())
-        .enableClass(this.myClass('titled-container'), this.title)
-        .style({ 'aspect-ratio': this.aspectRatio })
-        .callIf(!!this.title, function () {
-          this.start().addClass(this.myClass('title'), 'h500').translate(this.title, this.title).end()
-        })
-        .start(this.border, { data: this })
-        .tag(this.slot(function(currentView) {
+        .enableClass(this.myClass('titled-container'), this.title$)
+        .style({ 'aspect-ratio': this.aspectRatio$ })
+        .start()
+          .addClass(this.myClass('title'), 'h500')
+          .show(this.title$)
+          .add(this.title$)
+        .end()
+        .tag(this.border, {  data: this, size$: self.size$ }, this.content$);
+        this.content.add(this.slot(function(currentView) {
           return foam.u2.ViewSpec.createView(currentView, {
-            data$: this.data$ }, this, this.__subSubContext__);
-        })).end();
+            data$: self.data$}, this, this.__subSubContext__);
+        }));
     }
   ],
 
@@ -77,4 +83,4 @@ foam.CLASS({
       }
     }
   ]
-})
+});

--- a/src/foam/lang/Property.js
+++ b/src/foam/lang/Property.js
@@ -321,7 +321,8 @@ foam.CLASS({
       documentation: 'this axiom contains names of properties which are needed to be set when using projection as they are used for some other axioms of current property (eg tableCellFormatter can use another property\'s value for specific styling)',
       value: []
     },
-    'initObject'
+    'initObject',
+    'copyValueFrom'
   ],
 
   methods: [

--- a/src/foam/u2/Accordion.js
+++ b/src/foam/u2/Accordion.js
@@ -46,7 +46,7 @@ foam.CLASS({
     ^control {
       transition: transform 0.3s;
     }
-    ^.expanded ^control {
+    ^.expanded > ^toolbar ^control {
       transform: rotate(90deg);
     }
     ^control svg {
@@ -59,6 +59,7 @@ foam.CLASS({
   properties: [
     {
       name: 'title',
+      hidden: true,
       documentation: `
         Title of the accordion. The title property is pre-initialized as a foam.u2.Element
         that is already bound to the DOM. You should add content to this existing element
@@ -101,6 +102,7 @@ foam.CLASS({
     },
     {
       name: 'rightSection',
+      hidden: true,
       documentation: `
         Right section content. Can be a list of actions, a counter, ...etc
 
@@ -124,11 +126,13 @@ foam.CLASS({
     {
       class: 'String',
       name: 'controlGlyph',
+      hidden: true,
       value: 'next'
     },
     {
       class: 'String',
       name: 'togglerPosition',
+      hidden: true,
       view: {
         class: 'foam.u2.view.ChoiceView',
         choices: [ 'left', 'right' ]

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -199,6 +199,61 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'WrapperNode',
+  extends: 'foam.u2.Element',
+  documentation: `Special kind of node that can move itself and it's children between elements without causing rerenders
+  Uses the same fake element behaviour as FunctionNode but is not dynamic.
+  `,
+  properties: [
+    {
+      name: 'id',
+      factory: function() {
+        return 'wrapper' + foam.next$UID();
+      }
+    },
+    {
+      class: 'Boolean',
+      name: 'loaded_'
+    },
+    {
+      name: 'element_',
+      factory: function() { return this.document.createComment(this.id); }
+    },
+    {
+      name: 'endElement_',
+      factory: function() { return this.document.createComment('/' + this.id); }
+    },
+    { class: 'Array', name: 'nodesToMove_', hidden: true }
+  ],
+  methods: [
+    function moveTo(e) {
+      this.nodesToMove_ = [];
+      if ( this.parentNode )
+        this.parentNode.childNodes = this.parentNode.childNodes.filter(v => v !== this);
+      this.parentNode = e;
+      for ( let el = this.element_.nextSibling;
+        el != this.endElement_; el = el.nextSibling ) {
+        this.nodesToMove_.push(el);
+      }
+      e.add(this);
+    },
+    function render() {
+      if ( ! this.parentNode ) { this.detach(); return; }
+      this.element_.parentNode.appendChild(this.endElement_);
+      this.nodesToMove_.forEach(v => this.appendChild_(v));
+      this.nodesToMove_ = undefined;
+    },
+
+    // Append 'children' before /dynamic comment
+    function appendChild_(c) {
+      if ( ! this.endElement_.parentNode ) { this.detach(); return; }
+      this.endElement_.parentNode.insertBefore(c, this.endElement_);
+    }
+  ]
+});
+
 
 foam.CLASS({
   package: 'foam.u2',
@@ -476,6 +531,8 @@ foam.CLASS({
     {
       name: 'element_',
       transient: true,
+      hidden: true,
+      copyValueFrom: () => { return true; },
       factory: function() {
         var ret = this.namespace ?
           this.document.createElementNS(this.namespace, this.nodeName) :
@@ -504,6 +561,7 @@ foam.CLASS({
     {
       name: 'content',
       hidden: true,
+      transient: true,
       preSet: function(o, n) {
         // Prevent setting to 'this', which wouldn't change the behaviour.
         return n === this ? null : n ;
@@ -513,6 +571,7 @@ foam.CLASS({
       class: 'String',
       name: 'tooltip',
       attribute: true,
+      hidden: true,
       postSet: function(o, n) {
         if ( n && ! o ) {
           this.Tooltip.create({target: this, text$: this.tooltip$});
@@ -574,11 +633,13 @@ foam.CLASS({
       name: 'classes',
       documentation: 'CSS classes assigned to this Element. Stored as a map of true values.',
       transient: true,
+      hidden: true,
       factory: function() { return {}; }
     },
     {
       class: 'Map',
       name: 'css',
+      transient: true,
       hidden: true,
       documentation: 'Styles added to this Element.',
       factory: function() { return {}; }
@@ -594,6 +655,7 @@ foam.CLASS({
       name: 'children',
       documentation: 'Virtual property of non-String childNodes.',
       transient: true,
+      hidden: true,
       getter: function() {
         return this.childNodes.filter(function(c) {
           return typeof c !== 'string';
@@ -641,6 +703,7 @@ foam.CLASS({
       // TODO: remove after port from U2 to U3
       name: 'onload',
       transient: true,
+      hidden: true,
       factory: function() {
         return { sub: function(f) {
           console.warn('Deprecated us of ELement.onload.sub().');
@@ -2218,7 +2281,14 @@ foam.CLASS({
 
   documentation: 'A Controller is an Element which exports itself as "data".',
 
-  exports: [ 'as data' ]
+  exports: [ 'as data' ],
+
+  properties: [
+    {
+      name: 'shown',
+      hidden: true
+    }
+  ]
 });
 
 

--- a/src/foam/u2/ViewSpec.js
+++ b/src/foam/u2/ViewSpec.js
@@ -75,7 +75,7 @@ foam.CLASS({
 
             if ( spec.children ) {
               for ( var i = 0 ; i < spec.children.length ; i++ ) {
-                ret.tag(spec.children[0]);
+                ret.tag(spec.children[i]);
               }
             }
 

--- a/src/foam/u2/borders/NullBorder.js
+++ b/src/foam/u2/borders/NullBorder.js
@@ -17,13 +17,14 @@ foam.CLASS({
   properties: [
     {
       class: 'StringArray',
-      name: 'cssClasses'
-    },
+      name: 'cssClasses',
+      hidden: true
+    }
   ],
 
   methods: [
     function render() {
-      this.addClass(...this.cssClasses).tag('', {}, this.content$);
+      this.addClass(...this.cssClasses);
     }
   ]
 });

--- a/src/foam/u2/layout/Layouts.js
+++ b/src/foam/u2/layout/Layouts.js
@@ -42,3 +42,155 @@ foam.CLASS({
     }
   ]
 });
+
+
+foam.CLASS({
+  package: 'foam.u2.layout',
+  name: 'Layout',
+  extends: 'foam.u2.Element',
+  documentation: 'Element that acts as a wrapper div, can change between flex and grid based on properties',
+  css: `
+    ^ {
+      overflow: auto;
+      align-items: stretch;
+    }
+  `,
+  properties: [
+    {
+      name: 'shown',
+      hidden: true
+    },
+    {
+      name: 'tooltip',
+      hidden: true
+    },
+    {
+      class: 'String',
+      name: 'layoutType',
+      value: 'row',
+      view: {
+        class: 'foam.u2.view.ChoiceView',
+        choices: [['row', 'Horizontal'], ['column', 'Vertical'], 'grid']
+      },
+      postSet: function(_,n) {
+        if ( n === 'grid' ) {
+          this.autoGap = false;
+          this.align = ['stretch', 'stretch'];
+        }
+      }
+    },
+    {
+      class: 'String',
+      name: 'rows',
+      value: 2,
+      supportingLabel: 'Set to 0 for dynamic row sizing, rows will be sized by their biggest element',
+      visibility: function(layoutType) {
+        return layoutType !== 'grid' ? 'HIDDEN' : 'RW';
+      }
+    },
+     {
+      class: 'String',
+      name: 'columns',
+      value: 2,
+       visibility: function(layoutType) {
+        return layoutType !== 'grid' ? 'HIDDEN' : 'RW';
+      }
+    },
+    {
+      class: 'Boolean',
+      name: 'autoGap',
+      visibility: function(layoutType) {
+        return layoutType === 'grid' ? 'HIDDEN' : 'RW' ;
+      },
+      postSet: function(_,n) {
+        this.align = n ? 'flex-start': ['flex-start', 'flex-start'];
+      }
+    },
+    {
+      class: 'Int',
+      name: 'gap',
+      value: 10,
+      visibility: function(autoGap) {
+        return autoGap ? 'HIDDEN' : 'RW';
+      }
+    },
+    {
+      class: 'Array',
+      name: 'align',
+      // Hide until grid placement is fixed
+      visibility: function(layoutType) {
+        return layoutType === 'grid' ? 'HIDDEN' : 'RW' ;
+      },
+      view: function(_, X) {
+        return {
+          class: 'foam.u2.view.ChoiceView',
+          choices$: X.data.slot(function(autoGap, layoutType) {
+            if ( layoutType === 'grid' ) {
+              return [
+                [['stretch', 'stretch'], 'Fill'],
+                [['start', 'start'],     'Top Left'],
+                [['start', 'center'],    'Top Center'],
+                [['start', 'end'],       'Top Right'],
+                [['center', 'start'],    'Center Left'],
+                [['center', 'center'],   'Center'],
+                [['center', 'end'],      'Center Right'],
+                [['end', 'start'],       'Bottom Left'],
+                [['end', 'center'],      'Bottom Center'],
+                [['end', 'end'],         'Bottom Right']
+              ]
+            }
+            if ( autoGap ) {
+              return layoutType == 'row' ? [
+                ['flex-start', 'Top'], ['center', 'Center'], ['flex-end', 'Bottom']
+              ] : [
+                ['flex-start', 'Left'], ['center', 'Center'], ['flex-end', 'Right']
+              ];
+            }
+            return [
+              [['flex-start', 'flex-start'], 'Top Left'],
+              [['flex-start', 'center'],     'Top Center'],
+              [['flex-start', 'flex-end'],   'Top Right'],
+              [['center', 'flex-start'],     'Center Left'],
+              [['center', 'center'],         'Center'],
+              [['center', 'flex-end'],       'Center Right'],
+              [['flex-end', 'flex-start'],   'Bottom Left'],
+              [['flex-end', 'center'],       'Bottom Center'],
+              [['flex-end', 'flex-end'],     'Bottom Right']
+            ];
+          })
+        };
+      }
+    }
+  ],
+  methods: [
+    function render() {
+      this.SUPER();
+      this.addClass();
+      this.style({
+        display: this.layoutType$.map(v => v != 'grid' ? 'flex' : v),
+        'flex-direction': this.layoutType$.map(v => v != 'grid' ? v : 'unset'),
+        'grid-template-rows': this.slot(function(rows, layoutType) {
+          return layoutType === 'grid' ? rows <= 0 ? 'max-content' : `repeat(${rows}, minmax(0, 1fr))` : 'unset';
+        }),
+        'grid-template-columns': this.slot(function(columns, layoutType) {
+          return layoutType === 'grid' ? columns <= 0 ? 'max-content' : `repeat(${columns}, minmax(0, 1fr))` : 'unset';
+        }),
+        gap: this.slot(function(gap, autoGap) {
+          return autoGap ? 'initial' : gap + 'px';
+        }),
+        'justify-content': this.slot(function(align, autoGap, layoutType) {
+          if ( layoutType === 'grid' ) return  'unset';
+          return autoGap ? 'space-between' : align[(layoutType === 'row' ? 1 : 0)];
+        }),
+        'justify-items': this.slot(function(align, layoutType) {
+          if ( layoutType === 'grid' ) return align[1];
+          return 'unset';
+        }),
+        'align-items': this.slot(function(align, layoutType, autoGap){
+          if ( layoutType === 'grid' ) return  align[0];
+          return autoGap ? align : align[(layoutType === 'row' ? 0 : 1)];
+        })
+      });
+    }
+  ]
+});

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -107,7 +107,7 @@ foam.CLASS({
         // Upgrade single values to [value, value].
         for ( var i = 0 ; i < nu.length ; i++ ) {
           if ( ! Array.isArray(nu[i]) ) {
-            nu[i] = [ nu[i], nu[i] ];
+            nu[i] = [ nu[i], foam.String.labelize(nu[i]) ];
           }
         }
 

--- a/src/foam/u2/view/ViewConfiguratorView.js
+++ b/src/foam/u2/view/ViewConfiguratorView.js
@@ -21,6 +21,8 @@ foam.CLASS({
     'foam.u2.Tab'
   ],
 
+  exports: ['clsDAO'],
+
   TODO: "reactions_ dont currently work when set on view properties",
 
   constants: {
@@ -54,19 +56,31 @@ foam.CLASS({
       value: true
     },
     {
+      name: 'clsDAO',
+      hidden: true,
+      factory: function() {
+        let a = foam.dao.MDAO.create({ of: foam.mlang.LabeledValue }, this);
+        [...Object.keys(foam.USED), ...Object.keys(foam.UNUSED)].map(v => {
+          a.put(foam.mlang.LabeledValue.create({ label: v }), this);
+        });
+        return a;
+      }
+    },
+    {
       name: 'viewClass',
       section: 'viewSection',
-      view: {
-        class: 'foam.u2.view.ClassCompleterView',
-        filterPredicate: foam.mlang.predicate.Func.create({
-          fn: function(v) {
-            let cls = v
-            if ( foam.String.isInstance(cls) ) 
-              cls = this.__subContext__.maybeLookup(cls);
-            if ( ! cls ) return false;
-            if ( foam.u2.Element.isSubClass(cls) ) return true;
-          }
-        })
+      view: function(_,X) {
+        return {
+          class: 'foam.u2.view.RichChoiceView',
+          of: foam.mlang.LabeledValue,
+          search: true,
+          sections: [
+            {
+              heading: 'Classes',
+              dao: X.clsDAO
+            }
+          ]
+        };
       },
       expression: function(data_) {
         return data_?.cls_.id ?? '';
@@ -130,9 +144,13 @@ foam.CLASS({
         if ( cls ) {
           let el = cls.create({}, this);
           el.id = this.traceId;
-          el.element_.u3 = this;
+          el.element_.u3 = el;
+          let children = this.data_?.childNodes || [];
           el.replaceElement_(this.data_);
-          this.data_.detach();
+          this.data_.childNodes = [];
+          children.forEach(v => {
+            if ( v.moveTo ) v.moveTo(el);
+          });
           this.data_ = el;
         }
       }
@@ -154,7 +172,9 @@ foam.CLASS({
       name: 'updateViewSpec',
       isFramed: true,
       code: function() {
-        this.data = this.VIEW_SPEC_OUTPUTTER.objectify(this.data_);
+        let c = this.VIEW_SPEC_OUTPUTTER.objectify(this.data_);
+        if ( ! foam.Object.equals(this.data, c) )
+          this.data = c;
       }
     }
   ]


### PR DESCRIPTION
- Adds a 'layout' command to console. LayoutBlocks are essentially nested consoles and children can be added by typing in the layout command bar. (Drag and drop functionality coming after this PR). Layouts also allow for styling their child blocks in flex/grid layouts
- Adds borders to all console blocks: Blocks have updated UI, along with a new block properties tab in the right sidebar. This new tab allows setting block names and borders for now. Limited border support currently but more can be added easily. Blocks wrap their content in a WrapperNode so it can easily be moved between borders.
- Fixed flowChildren nesting and building flowChildren from a script and saving them to a FLOW script
