### PR TITLE
bring up block value access of flowChildren

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1152,7 +1152,7 @@ foam.CLASS({
       // Add bindings for children
       this.flowChildren.forEach(c => {
         if ( c.value ) {
-          s[c.flowName] = foam.lang.Holder.isInstance(c.value) ? c.value.value : c.value;
+          s[c.flowName] = foam.lang.Holder.isInstance(c.value) ? c.value.value : c.value?.value || c.value;
         }
       });
     },


### PR DESCRIPTION
Sum blocks required access <blockName>.value.value since the block was DAOPromt, value was sum and the actual value desired was value of sum.

Here we return the value.value as block.value if available.

@kgrgreer suggest