### PR TITLE
PT-FIXES DOS-327 DOS-600 Jar builds, Fix image file precedence

### DIFF
--- a/tools/ImageMaker.js
+++ b/tools/ImageMaker.js
@@ -17,7 +17,7 @@ exports.init = function() {
 
 exports.visitDir = function(pom, f, fn) {
   if ( f.name === 'images' || ( f.name === 'favicon' && ! fn.includes('images') ) ) {
-    this.log(`[Image Maker] Found ${fn}`);
+    this.verbose(`[Image Maker] Found ${fn}`);
     // Collect directories instead of copying immediately
     this.imageDirs.push(fn);
   }

--- a/tools/ImageMaker.js
+++ b/tools/ImageMaker.js
@@ -30,7 +30,7 @@ exports.end = function() {
     return;
   }
   
-  this.log(`[Image Maker] Processing ${this.imageDirs.length} image directories in reverse order`);
+  this.verbose(`[Image Maker] Processing ${this.imageDirs.length} image directories in reverse order`);
   
   // Reverse the array so application directories are processed last
   // That way if Application and FOAM have two images with same filename (e.g. export-icon.svg) then Application file will override FOAM image

--- a/tools/ImageMaker.js
+++ b/tools/ImageMaker.js
@@ -9,12 +9,36 @@ exports.description = 'Copies image/* files into /build/images';
 exports.init = function() {
   X.imagedir = X.builddir + '/images';
   this.ensureDir(X.imagedir);
+  // Collect image directories to process them in reverse order 
+  // Why Reverse: check exports.end (contains `this.copyDir(..)`)
+  this.imageDirs = [];
 }
 
 
 exports.visitDir = function(pom, f, fn) {
   if ( f.name === 'images' || ( f.name === 'favicon' && ! fn.includes('images') ) ) {
+    this.log(`[Image Maker] Found ${fn}`);
+    // Collect directories instead of copying immediately
+    this.imageDirs.push(fn);
+  }
+}
+
+// Process collected directories in reverse order
+exports.end = function() {
+  if ( ! this.imageDirs || this.imageDirs.length === 0 ) {
+    this.log('[Image Maker] No image directories to process');
+    return;
+  }
+  
+  this.log(`[Image Maker] Processing ${this.imageDirs.length} image directories in reverse order`);
+  
+  // Reverse the array so application directories are processed last
+  // That way if Application and FOAM have two images with same filename (e.g. export-icon.svg) then Application file will override FOAM image
+  // As opposed, to previously when FOAM images would overwrite Application images if name was same.
+  this.imageDirs.reverse().forEach(fn => {
     this.log(`[Image Maker] Copying ${fn} to ${X.imagedir}`);
     this.copyDir(fn, X.imagedir);
-  }
+  });
+  
+  this.log('[Image Maker] Completed copying images');
 }


### PR DESCRIPTION
Fix image file precedence by processing dirs in reverse.

The change ensures app-level images override framework images when they share the same filename by collecting directories first, then processing them in reverse order for jar builds.