### PR TITLE
replay - support setting synchronous replay from EasyDAO

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -568,6 +568,12 @@ foam.CLASS({
       value: true
     },
     {
+      documentation: 'See JDAO and F3FileJournal.  Default journal replay is asynchronous. Some models with business logic that reference self can cause deadlock when parsed out of order.  If journal processing hangs, set syncReplay to true to replay synchronously.',
+      class: 'Boolean',
+      name: 'syncReplay',
+      value: true
+    },
+    {
       documentation: `Enable NDiff in JDAO. Enable per DAO with this property or globally via JVM Parameter 'UseNDiff'`,
       class: 'Boolean',
       name: 'ndiff',
@@ -943,6 +949,7 @@ foam.CLASS({
             jdao.setFilename(getJournalName());
             jdao.setCluster(getCluster() && !getSaf());
             jdao.setWaitReplay(getWaitReplay());
+            jdao.setSyncReplay(getSyncReplay());
             jdao.setNdiff(getNdiff());
             // Setting of delegate must be last as it triggers replay
             jdao.setDelegate(delegate);

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -31,7 +31,7 @@ foam.CLASS({
       name: 'dao'
     },
     {
-      documentation: 'Perform replay synchronously. Manual workaround for deadlock with AsyncAssemblyLine',
+      documentation: 'Default journal replay is asynchronous. Some models with business logic that reference self can cause deadlock when parsed out of order.  If journal processing hangs, set syncReplay to true to replay synchronously.',
       class: 'Boolean',
       name: 'syncReplay'
     },

--- a/src/foam/dao/java/JDAO.js
+++ b/src/foam/dao/java/JDAO.js
@@ -64,10 +64,9 @@ In this current implementation setDelegate must be called last.`,
       name: 'journal'
     },
     {
-      documentation: 'Perform replay synchronously. Manual workaround for deadlock with AsyncAssemblyLine',
+      documentation: 'See F3FileJournal. Default journal replay is asynchronous. Some models with business logic that reference self can cause deadlock when parsed out of order.  If journal processing hangs, set syncReplay to true to replay synchronously.',
       class: 'Boolean',
-      name: 'syncReplay',
-      value: true
+      name: 'syncReplay'
     },
     {
       documentation: `Force caller to wait on nspec initailzation. The first call to 'get' for an nspec (x.get(servicename)) will have the calling thread wait on reply of service. This is the default behaviour and should be used for all essential services.  Also this should be used if the model is using SeqNo or NUID for id generation.`,

--- a/src/foam/util/concurrent/AbstractAssembly.js
+++ b/src/foam/util/concurrent/AbstractAssembly.js
@@ -76,7 +76,7 @@ foam.CLASS({
       javaCode: `
          while ( ! getIsCompleted() ) {
            try {
-             wait(1000);
+             wait();
            } catch (InterruptedException e) {
              // NOP
              Thread.currentThread().interrupt();


### PR DESCRIPTION
support setting synchronous replay from EasyDAO for models with business logic which cause deadlock when parsed out of order