### PR TITLE
PT-FIXES: DOS-669 : remove redundant CSS overflow property from LayoutNode

### DIFF
--- a/src/foam/core/reflow/LayoutBlock.js
+++ b/src/foam/core/reflow/LayoutBlock.js
@@ -139,6 +139,13 @@ foam.CLASS({
   name: 'LayoutNode',
   extends: 'foam.core.reflow.Block',
   mixins: ['foam.u2.layouts.LayoutChild', 'foam.core.reflow.LayoutUtils'],
+  
+  css: `
+    ^ {
+      overflow: hidden;
+    }
+  `,
+  
   methods: [
     function render() {
       this.addLayoutProps();

--- a/src/foam/core/reflow/LayoutBlock.js
+++ b/src/foam/core/reflow/LayoutBlock.js
@@ -139,11 +139,6 @@ foam.CLASS({
   name: 'LayoutNode',
   extends: 'foam.core.reflow.Block',
   mixins: ['foam.u2.layouts.LayoutChild', 'foam.core.reflow.LayoutUtils'],
-  css: `
-    ^ {
-      overflow: hidden;
-    }
-  `,
   methods: [
     function render() {
       this.addLayoutProps();

--- a/src/foam/core/reflow/LayoutBlock.js
+++ b/src/foam/core/reflow/LayoutBlock.js
@@ -139,13 +139,11 @@ foam.CLASS({
   name: 'LayoutNode',
   extends: 'foam.core.reflow.Block',
   mixins: ['foam.u2.layouts.LayoutChild', 'foam.core.reflow.LayoutUtils'],
-  
   css: `
     ^ {
       overflow: hidden;
     }
   `,
-  
   methods: [
     function render() {
       this.addLayoutProps();

--- a/src/foam/u2/filter/properties/PropertyFilterView.js
+++ b/src/foam/u2/filter/properties/PropertyFilterView.js
@@ -66,7 +66,7 @@ foam.CLASS({
     }
 
     ^container-filter {
-      position: absolute;
+      position: fixed;
       z-index: 100;
       margin-top: 8px;
 


### PR DESCRIPTION
daofilter view content was hidden 
<img width="353" height="348" alt="image" src="https://github.com/user-attachments/assets/f975b4de-133b-4aec-ba40-a0e19926faff" />
after this pr 
<img width="356" height="389" alt="image" src="https://github.com/user-attachments/assets/6c775639-f3ff-47f1-bcfa-a09ab5321929" />
