### PR TITLE
Remove-width-control

### DIFF
--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -89,23 +89,6 @@ foam.CLASS({
       }
     },
     {
-      class: 'Int',
-      name: 'width',
-      label: 'Chart Width (px)',
-      value: 400,
-      view: {
-        class: 'foam.u2.RangeView',
-        minValue: 200,
-        maxValue: 1200,
-        step: 10,
-        onKey: true
-      },
-      help: 'Width in pixels (200-1200)',
-      visibility: function(responsive) {
-        return !responsive ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    {
       class: 'Boolean',
       name: 'showLegend',
       label: 'Show Legend',
@@ -163,7 +146,7 @@ foam.CLASS({
       var self = this;
       // Add chart display configuration fields to the UI
       e.start('div').style({marginBottom: '10px'})
-        .add('Height: ', this.HEIGHT, 'px Width: ', this.WIDTH, 'px')
+        .add('Height: ', this.HEIGHT)
       .end()
       .start('div').style({marginBottom: '10px'})
         .add('Legend: ', this.SHOW_LEGEND)
@@ -233,7 +216,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height', 'width', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: ['responsive', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -331,7 +314,7 @@ foam.CLASS({
         responsive: this.responsive,
         maintainAspectRatio: this.maintainAspectRatio,
         height: this.height,
-        width: this.width,
+        
         showLegend: this.showLegend,
         legendPosition: this.legendPosition,
         showTooltips: this.showTooltips,
@@ -350,7 +333,7 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, horizontal, barThickness, xAxisLabel, yAxisLabel, showGridLines, 
-                                  responsive, maintainAspectRatio, height, width, showLegend, legendPosition, 
+                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.colors = colors;
         s.horizontal = horizontal;
@@ -361,7 +344,6 @@ foam.CLASS({
         s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
-        s.width = width;
         s.showLegend = showLegend;
         s.legendPosition = legendPosition;
         s.showTooltips = showTooltips;
@@ -394,7 +376,7 @@ foam.CLASS({
       clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-      clone.width$ = this.width$;
+
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;
@@ -447,7 +429,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height', 'width', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: ['responsive', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -534,7 +516,6 @@ foam.CLASS({
         responsive: this.responsive,
         maintainAspectRatio: this.maintainAspectRatio,
         height: this.height,
-        width: this.width,
         showLegend: this.showLegend,
         legendPosition: this.legendPosition,
         showTooltips: this.showTooltips,
@@ -551,7 +532,7 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, horizontal, xAxisLabel, yAxisLabel, showGridLines,
-                                  responsive, maintainAspectRatio, height, width, showLegend, legendPosition, 
+                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.colors = colors;
         s.horizontal = horizontal;
@@ -561,7 +542,6 @@ foam.CLASS({
         s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
-        s.width = width;
         s.showLegend = showLegend;
         s.legendPosition = legendPosition;
         s.showTooltips = showTooltips;
@@ -593,7 +573,7 @@ foam.CLASS({
       clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-      clone.width$ = this.width$;
+
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;
@@ -639,7 +619,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 3,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height', 'width', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: ['responsive', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -727,7 +707,7 @@ foam.CLASS({
         responsive: this.responsive,
         maintainAspectRatio: this.maintainAspectRatio,
         height: this.height,
-        width: this.width,
+        
         showLegend: this.showLegend,
         legendPosition: this.legendPosition,
         showTooltips: this.showTooltips,
@@ -745,7 +725,7 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(cutoutPercentage, rotation, colors, showPercentages, clockwise,
-                                  responsive, maintainAspectRatio, height, width, showLegend, legendPosition, 
+                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.cutoutPercentage = cutoutPercentage;
         s.rotation = rotation;
@@ -755,7 +735,6 @@ foam.CLASS({
         s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
-        s.width = width;
         s.showLegend = showLegend;
         s.legendPosition = legendPosition;
         s.showTooltips = showTooltips;
@@ -785,7 +764,7 @@ foam.CLASS({
       clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-      clone.width$ = this.width$;
+
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;
@@ -843,7 +822,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height', 'width', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: ['responsive', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -989,7 +968,7 @@ foam.CLASS({
           responsive: this.responsive,
           maintainAspectRatio: this.maintainAspectRatio,
           height: this.height,
-          width: this.width,
+          
           showLegend: this.showLegend,
           legendPosition: this.legendPosition,
           showTooltips: this.showTooltips,
@@ -1015,7 +994,7 @@ foam.CLASS({
           responsive: this.responsive,
           maintainAspectRatio: this.maintainAspectRatio,
           height: this.height,
-          width: this.width,
+          
           showLegend: this.showLegend,
           legendPosition: this.legendPosition,
           showTooltips: this.showTooltips,
@@ -1037,7 +1016,7 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, xAxisLabel, yAxisLabel, fill, tension, stepped, showPoints, pointRadius, showGridLines,
-                                  responsive, maintainAspectRatio, height, width, showLegend, legendPosition, 
+                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.colors = colors;
         s.xAxisLabel = xAxisLabel;
@@ -1051,7 +1030,6 @@ foam.CLASS({
         s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
-        s.width = width;
         s.showLegend = showLegend;
         s.legendPosition = legendPosition;
         s.showTooltips = showTooltips;
@@ -1087,7 +1065,7 @@ foam.CLASS({
       clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-      clone.width$ = this.width$;
+
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -56,13 +56,6 @@ foam.CLASS({
   properties: [
     {
       class: 'Boolean',
-      name: 'responsive',
-      label: 'Responsive',
-      value: true,
-      visibility: 'HIDDEN'
-    },
-    {
-      class: 'Boolean',
       name: 'maintainAspectRatio',
       label: 'Maintain Aspect Ratio',
       value: true
@@ -165,7 +158,7 @@ foam.CLASS({
         }))
       .end()
       .start('div').style({marginBottom: '10px'})
-        .add('Responsive: ', this.RESPONSIVE, ' Maintain Ratio: ', this.MAINTAIN_ASPECT_RATIO)
+        .add(' Maintain Ratio: ', this.MAINTAIN_ASPECT_RATIO)
       .end();
     }
   ]
@@ -216,7 +209,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: [ 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -311,10 +304,8 @@ foam.CLASS({
         xAxisLabel: this.xAxisLabel,
         yAxisLabel: this.yAxisLabel,
         showGridLines: this.showGridLines,
-        responsive: this.responsive,
         maintainAspectRatio: this.maintainAspectRatio,
         height: this.height,
-        
         showLegend: this.showLegend,
         legendPosition: this.legendPosition,
         showTooltips: this.showTooltips,
@@ -333,7 +324,7 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, horizontal, barThickness, xAxisLabel, yAxisLabel, showGridLines, 
-                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
+                                  maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.colors = colors;
         s.horizontal = horizontal;
@@ -341,7 +332,6 @@ foam.CLASS({
         s.xAxisLabel = xAxisLabel;
         s.yAxisLabel = yAxisLabel;
         s.showGridLines = showGridLines;
-        s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
         s.showLegend = showLegend;
@@ -373,10 +363,8 @@ foam.CLASS({
       clone.xAxisLabel$ = this.xAxisLabel$;
       clone.yAxisLabel$ = this.yAxisLabel$;
       clone.showGridLines$ = this.showGridLines$;
-      clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;
@@ -429,7 +417,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: [ 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -513,7 +501,6 @@ foam.CLASS({
         xAxisLabel: this.xAxisLabel,
         yAxisLabel: this.yAxisLabel,
         showGridLines: this.showGridLines,
-        responsive: this.responsive,
         maintainAspectRatio: this.maintainAspectRatio,
         height: this.height,
         showLegend: this.showLegend,
@@ -532,14 +519,13 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, horizontal, xAxisLabel, yAxisLabel, showGridLines,
-                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
+                                  maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.colors = colors;
         s.horizontal = horizontal;
         s.xAxisLabel = xAxisLabel;
         s.yAxisLabel = yAxisLabel;
         s.showGridLines = showGridLines;
-        s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
         s.showLegend = showLegend;
@@ -570,10 +556,8 @@ foam.CLASS({
       clone.xAxisLabel$ = this.xAxisLabel$;
       clone.yAxisLabel$ = this.yAxisLabel$;
       clone.showGridLines$ = this.showGridLines$;
-      clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;
@@ -619,7 +603,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 3,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: [ 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -704,7 +688,6 @@ foam.CLASS({
         cutoutPercentage: this.cutoutPercentage,
         clockwise: this.clockwise,
         rotation: this.rotation,
-        responsive: this.responsive,
         maintainAspectRatio: this.maintainAspectRatio,
         height: this.height,
         
@@ -725,14 +708,13 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(cutoutPercentage, rotation, colors, showPercentages, clockwise,
-                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
+                                  maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.cutoutPercentage = cutoutPercentage;
         s.rotation = rotation;
         s.colors = colors;
         s.showPercentages = showPercentages;
         s.clockwise = clockwise;
-        s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
         s.showLegend = showLegend;
@@ -761,7 +743,6 @@ foam.CLASS({
       clone.colors$ = this.colors$;
       clone.showPercentages$ = this.showPercentages$;
       clone.clockwise$ = this.clockwise$;
-      clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
 
@@ -822,7 +803,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: ['responsive', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: [ 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
     },
     {
       name: 'colors',
@@ -965,10 +946,8 @@ foam.CLASS({
           showPoints: this.showPoints,
           pointRadius: this.pointRadius,
           showGridLines: this.showGridLines,
-          responsive: this.responsive,
           maintainAspectRatio: this.maintainAspectRatio,
-          height: this.height,
-          
+          height: this.height,    
           showLegend: this.showLegend,
           legendPosition: this.legendPosition,
           showTooltips: this.showTooltips,
@@ -991,10 +970,8 @@ foam.CLASS({
           showPoints: this.showPoints,
           pointRadius: this.pointRadius,
           showGridLines: this.showGridLines,
-          responsive: this.responsive,
           maintainAspectRatio: this.maintainAspectRatio,
           height: this.height,
-          
           showLegend: this.showLegend,
           legendPosition: this.legendPosition,
           showTooltips: this.showTooltips,
@@ -1016,7 +993,7 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, xAxisLabel, yAxisLabel, fill, tension, stepped, showPoints, pointRadius, showGridLines,
-                                  responsive, maintainAspectRatio, height, showLegend, legendPosition, 
+                                  maintainAspectRatio, height, showLegend, legendPosition, 
                                   showTooltips, showTooltipSum, animate, animationDuration) { 
         s.colors = colors;
         s.xAxisLabel = xAxisLabel;
@@ -1027,7 +1004,6 @@ foam.CLASS({
         s.showPoints = showPoints;
         s.pointRadius = pointRadius;
         s.showGridLines = showGridLines;
-        s.responsive = responsive;
         s.maintainAspectRatio = maintainAspectRatio;
         s.height = height;
         s.showLegend = showLegend;
@@ -1062,10 +1038,8 @@ foam.CLASS({
       clone.showPoints$ = this.showPoints$;
       clone.pointRadius$ = this.pointRadius$;
       clone.showGridLines$ = this.showGridLines$;
-      clone.responsive$ = this.responsive$;
       clone.maintainAspectRatio$ = this.maintainAspectRatio$;
       clone.height$ = this.height$;
-
       clone.showLegend$ = this.showLegend$;
       clone.legendPosition$ = this.legendPosition$;
       clone.showTooltips$ = this.showTooltips$;

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -725,7 +725,7 @@ foam.CLASS({
     },
     
     function addToE(e) { 
-      e.add(this.chart_$);
+      e.style({ 'min-height': this.height$, height: this.height$ }).add(this.chart_$);
     }
   ]
 });
@@ -942,6 +942,9 @@ foam.CLASS({
   methods: [
     function toE(_, x) { 
       return x.E().add(this.chart_$);
+    },
+    function addToE(e) { 
+      e.style({ 'min-height': this.height$, height: this.height$ }).add(this.chart_$);
     }
   ]
 });

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -1060,7 +1060,7 @@ foam.CLASS({
           if ( decimalPlaces === 0 ) {
             value = parseInt(value).toLocaleString();
           } else {
-            value = parseDouble(value).toLocaleString(undefined, {
+            value = parseFloat(value).toLocaleString(undefined, {
               minimumFractionDigits: decimalPlaces,
               maximumFractionDigits: decimalPlaces
             });


### PR DESCRIPTION
We were hiding responsive and width, but if someone has a script with them it breaks their ui, so this just removes the options from dao agent and uses the right defaults from sinks 

also fixes the line chart not reacting to height changes