### PR TITLE
Address cronjobs not honouring their schedule and running at startup.

### DIFF
--- a/src/cronjobs.jrl
+++ b/src/cronjobs.jrl
@@ -9,7 +9,6 @@ p({
     "dayOfWeek": -1,
     "second": 0
   },
-  "scheduledTime": "2019-09-09T17:00:00.000Z",
   "id": "Renew rule history cron",
   "description": "Cron for renewing rule history - run every hour.",
   "code":

--- a/src/foam/core/alarming/cronjobs.jrl
+++ b/src/foam/core/alarming/cronjobs.jrl
@@ -9,11 +9,8 @@ p({
     "dayOfWeek":-1,
     "second":0
   },
-  "scheduledTime":"2019-09-09T16:56:00.000Z",
   "enabled":false,
   "id":"Alarming and Monitoring",
-  "lastRun":"2019-09-09T16:55:32.134Z",
-  "lastDuration":301,
   "code":"""
   import foam.core.alarming.AlarmConfig;
   import foam.core.alarming.MonitoringReport;

--- a/src/foam/core/cron/Cron.js
+++ b/src/foam/core/cron/Cron.js
@@ -44,10 +44,10 @@ foam.CLASS({
   tableColumns: [
     'id',
     'enabled',
-    'lastDuration',
-    'lastRun',
-    'status',
     'scheduledTime',
+    'status',
+    'lastRun',
+    'lastDuration',
     'run'
   ],
 

--- a/src/foam/core/cron/CronScheduleDAO.js
+++ b/src/foam/core/cron/CronScheduleDAO.js
@@ -25,11 +25,10 @@ foam.CLASS({
       javaCode: `
         Cron newCron = (Cron) obj;
         Cron oldCron = (Cron) getDelegate().find_(x, obj);
-
-        // new or on schedule change.
-        if ( oldCron == null ||
-             oldCron != null &&
-             ! SafetyUtil.equals(oldCron.getSchedule(), newCron.getSchedule()) ) {
+        if ( newCron.getStatus() == ScriptStatus.UNSCHEDULED ||
+             newCron.getStatus() == ScriptStatus.ERROR ||
+             ( oldCron != null &&
+               ! SafetyUtil.equals(oldCron.getSchedule(), newCron.getSchedule()) ) ) {
           newCron = updateScheduledTime(x, newCron);
         }
         return getDelegate().put_(x, newCron);

--- a/src/foam/core/cron/CronScheduleDAO.js
+++ b/src/foam/core/cron/CronScheduleDAO.js
@@ -9,10 +9,13 @@ foam.CLASS({
   name: 'CronScheduleDAO',
   extends: 'foam.dao.ProxyDAO',
 
-  documentation: 'Update cron scheduledTime on schedule changed',
+  documentation: 'Cron scheduledTime is storageTransient, calculate on find and select, and update on put',
 
   javaImports: [
     'foam.core.script.ScriptStatus',
+    'foam.dao.ProxySink',
+    'foam.dao.Sink',
+    'foam.lang.X',
     'foam.util.SafetyUtil'
   ],
 
@@ -22,13 +25,52 @@ foam.CLASS({
       javaCode: `
         Cron newCron = (Cron) obj;
         Cron oldCron = (Cron) getDelegate().find_(x, obj);
-        if ( newCron.getStatus() == ScriptStatus.UNSCHEDULED ||
-             newCron.getStatus() == ScriptStatus.ERROR ||
-             ( oldCron != null &&
-               ! SafetyUtil.equals(oldCron.getSchedule(), newCron.getSchedule()) ) ) {
-          newCron.setScheduledTime(newCron.getNextScheduledTime(x));
+
+        // new or on schedule change.
+        if ( oldCron == null ||
+             oldCron != null &&
+             ! SafetyUtil.equals(oldCron.getSchedule(), newCron.getSchedule()) ) {
+          newCron = updateScheduledTime(x, newCron);
         }
         return getDelegate().put_(x, newCron);
+      `
+    },
+    {
+      name: 'find_',
+      javaCode: `
+        Cron cron = (Cron) getDelegate().find_(x, id);
+        return updateScheduledTime(x, cron);
+      `
+    },
+    {
+      name: 'select_',
+      javaCode: `
+      Sink delegate = prepareSink(sink);
+      getDelegate().select_(x,
+        new ProxySink(x, delegate) {
+          public void put(Object obj, foam.lang.Detachable sub) {
+            getDelegate().put(updateScheduledTime(x, (Cron) obj), sub);
+          }
+        }, skip, limit, order, predicate);
+      return delegate;
+      `
+    },
+    {
+      name: 'updateScheduledTime',
+      args: 'X x, Cron cron',
+      type: 'Cron',
+      javaCode: `
+        if ( cron != null &&
+             cron.getEnabled() &&
+             ( cron.getStatus() == ScriptStatus.UNSCHEDULED ||
+               cron.getStatus() == ScriptStatus.ERROR ) &&
+             cron.getScheduledTime() == null ) {
+          if ( cron.isFrozen() ) {
+            cron = (Cron) cron.fclone();
+          }
+          cron.setScheduledTime(cron.getNextScheduledTime(x));
+        }
+        return cron;
       `
     }
   ]

--- a/src/foam/core/cron/CronScheduleDAO.js
+++ b/src/foam/core/cron/CronScheduleDAO.js
@@ -9,13 +9,10 @@ foam.CLASS({
   name: 'CronScheduleDAO',
   extends: 'foam.dao.ProxyDAO',
 
-  documentation: 'Cron scheduledTime is storageTransient, calculate on find and select, and update on put',
+  documentation: 'Recalculate next scheduledTime on update',
 
   javaImports: [
     'foam.core.script.ScriptStatus',
-    'foam.dao.ProxySink',
-    'foam.dao.Sink',
-    'foam.lang.X',
     'foam.util.SafetyUtil'
   ],
 
@@ -25,51 +22,17 @@ foam.CLASS({
       javaCode: `
         Cron newCron = (Cron) obj;
         Cron oldCron = (Cron) getDelegate().find_(x, obj);
-        if ( newCron.getStatus() == ScriptStatus.UNSCHEDULED ||
-             newCron.getStatus() == ScriptStatus.ERROR ||
-             ( oldCron != null &&
-               ! SafetyUtil.equals(oldCron.getSchedule(), newCron.getSchedule()) ) ) {
-          newCron = updateScheduledTime(x, newCron);
+        if ( newCron.getEnabled() &&
+             ( newCron.getStatus() == ScriptStatus.UNSCHEDULED ||
+               newCron.getStatus() == ScriptStatus.ERROR ||
+               ( oldCron != null &&
+                 ! SafetyUtil.equals(oldCron.getSchedule(), newCron.getSchedule()) ) ) ) {
+          if ( newCron.isFrozen() ) {
+            newCron = (Cron) newCron.fclone();
+          }
+          newCron.setScheduledTime(newCron.getNextScheduledTime(x));
         }
         return getDelegate().put_(x, newCron);
-      `
-    },
-    {
-      name: 'find_',
-      javaCode: `
-        Cron cron = (Cron) getDelegate().find_(x, id);
-        return updateScheduledTime(x, cron);
-      `
-    },
-    {
-      name: 'select_',
-      javaCode: `
-      Sink delegate = prepareSink(sink);
-      getDelegate().select_(x,
-        new ProxySink(x, delegate) {
-          public void put(Object obj, foam.lang.Detachable sub) {
-            getDelegate().put(updateScheduledTime(x, (Cron) obj), sub);
-          }
-        }, skip, limit, order, predicate);
-      return delegate;
-      `
-    },
-    {
-      name: 'updateScheduledTime',
-      args: 'X x, Cron cron',
-      type: 'Cron',
-      javaCode: `
-        if ( cron != null &&
-             cron.getEnabled() &&
-             ( cron.getStatus() == ScriptStatus.UNSCHEDULED ||
-               cron.getStatus() == ScriptStatus.ERROR ) &&
-             cron.getScheduledTime() == null ) {
-          if ( cron.isFrozen() ) {
-            cron = (Cron) cron.fclone();
-          }
-          cron.setScheduledTime(cron.getNextScheduledTime(x));
-        }
-        return cron;
       `
     }
   ]

--- a/src/foam/core/cron/CronScheduledComparator.js
+++ b/src/foam/core/cron/CronScheduledComparator.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.cron',
+  name: 'CronScheduledComparator',
+  implements: ['foam.mlang.order.Comparator'],
+
+  documentation: 'Comparator function for ordering Crons for table view.',
+
+  methods: [
+    {
+      name: 'compare',
+      javaCode: `
+          if ( o1 == null && o2 == null ) return 0;
+          if ( o1 == null ) return -1;
+          if ( o2 == null ) return 1;
+
+          Cron c1 = (Cron) o1;
+          Cron c2 = (Cron) o2;
+
+          // Enabled before disabled
+          if ( c1.getEnabled() && ! c2.getEnabled() ) return -1;
+          if ( ! c1.getEnabled() && c2.getEnabled() ) return 1;
+
+          // Scheduled Time - earliest first (next to run)
+          if ( c1.getScheduledTime() != null && c2.getScheduledTime() != null ) {
+            int result = c1.getScheduledTime().compareTo(c2.getScheduledTime());
+            if ( result == 0 )
+              return c1.getId().compareTo(c2.getId());
+            return result;
+          }
+          if ( c1.getScheduledTime() != null ) return 1;
+          if ( c2.getScheduledTime() != null ) return -1;
+
+          // Last Run - greatest (most recent) first
+          if ( c1.getLastRun() != null && c2.getLastRun() != null ) {
+            int result = c2.getLastRun().compareTo(c1.getLastRun());
+            if ( result == 0 )
+              return c1.getId().compareTo(c2.getId());
+            return result;
+          }
+          if ( c1.getLastRun() != null ) return 1;
+          if ( c2.getLastRun() != null ) return -1;
+
+          if ( c1.getEnabled() ) return -1;
+          if ( c2.getEnabled() ) return 1;
+
+          return c1.getId().compareTo(c2.getId());
+      `
+    },
+    {
+      name: 'createStatement',
+      javaCode: 'return null;',
+    },
+    {
+      name: 'prepareStatement',
+      javaCode: 'return;'
+    },
+  ]
+});

--- a/src/foam/core/cron/CronScheduler.js
+++ b/src/foam/core/cron/CronScheduler.js
@@ -93,9 +93,11 @@ foam.CLASS({
     final Logger logger = Loggers.logger(x, this);
     try {
       logger.info("initialize", "cronjobs", "start");
+      DAO cronJobDAO = (DAO) x.get(getCronJobDAO());
       DAO schedulableDAO = (DAO) getX().get(getSchedulableDAO());
       schedulableDAO.where(MLang.EQ(Schedulable.ENABLED, true)).
-        select(new Sink() {
+        select(new AbstractSink() {
+          @Override
           public void put(Object obj, Detachable sub) {
             Schedulable schedulable = (Schedulable) ((FObject) obj).fclone();
             Date from = schedulable.getLastRun();
@@ -108,19 +110,32 @@ foam.CLASS({
                   true
                 )
             );
-            ((DAO) x.get(getCronJobDAO())).put(schedulable);
+            cronJobDAO.put_(x, schedulable);
           }
-          public void remove(Object obj, Detachable sub) {}
-          public void eof() {}
-          public void reset(Detachable sub) {}
         });
+
+      // On startup calculate next scheduledTime
+      cronJobDAO.where(
+        MLang.AND(
+          MLang.EQ(Cron.ENABLED, true),
+          MLang.IN(Cron.STATUS, new ScriptStatus[] {
+            ScriptStatus.UNSCHEDULED,
+            ScriptStatus.ERROR
+          })
+        )
+      ).select(new AbstractSink() {
+        @Override
+        public void put(Object obj, Detachable sub) {
+          cronJobDAO.put_(x, (Cron) obj);
+        }
+      });
+
       logger.info("initialize", "cronjobs", "complete");
 
       while ( true ) {
         long delay = getCronDelay();
         if ( getEnabled() ) {
           Date now = new Date();
-          DAO cronJobDAO = (DAO) x.get(getCronJobDAO());
           cronJobDAO.where(
             MLang.AND(
               MLang.EQ(Cron.STATUS, ScriptStatus.RUNNING),
@@ -140,35 +155,32 @@ foam.CLASS({
 
           Min min = (Min) MLang.MIN(Cron.SCHEDULED_TIME);
           ArraySink arraySink = new ArraySink();
-          cronJobDAO.select_(x,
-              new Sequence.Builder(x)
-                .setArgs(new Sink[] {
-                  min,
-                  arraySink
-                }).build(),
-              0, foam.dao.AbstractDAO.MAX_SAFE_INTEGER,
-              null,
-              MLang.AND(
-                MLang.EQ(Cron.ENABLED, true),
-                MLang.IN(Cron.STATUS, new ScriptStatus[] {
-                  ScriptStatus.UNSCHEDULED,
-                  ScriptStatus.ERROR
-                }))
-             );
-          List<Cron> crons = (List) arraySink.getArray();
-          for ( Cron cron : crons ) {
-            try {
-              if ( cron.getScheduledTime().getTime() > now.getTime() ||
-                   ! cron.canRun(x) )
-                continue;
-
-              cron = (Cron) cron.fclone();
-              cron.setStatus(ScriptStatus.SCHEDULED);
-              cronJobDAO.put_(x, cron);
-            } catch (Throwable t) {
-              ((DAO) x.get("eventRecordDAO")).put(new EventRecord(x, this, "schedule", cron.getId(), LogLevel.ERROR, t));
+          cronJobDAO.where(
+            MLang.AND(
+              MLang.EQ(Cron.ENABLED, true),
+              MLang.LTE(Cron.SCHEDULED_TIME, now),
+              MLang.IN(Cron.STATUS, new ScriptStatus[] {
+                ScriptStatus.UNSCHEDULED,
+                ScriptStatus.ERROR
+              }))
+          ).select(new Sequence.Builder(x).setArgs(new Sink[] {
+            min,
+            new AbstractSink() {
+              @Override
+              public void put(Object obj, Detachable sub) {
+                Cron cron = (Cron) obj;
+                if ( cron.canRun(x) ) {
+                  cron = (Cron) cron.fclone();
+                  cron.setStatus(ScriptStatus.SCHEDULED);
+                  try {
+                    cronJobDAO.put_(x, cron);
+                  } catch ( Throwable t ) {
+                    ((DAO) x.get("eventRecordDAO")).put(new EventRecord(x, this, "schedule", cron.getId(), LogLevel.ERROR, t));
+                  }
+                }
+              }
             }
-          }
+          }).build());
 
           // Check for new cronjobs every 5 seconds if no current jobs
           // or if their next scheduled execution time is > 5s away

--- a/src/foam/core/cron/CronScheduler.js
+++ b/src/foam/core/cron/CronScheduler.js
@@ -17,28 +17,30 @@ foam.CLASS({
   documentation: ``,
 
   javaImports: [
+    'foam.core.COREService',
+    'foam.core.auth.EnabledAware',
+    'foam.core.cron.SimpleIntervalSchedule',
+    'foam.core.er.EventRecord',
+    'foam.core.logger.Logger',
+    'foam.core.logger.Loggers',
+    'foam.core.script.ScriptStatus',
+    'foam.dao.AbstractDAO',
+    'foam.dao.AbstractSink',
+    'foam.dao.ArraySink',
+    'foam.dao.DAO',
+    'foam.dao.MapDAO',
+    'foam.dao.Sink',
     'foam.lang.Agency',
     'foam.lang.AgencyTimerTask',
     'foam.lang.ContextAwareSupport',
     'foam.lang.Detachable',
     'foam.lang.FObject',
-    'foam.dao.AbstractDAO',
-    'foam.dao.AbstractSink',
-    'foam.dao.DAO',
-    'foam.dao.MapDAO',
-    'foam.dao.Sink',
     'foam.log.LogLevel',
     'foam.mlang.MLang',
     'foam.mlang.sink.Min',
-    'foam.core.alarming.Alarm',
-    'foam.core.alarming.AlarmReason',
-    'foam.core.auth.EnabledAware',
-    'foam.core.cron.SimpleIntervalSchedule',
-    'foam.core.logger.Logger',
-    'foam.core.logger.Loggers',
-    'foam.core.COREService',
-    'foam.core.script.ScriptStatus',
+    'foam.mlang.sink.Sequence',
     'java.util.Date',
+    'java.util.List',
     'java.util.Timer'
   ],
 
@@ -86,26 +88,6 @@ foam.CLASS({
       `
     },
     {
-      documentation: 'Get the minimum scheduled cron job',
-      name: 'getMinScheduledTime',
-      type: 'DateTime',
-      javaCode: `
-    Min min = (Min) ((DAO) getX().get(getCronJobDAO()))
-      .where(
-        MLang.AND(
-          MLang.EQ(Cron.ENABLED, true),
-          MLang.HAS(Cron.SCHEDULED_TIME)
-        ))
-      .select(MLang.MIN(Cron.SCHEDULED_TIME));
-
-    if ( min.getValue().equals(0) ) {
-      return null;
-    }
-
-    return (Date) min.getValue();
-      `
-    },
-    {
       name: 'execute',
       javaCode: `
     final Logger logger = Loggers.logger(x, this);
@@ -135,6 +117,7 @@ foam.CLASS({
       logger.info("initialize", "cronjobs", "complete");
 
       while ( true ) {
+        long delay = getCronDelay();
         if ( getEnabled() ) {
           Date now = new Date();
           DAO cronJobDAO = (DAO) x.get(getCronJobDAO());
@@ -155,49 +138,49 @@ foam.CLASS({
             }
           });
 
-          cronJobDAO.where(
-                         MLang.AND(
-                                   MLang.LTE(Cron.SCHEDULED_TIME, now),
-                                   MLang.EQ(Cron.ENABLED, true),
-                                   MLang.IN(Cron.STATUS, new ScriptStatus[] {
-                                                          ScriptStatus.UNSCHEDULED,
-                                                          ScriptStatus.ERROR,
-                                     })
-                                   )
-                         )
-            .orderBy(Cron.SCHEDULED_TIME)
-            .select(new AbstractSink() {
-                             @Override
-                             public void put(Object obj, Detachable sub) {
-                               Cron cron = (Cron) ((FObject) obj).fclone();
-                               try {
-                                 if ( cron.canRun(x) ) {
-                                   cron.setStatus(ScriptStatus.SCHEDULED);
-                                   cronJobDAO.put_(x, cron);
-                                 }
-                               } catch (Throwable t) {
-                                 logger.error("Unable to schedule cron job", cron.getId(), t.getMessage(), t);
-                                 Alarm alarm = new Alarm("CronScheduler - Unabled to schedule");
-                                 alarm.setSeverity(LogLevel.ERROR);
-                                 alarm.setReason(AlarmReason.CONFIGURATION);
-                                 alarm.setNote(cron.getId()+"\\n"+t.getMessage());
-                                 ((DAO) x.get("alarmDAO")).put(alarm);
-                               }
-                             }
-                           });
-        }
-        // Check for new cronjobs every 5 seconds if no current jobs
-        // or if their next scheduled execution time is > 5s away
-        // Delay at least a little bit to avoid blocking in case of a script error.
-        long delay = getCronDelay();
-        Date minScheduledTime = getMinScheduledTime();
-        if( minScheduledTime != null &&
-            getEnabled() ) {
-          delay = Math.abs(minScheduledTime.getTime() - System.currentTimeMillis());
-          delay = Math.min(getCronDelay(), delay);
-          delay = Math.max(500, delay);
-        }
+          Min min = (Min) MLang.MIN(Cron.SCHEDULED_TIME);
+          ArraySink arraySink = new ArraySink();
+          cronJobDAO.select_(x,
+              new Sequence.Builder(x)
+                .setArgs(new Sink[] {
+                  min,
+                  arraySink
+                }).build(),
+              0, foam.dao.AbstractDAO.MAX_SAFE_INTEGER,
+              null,
+              MLang.AND(
+                MLang.EQ(Cron.ENABLED, true),
+                MLang.IN(Cron.STATUS, new ScriptStatus[] {
+                  ScriptStatus.UNSCHEDULED,
+                  ScriptStatus.ERROR
+                }))
+             );
+          List<Cron> crons = (List) arraySink.getArray();
+          for ( Cron cron : crons ) {
+            try {
+              if ( cron.getScheduledTime().getTime() > now.getTime() ||
+                   ! cron.canRun(x) )
+                continue;
 
+              cron = (Cron) cron.fclone();
+              cron.setStatus(ScriptStatus.SCHEDULED);
+              cronJobDAO.put_(x, cron);
+            } catch (Throwable t) {
+              ((DAO) x.get("eventRecordDAO")).put(new EventRecord(x, this, "schedule", cron.getId(), LogLevel.ERROR, t));
+            }
+          }
+
+          // Check for new cronjobs every 5 seconds if no current jobs
+          // or if their next scheduled execution time is > 5s away
+          // Delay at least a little bit to avoid blocking in case of a script error.
+          Date minDate = (Date) min.getValue();
+          if( minDate != null &&
+              getEnabled() ) {
+            delay = Math.abs(minDate.getTime() - System.currentTimeMillis());
+            delay = Math.min(getCronDelay(), delay);
+            delay = Math.max(500, delay);
+          }
+        }
         try {
           Thread.sleep(delay);
         } catch ( InterruptedException e ) {
@@ -205,12 +188,7 @@ foam.CLASS({
         }
       }
     } catch (Throwable t) {
-      logger.error(t.getMessage(), t);
-      ((DAO) x.get("alarmDAO")).put(new foam.core.alarming.Alarm.Builder(x)
-        .setName("CronScheduler")
-        .setSeverity(foam.log.LogLevel.ERROR)
-        .setNote(t.getMessage())
-        .build());
+      ((DAO) x.get("eventRecordDAO")).put(new EventRecord(x, this, "execute", null, LogLevel.ERROR, t));
     }
     `
     }

--- a/src/foam/core/cron/services.jrl
+++ b/src/foam/core/cron/services.jrl
@@ -14,10 +14,6 @@ p({
               .build())
           )
       .setPm(true)
-      .setOrder(new foam.mlang.order.Comparator[] {
-        new foam.mlang.order.Desc.Builder(x).setArg1(foam.core.cron.Cron.ENABLED).build(),
-        new foam.mlang.order.Desc.Builder(x).setArg1(foam.core.cron.Cron.LAST_RUN).build()
-      })
       .setCluster(false)
       .setSaf(false)
       .build()
@@ -36,7 +32,8 @@ p({
     return new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.core.cron.Cron.getOwnClassInfo())
       .setInnerDAO(x.get("localCronJobDAO"))
-      .build();
+      .build()
+      .orderBy(new foam.core.cron.CronScheduledComparator());
   """,
   "client":"""
     {

--- a/src/foam/core/notification/cronjobs.jrl
+++ b/src/foam/core/notification/cronjobs.jrl
@@ -9,7 +9,6 @@ p({
     "dayOfWeek": -1,
     "second": 0
   },
-  "scheduledTime": "2019-09-10T05:00:00.000Z",
   "id": "expired notification",
   "description": "remove expired notifications",
   "code":

--- a/src/foam/core/notification/sms/cronjobs.jrl
+++ b/src/foam/core/notification/sms/cronjobs.jrl
@@ -1,7 +1,6 @@
 p({
   "class":"foam.core.cron.Cron",
   "enabled": false,
-  "scheduledTime": "2020-05-28T00:00.000Z",
   "schedule": {"class":"foam.core.cron.CronSchedule","minute":0,"second":0},
   "id": "Send sms messages",
   "description": "Send sms messages stored in smsMessageDAO every minute through twilio service",

--- a/src/foam/core/pm/cronjobs.jrl
+++ b/src/foam/core/pm/cronjobs.jrl
@@ -12,7 +12,6 @@ p({
     "dayOfWeek": -1,
     "second": 0
   },
-  "scheduledTime": "2019-09-09T17:00:00.000Z",
   "code":
   """
     rm = x.get("pmHourlyReduceManager");

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -215,6 +215,7 @@ foam.POM({
     { name: "cron/CronSchedule",                                                          flags: "js|java" },
     { name: "cron/CronScheduler",                                                         flags: "js|java" },
     { name: "cron/CronScheduleDAO",                                                       flags: "js|java" },
+    { name: "cron/CronScheduledComparator",                                               flags: "java" },
     { name: "cron/IntervalSchedule",                                                      flags: "js|java" },
     { name: "cron/MonthlyChoice",                                                         flags: "js|java" },
     { name: "cron/NeverSchedule",                                                         flags: "js" },


### PR DESCRIPTION
Calculate next scheduled time on 'select' to address cron jobs not honouring their scheduled and running at startup. Cleanup repository cronjob journals, removing storage transient properties left after copy and paste from runtime journals. Add custom comparator to order table view by Scheduled Time.