### PR TITLE
Jetty11 virtual threads (default false/off)

### DIFF
--- a/pom.js
+++ b/pom.js
@@ -55,14 +55,14 @@ foam.POM({
     'org.eclipse.angus:angus-activation:2.0.2',
     'org.eclipse.angus:angus-mail:2.0.3',
     'org.eclipse.angus:imap:2.0.3',
-    'org.eclipse.jetty:jetty-proxy:11.0.23',
-    'org.eclipse.jetty:jetty-alpn-java-server:11.0.23',
-    'org.eclipse.jetty:jetty-http:11.0.23',
-    'org.eclipse.jetty:jetty-jmx:11.0.23', // for source build
-    'org.eclipse.jetty:jetty-util:11.0.23',
-    'org.eclipse.jetty:jetty-util-ajax:11.0.23', // for source build
-    'org.eclipse.jetty.http2:http2-server:11.0.23',
-    'org.eclipse.jetty.websocket:websocket-jetty-server:11.0.23',
+    'org.eclipse.jetty:jetty-proxy:11.0.26',
+    'org.eclipse.jetty:jetty-alpn-java-server:11.0.26',
+    'org.eclipse.jetty:jetty-http:11.0.26',
+    'org.eclipse.jetty:jetty-jmx:11.0.26', // for source build
+    'org.eclipse.jetty:jetty-util:11.0.26',
+    'org.eclipse.jetty:jetty-util-ajax:11.0.26', // for source build
+    'org.eclipse.jetty.http2:http2-server:11.0.26',
+    'org.eclipse.jetty.websocket:websocket-jetty-server:11.0.26',
     'org.eclipse.parsson:parsson:1.1.7',
     'org.glassfish:javax.json:1.1.4',
     'org.jsoup:jsoup:1.15.1', // HTML Parser

--- a/src/foam/core/jetty/HttpServer.js
+++ b/src/foam/core/jetty/HttpServer.js
@@ -220,7 +220,7 @@ foam.CLASS({
         threadPool.setMaxThreads(jettyThreadPoolConfig.getMaxThreads());
         threadPool.setMinThreads(jettyThreadPoolConfig.getMinThreads());
         threadPool.setIdleTimeout(jettyThreadPoolConfig.getIdleTimeout());
-        if ( ! jettyThreadPoolConfig.getEnableVirtualThreads() ) {
+        if ( jettyThreadPoolConfig.getEnableVirtualThreads() ) {
           // https://jetty.org/docs/jetty/12/programming-guide/arch/threads.html#thread-pool-virtual-threads
           // Simple, unlimited, virtual thread Executor.
           threadPool.setVirtualThreadsExecutor(Executors.newVirtualThreadPerTaskExecutor());

--- a/src/foam/core/jetty/HttpServer.js
+++ b/src/foam/core/jetty/HttpServer.js
@@ -39,6 +39,7 @@ foam.CLASS({
     'java.util.Map',
     'java.util.Map.Entry',
     'java.util.Set',
+    'java.util.concurrent.Executors',
     'jakarta.servlet.Servlet',
     'jakarta.servlet.ServletContext',
     'org.apache.commons.io.IOUtils',
@@ -54,15 +55,16 @@ foam.CLASS({
     'org.eclipse.jetty.server.handler.gzip.GzipHandler',
     'org.eclipse.jetty.server.handler.StatisticsHandler',
     'org.eclipse.jetty.servlet.ServletHolder',
+    'org.eclipse.jetty.util.component.Container',
+    'org.eclipse.jetty.util.ssl.SslContextFactory',
+    'org.eclipse.jetty.util.thread.QueuedThreadPool',
+    'org.eclipse.jetty.util.thread.ThreadPool',
     'org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse',
     'org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest',
     'org.eclipse.jetty.websocket.server.JettyWebSocketCreator',
     'org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer',
     'org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer.Configurator',
     'org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer',
-    'org.eclipse.jetty.util.component.Container',
-    'org.eclipse.jetty.util.ssl.SslContextFactory',
-    'org.eclipse.jetty.util.thread.QueuedThreadPool'
   ],
 
   properties: [
@@ -218,6 +220,11 @@ foam.CLASS({
         threadPool.setMaxThreads(jettyThreadPoolConfig.getMaxThreads());
         threadPool.setMinThreads(jettyThreadPoolConfig.getMinThreads());
         threadPool.setIdleTimeout(jettyThreadPoolConfig.getIdleTimeout());
+        if ( ! jettyThreadPoolConfig.getEnableVirtualThreads() ) {
+          // https://jetty.org/docs/jetty/12/programming-guide/arch/threads.html#thread-pool-virtual-threads
+          // Simple, unlimited, virtual thread Executor.
+          threadPool.setVirtualThreadsExecutor(Executors.newVirtualThreadPerTaskExecutor());
+        }
 
         ConnectionStatistics stats = new ConnectionStatistics();
         org.eclipse.jetty.server.Server server =
@@ -225,7 +232,7 @@ foam.CLASS({
 
         if ( getEnableHttp() ) {
           getLogger().info("Starting,HTTP,port", port);
-          
+
           // Play nice behind reverse proxies
           // Respect X-Forwarded-For and X-Forwarded-Proto
           HttpConfiguration config = new HttpConfiguration();

--- a/src/foam/core/jetty/JettyThreadPoolConfig.js
+++ b/src/foam/core/jetty/JettyThreadPoolConfig.js
@@ -25,8 +25,7 @@ foam.CLASS({
     },
     {
       name: 'enableVirtualThreads',
-      class: 'Boolean',
-      value: true
+      class: 'Boolean'
     }
   ]
 });

--- a/src/foam/core/jetty/JettyThreadPoolConfig.js
+++ b/src/foam/core/jetty/JettyThreadPoolConfig.js
@@ -22,6 +22,11 @@ foam.CLASS({
       name: 'idleTimeout',
       class: 'Int',
       value: 60000
+    },
+    {
+      name: 'enableVirtualThreads',
+      class: 'Boolean',
+      value: true
     }
   ]
 });

--- a/src/foam/lang/VirtualThreadAgency.java
+++ b/src/foam/lang/VirtualThreadAgency.java
@@ -29,7 +29,7 @@ public class VirtualThreadAgency extends AbstractAgency implements COREService {
   }
 
   public VirtualThreadAgency() {
-    this("virtual-thread", true);
+    this("vt-", true);
   }
 
   public VirtualThreadAgency(String prefix) {

--- a/src/services.jrl
+++ b/src/services.jrl
@@ -140,7 +140,8 @@ p({
   "lazy": false,
   "serve": false,
   "serviceScript": `
-    return new foam.lang.VirtualThreadAgency();
+    return new foam.core.pool.ThreadPoolAgency.Builder(x)
+      .build();
   `
 })
 

--- a/src/services.jrl
+++ b/src/services.jrl
@@ -140,8 +140,7 @@ p({
   "lazy": false,
   "serve": false,
   "serviceScript": `
-    return new foam.core.pool.ThreadPoolAgency.Builder(x)
-      .build();
+    return new foam.lang.VirtualThreadAgency();
   `
 })
 


### PR DESCRIPTION
Enable use of virtual threads in jetty (when platform permits). 
Jetty 12 has additional support, but Jetty 11 -> 12 is a major migration.
Defaults to false - requires more high load testing. 
