### PR TITLE
IntervalSchedule - refactor nextScheduledTime to start calculation at 'from' date.

### DIFF
--- a/src/foam/core/cron/IntervalSchedule.js
+++ b/src/foam/core/cron/IntervalSchedule.js
@@ -37,10 +37,9 @@ foam.CLASS({
       javaFactory: 'return new foam.core.cron.TimeHMS();'
     },
     {
+      //TODO(jlhughes): split start into startDate and startTime
       class: 'DateTime',
-      name: 'start',
-      factory: function() { return new Date(); },
-      javaFactory: 'return new Date();'
+      name: 'start'
     }
   ],
 
@@ -48,35 +47,24 @@ foam.CLASS({
     {
       name: 'getNextScheduledTime',
       type: 'DateTime',
-      args: [
-        {
-          name: 'x',
-          type: 'X'
-        },
-        {
-          name: 'from',
-          type: 'java.util.Date'
-        }
-      ],
+      args: 'X x, java.util.Date from',
       javaCode:
 `
-Calendar now = Calendar.getInstance();
-now.setTime(from);
-
-Calendar start = Calendar.getInstance();
-start.setTime(getStart());
-if ( now.getTimeInMillis() < start.getTimeInMillis() ) {
-  return start.getTime();
+if ( getStart() != null &&
+     getStart().getTime() > from.getTime() ) {
+  return getStart();
 }
-
 Calendar next = Calendar.getInstance();
-next.setTime(getStart());
-while ( next.getTimeInMillis() < now.getTimeInMillis() ) {
+next.setTime(from);
+if ( getDuration().getHour() == 0 &&
+     getDuration().getMinute() == 0 &&
+     getDuration().getSecond() == 0 ) {
+  next.roll(Calendar.DATE, true);
+} else {
   next.add(Calendar.HOUR_OF_DAY, getDuration().getHour());
   next.add(Calendar.MINUTE,      getDuration().getMinute());
   next.add(Calendar.SECOND,      getDuration().getSecond());
 }
-
 return next.getTime();
 `
     },

--- a/src/foam/core/cron/test/IntervalScheduleTest.js
+++ b/src/foam/core/cron/test/IntervalScheduleTest.js
@@ -11,7 +11,12 @@ foam.CLASS({
 
   javaImports: [
     'foam.core.cron.*',
-    'java.util.Calendar'
+    'java.time.LocalDateTime',
+    'java.time.ZoneId',
+    'static java.time.temporal.ChronoUnit.DAYS',
+    'static java.time.temporal.ChronoUnit.SECONDS',
+    'java.util.Calendar',
+    'java.util.Date'
   ],
 
   methods: [
@@ -23,35 +28,43 @@ foam.CLASS({
       now.set(Calendar.MILLISECOND, 0);
 
       Calendar next = Calendar.getInstance();
-
-      Schedule testInterval = new IntervalSchedule.Builder(x)
-        .setStart(now.getTime())
+      Calendar future = Calendar.getInstance();
+      future.add(Calendar.MINUTE, 1);
+      IntervalSchedule testInterval = new IntervalSchedule.Builder(x)
+        .setStart(future.getTime())
         .setDuration(new TimeHMS.Builder(x)
-          .setHour(0).setMinute(0)
+          .setHour(0)
+          .setMinute(0)
           .setSecond(3)
           .build())
         .build();
 
       // TEST: start time should be the first scheduled time
       next.setTime(testInterval.getNextScheduledTime(x, now.getTime()));
-      test(now.getTime().equals(next.getTime()),
+      test(future.getTime().equals(next.getTime()),
         "First scheduled time for IntervalSchedule is start time"
       );
 
       // TEST: next time should be 3 seconds later
-      now.add(Calendar.SECOND, 1);
-      next.setTime(testInterval.getNextScheduledTime(x, now.getTime()));
-      now.add(Calendar.SECOND, 2);
-      test(now.getTime().equals(next.getTime()),
-        "Next interval minus duration equals current time"
-      );
+      // clear start time - interval schedule smallest unit is seconds
+      // and this test can run in the same millisecond
+      testInterval.setStart(null);
+      Date date = testInterval.getNextScheduledTime(x, next.getTime());
+      long seconds = SECONDS.between(next.getTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+      test( seconds == 3, "Next interval is duration seconds later. next: " + next.getTime().getTime()+", date: "+date.getTime()+", seconds: "+seconds);
 
-      // TEST: it should work tomorrow
-      now.add(Calendar.DATE, 1);
-      next.setTime(testInterval.getNextScheduledTime(x, now.getTime()));
-      test(now.getTime().equals(next.getTime()),
-        "Next interval minus duration equals current time"
-      );
+      // Duration 0, 0, 0 - will roll day
+      testInterval = new IntervalSchedule.Builder(x)
+        .setDuration(new TimeHMS.Builder(x)
+          .setHour(0)
+          .setMinute(0)
+          .setSecond(0)
+          .build())
+        .build();
+      Date first = testInterval.getNextScheduledTime(x, now.getTime());
+      Date second = testInterval.getNextScheduledTime(x, first);
+      long days = DAYS.between(first.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),second.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+      test(days == 1, "Zero duration rolls date. first: " + first.toString()+", second: "+second.toString()+", days: "+days);
       `
     }
   ]


### PR DESCRIPTION
refactor nextScheduledTime to start calculation at 'from' date.

Also, roll date on zero duration.
Previouly a while loop incremented the current time by the duration until it exceeded 'from'.  When duration was zero - zero hour, minute, second, the increment did nothing and while loop never exited.