### PR TITLE
Using &gt; and &lt; makes the angle brackets render properly

### DIFF
--- a/src/foam/demos/examples/parsers.fbe
+++ b/src/foam/demos/examples/parsers.fbe
@@ -667,7 +667,7 @@ Below is a very simple example which only adds one semantic action to our Gramma
 In this case it adds an action to the 'number' symbol so that numbers are converted
 to actual JS numbers, rather than being left as Strings.
 
-Semantic Actions are defined by creating a method named <SymbolName>Action. So in this
+Semantic Actions are defined by creating a method named &lt;SymbolName&gt;Action. So in this
 example, the 'numberAction' method is applied to results parsed by the 'number' parser.
 </pre>
 --
@@ -704,7 +704,7 @@ testP(p, [ '1', '1.1', '1.1b', '3.14159-26b' ]);
 
 ## Email Address Parser
 The following parser uses two semantic actions to parse email addresses which can be
-either simple like "john@email.com" or labelled like "John Doe <john@email.com>".
+either simple like "john@email.com" or labelled like "John Doe &lt;john@email.com&gt;".
 --
 foam.CLASS({
   name: 'EmailAddressParser',


### PR DESCRIPTION
Using &gt; and &lt; makes the angle brackets render properly. 
Using '<,>' hides them as they get "processed" resulting in not-rendering & hiding the inner content of the angle brackets