### PR TITLE
Add dot notation parsing to message tempaltes | pass implicit obj th…

### DIFF
--- a/src/foam/i18n/MessageTemplateParser.js
+++ b/src/foam/i18n/MessageTemplateParser.js
@@ -11,6 +11,22 @@ foam.CLASS({
     'foam.parse.Parsers',
     'foam.parse.ImperativeGrammar',
   ],
+  documentation: `model messages: [] supports templating for key/value
+replacement at runtime.
+
+general format:
+  messages: [
+    { name: 'MSG_CONSTANT1', message: 'Message text with one \${templateKey1} or more \${templateKey2} template keys' },
+    { name: 'MSG_CONSTANT2', message: '\${this.MSG_CONSTANT1} or \${this.propertyName}' },
+
+templateKey is resolved as follows:
+1. value is explicitly provided during rendering of the message:
+  this.E().... .add(this.MSG_CONSTANT1({ templateKey1: this.data...}))
+2. if preceeded with 'this', attempt match against messages Constants.
+3. if preceeded with 'this', attempt match this.data[key]. Also supports
+dot notation for FObject properties.
+  `,
+
   properties: [
     {
       name: 'value',

--- a/src/foam/i18n/MessageTemplateParser.js
+++ b/src/foam/i18n/MessageTemplateParser.js
@@ -16,15 +16,14 @@ replacement at runtime.
 
 general format:
   messages: [
-    { name: 'MSG_CONSTANT1', message: 'Message text with one \${templateKey1} or more \${templateKey2} template keys' },
-    { name: 'MSG_CONSTANT2', message: '\${this.MSG_CONSTANT1} or \${this.propertyName}' },
+    { name: 'MSG_CONSTANT1', message: 'Message text with one \${templateKey1} or more \${templateKey2} template keys', template: true },
+    { name: 'MSG_CONSTANT2', message: '\${this.MSG_CONSTANT1} or \${this.propertyName}', template: true },
 
 templateKey is resolved as follows:
 1. value is explicitly provided during rendering of the message:
   this.E().... .add(this.MSG_CONSTANT1({ templateKey1: this.data...}))
-2. if preceeded with 'this', attempt match against messages Constants.
-3. if preceeded with 'this', attempt match this.data[key]. Also supports
-dot notation for FObject properties.
+2. if preceeded with 'this', attempt match this[key] (can use class constants like other messages or instance values). 
+Also supports dot notation for FObject properties.
   `,
 
   properties: [

--- a/src/foam/i18n/MessageTemplateParser.js
+++ b/src/foam/i18n/MessageTemplateParser.js
@@ -32,7 +32,17 @@ foam.CLASS({
       return () => { return str; } 
     },
     function addParam(a) {
-      return map => { return map[a] } 
+      return map => {
+        if ( a.indexOf('.') != -1 ) {
+          let arr = a.split('.');
+          let ret = map;
+          arr.forEach(element => {
+            ret = ret[element];
+          });
+          return ret;
+        };
+        return map[a];
+      }
     }
   ],
   grammars: [

--- a/src/foam/i18n/Messages.js
+++ b/src/foam/i18n/Messages.js
@@ -143,9 +143,11 @@ foam.CLASS({
         });
         Object.defineProperty(proto, name, {
           get: function() {
-            return function(replacementMap) {
+            return function(replacementMap = {}) {
               let parsedValue = parser.valueParserResults;
-              return parsedValue.reduce(function(ret, v) {return ret + v(replacementMap)}, '');
+              if ( ! replacementMap['this'] )
+                replacementMap['this'] = this;
+              return parsedValue.reduce(function(ret, v) {return ret + v(replacementMap);}, '');
             };
           },
           configurable: true


### PR DESCRIPTION
…is when parsing templates

example:  
model with property 'capability' (of type Capability)

messages: [
  { name: 'UPLOAD_REQUEST_MSG',message: 'Provide' },
  { name: 'DOC_UPLOAD_SECTION', message: '${this.UPLOAD_REQUEST_MSG} ${this.capability.name}', template: true }
  ...

rendered with: 
this.add(this.DOC_UPLOAD_SECTION())