### PR TITLE
WriteOnlyF3FileJoural - unnecessarily overrides put

### DIFF
--- a/src/foam/dao/WriteOnlyF3FileJournal.js
+++ b/src/foam/dao/WriteOnlyF3FileJournal.js
@@ -9,13 +9,7 @@ foam.CLASS({
   name: 'WriteOnlyF3FileJournal',
   extends: 'foam.dao.F3FileJournal',
 
-  javaImports: [
-    'foam.lang.ClassInfo',
-    'foam.lang.FObject',
-    'foam.lib.formatter.JSONFObjectFormatter',
-    'foam.util.concurrent.AbstractAssembly',
-    'foam.util.SafetyUtil'
-  ],
+  documenation: 'A journal which does nothing on replay.',
 
   methods: [
     {
@@ -23,57 +17,6 @@ foam.CLASS({
       javaCode: `
         return;
       `
-    },
-    {
-      name: 'put',
-      type: 'FObject',
-      args: [ 'Context x', 'String prefix', 'DAO dao', 'foam.lang.FObject obj' ],
-      javaCode: `
-        final Object                 id  = obj.getProperty("id");
-        final ClassInfo              of  = dao.getOf();
-        final JSONFObjectFormatter fmt = formatter.get();
-
-        getLine().enqueue(new foam.util.concurrent.AbstractAssembly() {
-          FObject old;
-
-          public Object[] requestLocks() {
-            return new Object[] { id };
-          }
-
-          public void executeUnderLock() {
-            dao.put_(x, obj);
-          }
-
-          public void executeJob() {
-            try {
-              fmt.output(obj, of);
-            } catch (Throwable t) {
-              getLogger().error("Failed to format put", getFilename(), of.getId(), "id", id, t);
-              fmt.reset();
-            }
-          }
-
-          public void endJob(boolean isLast) {
-            if ( fmt.builder().length() == 0 ) return;
-
-            try {
-              writePut_(
-                x,
-                fmt.builder(),
-                getMultiLineOutput() ? "\\n" : "",
-                SafetyUtil.isEmpty(prefix) ? "" : prefix + ".");
-
-              if ( isLast ) getWriter().flush();
-            } catch (Throwable t) {
-              getLogger().error("Failed to write put", getFilename(), of.getId(), "id", id, t);
-            }  finally {
-              fmt.reset();
-            }
-          }
-        });
-
-        return obj;
-      `
-    },
+    }
   ]
 });


### PR DESCRIPTION
unnecessarily overrides put which did not consider old - always writing out the full object.

This addresses the alarm issue where all alarm puts resulted in a journal entry. 
The same missing logic also suppressed storageOptional. 