### PR TITLE
Fix bug in row label

### DIFF
--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -483,9 +483,10 @@ foam.CLASS({
     },
     {
       name: 'browseEnabled',
-      hidden: true,
+      value: true,
+      // hidden: true,
       // Only enable Browse action if this is the top-level DAOAgent
-      factory: function() { return this.block.value.select === this; }
+      // factory: function() { return this.block.value.select === this; }
     }
   ],
 
@@ -529,7 +530,6 @@ foam.CLASS({
           style({paddingLeft: '12px'}).
         add(this.PROP).
           add(this.SINK).
-          add(this.GENERATED_ROW_LABEL.__).
           add(this.TOP_N.__).
           add(this.SORT_ORDER.__).
           add(this.INCLUDE_OTHERS.__).
@@ -908,6 +908,53 @@ foam.CLASS({
   methods: [
     function execute(e) {
       e.tag(this.DownloadView);
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'LabeledDAOAgent',
+  extends: 'foam.core.reflow.AbstractSinkDAOAgent',
+
+  requires: [ 'foam.mlang.sink.LabeledSink' ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'label',
+      documentation: 'Label to identify this sink result for retrieval in genModel',
+      validateObj: function(label) {
+        /// dont allow spaces
+        if ( label.indexOf(' ') !== -1 ) return 'Label cannot contain spaces';
+      }
+    },
+    {
+      name: 'sink',
+      view: 'foam.core.reflow.SinkView',
+      documentation: 'The sink to delegate to'
+    }
+  ],
+
+  methods: [
+    function value(s) {
+      return s;
+    },
+    function createSink() {
+      return this.LabeledSink.create({
+        label: this.label,
+        delegate: this.sink ? this.sink.createSink() : null
+      });
+    },
+        function addToE(e) {
+      var self = this;
+      // TODO: figure out why BROWSE doesn't work after reloading
+      e.startContext({data: this}).
+        start().
+        add(this.LABEL.__)
+          .add(this.SINK).
+          end();
     }
   ]
 });

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -483,7 +483,6 @@ foam.CLASS({
     },
     {
       name: 'browseEnabled',
-      value: true,
       hidden: true,
       // Only enable Browse action if this is the top-level DAOAgent
       factory: function() { return this.block.value.select === this; }

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -932,13 +932,13 @@ foam.CLASS({
       name: 'label',
       documentation: 'Label to identify this sink result for retrieval in genModel',
       validateObj: function(label) {
-        /// has to be valid JavaScript variable name
-        /// start with letter, underscore, or dollar sign
+        // has to be valid JavaScript variable name
+        // start with letter, underscore, or dollar sign
         if ( ! label.match(/^[a-zA-Z_$]/) ) return 'Label must start with a letter, underscore';
-        /// then only letters, numbers, underscores, or dollar signs (no dashes)
+        // then only letters, numbers, underscores, or dollar signs (no dashes)
         if ( ! label.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*$/) ) return 'Label can only contain letters, numbers, underscores';
 
-        /// check for JavaScript reserved words
+        // check for JavaScript reserved words
         var reservedWords = ['break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default', 'delete', 'do', 'else', 'export', 'extends', 'finally', 'for', 'function', 'if', 'import', 'in', 'instanceof', 'new', 'return', 'super', 'switch', 'this', 'throw', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield', 'let', 'static', 'enum', 'implements', 'package', 'protected', 'interface', 'private', 'public'];
         if ( reservedWords.indexOf(label.toLowerCase()) !== -1 ) return 'Label cannot be a JavaScript reserved word';
       }

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -61,7 +61,22 @@ foam.CLASS({
 foam.CLASS({
   package: 'foam.core.reflow',
   name: 'AbstractSinkDAOAgent',
-  extends: 'foam.core.reflow.AbstractDAOAgent'
+  extends: 'foam.core.reflow.AbstractDAOAgent',
+
+  properties: [
+    {
+      name: 'sink',
+      preSet: function(o, n) {
+        // Temporary fix to recontextualize the object after load.
+        // TODO: remove once JSON parsing/loading is fixed
+        if ( n && n.__context__ != this.__subContext__ ) {
+          return n.clone(this.__subContext__);
+        }
+        return n;
+      }
+    }
+  ],
+
 });
 
 
@@ -419,15 +434,7 @@ foam.CLASS({
     },
     {
       name: 'sink',
-      view: { class: 'foam.core.reflow.SinkView', choice: 'foam.core.reflow.CountDAOAgent' },
-      preSet: function(o, n) {
-        // Temporary fix to recontextualize the object after load.
-        // TODO: remove once JSON parsing/loading is fixed
-        if ( n && n.__context__ != this.__subContext__ ) {
-          return n.clone(this.__subContext__);
-        }
-        return n;
-      }
+      view: { class: 'foam.core.reflow.SinkView', choice: 'foam.core.reflow.CountDAOAgent' }
     },
     {
       class: 'Int',
@@ -925,16 +932,15 @@ foam.CLASS({
       name: 'label',
       documentation: 'Label to identify this sink result for retrieval in genModel',
       validateObj: function(label) {
-        /// has to be valid css class name
-        /// start with letter or _
-        if ( ! label.match(/^[a-zA-Z_]/) ) return 'Label must start with a letter or underscore';
-        /// then only letters, numbers, - or _
-        if ( ! label.match(/^[a-zA-Z0-9_-]+$/) ) return 'Label can only contain letters, numbers, underscores or dashes';
-        
-        
-        /// dont allow spaces
-        if ( label.indexOf(' ') !== -1 ) return 'Label cannot contain spaces';
+        /// has to be valid JavaScript variable name
+        /// start with letter, underscore, or dollar sign
+        if ( ! label.match(/^[a-zA-Z_$]/) ) return 'Label must start with a letter, underscore';
+        /// then only letters, numbers, underscores, or dollar signs (no dashes)
+        if ( ! label.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*$/) ) return 'Label can only contain letters, numbers, underscores';
 
+        /// check for JavaScript reserved words
+        var reservedWords = ['break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default', 'delete', 'do', 'else', 'export', 'extends', 'finally', 'for', 'function', 'if', 'import', 'in', 'instanceof', 'new', 'return', 'super', 'switch', 'this', 'throw', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield', 'let', 'static', 'enum', 'implements', 'package', 'protected', 'interface', 'private', 'public'];
+        if ( reservedWords.indexOf(label.toLowerCase()) !== -1 ) return 'Label cannot be a JavaScript reserved word';
       }
     },
     {

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -430,12 +430,6 @@ foam.CLASS({
       }
     },
     {
-      class: 'String',
-      name: 'generatedRowLabel',
-      label: 'Generated Row Label',
-      documentation: 'Label for the generated row property in the model created by genModel().'
-    },
-    {
       class: 'Int',
       name: 'topN',
       label: 'Top N',
@@ -514,12 +508,11 @@ foam.CLASS({
           sortOrder: this.sortOrder,
           othersLabel: this.othersLabel,
           includeOthers: this.includeOthers,
-          generatedRowLabel: this.generatedRowLabel
         });
       }
 
       // Fall back to regular GroupBy
-      var groupBySink = this.GROUP_BY(expr, innerSink, undefined, this.generatedRowLabel);
+      var groupBySink = this.GROUP_BY(expr, innerSink, undefined);
 
       // Apply legacy group limit if specified
       if ( this.groupLimit > 0 ) {

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -484,9 +484,9 @@ foam.CLASS({
     {
       name: 'browseEnabled',
       value: true,
-      // hidden: true,
+      hidden: true,
       // Only enable Browse action if this is the top-level DAOAgent
-      // factory: function() { return this.block.value.select === this; }
+      factory: function() { return this.block.value.select === this; }
     }
   ],
 
@@ -926,8 +926,16 @@ foam.CLASS({
       name: 'label',
       documentation: 'Label to identify this sink result for retrieval in genModel',
       validateObj: function(label) {
+        /// has to be valid css class name
+        /// start with letter or _
+        if ( ! label.match(/^[a-zA-Z_]/) ) return 'Label must start with a letter or underscore';
+        /// then only letters, numbers, - or _
+        if ( ! label.match(/^[a-zA-Z0-9_-]+$/) ) return 'Label can only contain letters, numbers, underscores or dashes';
+        
+        
         /// dont allow spaces
         if ( label.indexOf(' ') !== -1 ) return 'Label cannot contain spaces';
+
       }
     },
     {

--- a/src/foam/core/reflow/FilteredDAOAgent.js
+++ b/src/foam/core/reflow/FilteredDAOAgent.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 

--- a/src/foam/core/reflow/FilteredDAOAgent.js
+++ b/src/foam/core/reflow/FilteredDAOAgent.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'FilteredDAOAgent',
+  extends: 'foam.core.reflow.AbstractSinkDAOAgent',
+
+  documentation: 'A DAO agent that filters data using a predicate before passing to a delegate sink',
+
+  requires: [
+    'foam.mlang.sink.FilteredSink',
+    'foam.parse.QueryParser'
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'where',
+      section: 'filter',
+      displayWidth: 60,
+      view: { class: 'foam.core.reflow.PredicateSuggestedField' },
+      documentation: 'Predicate expression to filter objects before putting them in the sink'
+    },
+    {
+      name: 'sink',
+      view: 'foam.core.reflow.SinkView',
+      documentation: 'The sink to delegate filtered objects to'
+    }
+  ],
+
+  methods: [
+    function value(s) {
+      return this.sink ? this.sink.value(s.delegate) : s;
+    },
+
+    function createSink() {
+      var predicate = null;
+      if ( this.where ) {
+        try {
+          predicate = this.QueryParser.create({of: this.of}).parseString(this.where);
+        } catch (x) {
+          console.warn('FilteredDAOAgent: Failed to parse predicate:', this.where, x);
+        }
+      }
+      var delegateSink = this.sink ? this.sink.createSink() : this.ArraySink.create();
+
+      return this.FilteredSink.create({
+        predicate: predicate,
+        delegate: delegateSink
+      });
+    },
+
+    function addToE(e) {
+      e.startContext({data: this}).
+        start().
+          style({display: 'flex', paddingLeft: '12px'}).
+          add(this.WHERE.__).
+          add(this.SINK).
+        end().
+        endContext();
+    }
+  ]
+});

--- a/src/foam/core/reflow/agents.jrl
+++ b/src/foam/core/reflow/agents.jrl
@@ -27,3 +27,4 @@ p({"class":"foam.core.reflow.SinkAgent", "id": 27, "label":"Line Chart", "value"
 p({"class":"foam.core.reflow.SinkAgent", "id": 28, "label":"Metric", "value":"foam.core.reflow.dashboard.DashboardMetricDAOAgent", "sink":true, "type":"chart", permissionRequired: true})
 p({"class":"foam.core.reflow.SinkAgent", "id": 30, "label":"Download", "value":"foam.core.reflow.DownloadDAOAgent", "sink":false, "type":"format", permissionRequired: true})
 p({"class":"foam.core.reflow.SinkAgent", "id": 31, "label":"Labeled",   "value":"foam.core.reflow.LabeledDAOAgent",      "sink":true,  "type":"structure"})
+p({"class":"foam.core.reflow.SinkAgent", "id": 32, "label":"Filtered",  "value":"foam.core.reflow.FilteredDAOAgent",     "sink":true,  "type":"structure"})

--- a/src/foam/core/reflow/agents.jrl
+++ b/src/foam/core/reflow/agents.jrl
@@ -26,3 +26,4 @@ p({"class":"foam.core.reflow.SinkAgent", "id": 26, "label":"Pie Chart", "value":
 p({"class":"foam.core.reflow.SinkAgent", "id": 27, "label":"Line Chart", "value":"foam.core.reflow.dashboard.DashboardLineChartDAOAgent", "sink":true, "type":"chart", permissionRequired: true})
 p({"class":"foam.core.reflow.SinkAgent", "id": 28, "label":"Metric", "value":"foam.core.reflow.dashboard.DashboardMetricDAOAgent", "sink":true, "type":"chart", permissionRequired: true})
 p({"class":"foam.core.reflow.SinkAgent", "id": 30, "label":"Download", "value":"foam.core.reflow.DownloadDAOAgent", "sink":false, "type":"format", permissionRequired: true})
+p({"class":"foam.core.reflow.SinkAgent", "id": 31, "label":"Labeled",   "value":"foam.core.reflow.LabeledDAOAgent",      "sink":true,  "type":"structure"})

--- a/src/foam/core/reflow/pom.js
+++ b/src/foam/core/reflow/pom.js
@@ -71,6 +71,7 @@ foam.POM({
     { name: 'control/CollectionsControl', flags: 'js' },
     { name: 'control/FlowsControl',     flags: 'js' },
     { name: 'control/ComponentsControl', flags: 'js' },
-    { name: 'FlowBrowserView',         flags: 'js' }
+    { name: 'FlowBrowserView',         flags: 'js' },
+    { name: 'FilteredDAOAgent',        flags: 'js' }
   ]
 });

--- a/src/foam/mlang/Expressions.js
+++ b/src/foam/mlang/Expressions.js
@@ -130,7 +130,7 @@ foam.CLASS({
     function CONSTANT(v) { return this.Constant.create({ value: v }); },
 
     function UNIQUE(expr, sink) { return this.Unique.create({ expr: expr, delegate: sink }); },
-    function GROUP_BY(expr, opt_sinkProto, opt_limit, opt_generatedRowLabel) { return this.GroupBy.create({ arg1: expr, arg2: opt_sinkProto || this.COUNT(), groupLimit: opt_limit || -1, generatedRowLabel: opt_generatedRowLabel }); },
+    function GROUP_BY(expr, opt_sinkProto, opt_limit) { return this.GroupBy.create({ arg1: expr, arg2: opt_sinkProto || this.COUNT(), groupLimit: opt_limit || -1 }); },
     function PLOT() { return this._nary_('Plot', arguments); },
     function MAP(expr, sink) { return this.Map.create({ arg1: expr, delegate: sink }); },
     function EXPLAIN(sink) { return this.Explain.create({ delegate: sink }); },

--- a/src/foam/mlang/pom.js
+++ b/src/foam/mlang/pom.js
@@ -76,6 +76,7 @@ foam.POM({
     { name: "sink/Reducible",                       flags: "js|java" },
     { name: "sink/TopNGroupBy",                     flags: "js|java" },
     { name: "sink/LabeledSink",                     flags: "js|java" },
+    { name: "sink/FilteredSink",                    flags: "js|java" },
     { name: "sink/Max",                             flags: "js|java" },
     { name: "sink/Min",                             flags: "js|java" },
     { name: "sink/Sum",                             flags: "js|java" },

--- a/src/foam/mlang/pom.js
+++ b/src/foam/mlang/pom.js
@@ -75,6 +75,7 @@ foam.POM({
     { name: "sink/AbstractUnarySink",               flags: "js|java" },
     { name: "sink/Reducible",                       flags: "js|java" },
     { name: "sink/TopNGroupBy",                     flags: "js|java" },
+    { name: "sink/LabeledSink",                     flags: "js|java" },
     { name: "sink/Max",                             flags: "js|java" },
     { name: "sink/Min",                             flags: "js|java" },
     { name: "sink/Sum",                             flags: "js|java" },

--- a/src/foam/mlang/sink/FilteredSink.js
+++ b/src/foam/mlang/sink/FilteredSink.js
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.mlang.sink',
+  name: 'FilteredSink',
+  extends: 'foam.dao.AbstractSink',
+  implements: [ 'foam.lang.Serializable' ],
+
+  documentation: 'A sink that filters objects using a predicate before passing them to a delegate sink',
+
+  properties: [
+    {
+      class: 'foam.mlang.predicate.PredicateProperty',
+      name: 'predicate',
+      documentation: 'Predicate to filter objects with'
+    },
+    {
+      class: 'foam.mlang.SinkProperty',
+      name: 'delegate',
+      documentation: 'The sink to delegate filtered objects to',
+      required: true
+    },
+    {
+      name: 'value',
+      documentation: 'The value from the delegated sink',
+      getter: function() {
+        return this.delegate ? this.delegate.value : null;
+      }
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      code: async function(obj, s) {
+        if ( this.predicate ) {
+          try {
+            var matches = await this.predicate.f(obj);
+            if ( ! matches ) {
+              return; // Skip this object
+            }
+          } catch (x) {
+            // If predicate evaluation fails, log and skip
+            console.warn('FilteredSink predicate evaluation failed:', x);
+            return;
+          }
+        }
+
+        if ( this.delegate ) {
+          this.delegate.put(obj, s);
+        }
+      },
+      javaCode: `if ( getPredicate() != null ) {
+  try {
+    boolean matches = getPredicate().f(obj);
+    if ( ! matches ) {
+      return; // Skip this object
+    }
+  } catch (Exception x) {
+    // If predicate evaluation fails, log and skip
+    System.err.println("FilteredSink predicate evaluation failed: " + x.getMessage());
+    return;
+  }
+}
+
+if ( getDelegate() != null ) {
+  getDelegate().put(obj, sub);
+}`
+    },
+    {
+      name: 'toString',
+      code: function() {
+        return 'FilteredSink(' +
+               (this.predicate ? this.predicate.toString() : 'no filter') +
+               ' -> ' +
+               (this.delegate ? this.delegate.toString() : 'null') + ')';
+      }
+    },
+
+    function toSummary() {
+      if ( this.delegate && this.delegate.toSummary ) {
+        return this.delegate.toSummary();
+      }
+      return this.value;
+    },
+
+    function valueOf() {
+      if ( this.delegate && this.delegate.valueOf ) {
+        return this.delegate.valueOf();
+      }
+      return this.value;
+    },
+
+    function addToE(e) {
+      if ( this.delegate && this.delegate.addToE ) {
+        this.delegate.addToE(e);
+      } else {
+        e.add(this.value);
+      }
+    },
+
+    function toProperties() {
+      if ( this.delegate && this.delegate.toProperties ) {
+        return this.delegate.toProperties();
+      }
+    },
+
+    function setPropertyValues(o, sink, ps) {
+      if ( this.delegate && this.delegate.setPropertyValues ) {
+        this.delegate.setPropertyValues(o, sink.delegate, ps);
+      } else if ( ps && ps.length > 0 ) {
+        ps[0].set(o, this.value);
+      }
+    },
+
+    function reduce(other) {
+      if ( ! other || ! foam.mlang.sink.FilteredSink.isInstance(other) ) return;
+
+      // Only reduce if predicates are equivalent
+      if ( this.predicate && other.predicate ) {
+        if ( this.predicate.toString() !== other.predicate.toString() ) return;
+      } else if ( this.predicate !== other.predicate ) {
+        return;
+      }
+
+      if ( this.delegate && this.delegate.reduce && other.delegate ) {
+        this.delegate.reduce(other.delegate);
+      }
+    }
+  ]
+});

--- a/src/foam/mlang/sink/FilteredSink.js
+++ b/src/foam/mlang/sink/FilteredSink.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 

--- a/src/foam/mlang/sink/GroupBy.js
+++ b/src/foam/mlang/sink/GroupBy.js
@@ -79,12 +79,6 @@ foam.CLASS({
     },
     {
       name: 'selection', hidden: true
-    },
-    {
-      class: 'String',
-      name: 'generatedRowLabel', 
-      label: 'Generated Row Label',
-      documentation: 'Label for the generated row property in the model created by genModel().'
     }
   ],
 
@@ -266,10 +260,6 @@ for (Object key : getGroups().keySet()) {
 
       model.plural = model.name;
       var props = this.arg2.toProperties ? this.arg2.toProperties() : this.arg2.VALUE ? [ this.arg2.VALUE ] : [];
-      /// override the label of the prop based on user they define
-      if (this.generatedRowLabel && props.length > 0) {
-        props[0].label = this.generatedRowLabel;
-      }
       model.properties.push.apply(model.properties, props);
 
       return model;

--- a/src/foam/mlang/sink/LabeledSink.js
+++ b/src/foam/mlang/sink/LabeledSink.js
@@ -83,7 +83,7 @@ foam.CLASS({
             // Clone the property and set its label to include our label prefix
             var newProp = p.clone ? p.clone() : foam.util.clone(p);
             newProp.name = this.label;
-            newProp.label = this.label;
+            newProp.label = foam.String.labelize(this.label);
             return newProp;
           });
         }

--- a/src/foam/mlang/sink/LabeledSink.js
+++ b/src/foam/mlang/sink/LabeledSink.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 

--- a/src/foam/mlang/sink/LabeledSink.js
+++ b/src/foam/mlang/sink/LabeledSink.js
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.mlang.sink',
+  name: 'LabeledSink',
+  extends: 'foam.dao.AbstractSink',
+  implements: [ 'foam.lang.Serializable' ],
+
+  documentation: 'A sink that wraps another sink with a label, allowing named results that can be retrieved in genModel',
+
+  properties: [
+    {
+      class: 'String',
+      name: 'label',
+      documentation: 'Label to identify this sink result'
+    },
+    {
+      class: 'foam.mlang.SinkProperty',
+      name: 'delegate',
+      documentation: 'The sink to delegate to',
+      required: true
+    },
+    {
+      name: 'value',
+      documentation: 'The value from the delegated sink',
+      getter: function() {
+        return this.delegate ? this.delegate.value : null;
+      }
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      code: function(obj, s) {
+        if ( this.delegate ) {
+          this.delegate.put(obj, s);
+        }
+      },
+      javaCode: `if ( getDelegate() != null ) {
+  getDelegate().put(obj, sub);
+}`
+    },
+    {
+      name: 'toString',
+      code: function() {
+        return 'LabeledSink(' + this.label + ': ' + (this.delegate ? this.delegate.toString() : 'null') + ')';
+      }
+    },
+
+    function toSummary() {
+      if ( this.delegate && this.delegate.toSummary ) {
+        return this.delegate.toSummary();
+      }
+      return this.value;
+    },
+
+    function valueOf() {
+      if ( this.delegate && this.delegate.valueOf ) {
+        return this.delegate.valueOf();
+      }
+      return this.value;
+    },
+
+    function addToE(e) {
+      if ( this.delegate && this.delegate.addToE ) {
+        this.delegate.addToE(e);
+      } else {
+        e.add(this.value);
+      }
+    },
+
+    function toProperties() {
+      if ( this.delegate && this.delegate.toProperties ) {
+        // Get properties from delegate and override their labels
+        var props = this.delegate.toProperties();
+        if ( Array.isArray(props)  && props.length > 0  && this.label) {
+          return props.map(p => {
+            // Clone the property and set its label to include our label prefix
+            var newProp = p.clone ? p.clone() : foam.util.clone(p);
+            newProp.name = this.label + '_' + (p.name || '');
+            newProp.label = this.label;
+            return newProp;
+          });
+        }
+        return props;
+      }
+    },
+
+    function setPropertyValues(o, sink, ps) {
+      if ( this.delegate && this.delegate.setPropertyValues ) {
+        // Delegate to the wrapped sink
+        this.delegate.setPropertyValues(o, sink.delegate, ps);
+      } else if ( ps && ps.length > 0 ) {
+        // Set the value using our label
+        ps[0].set(o, this.value);
+      }
+    },
+
+    function reduce(other) {
+      if ( ! other || ! foam.mlang.sink.LabeledSink.isInstance(other) ) return;
+      if ( this.label !== other.label ) return;
+
+      if ( this.delegate && this.delegate.reduce && other.delegate ) {
+        this.delegate.reduce(other.delegate);
+      }
+    }
+  ]
+});

--- a/src/foam/mlang/sink/LabeledSink.js
+++ b/src/foam/mlang/sink/LabeledSink.js
@@ -82,7 +82,7 @@ foam.CLASS({
           return props.map(p => {
             // Clone the property and set its label to include our label prefix
             var newProp = p.clone ? p.clone() : foam.util.clone(p);
-            newProp.name = this.label + '_' + (p.name || '');
+            newProp.name = this.label;
             newProp.label = this.label;
             return newProp;
           });

--- a/src/foam/mlang/sink/Sequence.js
+++ b/src/foam/mlang/sink/Sequence.js
@@ -67,11 +67,57 @@ foam.CLASS({
     },
 
     function toProperties() {
-      return this.args.map(a => a.toProperties ? a.toProperties() : a.VALUE ).flat();
+      var allProps = this.args.map(a => a.toProperties ? a.toProperties() : a.VALUE ).flat();
+      var nameCount = {};
+      var renamedProps = [];
+
+      // Track name usage and rename duplicates
+      allProps.forEach(prop => {
+        if ( ! prop || ! prop.name ) {
+          renamedProps.push(prop);
+          return;
+        }
+
+        var originalName = prop.name;
+        if ( nameCount[originalName] ) {
+          // This name already exists, create a unique version
+          nameCount[originalName]++;
+          var newProp = prop.clone ? prop.clone() : foam.util.clone(prop);
+          newProp.name = originalName + '_' + nameCount[originalName];
+          newProp.label = foam.String.labelize(newProp.name);
+          renamedProps.push(newProp);
+        } else {
+          // First occurrence of this name
+          nameCount[originalName] = 1;
+          renamedProps.push(prop);
+        }
+      });
+
+      return renamedProps;
     },
     function setPropertyValues(o, sink, ps) {
-      for ( var i = 0 ; i < this.args.length ; i++ )
-        ps[i].set(o, sink.args[i].value);
+      // Map through properties and set values from corresponding sink args
+      var propIndex = 0;
+      for ( var i = 0 ; i < this.args.length ; i++ ) {
+        var arg = this.args[i];
+        var argProps = arg.toProperties ? arg.toProperties() : [{ name: 'value' }];
+
+        if ( argProps && Array.isArray(argProps) ) {
+          // Each arg might contribute multiple properties
+          for ( var j = 0 ; j < argProps.length ; j++ ) {
+            if ( propIndex < ps.length ) {
+              ps[propIndex].set(o, arg.value);
+              propIndex++;
+            }
+          }
+        } else {
+          // Single property from this arg
+          if ( propIndex < ps.length ) {
+            ps[propIndex].set(o, arg.value);
+            propIndex++;
+          }
+        }
+      }
     }
   ]
 });


### PR DESCRIPTION
This pull request introduces two new structural DAO agents, `LabeledDAOAgent` and `FilteredDAOAgent`, to the reflow framework, enabling more flexible and composable data processing pipelines. It also removes the now-unnecessary `generatedRowLabel` property from group-by logic and updates the core sink infrastructure to support labeled and filtered sinks. These changes improve modularity, reusability, and clarity in how data is processed and labeled in reflow dashboards.

**New structural agents and sinks:**

* Added `LabeledDAOAgent` for wrapping sinks with a label, allowing named results to be retrieved in generated models. Includes validation for label names and UI integration. (`src/foam/core/reflow/AbstractDAOAgent.js` [[1]](diffhunk://#diff-c451c29128d1ca8e9963bbaf4f56f9bd50af813208a77d875fe55a59bae52553R914-R968) `src/foam/core/reflow/agents.jrl` [[2]](diffhunk://#diff-a63ded565ceaae88c3a5995ac645e1c85ccfc085a42d620419273834850437e2R29-R30) `src/foam/mlang/sink/LabeledSink.js` [[3]](diffhunk://#diff-93a9d57a1eaea306beb782628ae274500f397afae84e8167735f3c744313b2a4R1-R113) `src/foam/mlang/pom.js` [[4]](diffhunk://#diff-6c45e2df052198e5938e2d930f1d68b185f53a16031a9b3fbfbb0dffd7fcb6ceR78-R79)
* Added `FilteredDAOAgent` for filtering data using a predicate before passing it to a delegate sink. Includes a UI field for predicate entry and uses the new `FilteredSink`. (`src/foam/core/reflow/FilteredDAOAgent.js` [[1]](diffhunk://#diff-566a2c043e7fda120c98ea034458afaec47210329ac1521abb96d265fdaa3d53R1-R67) `src/foam/core/reflow/agents.jrl` [[2]](diffhunk://#diff-a63ded565ceaae88c3a5995ac645e1c85ccfc085a42d620419273834850437e2R29-R30) `src/foam/mlang/sink/FilteredSink.js` [[3]](diffhunk://#diff-797ca2500df0c5c42e3c7af259d449ccb1f401e4c75804770a17815680f79399R1-R135) `src/foam/mlang/pom.js` [[4]](diffhunk://#diff-6c45e2df052198e5938e2d930f1d68b185f53a16031a9b3fbfbb0dffd7fcb6ceR78-R79) `src/foam/core/reflow/pom.js` [[5]](diffhunk://#diff-10cf4f7fae291906f6e52b0f8b473bce1e3b580b25e786f6859e28c45c9a28f9L74-R75)

**GroupBy and property cleanup:**

* Removed the `generatedRowLabel` property from `AbstractDAOAgent` and `GroupBy`, simplifying group-by logic and parameter passing. (`src/foam/core/reflow/AbstractDAOAgent.js` [[1]](diffhunk://#diff-c451c29128d1ca8e9963bbaf4f56f9bd50af813208a77d875fe55a59bae52553L432-L437) [[2]](diffhunk://#diff-c451c29128d1ca8e9963bbaf4f56f9bd50af813208a77d875fe55a59bae52553L517-R516) [[3]](diffhunk://#diff-c451c29128d1ca8e9963bbaf4f56f9bd50af813208a77d875fe55a59bae52553L539) `src/foam/mlang/Expressions.js` [[4]](diffhunk://#diff-f105c7ca5813c4473614eeed1df165e3e3dfb2fa6a00088fffa5451ce69e7ab6L133-R133) `src/foam/mlang/sink/GroupBy.js` [[5]](diffhunk://#diff-b8467e9f76cbb4cedaff4408e30701a16e6fc69478996178a1e9c5dbe51c8fb8L82-L87) [[6]](diffhunk://#diff-b8467e9f76cbb4cedaff4408e30701a16e6fc69478996178a1e9c5dbe51c8fb8L269-L272)

These updates make it easier to compose, label, and filter data processing steps in FOAM's reflow dashboards, supporting more advanced analytics and reporting use cases.