### PR TITLE
Add preload/postload script to flow

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -440,9 +440,6 @@ foam.CLASS({
     ^.expanded > ^toolbar {
       padding: 0 0 0.8rem 16px;
     }
-    ^toolbar {
-      padding: 16px;
-    }
     ^content:has(> .foam-u2-Element-hidden) {
       display: none;
     }
@@ -1545,6 +1542,7 @@ foam.CLASS({
           this.selected = ( currentBlockName == this.flowName ) ?
             this :
             ( this.findFlowChildByName(currentBlockName) || this );
+          this.value.loadComplete.pub();
         } finally {
           this.feedback_ = false;
         }

--- a/src/foam/core/reflow/DAOPrompt.js
+++ b/src/foam/core/reflow/DAOPrompt.js
@@ -40,7 +40,6 @@ foam.CLASS({
           add(self.data.label$).
         end().
         start().show(self.loading$).tag(self.LoadingSpinner, {size: '32px'} ).end().
-        br().
           add(self.dynamic(async function(version) {
             var startTime = Date.now();
             // Clone is needed in case the select was loaded from a DAO and doesnt' have correct context.

--- a/src/foam/core/reflow/Flow.js
+++ b/src/foam/core/reflow/Flow.js
@@ -52,6 +52,8 @@ foam.CLASS({
 
   constants: { ROLE_PERMISSION_PREFIX: '@' },
 
+  topics: [ 'loadComplete' ],
+
   sections: [
     {
       name: 'general',
@@ -60,7 +62,8 @@ foam.CLASS({
     {
       name: 'scriptSection',
       title: 'Script',
-      collapsable: true
+      collapsable: true,
+      properties: [ 'preLoadScript', 'script', 'postLoadScript' ]
     }
   ],
 
@@ -178,9 +181,24 @@ foam.CLASS({
     },
     {
       class: 'String',
+      name: 'preLoadScript',
+      section: 'scriptSection',
+      documentation: 'Script to be run before the main script, typically used to set up classes or environment variables needed by the main script.',
+      reactive: false,
+      preSet: function(o, n) { return n.trim(); },
+      view: { class: 'foam.u2.tag.TextArea', rows: 10, cols: 60 }
+    },
+    {
+      class: 'String',
+      name: 'postLoadScript',
+      section: 'scriptSection',
+      reactive: false,
+      preSet: function(o, n) { return n.trim(); },
+      view: { class: 'foam.u2.tag.TextArea', rows: 10, cols: 60 }
+    },
+    {
+      class: 'String',
       name: 'script',
-      label: '',
-      columnLabel:'Script',
       section: 'scriptSection',
       reactive: false,
       value: '[\n\t\n]', // Is needed so that mementoMgr doesn't get confused on the first state

--- a/src/foam/core/reflow/LayoutBlock.js
+++ b/src/foam/core/reflow/LayoutBlock.js
@@ -76,6 +76,9 @@ foam.CLASS({
       padding: 0;
       overflow: hidden;
     }
+    ^content {
+      padding: 0;
+    }
   `,
   properties: [
     {

--- a/src/foam/core/reflow/Prompt.js
+++ b/src/foam/core/reflow/Prompt.js
@@ -93,6 +93,7 @@ foam.CLASS({
     },
     {
       name: 'prop',
+      hidden: true,
       transient: true
     }
   ],

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -622,10 +622,10 @@ foam.CLASS({
       if ( loaded ) {
         // Don't save the 'load' command
         this.block.del();
-
+        this.maybeCallScript(loaded.preLoadScript);
+        this.flow.loadComplete.sub(() => this.maybeCallScript(loaded.postLoadScript));
         this.selected = this.flow;
         this.flow.copyFrom(loaded);
-
         // HACK: after loading a flow the revision is set to 2 for some unknown
         // reason. This resets it back to 0.
         // TODO: find out why it is 2 and remove this code.
@@ -636,6 +636,11 @@ foam.CLASS({
           }
         });
       }
+    },
+    async function maybeCallScript(s) {
+        if ( s ) {
+          await eval('(async function() {' + s + '})').call(this)
+        }
     }
   ]
 });


### PR DESCRIPTION
- Each flow now has a preload and post load script that is run before and after the main script is run. This is useful to set up and register classes/daos that are used in the main script as otherwise JSON parsing of the main script might fail
- Some CSS changes to layout blocks to prevent duplicate padding being applied to them