### PR TITLE
PT-FIXES: DOS-942 Fix query parser

### DIFF
--- a/src/foam/parse/QueryParser.js
+++ b/src/foam/parse/QueryParser.js
@@ -425,7 +425,7 @@ foam.CLASS({
 
             // v[2], the values, is an array, which might have an 'and', 'or' or
             // 'negated' property on it. The default is 'or'. The partial
-            // evaluator for expressions can simplify the resulting Mlang further.
+            // evaluator for expressions can simplify the resulting MLang further.
             var prop   = v[0];
             var values = v[2];
             // Int is actually the parent of Float and Long, so this captures all
@@ -543,22 +543,31 @@ foam.CLASS({
             start = new Date(2000, 0, 1);
             end   = new Date(2000, 0, 1);
             var ops = [ 'FullYear', 'Month', 'Date', 'Hours', 'Minutes', 'Seconds', 'Milliseconds' ];
-            var defaults = [ 0, 1, 1, 0, 0, 0 ];
+            var defaults = [ 0, 1, 1, 0, 0, 0, 0 ]; // Fixed: Added 7th element for milliseconds
+
             for ( var i = 0 ; i < ops.length ; i++ ) {
-              var x = i * 2 > v.length ? defaults[i] : v[i * 2];
+              var x = i * 2 >= v.length ? defaults[i] : v[i * 2]; // Fixed: >= instead of >
+              // Handle undefined values by using defaults (fixed array bounds bug)
+              if ( x === undefined ) x = defaults[i];
               // Adjust for months being 0-based.
               var val = x - (i === 1 ? 1 : 0);
-              start['setUTC' + ops[i]](val);
-              end['setUTC' + ops[i]](val);
+              // IMPORTANT: Use local timezone methods (set*) NOT UTC methods (setUTC*)
+              // This ensures date queries match the user's local date boundaries.
+              // Using UTC caused queries like "2025/03/18" to match "2025/03/17" data
+              // because UTC midnight was converted to previous day in negative timezones.
+              start['set' + ops[i]](val);
+              end['set' + ops[i]](val);
             }
 
-            start.setUTCMilliseconds(0);
-            end.setUTCMilliseconds(0);
+            start.setMilliseconds(0);
+            end.setMilliseconds(0);
 
             // start and end are currently clones of each other. We bump the last
             // portion of the date and set it in end.
             var last = Math.floor(v.length / 2);
-            var op = 'UTC' + (ops[last] || ops[ops.length-1]);
+            var op = ops[last] || ops[ops.length-1];
+            // IMPORTANT: Use local timezone method (no 'UTC' prefix)
+            // This creates proper local date boundaries for queries
             end['set' + op](end['get' + op]() + 1);
 
             return [ start, end ];

--- a/src/foam/parse/test/QueryParserJSTest.js
+++ b/src/foam/parse/test/QueryParserJSTest.js
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Define test model before the test class
+foam.CLASS({
+  package: 'foam.parse.test',
+  name: 'QueryParserTestUser',
+  properties: [
+    { class: 'Long', name: 'id' },
+    { class: 'String', name: 'firstName' },
+    { class: 'String', name: 'lastName' },
+    { class: 'foam.lang.Date', name: 'birthday' },
+    { class: 'foam.lang.DateTime', name: 'lastLogin' },
+    { class: 'Boolean', name: 'emailVerified' }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.parse.test',
+  name: 'QueryParserJSTest',
+  extends: 'foam.core.test.JSTest',
+
+  documentation: 'JavaScript tests for QueryParser including date parsing fixes and timezone handling',
+
+  requires: [
+    'foam.parse.QueryParser',
+    'foam.parse.test.QueryParserTestUser'
+  ],
+
+  methods: [
+    async function runTest(x) {
+      this.testBasicQueries(x);
+      this.testDateParsing(x);
+      this.testDateParsingFixes(x);
+      this.testTimezoneHandling(x);
+      this.testArrayBoundsFix(x);
+      this.testComplexQueries(x);
+      this.testEdgeCases(x);
+    },
+
+    function testBasicQueries(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Basic equality tests
+      x.test(this.isValidQuery(parser, "id=6"), "Should parse id=6");
+      x.test(this.isValidQuery(parser, "firstName=Simon"), "Should parse firstName=Simon");
+      x.test(this.isValidQuery(parser, "firstName:Sim"), "Should parse firstName:Sim (contains)");
+
+      // Comparison operators
+      x.test(this.isValidQuery(parser, "id>20"), "Should parse id>20");
+      x.test(this.isValidQuery(parser, "id<20"), "Should parse id<20");
+      x.test(this.isValidQuery(parser, "id>=20"), "Should parse id>=20");
+      x.test(this.isValidQuery(parser, "id<=20"), "Should parse id<=20");
+
+      // Negation
+      x.test(this.isValidQuery(parser, "-id=6"), "Should parse -id=6 (negation)");
+      x.test(this.isValidQuery(parser, "NOT id=6"), "Should parse NOT id=6");
+
+      // Boolean operations
+      x.test(this.isValidQuery(parser, "id=6 OR firstName=Simon"), "Should parse OR query");
+      x.test(this.isValidQuery(parser, "id=6 AND firstName=Simon"), "Should parse AND query");
+      x.test(this.isValidQuery(parser, "firstName=abc id=20"), "Should parse implicit AND");
+
+      // Special predicates
+      x.test(this.isValidQuery(parser, "HAS:firstName"), "Should parse HAS predicate");
+      x.test(this.isValidQuery(parser, "IS:emailVerified"), "Should parse IS predicate");
+
+      // Lists
+      x.test(this.isValidQuery(parser, "firstName=Simon,John"), "Should parse value list");
+      x.test(this.isValidQuery(parser, "firstName:(Simon|John)"), "Should parse OR values");
+    },
+
+    function testDateParsing(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Various date formats that should work
+      x.test(this.isValidQuery(parser, "birthday=2020-09-10"), "Should parse YYYY-MM-DD");
+      x.test(this.isValidQuery(parser, "birthday=2020-09"), "Should parse YYYY-MM");
+      x.test(this.isValidQuery(parser, "birthday=2020"), "Should parse YYYY");
+      x.test(this.isValidQuery(parser, "lastLogin=today"), "Should parse relative date 'today'");
+      x.test(this.isValidQuery(parser, "lastLogin=today-2"), "Should parse relative date 'today-2'");
+
+      // Date ranges
+      x.test(this.isValidQuery(parser, "birthday=2010-9-10..2020-9-10"), "Should parse date range");
+
+      // Date comparisons
+      x.test(this.isValidQuery(parser, "birthday<2020-09-10"), "Should parse date less than");
+      x.test(this.isValidQuery(parser, "birthday>2020-09-10"), "Should parse date greater than");
+    },
+
+    function testDateParsingFixes(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Test the specific formats that were failing before our fixes
+      var problematicDates = [
+        "2025/03/17",  // The original failing case
+        "2025/03/18",  // Timezone issue case
+        "2025/12/31",  // Edge case
+        "2024/02/29",  // Leap year
+        "2025/01/01"   // New year
+      ];
+
+      problematicDates.forEach(dateStr => {
+        try {
+          var query = parser.parseString(`birthday=${dateStr}`);
+          x.test(query !== null && query !== undefined,
+                   `Should parse ${dateStr} without array bounds errors`);
+
+          // Verify we get a proper query structure
+          if ( query ) {
+            x.test(query.cls_ && query.cls_.name === 'And',
+                     `${dateStr} should create AND predicate`);
+          }
+        } catch (e) {
+          x.test(false, `Date parsing failed for ${dateStr}: ${e.message}`);
+        }
+      });
+    },
+
+    function testTimezoneHandling(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Test that dates are created in local timezone, not UTC
+      var query = parser.parseString('birthday=2025/03/18');
+
+      if ( query && query.args && query.args.length === 2 ) {
+        var gteClause = query.args[0];
+        var ltClause = query.args[1];
+
+        if ( gteClause && gteClause.arg2 ) {
+          var startDateConstant = gteClause.arg2;
+          // FOAM wraps dates in Constant objects, so get the actual value
+          var actualStartDate = startDateConstant.value || startDateConstant;
+          if ( actualStartDate instanceof Date ) {
+            x.test(!isNaN(actualStartDate.getTime()), "Start date should be valid");
+          }
+
+          // The key fix: dates should represent local date boundaries
+          // not UTC boundaries that get shifted in local timezone display
+        }
+
+        if ( ltClause && ltClause.arg2 ) {
+          var endDateConstant = ltClause.arg2;
+          // FOAM wraps dates in Constant objects, so get the actual value
+          var actualEndDate = endDateConstant.value || endDateConstant;
+          if ( actualEndDate instanceof Date ) {
+            x.test(!isNaN(actualEndDate.getTime()), "End date should be valid");
+          }
+        }
+      }
+    },
+
+    function testArrayBoundsFix(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // These formats specifically test the array bounds fix
+      // YY/MM/DD format creates array [YYYY, '/', MM, '/', DD] with length 5
+      // The old code tried to access elements beyond this length
+      var testCases = [
+        { format: "2025/03/17", desc: "slash format that caused original bug" },
+        { format: "2025-03-17", desc: "dash format for comparison" },
+        { format: "2025/1/1", desc: "single digit month/day" },
+        { format: "2025/12/31", desc: "max month/day values" }
+      ];
+
+      testCases.forEach(testCase => {
+        try {
+          var query = parser.parseString(`birthday=${testCase.format}`);
+          x.test(query !== null, `Array bounds fix: ${testCase.desc}`);
+
+          // Verify the query creates valid date ranges
+          if ( query && query.args && query.args.length === 2 ) {
+            var gteClause = query.args[0]; // Greater than or equal
+            var ltClause = query.args[1];  // Less than
+
+            if ( gteClause && gteClause.arg2 ) {
+              var startDateConstant = gteClause.arg2;
+              // FOAM wraps dates in Constant objects, so get the actual value
+              var actualStartDate = startDateConstant.value || startDateConstant;
+              x.test(actualStartDate instanceof Date && !isNaN(actualStartDate.getTime()),
+                       `Valid start date for ${testCase.format}`);
+            }
+
+            if ( ltClause && ltClause.arg2 ) {
+              var endDateConstant = ltClause.arg2;
+              // FOAM wraps dates in Constant objects, so get the actual value
+              var actualEndDate = endDateConstant.value || endDateConstant;
+              x.test(actualEndDate instanceof Date && !isNaN(actualEndDate.getTime()),
+                       `Valid end date for ${testCase.format}`);
+            }
+          }
+        } catch (e) {
+          x.test(false, `Array bounds test failed for ${testCase.format}: ${e.message}`);
+        }
+      });
+    },
+
+    function testComplexQueries(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Complex queries combining different elements
+      var complexQueries = [
+        "id=6 AND birthday=2025/03/17",
+        "firstName=John OR (birthday>2020-01-01 AND id<100)",
+        "(firstName=Simon AND id>10) OR birthday=2025/03/18",
+        "birthday=2025/03/17..2025/03/19 AND firstName:John"
+      ];
+
+      complexQueries.forEach(queryStr => {
+        x.test(this.isValidQuery(parser, queryStr),
+                 `Should parse complex query: ${queryStr}`);
+      });
+    },
+
+    function testEdgeCases(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Edge cases that should be handled gracefully
+      var edgeCases = [
+        { query: "birthday=2024/02/29", desc: "leap year date" },
+        { query: "birthday=2025/02/28", desc: "non-leap year february" },
+        { query: "birthday=2025/12/31", desc: "year end date" },
+        { query: "birthday=2025/01/01", desc: "year start date" },
+        { query: "birthday=1999/12/31", desc: "Y2K boundary" },
+        { query: "birthday=2000/01/01", desc: "millennium boundary" }
+      ];
+
+      edgeCases.forEach(testCase => {
+        try {
+          var query = parser.parseString(testCase.query);
+          x.test(query !== null, `Edge case: ${testCase.desc}`);
+        } catch (e) {
+          x.test(false, `Edge case failed - ${testCase.desc}: ${e.message}`);
+        }
+      });
+    },
+
+    function isValidQuery(parser, queryString) {
+      try {
+        var result = parser.parseString(queryString);
+        return result !== null && result !== undefined;
+      } catch (e) {
+        console.warn(`Query parsing failed for "${queryString}":`, e);
+        return false;
+      }
+    }
+  ]
+});

--- a/src/foam/parse/test/QueryParserJSTest.js
+++ b/src/foam/parse/test/QueryParserJSTest.js
@@ -118,6 +118,30 @@ foam.CLASS({
           x.test(false, `Date parsing failed for ${dateStr}: ${e.message}`);
         }
       });
+
+      // Test specific case: 2025/03/17 should create dates in 2025, not 275760
+      var specificQuery = parser.parseString('birthday=2025/03/17');
+      if ( specificQuery && specificQuery.args && specificQuery.args.length === 2 ) {
+        var startDate = (specificQuery.args[0].arg2.value || specificQuery.args[0].arg2);
+        var endDate = (specificQuery.args[1].arg2.value || specificQuery.args[1].arg2);
+
+        if ( startDate instanceof Date ) {
+          x.test(startDate.getFullYear() === 2025,
+                   `2025/03/17 start date should be in year 2025, got ${startDate.getFullYear()}`);
+          x.test(startDate.getMonth() === 2, // March is month 2 (0-based)
+                   `2025/03/17 start date should be in March (month 2), got ${startDate.getMonth()}`);
+          x.test(startDate.getDate() === 17,
+                   `2025/03/17 start date should be day 17, got ${startDate.getDate()}`);
+        }
+
+        if ( endDate instanceof Date ) {
+          x.test(endDate.getFullYear() === 2025,
+                   `2025/03/17 end date should be in year 2025, got ${endDate.getFullYear()}`);
+          // End date should be the next day (March 18)
+          x.test(endDate.getDate() === 18,
+                   `2025/03/17 end date should be day 18, got ${endDate.getDate()}`);
+        }
+      }
     },
 
     function testTimezoneHandling(x) {
@@ -160,36 +184,53 @@ foam.CLASS({
       // YY/MM/DD format creates array [YYYY, '/', MM, '/', DD] with length 5
       // The old code tried to access elements beyond this length
       var testCases = [
-        { format: "2025/03/17", desc: "slash format that caused original bug" },
-        { format: "2025-03-17", desc: "dash format for comparison" },
-        { format: "2025/1/1", desc: "single digit month/day" },
-        { format: "2025/12/31", desc: "max month/day values" }
+        { format: "2025/03/17", expectedYear: 2025, expectedMonth: 2, expectedDay: 17 },
+        { format: "2025-03-17", expectedYear: 2025, expectedMonth: 2, expectedDay: 17 },
+        { format: "2025/1/1", expectedYear: 2025, expectedMonth: 0, expectedDay: 1 },
+        { format: "2025/12/31", expectedYear: 2025, expectedMonth: 11, expectedDay: 31 }
       ];
 
       testCases.forEach(testCase => {
         try {
           var query = parser.parseString(`birthday=${testCase.format}`);
-          x.test(query !== null, `Array bounds fix: ${testCase.desc}`);
+          x.test(query !== null, `Should parse ${testCase.format}`);
 
-          // Verify the query creates valid date ranges
+          // Verify the query creates correct date ranges
           if ( query && query.args && query.args.length === 2 ) {
             var gteClause = query.args[0]; // Greater than or equal
             var ltClause = query.args[1];  // Less than
 
             if ( gteClause && gteClause.arg2 ) {
               var startDateConstant = gteClause.arg2;
-              // FOAM wraps dates in Constant objects, so get the actual value
               var actualStartDate = startDateConstant.value || startDateConstant;
+
               x.test(actualStartDate instanceof Date && !isNaN(actualStartDate.getTime()),
                        `Valid start date for ${testCase.format}`);
+
+              // Test exact expected values
+              x.test(actualStartDate.getFullYear() === testCase.expectedYear,
+                       `${testCase.format} start year should be ${testCase.expectedYear}, got ${actualStartDate.getFullYear()}`);
+              x.test(actualStartDate.getMonth() === testCase.expectedMonth,
+                       `${testCase.format} start month should be ${testCase.expectedMonth}, got ${actualStartDate.getMonth()}`);
+              x.test(actualStartDate.getDate() === testCase.expectedDay,
+                       `${testCase.format} start day should be ${testCase.expectedDay}, got ${actualStartDate.getDate()}`);
             }
 
             if ( ltClause && ltClause.arg2 ) {
               var endDateConstant = ltClause.arg2;
-              // FOAM wraps dates in Constant objects, so get the actual value
               var actualEndDate = endDateConstant.value || endDateConstant;
+
               x.test(actualEndDate instanceof Date && !isNaN(actualEndDate.getTime()),
                        `Valid end date for ${testCase.format}`);
+
+              // End date should be next day - calculate correctly for month/year rollovers
+              var expectedEndDate = new Date(testCase.expectedYear, testCase.expectedMonth, testCase.expectedDay + 1);
+              x.test(actualEndDate.getFullYear() === expectedEndDate.getFullYear(),
+                       `${testCase.format} end year should be ${expectedEndDate.getFullYear()}, got ${actualEndDate.getFullYear()}`);
+              x.test(actualEndDate.getMonth() === expectedEndDate.getMonth(),
+                       `${testCase.format} end month should be ${expectedEndDate.getMonth()}, got ${actualEndDate.getMonth()}`);
+              x.test(actualEndDate.getDate() === expectedEndDate.getDate(),
+                       `${testCase.format} end day should be ${expectedEndDate.getDate()}, got ${actualEndDate.getDate()}`);
             }
           }
         } catch (e) {

--- a/src/foam/parse/test/tests.jrl
+++ b/src/foam/parse/test/tests.jrl
@@ -1,2 +1,3 @@
 p({"class":"foam.parse.test.QueryParserUserTest","id":"QueryParserUserTest"})
+p({"class":"foam.parse.test.QueryParserJSTest","id":"QueryParserJSTest"})
 p({"class":"foam.parse.test.FScriptParserTest","id":"FScriptParserTest"})

--- a/src/pom.js
+++ b/src/pom.js
@@ -413,6 +413,7 @@ foam.POM({
     { name: "foam/parse/FScriptParser",                               flags: "js" },
     { name: "foam/parse/test/FScriptParserTestUser",                  flags: "js&test|java&test" },
     { name: "foam/parse/test/FScriptParserTest",                      flags: "js&test|java&test" },
+    { name: "foam/parse/test/QueryParserJSTest",                      flags: "js&test|java&test" },
     { name: "foam/parse/test/QueryParserUserTest",                    flags: "js&test|java&test" },
     { name: "foam/physics/Physical",                                  flags: "js" },
     { name: "foam/physics/Collider",                                  flags: "js" },


### PR DESCRIPTION
dates were coming back as invalid, due to missing one default 

and time zone issue was happening here, that we fixed in the adapt


and added test cases to make sure it doesnt happen again.