### PR TITLE
The combination of synchronous replay along with loading non-lazy DAO…

### DIFF
--- a/src/foam/core/boot/Boot.java
+++ b/src/foam/core/boot/Boot.java
@@ -201,13 +201,22 @@ public class Boot {
       }
     }
 
+    Agency agency = (Agency) root_.get("threadPool");
     serviceDAO_.where(EQ(CSpec.LAZY, false)).select(new AbstractSink() {
       @Override
       public void put(Object obj, Detachable sub) {
         CSpec sp = (CSpec) obj;
-
-        logger.info("Invoking Service", sp.getName());
-        root_.get(sp.getName());
+        if ( agency == null ) {
+          logger.info("Invoking Service", sp.getName());
+          root_.get(sp.getName());
+        } else {
+          agency.submit(root_, new ContextAgent() {
+              public void execute(X x) {
+                logger.info("Invoking Service", sp.getName());
+                x.get(sp.getName());
+              }
+            }, sp.getName());
+        }
       }
     });
   }

--- a/src/foam/core/boot/CSpecFactory.java
+++ b/src/foam/core/boot/CSpecFactory.java
@@ -202,6 +202,7 @@ public class CSpecFactory
         ns_ = null;
         spec_ = spec;
         if ( ! spec_.getLazy() ) {
+          logger.info("Invalidate create non-Lazy Service", spec_.getName());
           create(x_);
         }
       }

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -569,9 +569,16 @@ foam.CLASS({
       value: true
     },
     {
-      documentation: 'See JDAO and F3FileJournal.  Default journal replay is asynchronous. Some models with business logic that reference self can cause deadlock when parsed out of order.  If journal processing hangs, set syncReplay to true to replay synchronously.',
+      documentation: `REMOVED.  CSpec DAO loading is now a
+compbination of 'synchronous' replay along with 'asynchronous' non-lazy
+dao loading, which improves overall startup time.`,
       class: 'Boolean',
-      name: 'syncReplay'
+      name: 'syncReplay',
+      value: true,
+      javaSetter: `
+        if ( ! val )
+          foam.core.logger.StdoutLogger.instance().warning("EasyDAO.syncReplay:false support has been removed.");
+      `
     },
     {
       documentation: `Enable NDiff in JDAO. Enable per DAO with this property or globally via JVM Parameter 'UseNDiff'`,
@@ -708,12 +715,6 @@ foam.CLASS({
       generateJava: false,
     },
     {
-      class: 'Boolean',
-      name: 'refreshSessionTimer',
-      value: true,
-      generateJava: false,
-    },
-    {
       name: 'crunchBoxEnabled',
       generateJava: false,
       value: true
@@ -741,10 +742,7 @@ foam.CLASS({
           });
         }
 
-        return this.SessionClientBox.create({
-          delegate: box,
-          refreshSessionTimer: this.refreshSessionTimer
-        });
+        return this.SessionClientBox.create({delegate: box});
       }
     },
     {
@@ -963,7 +961,6 @@ foam.CLASS({
             jdao.setFilename(getJournalName());
             jdao.setCluster(getCluster() && !getSaf());
             jdao.setWaitReplay(getWaitReplay());
-            jdao.setSyncReplay(getSyncReplay());
             jdao.setNdiff(getNdiff());
             // Setting of delegate must be last as it triggers replay
             jdao.setDelegate(delegate);
@@ -1003,6 +1000,7 @@ foam.CLASS({
         <p>This process is transparent to the developer, and you can use your
         EasyDAO like any other DAO.</p>
       */
+      this.SUPER.apply(this, arguments);
 
       var daoType = typeof this.daoType === 'string' ?
         this.ALIASES[this.daoType] || this.daoType :

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -32,11 +32,6 @@ foam.CLASS({
       name: 'dao'
     },
     {
-      documentation: 'Default journal replay is asynchronous. Some models with business logic that reference self can cause deadlock when parsed out of order.  If journal processing hangs, set syncReplay to true to replay synchronously.',
-      class: 'Boolean',
-      name: 'syncReplay'
-    },
-    {
       documentation: 'Report of successfully processed lines during last replay',
       class: 'Int',
       name: 'passCount'
@@ -70,11 +65,7 @@ foam.CLASS({
         // NOTE: explicitly calling PM constructor as create only creates
         // a percentage of PMs, but we want all replay statistics
         PM pm = new PM(dao.getOf(), "replay." + getFilename());
-        AssemblyLine assemblyLine =
-          ( getSyncReplay() ||
-            x.get("threadPool") == null ) ?
-          new foam.util.concurrent.SyncAssemblyLine() :
-          new foam.util.concurrent.AsyncAssemblyLine(x, "replay");
+        AssemblyLine assemblyLine = new foam.util.concurrent.SyncAssemblyLine();
 
         try ( BufferedReader reader = getReader() ) {
           if ( reader == null ) {

--- a/src/foam/dao/java/JDAO.js
+++ b/src/foam/dao/java/JDAO.js
@@ -65,11 +65,6 @@ In this current implementation setDelegate must be called last.`,
       name: 'journal'
     },
     {
-      documentation: 'See F3FileJournal. Default journal replay is asynchronous. Some models with business logic that reference self can cause deadlock when parsed out of order.  If journal processing hangs, set syncReplay to true to replay synchronously.',
-      class: 'Boolean',
-      name: 'syncReplay'
-    },
-    {
       documentation: `Force caller to wait on nspec initailzation. The first call to 'get' for an nspec (x.get(servicename)) will have the calling thread wait on reply of service. This is the default behaviour and should be used for all essential services.  Also this should be used if the model is using SeqNo or NUID for id generation.`,
       class: 'Boolean',
       name: 'waitReplay',
@@ -123,14 +118,12 @@ In this current implementation setDelegate must be called last.`,
                   .setDao(delegate)
                   .setFilename(getFilename())
                   .setCreateFile(true)
-                  .setSyncReplay(getSyncReplay())
                   .build());
               } else {
                 setJournal(new F3FileJournal.Builder(runtimeStorageX)
                   .setDao(delegate)
                   .setFilename(getFilename())
                   .setCreateFile(false)
-                  .setSyncReplay(getSyncReplay())
                   .build());
               }
             }


### PR DESCRIPTION
The combination of synchronous replay along with loading non-lazy DAOs via agency (threadpool) produces the best overall startup times for many large journals.

Previously, asynchronous replay was ~10% faster than synchronous replay. But synchronous replay with asynchronous non-lazy loading is an additional ~10% faster again. (with Java 21. Java 25 shows every better performance).