### PR TITLE
build - add explicit support for /journals directory.  Users are expe…

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -555,6 +555,13 @@ function pom() {
     warning('Added /pom');
   }
 
+  // Special support for /journals.  Users are expecting it to behave
+  // like a default deployment directory; loading after the project
+  // poms and before the deployment poms.
+  // CAVEAT: This logic only supports /journals on the root project.
+  if ( existsSync(`${PROJECT_HOME}/journals/pom.js`) ) {
+    addPom(`${PROJECT_HOME}/journals/pom`);
+  }
   if ( globalThis['JOURNALS'] ) {
     JOURNALS.split(',').forEach(c => {
       if ( ! c ) return;


### PR DESCRIPTION
…cting it to behave like a default deployment directory; loading after the project poms, but before the deployment poms