### PR TITLE
pmake: move foam.POM SUPER() call earlier

### DIFF
--- a/tools/pmake.js
+++ b/tools/pmake.js
@@ -117,13 +117,13 @@ var pmake = function(...args) {
       self.verbose('[pmake] visitPOM', v.name, pom);
       v.visitPOM && v.visitPOM.bind(self, pom)();
     });
+    SUPER(pom);
     if ( ! seen[foam.cwd] ) {
       self.verbose('[pmake] procesDir', pom.path );
       processDir.bind(self, pom, foam.cwd, false, makers)();
       seen[foam.cwd] = true;
     }
 
-    SUPER(pom);
     makers.forEach(v => v.endVisitPOM && v.endVisitPOM(pom));
   }.bind(self);
 


### PR DESCRIPTION
This enusres that processDir is called on all depedency projects before the current project.

As a result things like JournalMaker will pick up journals from dependency projects:[] before the local files, which is more in line with user expectations.