### PR TITLE
Project tooling - convert deployment/appName to /journals and ensure …

### DIFF
--- a/tools/setup/ProjectTooling.js
+++ b/tools/setup/ProjectTooling.js
@@ -74,7 +74,6 @@ foam.POM({
 
       // base setup
       templateMerge(TEMPLATE_DIR, 'rootPOM.js', `${PROJECT_DIR}`, 'pom.js');
-      templateMerge(TEMPLATE_DIR, 'deploymentAppPOM.js', `${PROJECT_DIR}/deployment/${APP_NAME_LOW}`, 'pom.js');
       templateMerge(TEMPLATE_DIR, 'journalPOM.js', `${PROJECT_DIR}/${JOURNAL_DIR}`, 'pom.js');
       templateMerge(TEMPLATE_DIR, 'journalGroups.jrl', `${PROJECT_DIR}/${JOURNAL_DIR}`, `groups.jrl`);
       templateMerge(TEMPLATE_DIR, 'journalGroupPermissionJunctions.jrl', `${PROJECT_DIR}/${JOURNAL_DIR}`, `groupPermissionJunctions.jrl`);

--- a/tools/setup/deploymentDemoPOM.js
+++ b/tools/setup/deploymentDemoPOM.js
@@ -1,7 +1,4 @@
 foam.POM({
   name: 'demo',
-  description: 'Journal configuration specific to example or demonstration deployment',
-  projects: [
-    { name: '../{app}/pom' }
-  ]
+  description: 'Journal configuration specific to demonstration deployment'
 });

--- a/tools/setup/journalPOM.js
+++ b/tools/setup/journalPOM.js
@@ -1,3 +1,4 @@
 foam.POM({
-  name:'journals'
+  name:'journals',
+  description: 'Journal configuration common to all deployments'
 });

--- a/tools/setup/rootPOM.js
+++ b/tools/setup/rootPOM.js
@@ -3,7 +3,8 @@ foam.POM({
   excludes: [ '*' ],
   projects: [
     { name: 'foam3/pom'},
-    { name: 'src/{packagePath}/pom'}
+    { name: 'src/{packagePath}/pom'},
+    { name: 'journals/pom' }
   ],
   licenses: `
     // Add your license header here


### PR DESCRIPTION
…/journals journals work for all project types