### PR TITLE
[NP-11871] Fix a bug when comment not shown in TicketComment

### DIFF
--- a/src/foam/core/ticket/TicketComment.js
+++ b/src/foam/core/ticket/TicketComment.js
@@ -52,7 +52,8 @@ foam.CLASS({
     {
       class: 'String',
       name: 'comment',
-      columnPermissionRequired: true,
+      label: '',
+      columnLabel: 'Comment'
       view: {
         class: 'foam.u2.tag.TextArea', rows: 5, cols: 144
       },

--- a/src/foam/core/ticket/TicketComment.js
+++ b/src/foam/core/ticket/TicketComment.js
@@ -52,7 +52,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'comment',
-      label: '',
+      columnPermissionRequired: true,
       view: {
         class: 'foam.u2.tag.TextArea', rows: 5, cols: 144
       },

--- a/src/foam/u2/table/TableComponentView.js
+++ b/src/foam/u2/table/TableComponentView.js
@@ -70,7 +70,7 @@ foam.CLASS({
     },
     async function filterUnpermitted(arr) {
       const results = await Promise.all(arr.map( async p =>
-        ( p.hidden || ! p.label )? false :
+        p.hidden ? false :
         (! this.auth) ? true : ! p.columnPermissionRequired ||
         await this.auth.check(ctrl.__subContext__, `${this.of.name.toLowerCase()}.column.${p.name}`)));
       return arr.filter((_v, index) => results[index]);


### PR DESCRIPTION
According to the code below, having an empty label is equivalent to having columnPermissionRequired, but it doesn’t grant permission even to an admin.

https://github.com/kgrgreer/foam3/blob/84ea89d96d0723d920eb4ed384623f5725cae0b9/src/foam/u2/table/TableComponentView.js#L73

