### PR TITLE
MicrosoftGraphEmailAgent - disable cspec in foam to avoid startup errors

### DIFF
--- a/src/foam/core/notification/email/ms/services.jrl
+++ b/src/foam/core/notification/email/ms/services.jrl
@@ -5,7 +5,8 @@ p({
   service:{
     class:"foam.core.notification.email.ms.MicrosoftGraphEmailAgent",
     id: 'msGraph'
-  }
+  },
+  enabled: false
 })
 p({
   class: "foam.core.boot.CSpec",


### PR DESCRIPTION
Disable cspec in foam to avoid startup errors when running foam itself or an application using another email service.

Addresses issue: [MicrosoftGraphEmailAgent generates error for all non PT deployments](https://github.com/kgrgreer/foam3/issues/4213)

NOTE: PT requires a PR to enable this at the application level. 