### PR TITLE
Support domain based content security policies

### DIFF
--- a/deployment/https/csps.jrl.example
+++ b/deployment/https/csps.jrl.example
@@ -1,0 +1,33 @@
+// Example Production Content Security Policy
+p({
+  "class":"foam.core.http.csp.CSP",
+  "id":"default",
+  "policy":"""
+    default-src 'self' data: chrome-extension-resource:;
+    connect-src 'self' http://localhost:*/service/ https://fonts.googleapis.com/css2 https://www.google.com/pagead;
+    frame-src 'self' data: blob: filesystem:
+    frame-ancestors 'self';
+    font-src 'self' https://fonts.gstatic.com data: chrome-extension-resource:;
+    img-src 'self' data: blob: filesystem: https://play.google.com;
+    manifest-src 'self';
+    media-src * data: blob: filesystem:;
+    object-src 'self' data: blob: filesystem:;
+    report-uri /service/CSPReportWebAgent;
+    worker-src 'self';
+    script-src
+      'self'
+      'unsafe-eval'
+      https://cdn.plaid.com/link/v2/stable/link-initialize.js
+      https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.3/html2pdf.bundle.min.js
+      https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js
+      https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js
+      'sha256-HY1JzEwuxkis4xx0ggY23gbYY/MCEAE1T6+OQnWS2vA='
+      'sha256-NiNrLgJ8wbIXIi5saiR3XTd1Mxm4k0nju66GJsw4b9U='
+      'sha256-FLYDXBkz4oo/H5jEfYXqAGYUwERY44OO1yznaMCdMiU='
+      'sha256-G3UfiJBy6rwOk3glkBQuQDFA7IoCtiOT56gTh+IfNF0='
+      'sha256-VqQW98BZz58NothFoAKVTq/UrLorSsLU11mhJjLFzW0='
+      https://cdnjs.cloudflare.com/ajax/libs/ace/1.9.6/
+      'sha512-czfWedq9cnMibaqVP2Sw5Aw1PTTabHxMuTOkYkL15cbCYiatPIbxdV0zwhfBZKNODg0zFqmbz8f7rKmd6tfR/Q==';
+    style-src 'self' https://fonts.googleapis.com/css https://fonts.googleapis.com/css2 https://fonts.googleapis.com/icon data: chrome-extension-resource: 'unsafe-inline';
+  """
+})

--- a/deployment/https/services.jrl
+++ b/deployment/https/services.jrl
@@ -85,37 +85,7 @@ p({
     "filterMappings": [{
       "class": "foam.core.servlet.FilterMapping",
       "filterClass": "foam.core.http.csp.CSPFilter",
-      "pathSpec": "/*",
-      "initParameters": {
-        "CONTENT_SECURITY_POLICY": """
-          default-src 'self' data: chrome-extension-resource:;
-          connect-src 'self' http://localhost:*/service/ https://fonts.googleapis.com/css2 https://www.google.com/pagead;
-          frame-src 'self' data: blob: filesystem:
-          frame-ancestors 'self';
-          font-src 'self' https://fonts.gstatic.com data: chrome-extension-resource:;
-          img-src 'self' data: blob: filesystem: https://play.google.com;
-          manifest-src 'self';
-          media-src * data: blob: filesystem:;
-          object-src 'self' data: blob: filesystem:;
-          report-uri /service/CSPReportWebAgent;
-          worker-src 'self';
-          script-src
-            'self'
-            'unsafe-eval'
-            https://cdn.plaid.com/link/v2/stable/link-initialize.js
-            https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.3/html2pdf.bundle.min.js
-            https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js
-            https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js
-            'sha256-HY1JzEwuxkis4xx0ggY23gbYY/MCEAE1T6+OQnWS2vA='
-            'sha256-NiNrLgJ8wbIXIi5saiR3XTd1Mxm4k0nju66GJsw4b9U='
-            'sha256-FLYDXBkz4oo/H5jEfYXqAGYUwERY44OO1yznaMCdMiU='
-            'sha256-G3UfiJBy6rwOk3glkBQuQDFA7IoCtiOT56gTh+IfNF0='
-            'sha256-VqQW98BZz58NothFoAKVTq/UrLorSsLU11mhJjLFzW0='
-            https://cdnjs.cloudflare.com/ajax/libs/ace/1.9.6/
-            'sha512-czfWedq9cnMibaqVP2Sw5Aw1PTTabHxMuTOkYkL15cbCYiatPIbxdV0zwhfBZKNODg0zFqmbz8f7rKmd6tfR/Q==';
-          style-src 'self' https://fonts.googleapis.com/css https://fonts.googleapis.com/css2 https://fonts.googleapis.com/icon data: chrome-extension-resource: 'unsafe-inline';
-        """
-      }
+      "pathSpec": "/*"
     }]
   }
 })

--- a/src/foam/core/http/csp/CSP.js
+++ b/src/foam/core/http/csp/CSP.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.http.csp',
+  name: 'CSP',
+
+  documentation: 'Content-Security-Policy',
+
+  properties: [
+    {
+      name: 'id',
+      class: 'String'
+    },
+    {
+      name: 'description',
+      class: 'String'
+    },
+    {
+      // TODO: for now just a large string block, breakdown later
+      name: 'policy',
+      class: 'String',
+      view: { class: 'foam.u2.tag.TextArea', rows: 10, cols: 60 }
+    }
+  ]
+});

--- a/src/foam/core/http/csp/CSPFilter.js
+++ b/src/foam/core/http/csp/CSPFilter.js
@@ -77,15 +77,8 @@ falling back to the CONTENT_SECURITY_POLICY defined in CSpec "http".
       args: 'ServletRequest request, ServletResponse response, FilterChain chain',
       javaThrows: [ 'java.io.IOException', 'ServletException' ],
       javaCode: `
-        String name = request.getServerName();
-        String domain = name;
-        String subDomain = null;
-        String[] parts = domain.split(".");
-        if ( parts.length > 1 ) {
-          subDomain = parts[0];
-          domain = parts[1];
-        }
-        String policy = (String) getCache().get(name);
+        String domain = request.getServerName();
+        String policy = (String) getCache().get(domain);
         if ( SafetyUtil.isEmpty(policy) ) {
           policy = getDefaultCSP();
 
@@ -93,25 +86,21 @@ falling back to the CONTENT_SECURITY_POLICY defined in CSpec "http".
           if ( x != null ) {
             DAO themeDomainDAO = (DAO) x.get("themeDomainDAO");
             if ( themeDomainDAO != null ) {
-              Predicate pred = EQ(ThemeDomain.ID, domain);
-              if ( ! SafetyUtil.isEmpty(subDomain) ) {
-                pred = AND(pred, EQ(ThemeDomain.SUBDOMAIN, subDomain));
-              }
-              ThemeDomain themeDomain = (ThemeDomain) themeDomainDAO.find(pred);
+              ThemeDomain themeDomain = (ThemeDomain) themeDomainDAO.find(domain);
               if ( themeDomain != null &&
                    ! SafetyUtil.isEmpty(themeDomain.getContentSecurityPolicy()) ) {
                 DAO cspDAO = (DAO) x.get("cspDAO");
                 CSP csp = (CSP) cspDAO.find(themeDomain.getContentSecurityPolicy());
                 if ( csp != null &&
                      ! SafetyUtil.isEmpty(csp.getPolicy()) ) {
-                  foam.core.logger.StdoutLogger.instance().info("CSPFilter,doFilter,found domain policy for", name);
+                  foam.core.logger.StdoutLogger.instance().info("CSPFilter,doFilter,found domain policy for", domain);
                   policy = csp.getPolicy();
                   policy = policy.replaceAll("\\n", "");
                 }
               }
             }
           }
-          getCache().put(name, policy);
+          getCache().put(domain, policy);
         }
 
         if ( ! SafetyUtil.isEmpty(policy) ) {

--- a/src/foam/core/http/csp/CSPFilter.js
+++ b/src/foam/core/http/csp/CSPFilter.js
@@ -28,7 +28,7 @@ falling back to the CONTENT_SECURITY_POLICY defined in CSpec "http".
     'foam.util.SafetyUtil',
     'jakarta.servlet.*',
     'jakarta.servlet.http.HttpServletResponse',
-    'java.util.HashMap',
+    'java.util.concurrent.ConcurrentHashMap',
     'java.util.Map'
   ],
 
@@ -41,7 +41,7 @@ falling back to the CONTENT_SECURITY_POLICY defined in CSpec "http".
     {
       name: 'cache',
       class: 'Map',
-      javaFactory: 'return new HashMap();',
+      javaFactory: 'return new ConcurrentHashMap();',
       visibility: 'HIDDEN'
     }
   ],

--- a/src/foam/core/http/csp/CSPFilter.js
+++ b/src/foam/core/http/csp/CSPFilter.js
@@ -8,19 +8,43 @@ foam.CLASS({
   package: 'foam.core.http.csp',
   name: 'CSPFilter',
 
-  documentation: 'Content-Security-Policy servlet filter',
+  documentation: `Content-Security-Policy servlet filter.
+Attempts to find a 'domain' specific policy via ThemeDomain,
+falling back to the CONTENT_SECURITY_POLICY defined in CSpec "http".
+`,
 
   javaImplements: [ 'jakarta.servlet.Filter' ],
 
   javaImports: [
+    'foam.core.theme.ThemeDomain',
+    'foam.dao.AbstractSink',
+    'foam.dao.DAO',
+    'foam.lang.Detachable',
+    'foam.lang.X',
+    'foam.lang.XLocator',
+    'static foam.mlang.MLang.AND',
+    'static foam.mlang.MLang.EQ',
+    'foam.mlang.predicate.Predicate',
+    'foam.util.SafetyUtil',
     'jakarta.servlet.*',
-    'jakarta.servlet.http.HttpServletResponse'
+    'jakarta.servlet.http.HttpServletResponse',
+    'java.util.HashMap',
+    'java.util.Map'
   ],
 
-  javaCode: `
-    protected FilterConfig config_;
-    protected String csp_;
-  `,
+  properties: [
+    {
+      name: 'defaultCSP',
+      class: 'String',
+      visibility: 'HIDDEN'
+    },
+    {
+      name: 'cache',
+      class: 'Map',
+      javaFactory: 'return new HashMap();',
+      visibility: 'HIDDEN'
+    }
+  ],
 
   methods: [
     {
@@ -28,8 +52,24 @@ foam.CLASS({
       args: 'FilterConfig config',
       javaThrows: [ 'ServletException' ],
       javaCode: `
-        this.config_ = config;
-        this.csp_    = config.getInitParameter("CONTENT_SECURITY_POLICY");
+        setDefaultCSP(config.getInitParameter("CONTENT_SECURITY_POLICY"));
+
+        X x = (X) config.getServletContext().getAttribute("X");
+        DAO themeDomainDAO = (DAO) x.get("themeDomainDAO");
+        themeDomainDAO.listen(new AbstractSink() {
+          @Override
+          public void put(Object obj, Detachable sub) {
+            getCache().clear();
+          }
+        }, null);
+
+        DAO cspDAO = (DAO) x.get("cspDAO");
+        cspDAO.listen(new AbstractSink() {
+          @Override
+          public void put(Object obj, Detachable sub) {
+            getCache().clear();
+          }
+        }, null);
       `
     },
     {
@@ -37,8 +77,46 @@ foam.CLASS({
       args: 'ServletRequest request, ServletResponse response, FilterChain chain',
       javaThrows: [ 'java.io.IOException', 'ServletException' ],
       javaCode: `
-        var httpResponse = (HttpServletResponse) response;
-        httpResponse.setHeader("Content-Security-Policy", csp_);
+        String name = request.getServerName();
+        String domain = name;
+        String subDomain = null;
+        String[] parts = domain.split(".");
+        if ( parts.length > 1 ) {
+          subDomain = parts[0];
+          domain = parts[1];
+        }
+        String policy = (String) getCache().get(name);
+        if ( SafetyUtil.isEmpty(policy) ) {
+          policy = getDefaultCSP();
+
+          X x = (X) request.getServletContext().getAttribute("X");
+          if ( x != null ) {
+            DAO themeDomainDAO = (DAO) x.get("themeDomainDAO");
+            if ( themeDomainDAO != null ) {
+              Predicate pred = EQ(ThemeDomain.ID, domain);
+              if ( ! SafetyUtil.isEmpty(subDomain) ) {
+                pred = AND(pred, EQ(ThemeDomain.SUBDOMAIN, subDomain));
+              }
+              ThemeDomain themeDomain = (ThemeDomain) themeDomainDAO.find(pred);
+              if ( themeDomain != null &&
+                   ! SafetyUtil.isEmpty(themeDomain.getContentSecurityPolicy()) ) {
+                DAO cspDAO = (DAO) x.get("cspDAO");
+                CSP csp = (CSP) cspDAO.find(themeDomain.getContentSecurityPolicy());
+                if ( csp != null &&
+                     ! SafetyUtil.isEmpty(csp.getPolicy()) ) {
+                  foam.core.logger.StdoutLogger.instance().info("CSPFilter,doFilter,found domain policy for", name);
+                  policy = csp.getPolicy();
+                  policy = policy.replaceAll("\\n", "");
+                }
+              }
+            }
+          }
+          getCache().put(name, policy);
+        }
+
+        if ( ! SafetyUtil.isEmpty(policy) ) {
+          ((HttpServletResponse) response).setHeader("Content-Security-Policy", policy);
+        }
 
         chain.doFilter(request, response);
       `

--- a/src/foam/core/http/csp/services.jrl
+++ b/src/foam/core/http/csp/services.jrl
@@ -7,6 +7,22 @@ p({
 
 p({
   class: "foam.core.boot.CSpec",
+  name: "cspDAO",
+  description: "DAO containing Content Security Policies",
+  serve: true,
+  serviceScript: """
+    return new foam.dao.EasyDAO.Builder(x)
+      .setOf(foam.core.http.csp.CSP.getOwnClassInfo())
+      .setFuid(true)
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName("csps")
+      .build();
+    """,
+  client: "{\"of\":\"foam.core.http.csp.CSP\"}",
+})
+
+p({
+  class: "foam.core.boot.CSpec",
   name: "CSPViolationsDAO",
   description: "DAO containing CSP violation reports that are sent to the server by the clients.",
   serve: true,

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -506,6 +506,7 @@ foam.POM({
     { name: "ndiff/NDiffDAO",                                                             flags: "js|java" },
     { name: "ndiff/NDiffJournal",                                                         flags: "js|java" },
     { name: "ndiff/NDiffRuntimeDAO",                                                      flags: "js|java" },
+    { name: "http/csp/CSP",                                                               flags: "js|java" },
     { name: "http/csp/CSPFilter",                                                         flags: "java" },
     { name: "http/csp/CSPReportWebAgent",                                                 flags: "java" },
     { name: "http/csp/CSPViolation",                                                      flags: "js|java" },

--- a/src/foam/core/theme/ThemeDomain.js
+++ b/src/foam/core/theme/ThemeDomain.js
@@ -8,7 +8,7 @@ foam.CLASS({
   package: 'foam.core.theme',
   name: 'ThemeDomain',
 
-  documentation: 'mapping of domain to Theme. Note: is managed by the ThemeDomainDAO',
+  documentation: 'mapping of domain to Theme.',
 
   tableColumns: [
     'id',
@@ -41,6 +41,13 @@ foam.CLASS({
     {
       class: 'String',
       name: 'subdomain'
+    },
+    {
+      name: 'contentSecurityPolicy',
+      class: 'Reference',
+      of: 'foam.core.http.csp.CSP',
+      targetDAOKey: 'cspDAO',
+      value: 'default'
     }
   ]
 });


### PR DESCRIPTION
Domain (and sub domain) based Content Security Policy (CSP)

* CSP now defined in CSP model.  Presently the policy itself is just a string block. Future work can model the policy itself. 
* CSPFilter attempts to find policy by domain via ThemeDomain, falling back to the original "http" CSPec CSPFilter init parameters.
* removed CSP from foam itself.  Left an example, but policy is responsibility of application. 
* The production "http" CSpec's with CSP of NP and PT will continue to work. 