### PR TITLE
Journal - distinguish between create and update to speed replay.

### DIFF
--- a/src/foam/core/logger/LoggerJDAO.js
+++ b/src/foam/core/logger/LoggerJDAO.js
@@ -28,7 +28,7 @@ foam.CLASS({
         .setFilename(filename)
         .setCreateFile(true)
         .setDao(getDelegate())
-        .setLogger(new foam.core.logger.PrefixLogger(new Object[] { "[JDAO]", filename }, foam.core.logger.StdoutLogger.instance()))
+        .setLogger(new foam.core.logger.PrefixLogger(new Object[] { "LoggerJDAO", filename }, foam.core.logger.StdoutLogger.instance()))
         .build());
     }
   `,

--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -70,7 +70,6 @@ foam.CLASS({
         JSONFObjectFormatter b = new JSONFObjectFormatter();
         b.setPropertyPredicate(new StoragePropertyPredicate());
         b.setOutputShortNames(true);
-        b.setOutputDefaultClassNames(false);
         return b;
       }
       @Override

--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -121,6 +121,59 @@ foam.CLASS({
     }
   `,
 
+  constants: [
+    {
+      name: 'MODIFIED_BY',
+      type: 'String',
+      value: '// Modified by '
+    },
+    {
+      name: 'OP_CREATE',
+      type: 'String',
+      value: 'c('
+    },
+    {
+      name: 'OPEN_CREATE',
+      type: 'String',
+      value: 'c({'
+    },
+    {
+      name: 'OPEN_PUT',
+      type: 'String',
+      value: 'p({'
+    },
+    {
+      name: 'OP_PUT',
+      type: 'String',
+      value: 'p('
+    },
+    {
+      name: 'OPEN_REMOVE',
+      type: 'String',
+      value: 'r({'
+    },
+    {
+      name: 'OP_REMOVE',
+      type: 'String',
+      value: 'r('
+    },
+    {
+      name: 'OPEN_VERSION',
+      type: 'String',
+      value: 'v({'
+    },
+    {
+      name: 'CLOSE',
+      type: 'String',
+      value: '})'
+    },
+    {
+      name: 'OP_CLOSE',
+      type: 'String',
+      value: ')'
+    }
+  ],
+
   properties: [
     {
       class: 'Object',
@@ -143,7 +196,7 @@ foam.CLASS({
         if ( logger == null ) {
           logger = StdoutLogger.instance();
         }
-        return new PrefixLogger(new Object[] { "[JDAO]" }, logger);
+        return new PrefixLogger(new Object[] { "Journal", getFilename() }, logger);
       `,
       javaCloneProperty: '//noop'
     },
@@ -172,13 +225,13 @@ foam.CLASS({
 try {
   InputStream is = getX().get(Storage.class).getInputStream(getFilename());
   if ( is == null ) {
-    getLogger().warning("File not found", "for reading", getFilename());
+    getLogger().warning("File not found", "for reading");
     return null;
   }
   // Setting a larger buffer size increases performance by 10-15%
   return new BufferedReader(new InputStreamReader(is), 1024 * 1024 * 2);
 } catch ( Throwable t ) {
-  getLogger().error("Failed to initialize reader", getFilename(), t);
+  getLogger().error("Failed to initialize reader", t);
   throw new RuntimeException(t);
 }
       `
@@ -192,12 +245,12 @@ try {
 try {
   OutputStream os = getX().get(FileSystemStorage.class).getOutputStream(getFilename());
   if ( os == null ) {
-    getLogger().warning("File not found", "for writing", getFilename());
+    getLogger().warning("File not found", "for writing");
     return null;
   }
   return new BufferedWriter(new OutputStreamWriter(os));
 } catch ( Throwable t ) {
-  getLogger().error("Failed to initialize writer", getFilename(), t);
+  getLogger().error("Failed to initialize writer", t);
   throw new RuntimeException(t);
 }
       `
@@ -220,12 +273,12 @@ try {
       javaCode: `
         try {
           var writer = getWriter();
-          String entry = String.format("v({\\"version\\":\\"%s\\"})", version);
+          String entry = String.format("%s\\"version\\":\\"%s\\"%s", OPEN_VERSION, version, CLOSE);
           writer.write(entry);
           writer.newLine();
           writer.flush();
         } catch (java.io.IOException e) {
-          Loggers.logger(x, this).error("Failed to write to journal file: ", getFilename(), " for version ", version );
+          getLogger().error("Failed to write version", version);
         }
       `
     },
@@ -258,7 +311,7 @@ try {
                 fmt.output(obj, of);
               }
             } catch (Throwable t) {
-              getLogger().error("Failed to format put", getFilename(), of.getId(), "id", id, t);
+              getLogger().error("Failed to format put", of.getId(), "id", id, t);
               fmt.reset();
             }
           }
@@ -270,12 +323,13 @@ try {
               writeComment_(x, obj);
               writePut_(
                 x,
+                old == null,
                 fmt.builder(),
                 getMultiLineOutput() ? "\\n" : "",
                 SafetyUtil.isEmpty(prefix) ? "" : prefix + ".");
               if ( isLast ) getWriter().flush();
             } catch (Throwable t) {
-              getLogger().error("Failed to write put", getFilename(), of.getId(), "id", id, t);
+              getLogger().error("Failed to write put", of.getId(), "id", id, t);
             } finally {
               fmt.reset();
             }
@@ -287,17 +341,18 @@ try {
     },
     {
       name: 'writePut_',
-      javaThrows: [
-        'java.io.IOException'
-      ],
-      args: [ 'Context x', 'CharSequence record', 'String c', 'String prefix' ],
+      javaThrows: [ 'java.io.IOException' ],
+      args: 'Context x, Boolean create, CharSequence record, String c, String prefix',
       javaCode: `
-      PM pm = PM.create(x, "FileJournal", "write");
+      PM pm = PM.create(x, "FileJournal:write");
       BufferedWriter writer = getWriter();
       writer.write(prefix);
-      writer.write("p(");
+      if ( create )
+        writer.write(OP_CREATE);
+      else
+        writer.write(OP_PUT);
       writer.append(record);
-      writer.write(')');
+      writer.write(OP_CLOSE);
       writer.write(c);
       writer.newLine();
       pm.log(x);
@@ -329,7 +384,7 @@ try {
             toWrite.setProperty("id", obj.getProperty("id"));
             fmt.output(toWrite, dao.getOf());
           } catch (Throwable t) {
-            getLogger().error("Failed to write remove", getFilename(), dao.getOf().getId(), "id", id, t);
+            getLogger().error("Failed to write remove", dao.getOf().getId(), "id", id, t);
           }
         }
 
@@ -342,7 +397,7 @@ try {
 
             if ( isLast ) getWriter().flush();
           } catch (Throwable t) {
-            getLogger().error("Failed to write remove", getFilename(), dao.getOf().getId(), "id", id, t);
+            getLogger().error("Failed to write remove", dao.getOf().getId(), "id", id, t);
           }
         }
       });
@@ -359,9 +414,9 @@ try {
       javaCode: `
       write_(sb.get()
         .append(prefix)
-        .append("r(")
+        .append(OP_REMOVE)
         .append(record)
-        .append(")"));
+        .append(OP_CLOSE));
       getWriter().newLine();
       `
     },
@@ -387,6 +442,7 @@ try {
         User user = ((Subject) x.get("subject")).getUser();
         if ( user == null || user.getId() <= 1 ) return;
         if ( obj instanceof LastModifiedByAware && ((LastModifiedByAware) obj).getLastModifiedBy() != 0L ) return;
+
         long now    = System.currentTimeMillis();
         long userId = user.getId();
         if ( now == getLastTimestamp() && userId == getLastUser() ) return;
@@ -412,13 +468,13 @@ try {
         try {
           String line = reader.readLine();
           if ( line == null ) return null;
-          if ( ! line.equals("p({") && ! line.equals("r({") ) return line;
+          if ( ! line.equals(OPEN_PUT) && ! line.equals(OPEN_CREATE) && ! line.equals(OPEN_REMOVE) ) return line;
           stringBuilder.setLength(0);
           stringBuilder.append(line);
-          while( ! line.equals("})") ) {
+          while( ! line.equals(CLOSE) ) {
             if ( (line = reader.readLine()) == null ) break;
-            if ( line.equals("p({") ) {
-              getLogger().error("Entry is not properly closed: " + stringBuilder.toString());
+            if ( line.equals(OPEN_PUT) || line.equals(OPEN_CREATE) || line.equals(OPEN_REMOVE) ) {
+              getLogger().error("Entry is not properly closed", stringBuilder.toString());
             }
             stringBuilder.append("\\n");
             stringBuilder.append(line);
@@ -495,7 +551,7 @@ try {
           }
         }
       } catch(ClassCastException e) {
-        String msg = "******************* UNEXPECTED CCE " + oldFObject + " " + diffFObject + " " + prop.getName()+ " "+ getFilename();
+        String msg = "******************* UNEXPECTED CCE " + oldFObject + " " + diffFObject + " " + prop.getName();
         getLogger().error(msg);
         System.err.println(msg);
         throw e;

--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -70,6 +70,7 @@ foam.CLASS({
         JSONFObjectFormatter b = new JSONFObjectFormatter();
         b.setPropertyPredicate(new StoragePropertyPredicate());
         b.setOutputShortNames(true);
+        b.setOutputDefaultClassNames(false);
         return b;
       }
       @Override
@@ -119,6 +120,11 @@ foam.CLASS({
       p.setX(x);
       return p;
     }
+
+    final static public char OP_CREATE  = 'c';
+    final static public char OP_PUT     = 'p';
+    final static public char OP_REMOVE  = 'r';
+    final static public char OP_VERSION = 'v';
   `,
 
   constants: [
@@ -126,11 +132,6 @@ foam.CLASS({
       name: 'MODIFIED_BY',
       type: 'String',
       value: '// Modified by '
-    },
-    {
-      name: 'OP_CREATE',
-      type: 'String',
-      value: 'c('
     },
     {
       name: 'OPEN_CREATE',
@@ -143,19 +144,9 @@ foam.CLASS({
       value: 'p({'
     },
     {
-      name: 'OP_PUT',
-      type: 'String',
-      value: 'p('
-    },
-    {
       name: 'OPEN_REMOVE',
       type: 'String',
       value: 'r({'
-    },
-    {
-      name: 'OP_REMOVE',
-      type: 'String',
-      value: 'r('
     },
     {
       name: 'OPEN_VERSION',
@@ -166,6 +157,11 @@ foam.CLASS({
       name: 'CLOSE',
       type: 'String',
       value: '})'
+    },
+    {
+      name: 'OP_OPEN',
+      type: 'String',
+      value: '('
     },
     {
       name: 'OP_CLOSE',
@@ -351,6 +347,7 @@ try {
         writer.write(OP_CREATE);
       else
         writer.write(OP_PUT);
+      writer.write(OP_OPEN);
       writer.append(record);
       writer.write(OP_CLOSE);
       writer.write(c);

--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -411,6 +411,7 @@ try {
       write_(sb.get()
         .append(prefix)
         .append(OP_REMOVE)
+        .append(OP_OPEN)
         .append(record)
         .append(OP_CLOSE));
       getWriter().newLine();

--- a/src/foam/dao/AbstractFileJournal.js
+++ b/src/foam/dao/AbstractFileJournal.js
@@ -99,7 +99,7 @@ foam.CLASS({
         if ( logger == null ) {
           logger = StdoutLogger.instance();
         }
-        return new PrefixLogger(new Object[] { "[JDAO]", getFilename() }, logger);
+        return new PrefixLogger(new Object[] { "Journal", getFilename() }, logger);
       `
     },
     {

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -86,7 +86,7 @@ foam.CLASS({
               final char operation = entry.charAt(0);
               final String strEntry = entry.subSequence(2, length - 1).toString();
 
-              if ( operation == 'v' ) {
+              if ( operation == OP_VERSION ) {
                 JSONObject obj = new JSONObject(strEntry);
                 lastVersion = (String) obj.get("version");
                 continue;
@@ -106,16 +106,16 @@ foam.CLASS({
                     return;
                   }
                   switch ( operation ) {
-                    case 'c':
+                    case OP_CREATE:
                       dao.put(obj);
                       break;
 
-                    case 'p':
+                    case OP_PUT:
                       foam.lang.FObject old = dao.find(obj.getProperty("id"));
                       dao.put(old != null ? mergeFObject(old.fclone(), obj) : obj);
                       break;
 
-                    case 'r':
+                    case OP_REMOVE:
                       dao.remove(obj);
                       break;
                   }

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -60,7 +60,7 @@ foam.CLASS({
 
         String lastVersion = "";
 
-        getLogger().info("Replay starting", getFilename());
+        getLogger().info("Replay starting");
 
         // NOTE: explicitly calling PM constructor as create only creates
         // a percentage of PMs, but we want all replay statistics
@@ -78,7 +78,7 @@ foam.CLASS({
             if ( length < 3 ) {
               // Don't bother reporting lines with just spaces
               if ( entry.toString().trim().length() != 0 ) {
-                System.err.println("Malformed jrl entry " + getFilename() + " : " + entry);
+                getLogger().warning("Malformed journal entry", entry);
               }
               continue;
             }
@@ -101,11 +101,15 @@ foam.CLASS({
 
                 public void endJob(boolean isLast) {
                   if ( obj == null ) {
-                    getLogger().error("Parse error in the jrl file " + getFilename(), getParsingErrorMessage(strEntry), "entry Object is: ", strEntry);
+                    getLogger().error("Parse error in the journal", getParsingErrorMessage(strEntry), "entry Object is: ", strEntry);
                     failCount.incrementAndGet();
                     return;
                   }
                   switch ( operation ) {
+                    case 'c':
+                      dao.put(obj);
+                      break;
+
                     case 'p':
                       foam.lang.FObject old = dao.find(obj.getProperty("id"));
                       dao.put(old != null ? mergeFObject(old.fclone(), obj) : obj);
@@ -118,7 +122,7 @@ foam.CLASS({
                   long pass = passCount.incrementAndGet();
                   // Provide some feedback on long running replays
                   if ( pass % 10000 == 0 ) {
-                    getLogger().info("Replay progress", getFilename(), "processed", pass, "in", Duration.ofMillis(pm.getTime()));
+                    getLogger().info("Replay progress", "processed", pass, "in", Duration.ofMillis(pm.getTime()));
                   }
                 }
               });
@@ -127,7 +131,7 @@ foam.CLASS({
             }
           }
         } catch ( Throwable t) {
-          getLogger().error("Failed to read journal", dao.getOf().getId(), getFilename(), t);
+          getLogger().error("Failed to read journal", dao.getOf().getId(), t);
         } finally {
           setLastReplayVersion(lastVersion);
           setPassCount(passCount.get());
@@ -135,9 +139,9 @@ foam.CLASS({
           assemblyLine.shutdown();
           pm.log(x);
           if ( getFailCount() == 0 ) {
-            getLogger().info("Replay complete", getFilename(), "processed", passCount.get(), "of", failCount.get()+passCount.get(), "in", Duration.ofMillis(pm.getTime()));
+            getLogger().info("Replay complete", "processed", passCount.get(), "of", failCount.get()+passCount.get(), "in", Duration.ofMillis(pm.getTime()));
           } else {
-            getLogger().warning("Replay complete", getFilename(), "processed", passCount.get(), "of", failCount.get()+passCount.get(), "in", Duration.ofMillis(pm.getTime()));
+            getLogger().warning("Replay complete", "processed", passCount.get(), "of", failCount.get()+passCount.get(), "in", Duration.ofMillis(pm.getTime()));
           }
         }
       `

--- a/src/foam/dao/test/F3FileJournalTest.js
+++ b/src/foam/dao/test/F3FileJournalTest.js
@@ -1,0 +1,257 @@
+/**
+ * @license
+ * Copyright 2025 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'F3FileJournalTest',
+  extends: 'foam.core.test.Test',
+
+  javaImports: [
+    'foam.core.auth.*',
+    'foam.dao.AbstractF3FileJournal',
+    'foam.dao.DAO',
+    'foam.dao.ProxyDAO',
+    'foam.lang.X',
+    'static foam.mlang.MLang.COUNT',
+    'foam.mlang.sink.Count',
+    'foam.util.Auth',
+    'java.io.*',
+    'java.nio.file.*',
+    'java.util.HashMap',
+    'java.util.Map',
+    'java.util.Scanner'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        X testX = x;
+
+        Map<String, Integer> info = null;
+        Integer count = null;
+
+        // Single property ID, implements LastModifiedBy
+        foam.dao.java.JDAO userDAO = new foam.dao.java.JDAO();
+        userDAO.setX(x);
+        userDAO.setFilename("userJournal");
+        userDAO.setDelegate(new foam.dao.FUIDDAO(x, "userDAO", "id", 
+            new foam.core.auth.LastModifiedAwareDAO.Builder(x).setDelegate(new foam.dao.MDAO(foam.core.auth.User.getOwnClassInfo())).build()));
+        x = x.put("userDAO", new ProxyDAO.Builder(x).setDelegate(userDAO).build());
+
+        User user = new User(x);
+        user.setFirstName("test1FirstName");
+        user.setLastName("test1LastName");
+        user = (User) userDAO.put(user).fclone();
+
+        // create
+        // expect 2 lines: 1 // version, 2 c({ })
+        info = (Map<String, Integer>) find(x, "userJournal", user.getFirstName());
+        count = info.get(AbstractF3FileJournal.OPEN_VERSION);
+        test ( count != null && count.intValue() == 1, "User CREATE - One version found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_CREATE);
+        test ( count != null && count.intValue() == 1, "User CREATE - One create found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_PUT);
+        test ( count == null, "User CREATE - No put found "+count);
+
+        count = info.get(user.getFirstName());
+        test ( count != null && count.intValue() == 2, "User CREATE - User firstName found on line 2 "+count);
+
+        user.setUserName("test1UserName");
+        user = (User) userDAO.put(user).fclone();
+
+        info = (Map<String, Integer>) find(x, "userJournal", user.getFirstName(), user.getUserName());
+        count = info.get(AbstractF3FileJournal.OPEN_VERSION);
+        test ( count != null && count.intValue() == 1, "User UPDATE - One version found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_CREATE);
+        test ( count != null && count.intValue() == 1, "User UPDATE - One create found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_PUT);
+        test ( count != null && count.intValue() == 1, "User UPDATE - One put found "+count);
+
+        count = info.get(user.getFirstName());
+        test ( count != null && count.intValue() == 2, "User UPDATE - User firstName found on line 2 "+count);
+
+        count = info.get(user.getUserName());
+        test ( count != null && count.intValue() == 3, "User UPDATE - User userName found on line 3 "+count);
+
+        user = new User(x);
+        user.setFirstName("test2FirstName");
+        user.setLastName("test2LastName");
+        user = (User) userDAO.put(user).fclone();
+        user.setUserName("test2UserName");
+        user = (User) userDAO.put(user).fclone();
+
+        info = (Map<String, Integer>) find(x, "userJournal", user.getFirstName(), user.getUserName());
+        count = info.get(AbstractF3FileJournal.MODIFIED_BY);
+        test ( count == null, "User 2 - No Modified by found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_VERSION);
+        test ( count != null && count.intValue() == 1, "User 2 - One version found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_CREATE);
+        test ( count != null && count.intValue() == 2, "User 2 - Two create found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_PUT);
+        test ( count != null && count.intValue() == 2, "User 2 - Two put found "+count);
+
+        count = info.get(user.getFirstName());
+        test ( count != null && count.intValue() == 4, "User 2 - User firstName found on line 4 "+count);
+
+        count = info.get(user.getUserName());
+        test ( count != null && count.intValue() == 5, "User 2 - User userName found on line 5 "+count);
+
+        info = (Map<String, Integer>) find(x, "userJournal", user.getFirstName(), user.getUserName());
+
+        // Replay
+        userDAO = new foam.dao.java.JDAO();
+        userDAO.setX(x);
+        userDAO.setFilename("userJournal");
+        userDAO.setDelegate(new foam.dao.FUIDDAO(x, "userDAO", "id", 
+            new foam.core.auth.LastModifiedAwareDAO.Builder(x).setDelegate(new foam.dao.MDAO(foam.core.auth.User.getOwnClassInfo())).build()));
+        Count c = (Count) userDAO.select(COUNT());
+        test ( c.getValue() == 2, "User replay count 2 "+c);
+
+
+        // Multipart ID
+        foam.dao.java.JDAO languageDAO = new foam.dao.java.JDAO();
+        languageDAO.setX(x);
+        languageDAO.setFilename("languageJournal");
+        languageDAO.setDelegate(new foam.dao.MDAO(foam.core.auth.Language.getOwnClassInfo()));
+        x = x.put("languageDAO", new ProxyDAO.Builder(x).setDelegate(languageDAO).build());
+
+        Language language = new Language(x);
+        language.setCode("aaCode");
+        language.setVariant("aaVariant");
+        language = (Language) languageDAO.put(language);
+
+        info = (Map<String, Integer>) find(x, "languageJournal", language.getCode());
+        count = info.get(AbstractF3FileJournal.OPEN_VERSION);
+        test ( count != null && count.intValue() == 1, "Language CREATE - One version found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_CREATE);
+        test ( count != null && count.intValue() == 1, "Language CREATE - One create found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_PUT);
+        test ( count == null, "Language CREATE - No put found "+count);
+
+        count = info.get(language.getCode());
+        test ( count != null && count.intValue() == 2, "Language CREATE - Language code found on line 2 "+count);
+
+        language.setName("aaName");
+        language = (Language) languageDAO.put(language).fclone();
+
+        info = (Map<String, Integer>) find(x, "languageJournal", language.getCode(), language.getName());
+        count = info.get(AbstractF3FileJournal.MODIFIED_BY);
+        test ( count == null, "Language UPDATE - No Modified by found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_VERSION);
+        test ( count != null && count.intValue() == 1, "Language UPDATE - One version found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_CREATE);
+        test ( count != null && count.intValue() == 1, "Language UPDATE - One create found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_PUT);
+        test ( count != null && count.intValue() == 1, "Language UPDATE - One put found "+count);
+
+        // line 3 as code is part of id
+        count = info.get(language.getCode());
+        test ( count != null && count.intValue() == 3, "Language UPDATE - Language code found on line 3 "+count);
+
+        count = info.get(language.getName());
+        test ( count != null && count.intValue() == 3, "Language UPDATE - Language languageName found on line 3 "+count);
+
+        // become test user to trigger modifiedby
+        X y = Auth.sudo(testX, 185426801L);
+        language = new Language(y);
+        language.setCode("bbCode");
+        language.setVariant("bbVariant");
+        language = (Language) languageDAO.put_(y, language).fclone();
+        language.setName("bbName");
+        try {
+          // AbstractF3FileJournal.writeComment suppresses comment for
+          // calls in the same millisecond
+          Thread.currentThread().sleep(100L);
+        } catch (InterruptedException e) {
+          // nop
+        }
+        language = (Language) languageDAO.put_(y, language).fclone();
+
+        info = (Map<String, Integer>) find(x, "languageJournal", language.getCode(), language.getName());
+        count = info.get(AbstractF3FileJournal.MODIFIED_BY);
+        test ( count != null && count.intValue() == 2, "Language 2 - Two Modified by found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_VERSION);
+        test ( count != null && count.intValue() == 1, "Language 2 - One version found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_CREATE);
+        test ( count != null && count.intValue() == 2, "Language 2 - Two create found "+count);
+
+        count = info.get(AbstractF3FileJournal.OPEN_PUT);
+        test ( count != null && count.intValue() == 2, "Language 2 - Two put found "+count);
+
+        // Replay
+        languageDAO = new foam.dao.java.JDAO();
+        languageDAO.setX(x);
+        languageDAO.setFilename("languageJournal");
+        languageDAO.setDelegate(new foam.dao.MDAO(foam.core.auth.Language.getOwnClassInfo()));
+        c = (Count) languageDAO.select(COUNT());
+        test ( c.getValue() == 2, "Language replay count 2 "+c);
+      `
+    },
+    {
+      name: 'increment',
+      args: 'Map map, String op',
+      type: 'Map',
+      javaCode: `
+        Integer i = (Integer) map.get(op);
+        if ( i == null ) {
+          i = Integer.valueOf(1);
+        } else {
+          i = Integer.valueOf(i.intValue() +1);
+        }
+        map.put(op, i);
+        return map;
+      `, 
+    }
+  ],
+
+  javaCode: `
+    public Map find(X x, String fileName, String... matches) 
+      throws java.io.IOException {
+
+      foam.core.fs.FileSystemStorage fs = (foam.core.fs.FileSystemStorage) x.get(foam.core.fs.FileSystemStorage.class);
+      Map<String, Integer> info = new HashMap();
+      try ( Scanner sc = new Scanner(fs.getInputStream(fileName)) ) {
+        int lineNum = 1;
+        while ( sc.hasNextLine() ) {
+          String line = sc.nextLine();
+          if ( line.startsWith(AbstractF3FileJournal.OPEN_VERSION) )
+            increment(info, AbstractF3FileJournal.OPEN_VERSION);
+          else if ( line.startsWith(AbstractF3FileJournal.OPEN_CREATE) )
+            increment(info, AbstractF3FileJournal.OPEN_CREATE);
+          else if ( line.startsWith(AbstractF3FileJournal.OPEN_PUT) )
+            increment(info, AbstractF3FileJournal.OPEN_PUT);
+          else if ( line.startsWith(AbstractF3FileJournal.OPEN_REMOVE) )
+            increment(info, AbstractF3FileJournal.OPEN_REMOVE);
+          else if ( line.startsWith(AbstractF3FileJournal.MODIFIED_BY) )
+            increment(info, AbstractF3FileJournal.MODIFIED_BY);
+
+          for ( String match : matches ) {
+            if ( line.indexOf(match) >= 0 )
+              info.put(match, Integer.valueOf(lineNum));
+          }
+
+          lineNum += 1;
+        }
+      }
+      return info;
+    }
+  `
+});

--- a/src/foam/dao/test/F3FileJournalTest.js
+++ b/src/foam/dao/test/F3FileJournalTest.js
@@ -203,6 +203,16 @@ foam.CLASS({
         languageDAO.setDelegate(new foam.dao.MDAO(foam.core.auth.Language.getOwnClassInfo()));
         c = (Count) languageDAO.select(COUNT());
         test ( c.getValue() == 2, "Language replay count 2 "+c);
+
+        // Remove 
+        languageDAO.remove(language);
+        languageDAO = new foam.dao.java.JDAO();
+        languageDAO.setX(x);
+        languageDAO.setFilename("languageJournal");
+        languageDAO.setDelegate(new foam.dao.MDAO(foam.core.auth.Language.getOwnClassInfo()));
+        c = (Count) languageDAO.select(COUNT());
+        test ( c.getValue() == 1, "Language replay count 1 after remove "+c);
+
       `
     },
     {

--- a/src/foam/dao/test/tests.jrl
+++ b/src/foam/dao/test/tests.jrl
@@ -11,3 +11,7 @@ p({
   class:"foam.dao.test.OrDAOTest",
   id:"OrDAOTest"
 })
+p({
+  class:"foam.dao.test.F3FileJournalTest",
+  id:"F3FileJournalTest"
+})

--- a/src/pom.js
+++ b/src/pom.js
@@ -1118,6 +1118,7 @@ foam.POM({
     { name: "foam/dao/WriteOnlyF3FileJournal",                        flags: "js|java" },
     { name: "foam/dao/test/ArrayDAOTest",                             flags: "js&test|java&test" },
     { name: "foam/dao/test/FileRollCmdTest",                          flags: "js&test|java&test" },
+    { name: "foam/dao/test/F3FileJournalTest",                        flags: "js&test|java&test" },
     { name: "foam/dao/test/OrDAOTest",                                flags: "js&test|java&test" },
     { name: "foam/lib/ExternalPropertyPredicate",                     flags: "js|java" },
     { name: "foam/lib/StorageTransientPropertyPredicate",             flags: "js|java" },


### PR DESCRIPTION
Journal - distinguish between create and update to speed replay. 
create operations now output c({..}), and update operations output p({...}). 
Change is backward compatible.
During replay, a create operation 'c(' can forgo old lookup. 
Also
- created constants for journal magic strings such as the opening and closing crud indicators c({, p({.  The constants simplified test case creation.
- cleaned up log messages, reducing duplicate output such as the journal filename.