### PR TITLE
PT-FIXES: DOS-1311 : add support for DDMMMYYYY format in DateParser and tests

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -47,6 +47,11 @@ foam.ENUM({
       name: 'YYYYDDMM',
       label: 'yyyy/dd/mm',
       documentation: 'Year-Day-Month format (yyyy/dd/mm, yyyy-dd-mm, yyyyddmm, yy/dd/mm, yy-dd-mm, yyddmm)'
+    },
+    {
+      name: 'DDMMMYYYY',
+      label: 'dd-mmm-yyyy',
+      documentation: 'Day-MonthName-Year format (31-JAN-2025, 03-FEB-2025, 31JAN2025, 03FEB2025)'
     }
   ]
 });
@@ -168,6 +173,8 @@ foam.CLASS({
           return 'ddmmyyyy';
         case 'YYYYDDMM':
           return 'yyyyddmm';
+        case 'DDMMMYYYY':
+          return 'ddmmmyyyy';
         case 'STANDARD':
         default:
           return 'START';

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -33,7 +33,7 @@ foam.CLASS({
   properties: [
     {
       name: 'baseGrammar_',
-      value: function(alt, anyChar, chars, optional, range, repeat, seq, str, sym) {
+      value: function(alt, anyChar, chars, literalIC, optional, range, repeat, seq, str, sym) {
         return {
           START: sym('dateOrDatetime'),
 
@@ -291,6 +291,23 @@ foam.CLASS({
           // YYDDMM compact: 6 digits
           'yyddmm-compact': str(repeat(range('0', '9'), null, 6)),
 
+          // DDMMMYYYY - NOT in main dateOrDatetime, accessible via opt_name only
+          // Covers: DD-MMM-YYYY, DD/MMM/YYYY, DDMMMYYYY (31-JAN-2025, 03-FEB-2025, 31JAN2025)
+          ddmmmyyyy: alt(
+            sym('ddmmmyyyy-sep'),
+            sym('ddmmmyyyy-compact')
+          ),
+
+          // DDMMMYYYY with separators: DD-MMM-YYYY, DD/MMM/YYYY
+          'ddmmmyyyy-sep': seq(
+            sym('day2'), chars('-/'), sym('month3alpha'), chars('-/'), sym('year4')
+          ),
+
+          // DDMMMYYYY compact: DDMMMYYYY (no separators, like 31JAN2025)
+          'ddmmmyyyy-compact': seq(
+            sym('day2'), sym('month3alpha'), sym('year4')
+          ),
+
           // Component parsers
           year4: str(repeat(range('0', '9'), null, 4)),
           year4_1900_2999: str(alt(
@@ -299,6 +316,20 @@ foam.CLASS({
           )),
           year2: str(seq(range('0', '9'), range('0', '9'))),
           month2: str(seq(range('0', '1'), range('0', '9'))),
+          month3alpha: alt(
+            literalIC('JAN'),
+            literalIC('FEB'),
+            literalIC('MAR'),
+            literalIC('APR'),
+            literalIC('MAY'),
+            literalIC('JUN'),
+            literalIC('JUL'),
+            literalIC('AUG'),
+            literalIC('SEP'),
+            literalIC('OCT'),
+            literalIC('NOV'),
+            literalIC('DEC')
+          ),
           day2: str(seq(range('0', '3'), range('0', '9'))),
           hour2: str(seq(range('0', '2'), range('0', '9'))),
           minute2: str(seq(range('0', '5'), range('0', '9'))),
@@ -586,6 +617,26 @@ foam.CLASS({
               month: parseInt(v.substring(4, 6)) - 1,
               day: parseInt(v.substring(2, 4))
             };
+          },
+
+          // DDMMMYYYY with separators: DD-MMM-YYYY, DD/MMM/YYYY
+          // v = [DD, sep, MMM, sep, YYYY]
+          'ddmmmyyyy-sep': function(v) {
+            return {
+              year: parseInt(v[4]),
+              month: self.parseMonthName(v[2]),
+              day: parseInt(v[0])
+            };
+          },
+
+          // DDMMMYYYY compact: DDMMMYYYY "31JAN2025"
+          // v = [DD, MMM, YYYY]
+          'ddmmmyyyy-compact': function(v) {
+            return {
+              year: parseInt(v[2]),
+              month: self.parseMonthName(v[1]),
+              day: parseInt(v[0])
+            };
           }
         };
 
@@ -693,6 +744,21 @@ foam.CLASS({
           return 2000 + twoDigitYear;
         }
         return 1900 + twoDigitYear;
+      }
+    },
+
+    {
+      name: 'parseMonthName',
+      documentation: 'Converts 3-letter month abbreviation to 0-based month index (JAN→0, FEB→1, etc.)',
+      code: function(monthName) {
+        // Convert to uppercase for case-insensitive matching
+        var month = monthName.toUpperCase();
+        var months = {
+          'JAN': 0, 'FEB': 1, 'MAR': 2, 'APR': 3,
+          'MAY': 4, 'JUN': 5, 'JUL': 6, 'AUG': 7,
+          'SEP': 8, 'OCT': 9, 'NOV': 10, 'DEC': 11
+        };
+        return months[month] !== undefined ? months[month] : 0;
       }
     },
 

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -21,6 +21,7 @@ foam.CLASS({
       this.testYYMMDDFormats(x);
       this.testDDMMYYYYFormats(x);
       this.testYYYYDDMMFormats(x);
+      this.testDDMMMYYYYFormats(x);
       this.testDateTimeFormats(x);
       this.testParseDateString(x);
       this.testParseDateTime(x);
@@ -362,6 +363,90 @@ foam.CLASS({
           x.test(pass, `YYDDMM-Compact Test${i + 1}: ${testCase.input} (opt_name='yyyyddmm')`);
         } catch (e) {
           x.test(false, `YYDDMM-Compact Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
+      });
+    },
+
+    function testDDMMMYYYYFormats(x) {
+      let parser = this.DateParser.create();
+
+      // Test DDMMMYYYY with separators - requires opt_name='ddmmmyyyy'
+      let ddmmmyyyySep = [
+        { input: '31-JAN-2025', year: 2025, month: 0, day: 31 },
+        { input: '03-FEB-2025', year: 2025, month: 1, day: 3 },
+        { input: '15/MAR/2024', year: 2024, month: 2, day: 15 },
+        { input: '25-DEC-2025', year: 2025, month: 11, day: 25 },
+        { input: '01-JAN-2000', year: 2000, month: 0, day: 1 },
+        { input: '29-FEB-2024', year: 2024, month: 1, day: 29 }, // Leap year
+        { input: '15/jun/2025', year: 2025, month: 5, day: 15 }, // Lowercase
+        { input: '10-Jul-2025', year: 2025, month: 6, day: 10 }  // Mixed case
+      ];
+
+      ddmmmyyyySep.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'ddmmmyyyy');
+          let pass = result &&
+                     result.getUTCFullYear() === testCase.year &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === testCase.day &&
+                     result.getUTCHours() === 12;
+          x.test(pass, `DDMMMYYYY-Sep Test${i + 1}: ${testCase.input} (opt_name='ddmmmyyyy')`);
+        } catch (e) {
+          x.test(false, `DDMMMYYYY-Sep Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
+      });
+
+      // Test DDMMMYYYY compact (no separators) - requires opt_name='ddmmmyyyy'
+      let ddmmmyyyyCompact = [
+        { input: '31JAN2025', year: 2025, month: 0, day: 31 },
+        { input: '03FEB2025', year: 2025, month: 1, day: 3 },
+        { input: '15MAR2024', year: 2024, month: 2, day: 15 },
+        { input: '25DEC2025', year: 2025, month: 11, day: 25 },
+        { input: '29FEB2024', year: 2024, month: 1, day: 29 }, // Leap year
+        { input: '15jun2025', year: 2025, month: 5, day: 15 }, // Lowercase
+        { input: '10Jul2025', year: 2025, month: 6, day: 10 }  // Mixed case
+      ];
+
+      ddmmmyyyyCompact.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'ddmmmyyyy');
+          let pass = result &&
+                     result.getUTCFullYear() === testCase.year &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === testCase.day &&
+                     result.getUTCHours() === 12;
+          x.test(pass, `DDMMMYYYY-Compact Test${i + 1}: ${testCase.input} (opt_name='ddmmmyyyy')`);
+        } catch (e) {
+          x.test(false, `DDMMMYYYY-Compact Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
+      });
+
+      // Test all months
+      let allMonths = [
+        { input: '15-JAN-2025', month: 0 },
+        { input: '15-FEB-2025', month: 1 },
+        { input: '15-MAR-2025', month: 2 },
+        { input: '15-APR-2025', month: 3 },
+        { input: '15-MAY-2025', month: 4 },
+        { input: '15-JUN-2025', month: 5 },
+        { input: '15-JUL-2025', month: 6 },
+        { input: '15-AUG-2025', month: 7 },
+        { input: '15-SEP-2025', month: 8 },
+        { input: '15-OCT-2025', month: 9 },
+        { input: '15-NOV-2025', month: 10 },
+        { input: '15-DEC-2025', month: 11 }
+      ];
+
+      allMonths.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'ddmmmyyyy');
+          let pass = result &&
+                     result.getUTCFullYear() === 2025 &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === 15;
+          x.test(pass, `DDMMMYYYY All Months Test${i + 1}: ${testCase.input} should parse to month ${testCase.month}`);
+        } catch (e) {
+          x.test(false, `DDMMMYYYY All Months Test${i + 1}: ${testCase.input} - ${e.message}`);
         }
       });
     },

--- a/src/foam/util/test/DateUtilJSTest.js
+++ b/src/foam/util/test/DateUtilJSTest.js
@@ -19,6 +19,7 @@ foam.CLASS({
       this.testParseDateString_MM_DD_YYYY(x);
       this.testParseDateString_YYMMDD(x);
       this.testParseDateString_YY_MM_DD(x);
+      this.testParseDateString_DDMMMYYYY(x);
       this.testParseDateString_InvalidDate(x);
       this.testParseDateString_UnsupportedFormat(x);
       this.testParseDateString_LeapYear(x);
@@ -185,6 +186,52 @@ foam.CLASS({
       }
 
       x.test(year2 === expectedYear85, `YY-MM-DD format - year is ${expectedYear85} (expected ${expectedYear85}, got ${year2})`);
+    },
+
+    function testParseDateString_DDMMMYYYY(x) {
+      // Test DDMMMYYYY format with separators (31-JAN-2025, 03-FEB-2025)
+      var date1 = foam.util.DateUtil.parseDateString('31-JAN-2025', 'ddmmmyyyy');
+      var year1 = date1.getFullYear();
+      var month1 = date1.getMonth();
+      var day1 = date1.getDate();
+      x.test(year1 === 2025, `DDMMMYYYY format (31-JAN-2025) - year is 2025 (expected 2025, got ${year1})`);
+      x.test(month1 === 0, `DDMMMYYYY format (31-JAN-2025) - month is January (0) (expected 0, got ${month1})`);
+      x.test(day1 === 31, `DDMMMYYYY format (31-JAN-2025) - day is 31 (expected 31, got ${day1})`);
+
+      var date2 = foam.util.DateUtil.parseDateString('03-FEB-2025', 'ddmmmyyyy');
+      var year2 = date2.getFullYear();
+      var month2 = date2.getMonth();
+      var day2 = date2.getDate();
+      x.test(year2 === 2025, `DDMMMYYYY format (03-FEB-2025) - year is 2025 (expected 2025, got ${year2})`);
+      x.test(month2 === 1, `DDMMMYYYY format (03-FEB-2025) - month is February (1) (expected 1, got ${month2})`);
+      x.test(day2 === 3, `DDMMMYYYY format (03-FEB-2025) - day is 3 (expected 3, got ${day2})`);
+
+      // Test with slash separator
+      var date3 = foam.util.DateUtil.parseDateString('15/MAR/2024', 'ddmmmyyyy');
+      var year3 = date3.getFullYear();
+      var month3 = date3.getMonth();
+      var day3 = date3.getDate();
+      x.test(year3 === 2024, `DDMMMYYYY format (15/MAR/2024) - year is 2024 (expected 2024, got ${year3})`);
+      x.test(month3 === 2, `DDMMMYYYY format (15/MAR/2024) - month is March (2) (expected 2, got ${month3})`);
+      x.test(day3 === 15, `DDMMMYYYY format (15/MAR/2024) - day is 15 (expected 15, got ${day3})`);
+
+      // Test compact format (no separators)
+      var date4 = foam.util.DateUtil.parseDateString('31JAN2025', 'ddmmmyyyy');
+      var year4 = date4.getFullYear();
+      var month4 = date4.getMonth();
+      var day4 = date4.getDate();
+      x.test(year4 === 2025, `DDMMMYYYY compact (31JAN2025) - year is 2025 (expected 2025, got ${year4})`);
+      x.test(month4 === 0, `DDMMMYYYY compact (31JAN2025) - month is January (0) (expected 0, got ${month4})`);
+      x.test(day4 === 31, `DDMMMYYYY compact (31JAN2025) - day is 31 (expected 31, got ${day4})`);
+
+      // Test case insensitivity
+      var date5 = foam.util.DateUtil.parseDateString('15-jun-2025', 'ddmmmyyyy');
+      var month5 = date5.getMonth();
+      x.test(month5 === 5, `DDMMMYYYY lowercase (15-jun-2025) - month is June (5) (expected 5, got ${month5})`);
+
+      var date6 = foam.util.DateUtil.parseDateString('10-Jul-2025', 'ddmmmyyyy');
+      var month6 = date6.getMonth();
+      x.test(month6 === 6, `DDMMMYYYY mixed case (10-Jul-2025) - month is July (6) (expected 6, got ${month6})`);
     },
 
     function testParseDateString_InvalidDate(x) {


### PR DESCRIPTION
added the DDMMMYYYY format as an option in the upload, was thinking it can be merged with dd/mm/yyyy

but dont know if the alts will make it slow? since we will more than one, and its not clear to the user since  dd/mm/yyyy is numbers but ours is MMM ? 