### PR TITLE
fix: add null check for FSFile retrieval and log error if not found

### DIFF
--- a/src/foam/core/fs/FSFileContentDAO.js
+++ b/src/foam/core/fs/FSFileContentDAO.js
@@ -34,6 +34,10 @@ foam.CLASS({
           if ( ret != null ) return ret;
 
           FSFile file = (FSFile) ((DAO) x.get("FSFileDAO")).find((String) id);
+          if ( file == null ) {
+            Loggers.logger(x, this).error("Error getting content: FSFile not found for id: ", (String) id);
+            return null;
+          }
           if ( file.getIsDirectory() ) {
             Loggers.logger(x, this).error("Error getting content: ", (String) file.getId(), "file is a directory");
             return null;


### PR DESCRIPTION
Exceptions from decorators fail silently on client. Returning null ensures logic can be placed around errors