### PR TITLE
DNM: Pass complete object to the actionList when using projections

### DIFF
--- a/src/foam/u2/table/UnstyledTableRow.js
+++ b/src/foam/u2/table/UnstyledTableRow.js
@@ -102,7 +102,7 @@ foam.CLASS({
           .tag(this.OverlayActionListView, {
             data: Object.values(actions),
             lazy: true,
-            obj: obj,
+            id: obj.id,
             dao: self.actionDAO,
             showDropdownIcon: false,
             buttonStyle: 'TERTIARY',

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -66,7 +66,19 @@ foam.CLASS({
       class: 'Boolean',
       name: 'overlayInitialized_'
     },
-    'dao',
+    {
+      name: 'dao',
+      documentation: `Optional DAO to re-fetch the object from before passing it to actions.
+       Useful when creating action lists for incomplete objects like projections.`
+    },
+    {
+      class: 'String',
+      name: 'id',
+      documentation: `Id for the obj the actions use as data, must be provided if dao is provided.`,
+      factory: function() {
+        return this.obj?.id;
+      }
+    },
     {
       class: 'Boolean',
       name: 'showDropdownIcon',
@@ -244,7 +256,7 @@ foam.CLASS({
       this.overlay_.open(x, y);
 
       if ( ! this.obj && this.dao ) {
-        this.obj = await this.dao.inX(this.__context__).find(this.obj.id);
+        this.obj = await this.dao.inX(this.__context__).find(this.id);
       }
 
       self.availabilities_$.follow(self.createAvailabilitySlotArray())

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -75,8 +75,8 @@ foam.CLASS({
       class: 'String',
       name: 'id',
       documentation: `Id for the obj the actions use as data, must be provided if dao is provided.`,
-      factory: function() {
-        return this.obj?.id;
+      expression: function(obj) {
+        return obj?.id;
       }
     },
     {
@@ -256,6 +256,7 @@ foam.CLASS({
       this.overlay_.open(x, y);
 
       if ( ! this.obj && this.dao ) {
+        foam.assert(this.id, 'Id must be provided when obj needs to be fetched in OverlayActionListView');
         this.obj = await this.dao.inX(this.__context__).find(this.id);
       }
 


### PR DESCRIPTION
Changes the table rows to pass ids to overlayActionListView instead of incomplete projections (which was breaking availability and clearing properties unintentionally). 

Also fixes a bug in OverlayActionListView which broke the id passing behaviour