### PR TITLE
Add formatLocale method and update TableCellFormatter usage

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -294,6 +294,12 @@ foam.CLASS({
       value: function(val, timeFirst = false) {
         return foam.Date.formatDate(val, timeFirst);
       }
+    },
+    {
+      name: 'formatLocale',
+      value: function(val) {
+        return foam.util.DateUtil.format(val);
+      }
     }
   ]
 });
@@ -344,6 +350,12 @@ foam.CLASS({
         // Use DateUtil.formatWithTimeControl with timeFirst parameter and UTC timezone
         var result = foam.util.DateUtil.formatWithTimeControl(val, timeFirst, 'UTC');
         return result;
+      }
+    },
+    {
+      name: 'formatLocale',
+      value: function(val) {
+        return foam.util.DateUtil.format(val, 'UTC');
       }
     }
   ]

--- a/src/foam/u2/view/RODateTimeView.js
+++ b/src/foam/u2/view/RODateTimeView.js
@@ -18,15 +18,30 @@ foam.CLASS({
       factory: function() {
         return {};
       }
+    },
+    {
+      name: 'prop'
     }
   ],
 
   methods: [
+    function fromProperty(prop) {
+      this.SUPER(prop);
+      this.prop = prop;
+    },
+
     function render() {
       this.SUPER();
+      var self = this;
       this.start().
         addClass(this.myClass()).
-        add(this.data$.map(d => d ? new Date(d).toLocaleString(foam.locale, this.options) : foam.u2.DateTimeView.DATE_FORMAT)).
+        add(this.data$.map(d => {
+          if ( ! d ) return foam.u2.DateTimeView.DATE_FORMAT;
+          if ( self.prop && self.prop.formatLocale ) {
+            return self.prop.formatLocale(d);
+          }
+          return new Date(d).toLocaleString(foam.locale, self.options);
+        })).
       end();
     }
   ]

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -408,11 +408,9 @@ foam.CLASS({
     {
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
-      value: function(date) {
-        // allow the browser to deal with this since we are technically using the user's preference
+      value: function(date, obj, axiom) {
         if ( date ) {
-          // toLocaleString includes date and time (uses local timezone)
-          var formattedDate = date.toLocaleString(foam.locale);
+          var formattedDate = axiom.formatLocale(date);
           this.add(formattedDate);
           this.tooltip = formattedDate;
         }
@@ -436,10 +434,9 @@ foam.CLASS({
     {
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
-      value: function(date) {
+      value: function(date, obj, axiom) {
         if ( date ) {
-          // Format as UTC using locale-default format
-          var formattedDate = foam.util.DateUtil.format(date, 'UTC');
+          var formattedDate = axiom.formatLocale(date);
           this.add(formattedDate);
           this.tooltip = formattedDate;
         }


### PR DESCRIPTION
Introduce a new `formatLocale` method for Date properties and modify the `TableCellFormatter` and RO datetimeview to utilize this method for date formatting