### PR TITLE
UserLifecycleTicket - propagate exceptions in Sink and Rules back to Ticket for reporting

### DIFF
--- a/src/foam/core/auth/UserLifecycleTicket.js
+++ b/src/foam/core/auth/UserLifecycleTicket.js
@@ -8,7 +8,8 @@ foam.CLASS({
   name: 'UserLifecycleTicket',
   extends: 'foam.core.ticket.Ticket',
 
-  documentation: `Ticket to coordinate the changing of a User's lifecycle state.  Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
+  documentation: `Ticket to coordinate the changing of a User's lifecycle state.
+Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
 
   implements: [
     'foam.mlang.Expressions'
@@ -55,7 +56,8 @@ foam.CLASS({
           s.push(['CLOSED', 'CLOSED']);
         }
         return s;
-      }
+      },
+      compare: function() { return 0; }
     },
     {
       name: 'comment',
@@ -83,51 +85,16 @@ foam.CLASS({
       }
     },
     {
-      name: 'state',
-      hidden: true,
-      transient: true
-    },
-    {
       name: 'currentLifecycleState',
       class: 'foam.lang.Enum',
       of: 'foam.core.auth.LifecycleState',
       value: foam.core.auth.LifecycleState.PENDING,
       transient: true,
+      compare: function() { return 0; },
       visibility: 'RO',
       section: 'infoSection',
       order: 7,
-      gridColumns: 6,
-      view: function(_, X) {
-        X.data.state = foam.core.auth.LifecycleState.PENDING;
-        if ( ! X.data.createdFor ) {
-          X.data.createdFor$.sub(function() {
-            X.userDAO.find(X.data.createdFor).then(function(user) {
-              X.data.state = user.lifecycleState;
-            });
-            X.sessionDAO.find(X.data.EQ(X.data.Session.USER_ID, X.data.createdFor)).then(function(session) {
-              if ( ! session )
-                return;
-              X.data.loggedIn = session.uses > 0 && session.remoteHost;
-              X.data.lastActivity = Date.now() - session.lastUsed.getTime();
-            });
-          });
-        } else {
-          X.userDAO.find(X.data.createdFor).then(function(user) {
-            X.data.state = user.lifecycleState;
-          });
-          X.sessionDAO.find(X.data.EQ(X.data.Session.USER_ID, X.data.createdFor)).then(function(session) {
-            if ( ! session )
-              return;
-            X.data.loggedIn = session.uses > 0 && session.remoteHost;
-            X.data.lastActivity = Date.now() - session.lastUsed.getTime();
-          });
-        }
-        return {
-          class: 'foam.u2.view.ReadOnlyEnumView',
-          of: 'foam.core.auth.LifecycleState',
-          data$: X.data.state$
-        };
-      }
+      gridColumns: 6
     },
     {
       name: 'requestedLifecycleState',
@@ -203,7 +170,8 @@ foam.CLASS({
       name: 'current',
       class: 'List',
       transient: true,
-      hidden: true
+      hidden: true,
+      compare: function() { return 0; }
     },
     {
       name: 'assignedTo',
@@ -216,6 +184,43 @@ foam.CLASS({
     {
       name: 'externalComment',
       hidden: true
+    },
+    {
+      documentation: 'Allow sink or rule to report exception',
+      name: 'exception',
+      class: 'Object',
+      storageTransient: true,
+      hidden: true,
+      compare: function() { return 0; }
+    },
+    {
+      name: 'comments',
+      compare: function() { return 0; }
+    }
+  ],
+
+  methods: [
+    function init() {
+      this.SUPER();
+      this.fetchUserSession(this);
+    },
+    {
+      name: 'fetchUserSession',
+      code: function() {
+        var self = this;
+        self.userDAO.find(self.createdFor).then(function(user) {
+          self.currentLifecycleState = user.lifecycleState;
+        });
+        self.sessionDAO.find(self.EQ(self.Session.USER_ID, self.createdFor)).then(function(session) {
+          if ( ! session ) {
+            self.loggedIn = false;
+            self.clearProperty('lastActivity');
+          } else {
+            self.loggedIn = session.uses > 0 && session.remoteHost;
+            self.lastActivity = Date.now() - session.lastUsed.getTime();
+          }
+        });
+      }
     }
   ],
 
@@ -235,7 +240,8 @@ foam.CLASS({
       isAvailable: function(status, id) {
         return id && status !== 'CLOSED';
       },
-      code: function(X) {
+      code: async function(X) {
+        var self = this;
         if ( ! this.comment ) {
           this.notify(this.COMMENT_REQUIRED, '', this.LogLevel.ERROR, true);
           return;
@@ -249,6 +255,7 @@ foam.CLASS({
           this.ticketDAO.cmd(this.AbstractDAO.RESET_CMD);
           this.finished.pub();
           this.notify(this.SUCCESS_CLOSED, '', this.LogLevel.INFO, true);
+          self.pollDAO(X);
         }, e => {
           this.throwError.pub(e);
           this.notify(e.message, '', this.LogLevel.ERROR, true);
@@ -259,6 +266,37 @@ foam.CLASS({
       class: 'foam.comics.v3.ComicsAction',
       name: 'save',
       isAvailable: () => false
+    }
+  ],
+
+  listeners: [
+    {
+      name: 'pollDAO',
+      isMerged: true,
+      delay: 1000,
+      code: function(X) {
+        console.log('pollDAO');
+        var self = this;
+        return this.ticketDAO.find(this.id).then(function(t) {
+          // NOTE: compare functions added to properties not to be
+          // included in equals.
+          if ( foam.util.equals(self, t) ) {
+            X.detailView.finished.pub();
+          } else {
+            // Perform copyFrom. After a poll with no changes,
+            // polling will end.
+
+            // HACK: expecting FObject.js copyFrom to copy all properties,
+            // but it's default copy logic uses hasOwnProperty, so only
+            // explicitly defined properties of this subclass are copied.
+            // Setting cls_ forces copyFrom to skip the default block and
+            // just copy named properties which exist in both objects.
+            t.cls_ = '';
+            self.copyFrom(t);
+            self.pollDAO(X);
+          }
+        });
+      }
     }
   ]
 });

--- a/src/foam/core/auth/UserLifecycleTicketRuleAction.js
+++ b/src/foam/core/auth/UserLifecycleTicketRuleAction.js
@@ -58,12 +58,15 @@ foam.CLASS({
               ticketComment.setComment(ticket.getComment());
               ticketComment.setTicket(ticket.getId());
               ((DAO) x.get("ticketCommentDAO")).put_(x, ticketComment);
+              UserLifecycleTicket.COMMENT.clear(ticket);
             }
 
             // Previous updated list is stored in current for this run,
             // and saved back to updated if the run was aborted.
             ticket.setCurrent(ticket.getUpdated()); // List.copyOf(ticket.getUpdated()));
             UserLifecycleTicket.UPDATED.clear(ticket);
+            UserLifecycleTicket.MESSAGE.clear(ticket);
+            UserLifecycleTicket.EXCEPTION.clear(ticket);
 
             try {
               // run if
@@ -102,11 +105,12 @@ foam.CLASS({
                   ((DAO) ruler.getX().get("localUserDAO")).put(user);
                 }
               }
-              ticket.setMessage(null);
-              ticket.setComment(old.getName()+" -> "+nu.getName()+" successful");
+              if ( ticket.getException() != null ) {
+                throw (Throwable) ticket.getException();
+              }
+              ticket.setComment(ticket.getComment()+" "+old.getName()+" -> "+nu.getName()+" successful");
             } catch (Throwable t) {
-              ticket.setMessage(t.getMessage());
-              ticket.setComment(old.getName()+" -> "+nu.getName()+" failed: "+t.getMessage());
+              ticket.setComment("WARNING: "+old.getName()+" -> "+nu.getName()+" failed: "+t.getClass().getSimpleName()+" "+t.getMessage());
               if ( ! ( t instanceof IllegalStateException ) ) {
                 ((Logger) x.get("logger")).warning(ticket.getComment(), t);
               }
@@ -114,9 +118,16 @@ foam.CLASS({
                    nu == LifecycleState.DELETED ) {
                 user.setLifecycleState(LifecycleState.DISABLED);
                 updateSessions(x, user, LifecycleState.DELETED);
-                ((Logger) x.get("logger")).warning("UserLifecycleTicket", user.getId(), "Failed",ticket.getRequestedLifecycleState(), "only disabling", t.getMessage());
-                ((DAO) ruler.getX().get("localUserDAO")).put(user);
+                try {
+                  ((DAO) ruler.getX().get("localUserDAO")).put(user);
+                  ((Logger) x.get("logger")).warning("UserLifecycleTicket", user.getId(), "Failed",ticket.getRequestedLifecycleState(), "only disabling", t.getMessage());
+                  ticket.setComment(ticket.getComment() + ". Only disabling user.");
+                } catch (Throwable th) {
+                  ((Logger) x.get("logger")).error("UserLifecycleTicket", user.getId(), "Failed disabling user", ticket.getRequestedLifecycleState(), th.getMessage(), th);
+                  ticket.setComment(ticket.getComment() + ". ERROR failed disabling user: "+th.getMessage());
+                }
               }
+              ticket.setMessage(ticket.getComment());
               ticket.setUpdated(ticket.getCurrent());
               ticket.setStatus(((Ticket)oldObj).getStatus());
             }

--- a/src/foam/core/auth/UserLifecycleTicketSink.js
+++ b/src/foam/core/auth/UserLifecycleTicketSink.js
@@ -75,6 +75,7 @@ foam.CLASS({
         logger.error("DAO not found", getDaoKey(), update, "not updated");
         return;
       }
+    try {
       if ( obj instanceof LifecycleAware ) {
         LifecycleAware aware = ((LifecycleAware) obj);
         LifecycleState requestedState = getLifecycleState();
@@ -132,6 +133,10 @@ foam.CLASS({
         logger.debug(update);
         ticket.getUpdated().add(update);
       }
+    } catch (Throwable t) {
+      logger.error(t);
+      ticket.setException(t);
+    }
       `
     },
     {


### PR DESCRIPTION
Propagate exceptions in Sink and Rules back to Ticket for reporting. Refactor to ensure currentLifecycleState is updated after User state modified