### PR TITLE
feat(browser): add user data directory support for Chrome configuration

### DIFF
--- a/src/foam/core/browser/BrowserAgent.js
+++ b/src/foam/core/browser/BrowserAgent.js
@@ -286,6 +286,10 @@ new BrowserAgent(...) {
       BrowserConfig bc = (BrowserConfig) ((DAO) x.get("browserConfigDAO")).find(AND(EQ(BrowserConfig.ENABLED, true), EQ(BrowserConfig.TYPE, getType())));
       List list = new ArrayList();
       list.add(bc.getExecutable(x));
+      // Add user data directory FIRST if configured (must be before other flags)
+      if ( bc.getDataDir() != null && !bc.getDataDir().isEmpty() ) {
+        list.add("--user-data-dir=" + bc.getDataDir());
+      }
       if ( getHeadless() ) {
         list.addAll(List.of(bc.getHeadlessFlags()));
       } else {

--- a/src/foam/core/browser/BrowserConfig.js
+++ b/src/foam/core/browser/BrowserConfig.js
@@ -46,6 +46,11 @@ foam.CLASS({
     {
       name: 'headedFlags',
       class: 'StringArray'
+    },
+    {
+      name: 'dataDir',
+      class: 'String',
+      documentation: 'Directory for browser user data and cache. If not set, browser defaults to system temp or profile directory.'
     }
   ],
 

--- a/src/foam/core/browser/browserconfigs.jrl
+++ b/src/foam/core/browser/browserconfigs.jrl
@@ -27,3 +27,37 @@ p({
     "--no-sandbox"
   ]
 })
+
+p({
+  class: "foam.core.browser.BrowserConfig",
+  id: "chrome-dataDir",
+  type: "chrome-dataDir",
+  enabled: true,
+  execPaths: [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/google-chrome",
+    "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
+  ],
+  dataDir: "/var/lib/chrome-headless",
+  headlessFlags: [
+    "--auto-open-devtools-for-tabs",
+    "--enable-automation",
+    "--disable-dev-shm-usage",
+    "--disable-features=VizDisplayCompositor",
+    "--disable-gpu",
+    "--disable-web-security",
+    "--headless",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--new-instance",
+    "--remote-debugging-port=9222",
+    "--run-all-compositor-stages-before-draw",
+    "--no-sandbox"
+  ],
+  headedFlags: [
+    "--disable-gpu",
+    "--incognito",
+    "--new-window",
+    "--no-sandbox"
+  ]
+})


### PR DESCRIPTION
Chrome leaves behind /tmp/.com.google.Chrome.*
When using this often we want to be able to clean up.
This PR allows for a BrowserConfig that will specify a folder path for these temp files, enabling for a clean and safe clean up.
Example clean up cron:
0 3 * * * root find /var/lib/chrome-headless -maxdepth 1 -type d -mtime +1 -exec bash -c 'fuser -s "$1" || rm -rf "$1"' _ {} \;