### PR TITLE
fix: mark properties as transient in CapabilityWizardlet, QuickAgent, and BaseWizardlet

### DIFF
--- a/src/foam/core/crunch/ui/CapabilityWizardlet.js
+++ b/src/foam/core/crunch/ui/CapabilityWizardlet.js
@@ -63,7 +63,8 @@ foam.CLASS({
     {
       name: 'isAvailablePromise',
       factory: () => Promise.resolve(),
-      hidden: true
+      hidden: true,
+      transient: true
     },
     {
       name: 'isAvailable',
@@ -95,6 +96,7 @@ foam.CLASS({
     {
       name: 'wao',
       hidden: true,
+      transient: true,
       factory: function () {
         return this.ProxyWAO.create({}, this.__context__);
       }

--- a/src/foam/u2/wizard/agents/QuickAgent.js
+++ b/src/foam/u2/wizard/agents/QuickAgent.js
@@ -17,7 +17,8 @@ foam.CLASS({
   properties: [
     {
       class: 'Function',
-      name: 'executeFn'
+      name: 'executeFn',
+      transient: true,
     }
   ],
 

--- a/src/foam/u2/wizard/wizardlet/BaseWizardlet.js
+++ b/src/foam/u2/wizard/wizardlet/BaseWizardlet.js
@@ -260,6 +260,7 @@ foam.CLASS({
     {
       class: 'foam.util.FObjectSpec',
       name: 'exceptionAgent',
+      transient: true,
       documentation: `
         Wizardlet's exception handler. This is an FObjectSpec so that it may
         be created in the correct subcontext at the time when it is needed.
@@ -331,6 +332,7 @@ foam.CLASS({
     {
       name: '__subSubContext__',
       documentation: 'Current subContext to use when creating view.',
+      transient: true,
       factory: function() { return this.__subContext__; }
     },
     {


### PR DESCRIPTION
fix json/j export on the client.

dont know if it breaks the normal flows though @jlhughes @noodlemoodle please check since I dont use them