### PR TITLE
NUIDGenerator - refactor init to handle multithreading

### DIFF
--- a/src/foam/util/NUIDGenerator.js
+++ b/src/foam/util/NUIDGenerator.js
@@ -36,7 +36,7 @@ foam.CLASS({
   }
 
   AtomicLong seqNo_ = new AtomicLong();
-  volatile AtomicBoolean initMaxSeqNo_ = new AtomicBoolean(false);
+  AtomicBoolean initMaxSeqNo_ = new AtomicBoolean(false);
   `,
 
   properties: [

--- a/src/foam/util/NUIDGenerator.js
+++ b/src/foam/util/NUIDGenerator.js
@@ -36,7 +36,7 @@ foam.CLASS({
   }
 
   AtomicLong seqNo_ = new AtomicLong();
-  AtomicBoolean initMaxSeqNo_ = new AtomicBoolean(false);
+  volatile AtomicBoolean initMaxSeqNo_ = new AtomicBoolean(false);
   `,
 
   properties: [
@@ -87,18 +87,25 @@ foam.CLASS({
     {
       name: 'initMaxSeqNo',
       javaCode: `
-        if ( ! initMaxSeqNo_.getAndSet(true) ) {
-          Logger logger = Loggers.logger(getX(), this);
-          logger.info(getSalt(), "max", "find");
-          getDao().select(new AbstractSink() {
-            @Override
-            public void put(Object obj, Detachable sub) {
-              var id = (long) getPropertyInfo().get(obj);
-              maybeUpdateSeqNo(id);
-            }
-          });
-          Loggers.logger(getX(), this).info(getSalt(), "max", "found", seqNo_.get());
+      if ( ! initMaxSeqNo_.get() ) {
+        synchronized ( initMaxSeqNo_ ) {
+          if ( ! initMaxSeqNo_.get() ) {
+            Logger logger = Loggers.logger(getX(), this);
+            logger.info(getSalt(), "max", "find");
+            getDao().select(new AbstractSink() {
+              @Override
+              public void put(Object obj, Detachable sub) {
+                var id = (long) getPropertyInfo().get(obj);
+                maybeUpdateSeqNo(id);
+              }
+              public void eof() {
+                initMaxSeqNo_.getAndSet(true);
+              }
+            });
+            Loggers.logger(getX(), this).info(getSalt(), "max", "found", seqNo_.get());
+          }
         }
+      }
       `
     },
     {


### PR DESCRIPTION
Refactor init to handle multithreading. 
The DAO loading is lazy and internal to the service, so not protected by normal CSpecFactory logic.  Large DAOs can takes minutes to load and some UIDs are shared across DAOs resulting in multiple threads requesting 'next' and triggering init. 

- [x] Tested and running in production. 