### PR TITLE
feat(date-parser): add support for single-digit months and days in various date formats

### DIFF
--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -89,28 +89,29 @@ foam.CLASS({
 
         // YYYYMMDD with separators and optional time
         // YYYY-MM-DD, YYYY/MM/DD, YYYY-MM-DDTHH:MM, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS.sss
+        // Supports single-digit months and days (e.g., 2025-1-5)
         yyyymmddsep: alt(
           // With fractional seconds (milliseconds/microseconds) and timezone
           seq(
-            sym('year4'), chars('-/'), sym('month2'), chars('-/'), sym('day2'),
+            sym('year4'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'), '.', sym('fractionalSeconds'),
             optional(sym('timezone'))
           ),
           // With seconds and timezone
           seq(
-            sym('year4'), chars('-/'), sym('month2'), chars('-/'), sym('day2'),
+            sym('year4'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'),
             optional(sym('timezone'))
           ),
           // With minutes and timezone
           seq(
-            sym('year4'), chars('-/'), sym('month2'), chars('-/'), sym('day2'),
+            sym('year4'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'),
             optional(sym('timezone'))
           ),
           // Date only
           seq(
-            sym('year4'), chars('-/'), sym('month2'), chars('-/'), sym('day2')
+            sym('year4'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible')
           )
         ),
 
@@ -202,28 +203,29 @@ foam.CLASS({
 
         // YYMMDD with separators and optional time
         // YY-MM-DD, YY/MM/DD, YY-MM-DD HH:MM, YY-MM-DD HH:MM:SS with optional timezone
+        // Supports single-digit months and days (e.g., 25-1-5)
         yymmddsep: alt(
           // With fractional seconds and timezone
           seq(
-            sym('year2'), chars('-/'), sym('month2'), chars('-/'), sym('day2'),
+            sym('year2'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'), '.', sym('fractionalSeconds'),
             optional(sym('timezone'))
           ),
           // With seconds and timezone
           seq(
-            sym('year2'), chars('-/'), sym('month2'), chars('-/'), sym('day2'),
+            sym('year2'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'),
             optional(sym('timezone'))
           ),
           // With minutes and timezone
           seq(
-            sym('year2'), chars('-/'), sym('month2'), chars('-/'), sym('day2'),
+            sym('year2'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'),
             optional(sym('timezone'))
           ),
           // Date only
           seq(
-            sym('year2'), chars('-/'), sym('month2'), chars('-/'), sym('day2')
+            sym('year2'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('dayFlexible')
           )
         ),
 
@@ -281,28 +283,29 @@ foam.CLASS({
         // DDMMYYYY with separators and optional time
         // DD-MM-YYYY, DD/MM/YYYY, DD-MM-YYYY HH:MM, DD-MM-YYYY HH:MM:SS
         // DD-MM-YYYYTHH:MM:SS+TZ (with T separator and timezone)
+        // Supports single-digit days and months (e.g., 5-1-2025)
         ddmmyyyysep: alt(
           // With fractional seconds and timezone
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year4'),
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year4'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'), '.', sym('fractionalSeconds'),
             optional(sym('timezone'))
           ),
           // With seconds and timezone
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year4'),
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year4'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'),
             optional(sym('timezone'))
           ),
           // With minutes and timezone
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year4'),
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year4'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'),
             optional(sym('timezone'))
           ),
           // Date only
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year4')
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year4')
           )
         ),
 
@@ -328,28 +331,29 @@ foam.CLASS({
         // DDMMYY with separators and optional time (2-digit year)
         // DD-MM-YY, DD/MM/YY, DD-MM-YY HH:MM, DD-MM-YY HH:MM:SS
         // DD-MM-YYTHH:MM:SS+TZ (with T separator and timezone)
+        // Supports single-digit days and months (e.g., 5-1-25)
         ddmmyysep: alt(
           // With fractional seconds and timezone
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year2'),
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year2'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'), '.', sym('fractionalSeconds'),
             optional(sym('timezone'))
           ),
           // With seconds and timezone
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year2'),
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year2'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'),
             optional(sym('timezone'))
           ),
           // With minutes and timezone
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year2'),
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year2'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'),
             optional(sym('timezone'))
           ),
           // Date only
           seq(
-            sym('day2'), chars('-/'), sym('month2'), chars('-/'), sym('year2')
+            sym('dayFlexible'), chars('-/'), sym('monthFlexible'), chars('-/'), sym('year2')
           )
         ),
 
@@ -368,28 +372,29 @@ foam.CLASS({
         // YYYYDDMM with separators and optional time
         // YYYY-DD-MM, YYYY/DD/MM, YYYY-DD-MM HH:MM, YYYY-DD-MM HH:MM:SS
         // YYYY-DD-MMTHH:MM:SS+TZ (with T separator and timezone)
+        // Supports single-digit days and months (e.g., 2025-5-1)
         yyyyddmmsep: alt(
           // With fractional seconds and timezone
           seq(
-            sym('year4'), chars('-/'), sym('day2'), chars('-/'), sym('month2'),
+            sym('year4'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'), '.', sym('fractionalSeconds'),
             optional(sym('timezone'))
           ),
           // With seconds and timezone
           seq(
-            sym('year4'), chars('-/'), sym('day2'), chars('-/'), sym('month2'),
+            sym('year4'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'),
             optional(sym('timezone'))
           ),
           // With minutes and timezone
           seq(
-            sym('year4'), chars('-/'), sym('day2'), chars('-/'), sym('month2'),
+            sym('year4'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'),
             optional(sym('timezone'))
           ),
           // Date only
           seq(
-            sym('year4'), chars('-/'), sym('day2'), chars('-/'), sym('month2')
+            sym('year4'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible')
           )
         ),
 
@@ -421,28 +426,29 @@ foam.CLASS({
         // YYDDMM with separators and optional time
         // YY-DD-MM, YY/DD/MM, YY-DD-MM HH:MM, YY-DD-MM HH:MM:SS
         // YY-DD-MMTHH:MM:SS+TZ (with T separator and timezone)
+        // Supports single-digit days and months (e.g., 25-5-1)
         yyddmmsep: alt(
           // With fractional seconds and timezone
           seq(
-            sym('year2'), chars('-/'), sym('day2'), chars('-/'), sym('month2'),
+            sym('year2'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'), '.', sym('fractionalSeconds'),
             optional(sym('timezone'))
           ),
           // With seconds and timezone
           seq(
-            sym('year2'), chars('-/'), sym('day2'), chars('-/'), sym('month2'),
+            sym('year2'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'), ':', sym('second2'),
             optional(sym('timezone'))
           ),
           // With minutes and timezone
           seq(
-            sym('year2'), chars('-/'), sym('day2'), chars('-/'), sym('month2'),
+            sym('year2'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible'),
             sym('datetimesep'), sym('hour2'), ':', sym('minute2'),
             optional(sym('timezone'))
           ),
           // Date only
           seq(
-            sym('year2'), chars('-/'), sym('day2'), chars('-/'), sym('month2')
+            sym('year2'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('monthFlexible')
           )
         ),
 
@@ -450,8 +456,9 @@ foam.CLASS({
         yyddmmcompact: str(repeat(range('0', '9'), null, 6, 6)),
 
         // YYYYDDMMM with separators: YYYY-DD-MMM, YYYY/DD/MMM
+        // Supports single-digit days (e.g., 2025-5-JAN)
         yyyyddmmmsep: seq(
-          sym('year4'), chars('-/'), sym('day2'), chars('-/'), sym('month3alpha')
+          sym('year4'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('month3alpha')
         ),
 
         // YYYYDDMMM compact: YYYYDDMMM (no separators, like 202531JAN)
@@ -460,8 +467,9 @@ foam.CLASS({
         ),
 
         // DDMMMYYYY with separators: DD-MMM-YYYY, DD/MMM/YYYY
+        // Supports single-digit days (e.g., 5-JAN-2025)
         ddmmmyyyysep: seq(
-          sym('day2'), chars('-/'), sym('month3alpha'), chars('-/'), sym('year4')
+          sym('dayFlexible'), chars('-/'), sym('month3alpha'), chars('-/'), sym('year4')
         ),
 
         // DDMMMYYYY compact: DDMMMYYYY (no separators, like 31JAN2025)
@@ -469,14 +477,16 @@ foam.CLASS({
           sym('day2'), sym('month3alpha'), sym('year4')
         ),
 
-        // MMM dd yyyy with spaces: "Jan 02 2025"
+        // MMM dd yyyy with spaces: "Jan 02 2025" or "Jan 2 2025"
+        // Supports single-digit days
         mmmddyyyyspace: seq(
-          sym('month3alpha'), ' ', sym('day2'), ' ', sym('year4')
+          sym('month3alpha'), ' ', sym('dayFlexible'), ' ', sym('year4')
         ),
 
-        // DD MMM YYYY with spaces: "15 JAN 2025"
+        // DD MMM YYYY with spaces: "15 JAN 2025" or "5 JAN 2025"
+        // Supports single-digit days
         ddmmmyyyyspace: seq(
-          sym('day2'), ' ', sym('month3alpha'), ' ', sym('year4')
+          sym('dayFlexible'), ' ', sym('month3alpha'), ' ', sym('year4')
         ),
 
         // Component parsers
@@ -486,23 +496,23 @@ foam.CLASS({
           seq('2', range('0', '9'), range('0', '9'), range('0', '9'))
         )),
         year2: str(seq(range('0', '9'), range('0', '9'))),
-        month2: str(seq(range('0', '1'), range('0', '9'))),
-        
-        //TODO: Add support for single-digit dates in other formats.
+        month2: str(seq(range('0', '1'), range('0', '9'))),  // Used in compact formats (without separators)
 
-        // New flexible parsers to support single digits (e.g. 7/2/2025)
-        // Month: 1-9, 01-09, 10-12
+        // Flexible parsers to support single digits (e.g. 7/2/2025) in formats with separators
+        // Allows slightly out-of-range values for JavaScript Date normalization:
+        // - Month 0 → December of previous year, Month 13 → January of next year
+        // - Day 0 → last day of previous month, Day 32 → normalized to next month
+        // But rejects obviously invalid values like 99
         monthFlexible: alt(
-          str(seq('1', range('0', '2'))),      // 10, 11, 12
-          str(seq('0', range('1', '9'))),      // 01-09
-          range('1', '9')                       // 1-9 (single digit, already a string)
+          str(seq('1', range('0', '9'))),      // 10-19 (allows 13 for normalization)
+          str(seq('0', range('0', '9'))),      // 00-09
+          range('0', '9')                       // 0-9 (single digit)
         ),
-        // Day: 1-9, 01-09, 10-31
+        // Day: 0-39 range to allow normalization (e.g., Feb 30 → Mar 2)
         dayFlexible: alt(
-          str(seq('3', range('0', '1'))),      // 30, 31
-          str(seq(range('1', '2'), range('0', '9'))), // 10-29
-          str(seq('0', range('1', '9'))),      // 01-09
-          range('1', '9')                       // 1-9 (single digit, already a string)
+          str(seq('3', range('0', '9'))),      // 30-39
+          str(seq(range('0', '2'), range('0', '9'))), // 00-29
+          range('0', '9')                       // 0-9 (single digit)
         ),
 
         month3alpha: alt(
@@ -519,7 +529,7 @@ foam.CLASS({
           literalIC('NOV'),
           literalIC('DEC')
         ),
-        day2: str(seq(range('0', '3'), range('0', '9'))),
+        day2: str(seq(range('0', '3'), range('0', '9'))),  // Used in compact formats (without separators)
         hour2: str(seq(range('0', '2'), range('0', '9'))),
         minute2: str(seq(range('0', '5'), range('0', '9'))),
         second2: str(seq(range('0', '5'), range('0', '9'))),

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -49,7 +49,14 @@ foam.CLASS({
         { input: '2025/01/15', year: 2025, month: 0, day: 15 },
         { input: '2024-12-31', year: 2024, month: 11, day: 31 },
         { input: '2000-02-29', year: 2000, month: 1, day: 29 }, // Leap year
-        { input: '1999-01-01', year: 1999, month: 0, day: 1 }
+        { input: '1999-01-01', year: 1999, month: 0, day: 1 },
+        // Single-digit month and day support
+        { input: '2025-1-5', year: 2025, month: 0, day: 5 },
+        { input: '2025/1/5', year: 2025, month: 0, day: 5 },
+        { input: '2025-7-2', year: 2025, month: 6, day: 2 },
+        { input: '2025/7/2', year: 2025, month: 6, day: 2 },
+        { input: '2025-1-15', year: 2025, month: 0, day: 15 },
+        { input: '2025-12-5', year: 2025, month: 11, day: 5 }
       ];
 
       // Test YYYYMMDD with separators
@@ -134,7 +141,10 @@ foam.CLASS({
         { input: '2025-01-15 14:30:45.1', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 100 },
         { input: '2025-01-15T14:30:45.12', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 120 },
         { input: '2025-01-15 14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123 },
-        { input: '2025/01/15T14:30:45.999999', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 999 }
+        { input: '2025/01/15T14:30:45.999999', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 999 },
+        // Single-digit month and day with time
+        { input: '2025-1-5 14:30:45.123', year: 2025, month: 0, day: 5, hour: 14, minute: 30, second: 45, millisecond: 123 },
+        { input: '2025/7/2T10:15:30.500', year: 2025, month: 6, day: 2, hour: 10, minute: 15, second: 30, millisecond: 500 }
       ];
 
       yyyymmddFractional.forEach((testCase, i) => {
@@ -158,7 +168,12 @@ foam.CLASS({
         { input: '2/28/2025', year: 2025, month: 1, day: 28 },
         { input: '01-15-2025', year: 2025, month: 0, day: 15 },
         { input: '12/31/2024', year: 2024, month: 11, day: 31 },
-        { input: '02/29/2000', year: 2000, month: 1, day: 29 }
+        { input: '02/29/2000', year: 2000, month: 1, day: 29 },
+        // More single-digit month and day support
+        { input: '7/2/2025', year: 2025, month: 6, day: 2 },
+        { input: '7-2-2025', year: 2025, month: 6, day: 2 },
+        { input: '1-5-2025', year: 2025, month: 0, day: 5 },
+        { input: '9/9/2025', year: 2025, month: 8, day: 9 }
       ];
 
       // Test MMDDYYYY with separators
@@ -244,7 +259,10 @@ foam.CLASS({
         { input: '1/5/2025 14:30:45.1', year: 2025, month: 0, day: 5, hour: 14, minute: 30, second: 45, millisecond: 100 },
         { input: '01/15/2025T14:30:45.12', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 120 },
         { input: '01-15-2025 14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123 },
-        { input: '01/15/2025T14:30:45.999999', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 999 }
+        { input: '01/15/2025T14:30:45.999999', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 999 },
+        // More single-digit month and day with time
+        { input: '7/2/2025 10:15:30.500', year: 2025, month: 6, day: 2, hour: 10, minute: 15, second: 30, millisecond: 500 },
+        { input: '7-2-2025T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123 }
       ];
 
       mmddyyyyFractional.forEach((testCase, i) => {
@@ -264,7 +282,13 @@ foam.CLASS({
       let mmddyySep = [
         { input: '01/15/25', year: 2025, month: 0, day: 15 },
         { input: '01-15-25', year: 2025, month: 0, day: 15 },
-        { input: '02/29/00', year: 2000, month: 1, day: 29 }
+        { input: '02/29/00', year: 2000, month: 1, day: 29 },
+        // Single-digit month and day support
+        { input: '1/5/25', year: 2025, month: 0, day: 5 },
+        { input: '7-2-25', year: 2025, month: 6, day: 2 },
+        { input: '9/9/25', year: 2025, month: 8, day: 9 },
+        { input: '1-15-25', year: 2025, month: 0, day: 15 },
+        { input: '12/5/25', year: 2025, month: 11, day: 5 }
       ];
 
       // Test MMDDYY with separators
@@ -295,7 +319,10 @@ foam.CLASS({
         { input: '03-27-25T10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467 },
         { input: '01-15-25 14:30:45.1', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 100 },
         { input: '01/15/25T14:30:45.12', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 120 },
-        { input: '01-15-25 14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123 }
+        { input: '01-15-25 14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123 },
+        // Single-digit month and day with time
+        { input: '7/2/25 10:15:30.500', year: 2025, month: 6, day: 2, hour: 10, minute: 15, second: 30, millisecond: 500 },
+        { input: '1-5-25T14:30:45.123', year: 2025, month: 0, day: 5, hour: 14, minute: 30, second: 45, millisecond: 123 }
       ];
 
       mmddyyFractional.forEach((testCase, i) => {
@@ -316,7 +343,13 @@ foam.CLASS({
         { input: '15/01/2025', year: 2025, month: 0, day: 15 },
         { input: '15-01-2025', year: 2025, month: 0, day: 15 },
         { input: '31/12/2024', year: 2024, month: 11, day: 31 },
-        { input: '29/02/2000', year: 2000, month: 1, day: 29 }
+        { input: '29/02/2000', year: 2000, month: 1, day: 29 },
+        // Single-digit day and month support
+        { input: '5/1/2025', year: 2025, month: 0, day: 5 },
+        { input: '2-7-2025', year: 2025, month: 6, day: 2 },
+        { input: '9/9/2025', year: 2025, month: 8, day: 9 },
+        { input: '15/1/2025', year: 2025, month: 0, day: 15 },
+        { input: '5-12-2025', year: 2025, month: 11, day: 5 }
       ];
 
       ddmmyyyySep.forEach((testCase, i) => {
@@ -442,7 +475,11 @@ foam.CLASS({
       let ddmmyySep = [
         { input: '15/01/25', year: 2025, month: 0, day: 15 },
         { input: '31/12/24', year: 2024, month: 11, day: 31 },
-        { input: '29/02/00', year: 2000, month: 1, day: 29 }
+        { input: '29/02/00', year: 2000, month: 1, day: 29 },
+        // Single-digit day and month support
+        { input: '5/1/25', year: 2025, month: 0, day: 5 },
+        { input: '2-7-25', year: 2025, month: 6, day: 2 },
+        { input: '9/9/25', year: 2025, month: 8, day: 9 }
       ];
 
       ddmmyySep.forEach((testCase, i) => {
@@ -483,7 +520,13 @@ foam.CLASS({
         { input: '15-01-2025 14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
         // Test DDMMYY format with fractional seconds too
         { input: '27-03-25 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467, opt_name: 'ddmmyyyy' },
-        { input: '15-01-25T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' }
+        { input: '15-01-25T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
+        // Single-digit day and month with time
+        { input: '5/1/2025 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'ddmmyyyy' },
+        { input: '2-7-2025T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
+        // Single-digit DDMMYY with time
+        { input: '5/1/25 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'ddmmyyyy' },
+        { input: '2-7-25T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' }
       ];
 
       ddmmyyyyFractional.forEach((testCase, i) => {
@@ -513,7 +556,13 @@ foam.CLASS({
         { input: '2025/15/01', year: 2025, month: 0, day: 15 },
         { input: '2025-15-01', year: 2025, month: 0, day: 15 },
         { input: '2024/31/12', year: 2024, month: 11, day: 31 },
-        { input: '2000/29/02', year: 2000, month: 1, day: 29 }
+        { input: '2000/29/02', year: 2000, month: 1, day: 29 },
+        // Single-digit day and month support
+        { input: '2025/5/1', year: 2025, month: 0, day: 5 },
+        { input: '2025-2-7', year: 2025, month: 6, day: 2 },
+        { input: '2025/9/9', year: 2025, month: 8, day: 9 },
+        { input: '2025-15/1', year: 2025, month: 0, day: 15 },
+        { input: '2025/5-12', year: 2025, month: 11, day: 5 }
       ];
 
       yyyyddmmSep.forEach((testCase, i) => {
@@ -639,7 +688,11 @@ foam.CLASS({
         { input: '25/15/01', year: 2025, month: 0, day: 15 },
         { input: '24-31-12', year: 2024, month: 11, day: 31 },
         { input: '00/29/02', year: 2000, month: 1, day: 29 },
-        { input: '99/15/01', year: 1999, month: 0, day: 15 }
+        { input: '99/15/01', year: 1999, month: 0, day: 15 },
+        // Single-digit day and month support
+        { input: '25/5/1', year: 2025, month: 0, day: 5 },
+        { input: '25-2-7', year: 2025, month: 6, day: 2 },
+        { input: '25/9/9', year: 2025, month: 8, day: 9 }
       ];
 
       yyddmmSep.forEach((testCase, i) => {
@@ -687,7 +740,13 @@ foam.CLASS({
         { input: '2025-15-01 14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyyyddmm' },
         // Test YYDDMM format with fractional seconds too
         { input: '25-27-03 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467, opt_name: 'yyddmm' },
-        { input: '25-15-01T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyddmm' }
+        { input: '25-15-01T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyddmm' },
+        // Single-digit day and month with time
+        { input: '2025/5/1 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'yyyyddmm' },
+        { input: '2025-2-7T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyyyddmm' },
+        // Single-digit YYDDMM with time
+        { input: '25/5/1 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'yyddmm' },
+        { input: '25-2-7T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyddmm' }
       ];
 
       yyyyddmmFractional.forEach((testCase, i) => {
@@ -722,7 +781,11 @@ foam.CLASS({
         { input: '01-JAN-2000', year: 2000, month: 0, day: 1 },
         { input: '29-FEB-2024', year: 2024, month: 1, day: 29 }, // Leap year
         { input: '15/jun/2025', year: 2025, month: 5, day: 15 }, // Lowercase
-        { input: '10-Jul-2025', year: 2025, month: 6, day: 10 }  // Mixed case
+        { input: '10-Jul-2025', year: 2025, month: 6, day: 10 }, // Mixed case
+        // Single-digit day support
+        { input: '5-JAN-2025', year: 2025, month: 0, day: 5 },
+        { input: '2/FEB/2025', year: 2025, month: 1, day: 2 },
+        { input: '9-MAR-2025', year: 2025, month: 2, day: 9 }
       ];
 
       // Test with STANDARD format (no opt_name) - month names are unambiguous!
@@ -800,7 +863,11 @@ foam.CLASS({
       let yyyyddmmmTests = [
         { input: '2025-31-JAN', year: 2025, month: 0, day: 31 },
         { input: '2024/15/MAR', year: 2024, month: 2, day: 15 },
-        { input: '202531JAN', year: 2025, month: 0, day: 31 }  // Compact works too!
+        { input: '202531JAN', year: 2025, month: 0, day: 31 }, // Compact works too!
+        // Single-digit day support
+        { input: '2025-5-JAN', year: 2025, month: 0, day: 5 },
+        { input: '2025/2/FEB', year: 2025, month: 1, day: 2 },
+        { input: '2025-9-MAR', year: 2025, month: 2, day: 9 }
       ];
 
       yyyyddmmmTests.forEach((testCase, i) => {
@@ -825,7 +892,11 @@ foam.CLASS({
         { input: 'JAN 01 2000', year: 2000, month: 0, day: 1 },
         { input: 'FEB 29 2024', year: 2024, month: 1, day: 29 }, // Leap year
         { input: 'jun 15 2025', year: 2025, month: 5, day: 15 }, // Lowercase
-        { input: 'Jul 10 2025', year: 2025, month: 6, day: 10 }  // Mixed case
+        { input: 'Jul 10 2025', year: 2025, month: 6, day: 10 }, // Mixed case
+        // Single-digit day support
+        { input: 'JAN 5 2025', year: 2025, month: 0, day: 5 },
+        { input: 'FEB 2 2025', year: 2025, month: 1, day: 2 },
+        { input: 'MAR 9 2025', year: 2025, month: 2, day: 9 }
       ];
 
       mmmddyyyySpace.forEach((testCase, i) => {
@@ -880,7 +951,11 @@ foam.CLASS({
         { input: '01 JAN 2000', year: 2000, month: 0, day: 1 },
         { input: '29 FEB 2024', year: 2024, month: 1, day: 29 }, // Leap year
         { input: '15 jun 2025', year: 2025, month: 5, day: 15 }, // Lowercase
-        { input: '10 Jul 2025', year: 2025, month: 6, day: 10 }  // Mixed case
+        { input: '10 Jul 2025', year: 2025, month: 6, day: 10 }, // Mixed case
+        // Single-digit day support
+        { input: '5 JAN 2025', year: 2025, month: 0, day: 5 },
+        { input: '2 FEB 2025', year: 2025, month: 1, day: 2 },
+        { input: '9 MAR 2025', year: 2025, month: 2, day: 9 }
       ];
 
       ddmmmyyyySpace.forEach((testCase, i) => {
@@ -967,30 +1042,51 @@ foam.CLASS({
         { input: '2025-01-15 14:30:45.1', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 100 },
         { input: '2025-01-15 14:30:45.12', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 120 },
         { input: '2025-01-15 14:30:45.999999', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 999 },
+        // Single-digit YYYY-MM-DD with fractional seconds
+        { input: '2025-1-5 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500 },
+        { input: '2025/7/2T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123 },
 
         // MM-DD-YYYY format with fractional seconds
         { input: '03-27-2025 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467 },
         { input: '01-15-2025T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123 },
+        // Single-digit MM-DD-YYYY with fractional seconds
+        { input: '7/2/2025 10:15:30.500', year: 2025, month: 6, day: 2, hour: 10, minute: 15, second: 30, millisecond: 500 },
+        { input: '1-5-2025T14:30:45.123', year: 2025, month: 0, day: 5, hour: 14, minute: 30, second: 45, millisecond: 123 },
 
         // MM-DD-YY format with fractional seconds
         { input: '03-27-25 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467 },
         { input: '01-15-25T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123 },
+        // Single-digit MM-DD-YY with fractional seconds
+        { input: '7/2/25 10:15:30.500', year: 2025, month: 6, day: 2, hour: 10, minute: 15, second: 30, millisecond: 500 },
+        { input: '1-5-25T14:30:45.123', year: 2025, month: 0, day: 5, hour: 14, minute: 30, second: 45, millisecond: 123 },
 
         // DD-MM-YYYY format with fractional seconds
         { input: '27-03-2025 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467, opt_name: 'ddmmyyyy' },
         { input: '15-01-2025T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
+        // Single-digit DD-MM-YYYY with fractional seconds
+        { input: '5/1/2025 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'ddmmyyyy' },
+        { input: '2-7-2025T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
 
         // DD-MM-YY format with fractional seconds
         { input: '27-03-25 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467, opt_name: 'ddmmyyyy' },
         { input: '15-01-25T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
+        // Single-digit DD-MM-YY with fractional seconds
+        { input: '5/1/25 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'ddmmyyyy' },
+        { input: '2-7-25T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'ddmmyyyy' },
 
         // YYYY-DD-MM format with fractional seconds
         { input: '2025-27-03 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467, opt_name: 'yyyyddmm' },
         { input: '2025-15-01T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyyyddmm' },
+        // Single-digit YYYY-DD-MM with fractional seconds
+        { input: '2025/5/1 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'yyyyddmm' },
+        { input: '2025-2-7T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyyyddmm' },
 
         // YY-DD-MM format with fractional seconds
         { input: '25-27-03 10:34:14.467000', year: 2025, month: 2, day: 27, hour: 10, minute: 34, second: 14, millisecond: 467, opt_name: 'yyddmm' },
-        { input: '25-15-01T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyddmm' }
+        { input: '25-15-01T14:30:45.123456', year: 2025, month: 0, day: 15, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyddmm' },
+        // Single-digit YY-DD-MM with fractional seconds
+        { input: '25/5/1 10:15:30.500', year: 2025, month: 0, day: 5, hour: 10, minute: 15, second: 30, millisecond: 500, opt_name: 'yyddmm' },
+        { input: '25-2-7T14:30:45.123', year: 2025, month: 6, day: 2, hour: 14, minute: 30, second: 45, millisecond: 123, opt_name: 'yyddmm' }
       ];
 
       fractionalTests.forEach((testCase, i) => {


### PR DESCRIPTION

- Updated DateGrammar.js to allow single-digit months and days in formats like YYYY-MM-DD, DD-MM-YYYY, and others.
- Enhanced test cases in DateParserTest.js to validate single-digit month and day parsing.


adds on top of https://github.com/kgrgreer/foam3/pull/4655