### PR TITLE
Fix RulerDAO Cache Update for Soft-Deleted Rules

### DIFF
--- a/src/foam/core/ruler/UpdateRulesListSink.js
+++ b/src/foam/core/ruler/UpdateRulesListSink.js
@@ -51,12 +51,14 @@ foam.CLASS({
               List<Rule> rules = ((ArraySink) groupBy.getGroups().get(ruleGroup)).getArray();
               Rule foundRule = Rule.findById(rules, rule.getId());
               if ( foundRule != null ) {
-                rules.remove(foundRule);
-                if ( rule.getEnabled() ) {
+              rules.remove(foundRule);
+                // Only re-add if enabled AND not deleted (lifecycleState check handles soft-delete via remove_)
+                if ( rule.getEnabled() && rule.getLifecycleState() != foam.core.auth.LifecycleState.DELETED ) {
                   rules.add(foundRule.updateRule(rule));
                 }
               } else {
-                if ( rule.getEnabled() ) {
+                // Only add new rule if enabled AND not deleted
+                if ( rule.getEnabled() && rule.getLifecycleState() != foam.core.auth.LifecycleState.DELETED ) {
                   rules.add(rule);
                 }
               }


### PR DESCRIPTION

## Summary
- Fix `UpdateRulesListSink` to properly remove soft-deleted rules from the RulerDAO cache
- Rules deleted via `ruleDAO.remove()` now correctly invalidate the cache

## Problem
When a rule was removed via `ruleDAO.remove()`, the rule continued to execute until the server was restarted. The RulerDAO cache was not being updated properly for soft-deleted rules.

## Root Cause Analysis

### How Rule Implements LifecycleAware

1. **Rule Model** (`foam/core/ruler/Rule.js`)
   - Has a `lifecycleState` property of type `foam.core.auth.LifecycleState`
   - This makes it assignable to the `LifecycleAware` interface

2. **EasyDAO Auto-Detection** (`foam/dao/EasyDAO.js`)
   ```java
   lifecycleAware: {
     javaFactory: 'return getEnableInterfaceDecorators() &&
                   getOf().isAssignableTo(foam.core.auth.LifecycleAware.class);'
   }
   ```
   - EasyDAO automatically detects if a model is `LifecycleAware`
   - If true, it wraps the DAO with `LifecycleAwareDAO` decorator

3. **LifecycleAwareDAO.remove_()** (`foam/core/auth/LifecycleAwareDAO.js`)
   ```java
   if ( obj instanceof LifecycleAware ) {
     LifecycleAware clone = (LifecycleAware) obj.fclone();
     clone.setLifecycleState(LifecycleState.DELETED);
     obj = getDelegate().put_(x, (FObject) clone);  // <-- Uses PUT, not remove!
   }
   ```
   - **Key insight**: `remove_()` doesn't actually delete - it **soft-deletes** by:
     1. Cloning the object
     2. Setting `lifecycleState = DELETED`
     3. Calling `put_()` (NOT `remove_()`)

4. **The Bug in UpdateRulesListSink.put()**
   - Since soft-delete calls `put_()`, `UpdateRulesListSink.put()` is triggered
   - The old code only checked `rule.getEnabled()`:
     ```java
     if ( rule.getEnabled() ) {
       rules.add(rule);  // Rule was re-added even though it was soft-deleted!
     }
     ```
   - Since `enabled` wasn't changed (only `lifecycleState`), deleted rules stayed in cache

## The Fix

Updated `UpdateRulesListSink.put()` to check **both** `enabled` AND `lifecycleState`:

```java
// Only re-add if enabled AND not deleted (lifecycleState check handles soft-delete via remove_)
if ( rule.getEnabled() && rule.getLifecycleState() != foam.core.auth.LifecycleState.DELETED ) {
  rules.add(foundRule.updateRule(rule));
}
```

Now rules are removed from cache when:
- `enabled = false` (explicit disable via put)
- OR `lifecycleState = DELETED` (soft-delete via remove)

## Files Changed
- `src/foam/core/ruler/UpdateRulesListSink.js` - Added lifecycleState check in `put()` method

