### PR TITLE
feat(rule-refresh): add RuleRefreshService and related classes for DAO refresh functionality

### DIFF
--- a/src/foam/core/ruler/Rule.js
+++ b/src/foam/core/ruler/Rule.js
@@ -23,10 +23,14 @@ foam.CLASS({
   ],
 
   imports: [
+    'notify',
+    'ruleRefreshService',
     'userDAO?'
   ],
 
   requires: [
+    'foam.core.dao.Operation',
+    'foam.log.LogLevel',
     'foam.mlang.predicate.True'
   ],
 
@@ -532,6 +536,55 @@ foam.CLASS({
         appropriate user for which the permission is checked.
       `,
       javaCode: 'return null;'
+    }
+  ],
+
+  actions: [
+    {
+      name: 'refreshDAO',
+      label: 'Refresh DAO',
+      toolTip: 'Re-process all records in the target DAO by re-putting them to trigger onCreate rules',
+      icon: 'images/refresh-icon.svg',
+      availablePermissions: ['rule.refreshDAO'],
+      confirmationRequired: function() {
+        return true;
+      },
+      isAvailable: function(id, daoKey) {
+        return id && daoKey;
+      },
+      code: async function(X) {
+        try {
+          var ruleId = this.id;
+
+          if ( ! ruleId ) {
+            this.notify('Cannot refresh: Rule ID is not set', '', this.LogLevel.ERROR);
+            return;
+          }
+
+          this.notify('Starting DAO refresh for ' + this.daoKey + '...', '', this.LogLevel.INFO);
+
+          var result = await this.ruleRefreshService.refreshDAO(ruleId);
+
+          var message = 'DAO refresh completed: ' + result.processedCount + ' processed, ' + result.updatedCount + ' updated';
+          if ( result.failedCount > 0 ) {
+            message += ', ' + result.failedCount + ' failed';
+          }
+          message += ' (' + (result.duration / 1000).toFixed(1) + 's)';
+
+          this.notify(
+            message,
+            '',
+            result.failedCount > 0 ? this.LogLevel.WARN : this.LogLevel.INFO
+          );
+        } catch (e) {
+          this.notify(
+            'DAO refresh failed: ' + e.message,
+            '',
+            this.LogLevel.ERROR
+          );
+          throw e;
+        }
+      }
     }
   ],
 

--- a/src/foam/core/ruler/RuleRefreshResult.js
+++ b/src/foam/core/ruler/RuleRefreshResult.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.ruler',
+  name: 'RuleRefreshResult',
+
+  documentation: 'Result object returned by RuleRefreshService.refreshDAO()',
+
+  properties: [
+    {
+      class: 'String',
+      name: 'ruleId',
+      documentation: 'The ID of the rule whose DAO was refreshed'
+    },
+    {
+      class: 'String',
+      name: 'daoKey',
+      documentation: 'The DAO key that was refreshed'
+    },
+    {
+      class: 'Long',
+      name: 'processedCount',
+      documentation: 'Number of records processed (re-put)'
+    },
+    {
+      class: 'Long',
+      name: 'updatedCount',
+      documentation: 'Number of records that were actually modified by rules'
+    },
+    {
+      class: 'Long',
+      name: 'failedCount',
+      documentation: 'Number of records that failed to process'
+    },
+    {
+      class: 'Long',
+      name: 'duration',
+      documentation: 'Time taken to complete the refresh in milliseconds'
+    },
+    {
+      class: 'Boolean',
+      name: 'success',
+      value: true,
+      documentation: 'Whether the refresh completed successfully'
+    },
+    {
+      class: 'String',
+      name: 'errorMessage',
+      documentation: 'Error message if the refresh failed'
+    }
+  ]
+});

--- a/src/foam/core/ruler/RuleRefreshService.js
+++ b/src/foam/core/ruler/RuleRefreshService.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.core.ruler',
+  name: 'RuleRefreshService',
+
+  skeleton: true,
+  client: true,
+  proxy: true,
+
+  documentation: `
+    Service to trigger a full DAO refresh for a given rule.
+    This re-puts all records in the rule's target DAO, effectively
+    triggering all onCreate rules to re-process the data.
+  `,
+
+  methods: [
+    {
+      name: 'refreshDAO',
+      async: true,
+      documentation: `
+        Refresh all records in the DAO associated with the given rule.
+        Selects all records and re-puts them to trigger onCreate rules.
+      `,
+      type: 'foam.core.ruler.RuleRefreshResult',
+      args: 'String ruleId'
+    }
+  ]
+});

--- a/src/foam/core/ruler/SimpleRuleRefreshService.java
+++ b/src/foam/core/ruler/SimpleRuleRefreshService.java
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2024 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core.ruler;
+
+import foam.lang.ContextAwareSupport;
+import foam.lang.X;
+import foam.dao.ArraySink;
+import foam.dao.DAO;
+import foam.core.auth.AuthService;
+import foam.core.auth.AuthorizationException;
+import foam.core.dao.Operation;
+import foam.core.logger.Logger;
+import foam.core.pm.PM;
+import java.util.List;
+
+/**
+ * Simple implementation of RuleRefreshService that refreshes all records
+ * in a rule's target DAO by re-putting them to trigger onCreate rules.
+ */
+public class SimpleRuleRefreshService
+  extends ContextAwareSupport
+  implements RuleRefreshService
+{
+
+  public SimpleRuleRefreshService(X x) {
+    setX(x);
+  }
+
+  @Override
+  public RuleRefreshResult refreshDAO(String ruleId) {
+    X x = getX();
+    Logger logger = (Logger) x.get("logger");
+    PM pm = PM.create(x, this.getClass(), "refreshDAO");
+
+    RuleRefreshResult result = new RuleRefreshResult();
+    result.setRuleId(ruleId);
+
+    long startTime = System.currentTimeMillis();
+
+    try {
+      // Check permission
+      AuthService auth = (AuthService) x.get("auth");
+      if ( ! auth.check(x, "rule.refreshDAO") ) {
+        throw new AuthorizationException("You do not have permission to refresh DAO data.");
+      }
+
+      // Find the rule
+      DAO ruleDAO = (DAO) x.get("ruleDAO");
+      Rule rule = (Rule) ruleDAO.find(ruleId);
+
+      if ( rule == null ) {
+        throw new RuntimeException("Rule not found: " + ruleId);
+      }
+
+      if ( ! rule.getEnabled() ) {
+        throw new RuntimeException("Rule is not enabled. Enable the rule first before refreshing.");
+      }
+
+      // Validate operation type - only UPDATE or CREATE_OR_UPDATE will be triggered by re-putting
+      Operation op = rule.getOperation();
+      if ( op != Operation.UPDATE && op != Operation.CREATE_OR_UPDATE ) {
+        throw new RuntimeException("DAO refresh is only supported for UPDATE or CREATE_OR_UPDATE rules. This rule has operation '" + op.getLabel() + "' which will not be triggered by re-putting existing records.");
+      }
+
+      String daoKey = rule.getDaoKey();
+      if ( daoKey == null || daoKey.isEmpty() ) {
+        throw new RuntimeException("Rule does not have a DAO key configured: " + ruleId);
+      }
+
+      result.setDaoKey(daoKey);
+
+      // Get the target DAO
+      DAO targetDAO = (DAO) x.get(daoKey);
+      if ( targetDAO == null ) {
+        throw new RuntimeException("DAO not found: " + daoKey);
+      }
+
+      logger.info("Starting DAO refresh for rule: " + ruleId + ", DAO: " + daoKey);
+
+      // Select all records and re-put them
+      ArraySink sink = (ArraySink) targetDAO.select(new ArraySink());
+      List records = sink.getArray();
+
+      long processedCount = 0;
+      long updatedCount = 0;
+      long failedCount = 0;
+
+      for ( Object record : records ) {
+        try {
+          // Clone and re-put to trigger rules
+          foam.lang.FObject original = (foam.lang.FObject) record;
+          foam.lang.FObject clone = original.fclone();
+          foam.lang.FObject updated = (foam.lang.FObject) targetDAO.put(clone);
+          processedCount++;
+
+          // Check if the record was actually modified
+          if ( ! original.equals(updated) ) {
+            updatedCount++;
+          }
+        } catch ( Exception e ) {
+          failedCount++;
+          logger.warning("Failed to refresh record in " + daoKey + ": " + e.getMessage());
+        }
+      }
+
+      result.setProcessedCount(processedCount);
+      result.setUpdatedCount(updatedCount);
+      result.setFailedCount(failedCount);
+      result.setSuccess(failedCount == 0);
+      result.setDuration(System.currentTimeMillis() - startTime);
+
+      if ( failedCount > 0 ) {
+        result.setErrorMessage(failedCount + " records failed to process");
+      }
+
+      logger.info("DAO refresh completed for rule: " + ruleId +
+                  ", processed: " + processedCount +
+                  ", updated: " + updatedCount +
+                  ", failed: " + failedCount +
+                  ", duration: " + result.getDuration() + "ms");
+
+    } catch ( Exception e ) {
+      result.setSuccess(false);
+      result.setErrorMessage(e.getMessage());
+      result.setDuration(System.currentTimeMillis() - startTime);
+      logger.error("DAO refresh failed for rule: " + ruleId, e);
+      throw new RuntimeException("DAO refresh failed: " + e.getMessage(), e);
+    } finally {
+      pm.log(x);
+    }
+
+    return result;
+  }
+}

--- a/src/foam/core/ruler/pom.js
+++ b/src/foam/core/ruler/pom.js
@@ -5,6 +5,8 @@ foam.POM({
   ],
   files: [
     { name: "Rule",                                                    flags: "js|java" },
+    { name: "RuleRefreshResult",                                       flags: "js|java" },
+    { name: "RuleRefreshService",                                      flags: "js|java" },
     { name: "RuleGroup",                                               flags: "js|java" },
     { name: "Ruled",                                                   flags: "js|java" },
     { name: "FindRuledCommand",                                        flags: "js|java" },
@@ -49,6 +51,7 @@ foam.POM({
   javaFiles: [
     { name: "RuleEngine" },
     { name: "RetryManager" },
+    { name: "SimpleRuleRefreshService" },
     { name: "cron/RenewRuleHistoryCron" },
     { name: "test/DummyErroneousPredicate",                            flags: "test" },
     { name: "test/RulerDAOTest",                                       flags: "test" }

--- a/src/foam/core/ruler/services.jrl
+++ b/src/foam/core/ruler/services.jrl
@@ -85,6 +85,28 @@ p({
   """
 })
 p({
+  "class": "foam.core.boot.CSpec",
+  "name": "ruleRefreshService",
+  "lazy": true,
+  "serve": true,
+  "authenticate": true,
+  "boxClass": "foam.core.ruler.RuleRefreshServiceSkeleton",
+  "serviceScript": "return new foam.core.ruler.SimpleRuleRefreshService(x);",
+  "client": """
+    {
+      "class": "foam.core.ruler.ClientRuleRefreshService",
+      "delegate": {
+        "class": "foam.box.SessionClientBox",
+        "delegate": {
+          "class": "foam.box.HTTPBox",
+          "url": "service/ruleRefreshService"
+        }
+      }
+    }
+  """
+})
+
+p({
   "class":"foam.core.boot.CSpec",
   "name":"ruleHistoryDAO",
   "serve":true,


### PR DESCRIPTION
## Summary

Add a "Refresh DAO" action to Rules that allows users to re-apply rule logic to all existing records in the target DAO.

## Motivation

When a user modifies a rule, the changes only apply to new or subsequently updated records. Existing records remain unchanged.

This feature allows users to re-process all existing records so that updated rule logic is applied retroactively, which is essential for:

- Data transformation rules that need to be re-applied after corrections
- Validation rules that have been refined

## Changes

### New Files
- **RuleRefreshService.js** - Service interface with skeleton/client/proxy generation
- **RuleRefreshResult.js** - Result model tracking processed, updated, and failed counts
- **SimpleRuleRefreshService.java** - Backend implementation that streams and re-puts records

### Modified Files
- **Rule.js** - Added "Refresh DAO" action with permission check and user notifications
- **pom.js** - Registered new files
- **services.jrl** - Registered the refresh service

## Features

- Refresh action available on Rule detail view
- Requires `rule.refreshDAO` permission
- Only supports UPDATE and CREATE_OR_UPDATE rules (clear error message for other types)
- Tracks and displays:
  - Records processed
  - Records actually updated
  - Records failed
  - Duration
- Progress and completion notifications

## Testing

1. Navigate to a Rule with UPDATE or CREATE_OR_UPDATE operation
2. Click "Refresh DAO" action
3. Confirm the action
4. Verify notification shows processed/updated counts

