### PR TITLE
SessionService - Update CSpec - had fallen out of date.

### DIFF
--- a/deployment/test/rules.jrl
+++ b/deployment/test/rules.jrl
@@ -48,7 +48,7 @@ p({
   "lifecycleState": 1,
   "predicate": {
     class: "foam.core.ruler.predicate.FScriptRulePredicate",
-    query: 'o.lifecycleState == foam.core.auth.LifecycleState.ACTIVE && n.lifecycleState == foam.core.auth.LifecycleState.DELETED && n.loginEnabled == true && n.type == "User"',
+    query: 'o.lifecycleState == foam.core.auth.LifecycleState.ACTIVE && n.lifecycleState == foam.core.auth.LifecycleState.DELETED && n.loginEnabled == true && n.type == "User"'
   },
   action: {
     "class": "foam.core.auth.UserLifecycleDeletedRuleAction"

--- a/src/foam/core/auth/UserLifecycleTicket.js
+++ b/src/foam/core/auth/UserLifecycleTicket.js
@@ -24,7 +24,8 @@ Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
 
   imports: [
     'userDAO',
-    'sessionDAO'
+    'sessionDAO?',
+    'sessionService'
   ],
 
   requires: [
@@ -208,18 +209,22 @@ Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
       name: 'fetchUserSession',
       code: function() {
         var self = this;
-        self.userDAO.find(self.createdFor).then(function(user) {
-          self.currentLifecycleState = user.lifecycleState;
-        });
-        self.sessionDAO.find(self.EQ(self.Session.USER_ID, self.createdFor)).then(function(session) {
-          if ( ! session ) {
-            self.loggedIn = false;
-            self.clearProperty('lastActivity');
-          } else {
-            self.loggedIn = session.uses > 0 && session.remoteHost;
-            self.lastActivity = Date.now() - session.lastUsed.getTime();
-          }
-        });
+        if ( this.sessionDAO ) {
+          this.userDAO.find(self.createdFor).then(function(user) {
+            self.currentLifecycleState = user.lifecycleState;
+          });
+          this.sessionDAO.find(self.EQ(self.Session.USER_ID, self.createdFor)).then(function(session) {
+            if ( ! session ) {
+              self.loggedIn = false;
+              self.clearProperty('lastActivity');
+            } else {
+              self.loggedIn = session.uses > 0 && session.remoteHost;
+              self.lastActivity = Date.now() - session.lastUsed.getTime();
+            }
+          });
+        } else {
+          this.sessionService.expireSession();
+        }
       }
     }
   ],

--- a/src/foam/core/auth/UserLifecycleTicket.js
+++ b/src/foam/core/auth/UserLifecycleTicket.js
@@ -24,8 +24,7 @@ Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
 
   imports: [
     'userDAO',
-    'sessionDAO?',
-    'sessionService'
+    'sessionDAO?'
   ],
 
   requires: [
@@ -209,6 +208,7 @@ Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
       name: 'fetchUserSession',
       code: function() {
         var self = this;
+        // sessionDAO not accessible when user deleting self.
         if ( this.sessionDAO ) {
           this.userDAO.find(self.createdFor).then(function(user) {
             self.currentLifecycleState = user.lifecycleState;
@@ -222,8 +222,6 @@ Changing to 'DELETED', for example, will also mark associated UCJs as deleted.`,
               self.lastActivity = Date.now() - session.lastUsed.getTime();
             }
           });
-        } else {
-          this.sessionService.expireSession();
         }
       }
     }

--- a/src/foam/core/auth/test/UserLifecycleTicketTest.js
+++ b/src/foam/core/auth/test/UserLifecycleTicketTest.js
@@ -19,14 +19,16 @@ foam.CLASS({
 `,
 
   javaImports: [
-    'foam.lang.X',
-    'foam.dao.ArraySink',
-    'foam.dao.DAO',
-    'foam.dao.MDAO',
-    'static foam.mlang.MLang.*',
     'foam.core.auth.*',
     'foam.core.crunch.*',
     'foam.core.logger.Loggers',
+    'foam.core.ticket.Ticket',
+    'foam.dao.ArraySink',
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.lang.X',
+    'static foam.mlang.MLang.*',
+    'foam.mlang.sink.Count',
     'foam.test.TestUtils',
     'foam.util.Auth',
     'java.util.List'
@@ -60,6 +62,7 @@ foam.CLASS({
     user.setGroup("test");
     user.setEmail(user.getUserName()+"@foamdev.com");
     user.setEmailVerified(true);
+    user.setLoginEnabled(true); // delete rule looking for this.
     user = (User) userDAO.put(user);
 
     X userX = Auth.sudo(x, user);
@@ -133,9 +136,24 @@ foam.CLASS({
     // 1. LifecycleAwareDAO which will map remove to put lifecycleState DELETED
     // 2. which in turn triggers UserLifecycleDeletedRuleAction to create ticket
     // and delete associated data.
+    Count beforeCount = (Count) ticketDAO.select(COUNT());
     ((DAO) x.get("userDAO")).remove(user);
     user = (User) ((DAO) x.get("userDAO")).find(user.getId());
     test ( user == null || user.getLifecycleState() == LifecycleState.DELETED, "user deleted: " + (user != null ? user.getLifecycleState().toString() : "null"));
+
+    try {
+      Thread.currentThread().sleep(500);
+    } catch (InterruptedException e) {
+      // nop
+    }
+
+    Count afterCount = (Count) ticketDAO.select(COUNT());
+    test ( ((Long)afterCount.getValue()) - ((Long)beforeCount.getValue()) == 1, "Auto generated ticket created" );
+    UserLifecycleTicket triggerTicket = (UserLifecycleTicket) ticketDAO.find(AND(EQ(Ticket.CREATED_FOR, user.getId()), EQ(Ticket.TYPE, "UserLifecycleTicket")));
+    test ( triggerTicket != null && ticket.getId() != triggerTicket.getId(), "Found auto generated ticket");
+    if ( triggerTicket != null ) {
+      test ( triggerTicket.getStatus().equals("CLOSED"), "Auto generated Ticket CLOSED "+ triggerTicket.getStatus() + " " + triggerTicket.getMessage());
+    }
 
     userCapabilityJunctions = (List<UserCapabilityJunction>) ((ArraySink) userCapabilityJunctionDAO
         .where(EQ(UserCapabilityJunction.SOURCE_ID, user.getId()))

--- a/src/foam/core/session/SessionService.js
+++ b/src/foam/core/session/SessionService.js
@@ -9,6 +9,7 @@ foam.INTERFACE({
   name: 'SessionService',
 
   skeleton: true,
+  client: true,
 
   documentation: `
     A service that can be used to create sessions for users. The idea behind

--- a/src/foam/core/session/services.jrl
+++ b/src/foam/core/session/services.jrl
@@ -37,7 +37,21 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "sessionService",
   "serve": true,
-  "serviceClass": "foam.core.session.SimpleSessionService"
+  "boxClass": "foam.core.session.SessionServiceSkeleton",
+  "serviceClass": "foam.core.session.SimpleSessionService",
+  "client":
+    """
+      {
+        "class": "foam.core.session.ClientSessionService",
+        "delegate": {
+          "class": "foam.box.SessionClientBox",
+          "delegate": {
+            "class": "foam.box.HTTPBox",
+            "url": "service/sessionService"
+          }
+        }
+      }
+    """
 })
 
 p({

--- a/src/groupPermissionJunctions.jrl
+++ b/src/groupPermissionJunctions.jrl
@@ -82,6 +82,7 @@ p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.approvalRequestDAO"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.approvalRequestClassificationDAO"})
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"menu.read.set-password"})
+p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"basicUser",targetId:"service.sessionService"})
 
 // foam
 p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"foam",targetId:"group.read.foam"})


### PR DESCRIPTION
SessionService was designed to allow a non-privileged user to interact with their session, rather than direct access to sessionDAO from the client.  
Used in this case to expire their own session when they delete their user account.

The CSpec configuration was no longer valid, from non-use over time.  
Interface now creates client and the cspec now specifies the client configuration. 

- [X] Test cases