### PR TITLE
PT-FIXES:1908 : Fix race condition in QueryCachingDAO when cache is purged during async select

### DIFF
--- a/src/foam/dao/QueryCachingDAO.js
+++ b/src/foam/dao/QueryCachingDAO.js
@@ -63,6 +63,12 @@ foam.CLASS({
 
         // Ensure we have cache for request
         self.fillCache_(key, requestStartIdx, requestEndIdx, x, sink, order, predicate).then(() => {
+          // Guard against cache being purged while fillCache_ was pending
+          if ( ! self.cache[key] ) {
+            sink.eof();
+            resolve(sink);
+            return;
+          }
 
           let endIdx = requestEndIdx <= self.cache[key].length ? requestEndIdx : self.cache[key].length;
 
@@ -146,6 +152,9 @@ foam.CLASS({
         // console.log('******** QUERYCACHE*** HAS MISSING DATA ***: predicte: ' + predicate + ' startIdx: ' + startIdx + ' endIdx: ' + endIdx);
         let self = this;
         return this.delegate.select_(x, sink, startIdx, endIdx - startIdx, order, predicate).then(function(result) {
+          // Guard against cache being purged while select was pending
+          if ( ! self.cache[key] ) return;
+
           if ( foam.dao.ArraySink.isInstance(sink) ) {
             // ArraySink
             // Update cache with missing data

--- a/src/foam/dao/QueryCachingDAO.js
+++ b/src/foam/dao/QueryCachingDAO.js
@@ -63,12 +63,8 @@ foam.CLASS({
 
         // Ensure we have cache for request
         self.fillCache_(key, requestStartIdx, requestEndIdx, x, sink, order, predicate).then(() => {
-          // Guard against cache being purged while fillCache_ was pending
-          if ( ! self.cache[key] ) {
-            sink.eof();
-            resolve(sink);
-            return;
-          }
+          // Re-create cache entry if it was purged while fillCache_ was pending
+          if ( ! self.cache[key] ) self.cache[key] = [];
 
           let endIdx = requestEndIdx <= self.cache[key].length ? requestEndIdx : self.cache[key].length;
 
@@ -152,8 +148,8 @@ foam.CLASS({
         // console.log('******** QUERYCACHE*** HAS MISSING DATA ***: predicte: ' + predicate + ' startIdx: ' + startIdx + ' endIdx: ' + endIdx);
         let self = this;
         return this.delegate.select_(x, sink, startIdx, endIdx - startIdx, order, predicate).then(function(result) {
-          // Guard against cache being purged while select was pending
-          if ( ! self.cache[key] ) return;
+          // Re-create cache entry if it was purged while select was pending
+          if ( ! self.cache[key] ) self.cache[key] = [];
 
           if ( foam.dao.ArraySink.isInstance(sink) ) {
             // ArraySink

--- a/src/foam/dao/QueryCachingDAO.js
+++ b/src/foam/dao/QueryCachingDAO.js
@@ -63,7 +63,7 @@ foam.CLASS({
 
         // Ensure we have cache for request
         self.fillCache_(key, requestStartIdx, requestEndIdx, x, sink, order, predicate).then(() => {
-          // Re-create cache entry if it was purged while fillCache_ was pending
+          // Re-create cache entry if purged during async fillCache_
           if ( ! self.cache[key] ) self.cache[key] = [];
 
           let endIdx = requestEndIdx <= self.cache[key].length ? requestEndIdx : self.cache[key].length;
@@ -148,7 +148,7 @@ foam.CLASS({
         // console.log('******** QUERYCACHE*** HAS MISSING DATA ***: predicte: ' + predicate + ' startIdx: ' + startIdx + ' endIdx: ' + endIdx);
         let self = this;
         return this.delegate.select_(x, sink, startIdx, endIdx - startIdx, order, predicate).then(function(result) {
-          // Re-create cache entry if it was purged while select was pending
+          // Re-create cache entry if purged during async select
           if ( ! self.cache[key] ) self.cache[key] = [];
 
           if ( foam.dao.ArraySink.isInstance(sink) ) {


### PR DESCRIPTION

### Problem

`QueryCachingDAO` throws `TypeError: Cannot set properties of undefined (setting '0')` when the cache is purged while an async select operation is in progress.

**Stack trace:**
```
QueryCachingDAO.js:159 Uncaught (in promise) TypeError: Cannot set properties of undefined (setting '0')
    at QueryCachingDAO.js:159:47
```

### Root Cause

A race condition exists between async select operations and cache purging:

1. `select_()` creates a cache entry: `this.cache[key] = []`
2. `fillCache_()` calls `this.delegate.select_()` (async)
3. While waiting, a reset event propagates through the DAO chain
4. `purgeCache()` is triggered via `on.reset.sub()`, setting `this.cache = {}`
5. Async select resolves and tries to write to `self.cache[key]` which is now `undefined`

### Solution

Re-create the cache entry if it was purged during async operations. This both fixes the error and preserves the cache benefit.

**In `fillCache_()` (line 156):**
```javascript
return this.delegate.select_(...).then(function(result) {
  // Re-create cache entry if it was purged while select was pending
  if ( ! self.cache[key] ) self.cache[key] = [];

  // ... write to cache
});
```

**In `select_()` (line 67):**
```javascript
self.fillCache_(...).then(() => {
  // Re-create cache entry if it was purged while fillCache_ was pending
  if ( ! self.cache[key] ) self.cache[key] = [];

  // ... read from cache
});
```

### How It Works

- If the cache was purged during the async operation, we re-create the cache entry
- The freshly fetched data is then cached for subsequent requests
- This preserves the caching benefit while fixing the crash

### Files Changed

- `src/foam/dao/QueryCachingDAO.js`
