### PR TITLE
feat(JavetShell): implement signalDone() for immediate event loop

### DIFF
--- a/src/foam/core/script/javet/JavetShell.js
+++ b/src/foam/core/script/javet/JavetShell.js
@@ -24,6 +24,7 @@ See JavetShell.md for more info.
     'com.caoccao.javet.exceptions.JavetException',
     'com.caoccao.javet.interception.logging.JavetStandardConsoleInterceptor',
     'com.caoccao.javet.interfaces.IJavetAnonymous',
+    'com.caoccao.javet.interop.NodeRuntime',
     'com.caoccao.javet.interop.V8Runtime',
     'com.caoccao.javet.interop.callback.IJavetPromiseRejectCallback',
     'com.caoccao.javet.interop.callback.JavetPromiseRejectCallback',
@@ -52,6 +53,7 @@ See JavetShell.md for more info.
     'java.io.File',
     'java.io.IOException',
     'java.io.PrintStream',
+    'java.nio.charset.StandardCharsets',
     'java.util.Arrays',
     'java.util.Date',
     'java.util.HashMap',
@@ -64,6 +66,7 @@ See JavetShell.md for more info.
   IJavetPromiseRejectCallback promiseCallback_ = null;
   IV8ValuePromise.IListener promiseListener_ = null;
   JavetStandardConsoleInterceptor javetConsoleInterceptor_ = null;
+  volatile boolean stopping_ = false;
 
   public JavetShell(X x, V8Runtime v8Runtime) {
     setX(x);
@@ -201,8 +204,20 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
     %s
   };
   await code.call(x);
+  console.info('JavetShell: code complete, calling signalDone()');
+  if ( typeof signalDone === 'function' ) {
+    signalDone();
+  } else {
+    console.error('JavetShell: signalDone is not defined!');
+  }
 }, err => {
   console.error('%s', err);
+  console.info('JavetShell: error path, calling signalDone()');
+  if ( typeof signalDone === 'function' ) {
+    signalDone();
+  } else {
+    console.error('JavetShell: signalDone is not defined!');
+  }
 });
             """.formatted(session.getId(), getCode(), getId()));
           } else {
@@ -232,7 +247,6 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
       final Logger log = logger;
       PrintStream ps = (PrintStream) getPrintStream();
 
-      // DEVELOPER NOTE: Another attempt at exiting await early - no affect
       promiseCallback_ = new JavetPromiseRejectCallback(v8Runtime.getLogger()) {
         public void callback(JavetPromiseRejectEvent event, V8ValuePromise promise, V8Value value) {
           log.info("JavetPromiseRejectCallback", event, promise, value);
@@ -251,13 +265,6 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
         }
         public void onFulfilled(V8Value v8Value) {
           logger.debug("listener,onFufilled", v8Value);
-          // DEVELOPER NOTE: how to inform the v8Runtime to stop waiting?
-          // Following had no effect.
-          // try {
-          //   v8ValuePromise_.resolve(v8Value);
-          // } catch (JavetException e) {
-          //   logger.error("onFulfillment.resolve", v8Value, e);
-          // }
         }
         public void onRejected(V8Value v8Value) {
           logger.warning("listener,onRejected", v8Value);
@@ -287,6 +294,33 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
       javetConsoleInterceptor_.register(new IV8ValueObject[] {v8Runtime.getGlobalObject()});
 
       v8Runtime.allowEval(getAllowEval());
+
+      // Expose signalDone() function to JavaScript so scripts can signal completion
+      // This calls setStopping(true) which causes await(RunOnce) to return false
+      logger.debug("v8Runtime class", v8Runtime.getClass().getName());
+      if ( v8Runtime instanceof NodeRuntime ) {
+        logger.debug("Binding signalDone() to NodeRuntime");
+        NodeRuntime nodeRuntime = (NodeRuntime) v8Runtime;
+        v8Runtime.getGlobalObject().bind(new IJavetAnonymous() {
+          @V8Function(name = "signalDone")
+          public void signalDone() {
+            logger.debug("signalDone called - setting stop flag");
+            // Set flag to break out of await loop (single-threaded pattern)
+            stopping_ = true;
+            // Also tell Node.js to stop scheduling new tasks
+            nodeRuntime.setStopping(true);
+          }
+        });
+      } else {
+        // For non-Node V8Runtime, signalDone is a no-op (event loop drains naturally)
+        logger.debug("v8Runtime is V8Runtime (not Node), signalDone will be no-op");
+        v8Runtime.getGlobalObject().bind(new IJavetAnonymous() {
+          @V8Function(name = "signalDone")
+          public void signalDone() {
+            logger.debug("signalDone called (V8Runtime) - no-op");
+          }
+        });
+      }
       `
     },
     {
@@ -299,6 +333,15 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
       if ( getAllowEval() )
         v8Runtime.allowEval(false);
 
+      // Proper shutdown sequence for NodeRuntime:
+      // 1. terminateExecution() - stops any running synchronous code
+      // 2. setStopping(true) - signals event loop to stop
+      // 3. lowMemoryNotification() - cleanup
+      // 4. close() - release resources
+      v8Runtime.terminateExecution();
+      if ( v8Runtime instanceof NodeRuntime ) {
+        ((NodeRuntime) v8Runtime).setStopping(true);
+      }
       v8Runtime.lowMemoryNotification();
       v8Runtime.close();
       `
@@ -311,18 +354,18 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
       final Logger logger = Loggers.logger(x, this, "executeString");
       logger.debug("string", string);
       logger.debug("executing");
+      stopping_ = false; // Reset flag for this execution
       // v8Runtime.setPromiseRejectCallback(promiseCallback_);
       try ( V8ValuePromise v8ValuePromise = v8Runtime.getExecutor(string).execute() ) {
         v8ValuePromise.register(promiseListener_);
         logger.debug("waiting");
-        v8Runtime.await();
-        logger.debug("complete");
 
-        // DEVELOPER NOTE: have the promiseListener_ affect this await.
-        // see https://github.com/caoccao/Javet/blob/main/src/test/java/com/caoccao/javet/values/reference/TestV8ValuePromise.java
-        // Not clear from example how to stop the await.
-        // See comments in promiseListener_
-        // and Guard timeout in JavetShellFactory
+        // Use RunOnce mode with flag check - signalDone() sets stopping_=true
+        // This is the single-threaded pattern: flag breaks the loop immediately
+        while ( ! stopping_ && v8Runtime.await(V8AwaitMode.RunOnce) ) {
+          // continue processing events until signalDone() or no more tasks
+        }
+        logger.debug("complete", stopping_ ? "signalDone called" : "event loop drained");
       }
       `
     },
@@ -337,11 +380,34 @@ foam.core.client.ClientBuilder.create({sessionID: '%s'}).promise.then(async clie
       }
       final Logger logger = Loggers.logger(x, this, "executeFile", filename);
       logger.debug("loading");
-      try ( V8ValuePromise v8ValuePromise = v8Runtime.getExecutor(file).execute() ) {
+
+      // Read file content and wrap with signalDone() auto-append
+      String fileContent = new String(java.nio.file.Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+      String wrappedCode = """
+(async () => {
+  try {
+    %s
+  } finally {
+    console.info('JavetShell: file execution complete, calling signalDone()');
+    if ( typeof signalDone === 'function' ) {
+      signalDone();
+    } else {
+      console.error('JavetShell: signalDone is not defined!');
+    }
+  }
+})();
+      """.formatted(fileContent);
+
+      stopping_ = false; // Reset flag for this execution
+      try ( V8ValuePromise v8ValuePromise = v8Runtime.getExecutor(wrappedCode).execute() ) {
         v8ValuePromise.register(promiseListener_);
         logger.debug("waiting");
-        v8Runtime.await();
-        logger.debug("complete");
+
+        // Use RunOnce mode with flag check - signalDone() sets stopping_=true
+        while ( ! stopping_ && v8Runtime.await(V8AwaitMode.RunOnce) ) {
+          // continue processing events until signalDone() or no more tasks
+        }
+        logger.debug("complete", stopping_ ? "signalDone called" : "event loop drained");
       }
       `
     }

--- a/src/foam/core/script/javet/JavetShell.md
+++ b/src/foam/core/script/javet/JavetShell.md
@@ -4,9 +4,11 @@ The Javet system allows the server to run FOAM client code in a Node.js process.
 
 **NOTE**: first build will require `--cleanAll,all` as this PR pulls in new Java libraries.
 
-### Outstanding
+### Signal Done
 
-- After script execution the executor waits until timeout - approximately 10 seconds. See `DEVELOPER NOTE`s in `JavetShell.js` and `JavetShellFactory.js`. 
+The shell automatically calls `signalDone()` after the user code completes, which stops the Node.js event loop immediately. This avoids the ~10 second timeout that would otherwise occur waiting for the event loop to drain.
+
+Both inline code (`setCode()`) and file-based scripts (`setFilename()`) auto-append `signalDone()` - no manual intervention needed. 
 
 ## Use
 

--- a/src/foam/core/script/javet/test/JavetShell.md
+++ b/src/foam/core/script/javet/test/JavetShell.md
@@ -4,9 +4,11 @@ The Javet system allows the server to run FOAM client code in a Node.js process.
 
 **NOTE**: first build will require --cleanAll,all as this PR pulls in new Java libraries.
 
-### Outstanding
+### Signal Done
 
-- After script execution the executor waits until timeout - approximately 10 seconds. See `DEVELOPER NOTE`s in `JavetShell.js` and `JavetShellFactory.js`. 
+The shell automatically calls `signalDone()` after the user code completes, which stops the Node.js event loop immediately. This avoids the ~10 second timeout that would otherwise occur waiting for the event loop to drain.
+
+Both inline code (`setCode()`) and file-based scripts (`setFilename()`) auto-append `signalDone()` - no manual intervention needed. 
 
 ## Use
 

--- a/src/foam/core/script/javet/test/JavetShellConcurrentTest.js
+++ b/src/foam/core/script/javet/test/JavetShellConcurrentTest.js
@@ -60,6 +60,7 @@ x.createSubContext({b: id});
 for ( let i = 0; i < %s; i++ ) {
   console.info('loop', id, i);
 }
+// signalDone() is auto-appended by JavetShell code wrapper
         """;
         PrintStream ps = new PrintStream(new ByteArrayOutputStream()) {
           @Override


### PR DESCRIPTION
## Problem

JavetShell executions took ~31 seconds to complete because the Node.js event loop had to drain completely before returning. This was due to the blocking `v8Runtime.await()` call waiting for all pending tasks to finish.

## Solution

Implemented `signalDone()` - a JavaScript function that signals execution is complete, allowing immediate exit from the await loop.

### Key Changes

1. **Added `signalDone()` function** - Exposed from Java to JavaScript via Javet's `@V8Function` binding
2. **Flag-based exit pattern** - Uses `volatile boolean stopping_` for single-threaded immediate exit
3. **Non-blocking await loop** - Changed from `await()` to `await(V8AwaitMode.RunOnce)` with flag check
4. **Auto-append** - `signalDone()` is automatically called after user code completes (both inline and file-based)

### Implementation Details

```java
// Flag for single-threaded exit
volatile boolean stopping_ = false;

// signalDone() - bound to JavaScript globalThis
@V8Function(name = "signalDone")
public void signalDone() {
    stopping_ = true;
    nodeRuntime.setStopping(true);
}

// Await loop - checks flag FIRST for immediate exit
while (!stopping_ && v8Runtime.await(V8AwaitMode.RunOnce)) {
    // process events until signalDone() or no more tasks
}
```

### Why This Pattern?

Based on [Javet documentation](https://www.caoccao.com/Javet/tutorial/advanced/interact_with_node_js.html):

1. `await(RunOnce)` executes inside the event loop - `signalDone()` runs during task draining
2. `setStopping(true)` alone only prevents NEW tasks; existing tasks still drain
3. `await(RunOnce)` keeps returning `true` while tasks exist
4. **The flag provides immediate exit control** that `setStopping(true)` alone cannot provide in single-threaded context

### Cleanup Sequence

Proper resource cleanup in `teardown()`:

```java
v8Runtime.terminateExecution();           // 1. Stop running code
((NodeRuntime) v8Runtime).setStopping(true); // 2. Signal event loop
v8Runtime.lowMemoryNotification();        // 3. GC hint
v8Runtime.close();                        // 4. Release resources
```

## Performance

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Execution Time | ~31 seconds | ~1.5 seconds | **20x faster** |

## Files Changed

- `foam/core/script/javet/JavetShell.js` - Main implementation
- `foam/core/script/javet/test/JavetShellConcurrentTest.js` - Updated test

## Testing

```bash
./build.sh server-tests:JavetShellConcurrentTest
```

Results:
```
✓ SUCCESS: Expected count 1250
✓ SUCCESS: Other globalThis.a and x.b not found
TEST REPORT SERVER - TEST CASES: 1, TESTS: 2 (PT1.541S)
PASSED: 2
FAILED: 0
```

## References

- [Javet - Can Node.js Event Loop be Skipped?](https://www.caoccao.com/Javet/faq/troubleshooting/can_node_js_event_loop_be_skipped.html)
- [Javet - Interact with Node.js](https://www.caoccao.com/Javet/tutorial/advanced/interact_with_node_js.html)
- [Javet GitHub Issue #205](https://github.com/caoccao/Javet/issues/205)
- [Javet GitHub Issue #409](https://github.com/caoccao/Javet/issues/409)
