### PR TITLE
Fix Infinite Recursion in Property Comparison

### DIFF
--- a/src/foam/lang/FObject.js
+++ b/src/foam/lang/FObject.js
@@ -871,13 +871,9 @@ foam.CLASS({
 
       // FUTURE: check 'id' first
       // FUTURE: order properties
-      // Exclude transient properties from comparison - they are runtime-only
-      // and can cause infinite recursion (e.g., the __ property from Element2.js
-      // returns a self-referential object that loops: String -> __ -> String -> ...)
       var ps = this.cls_.getAxiomsByClass(foam.lang.Property).filter(p => {
         return ! foam.dao.DAOProperty.isInstance(p)
           && ! foam.dao.ManyToManyRelationshipProperty.isInstance(p)
-          && ! p.transient
           && ! p.expression;
       });
       for ( var i = 0 ; i < ps.length ; i++ ) {

--- a/src/foam/lang/FObject.js
+++ b/src/foam/lang/FObject.js
@@ -871,9 +871,13 @@ foam.CLASS({
 
       // FUTURE: check 'id' first
       // FUTURE: order properties
+      // Exclude transient properties from comparison - they are runtime-only
+      // and can cause infinite recursion (e.g., the __ property from Element2.js
+      // returns a self-referential object that loops: String -> __ -> String -> ...)
       var ps = this.cls_.getAxiomsByClass(foam.lang.Property).filter(p => {
         return ! foam.dao.DAOProperty.isInstance(p)
           && ! foam.dao.ManyToManyRelationshipProperty.isInstance(p)
+          && ! p.transient
           && ! p.expression;
       });
       for ( var i = 0 ; i < ps.length ; i++ ) {

--- a/src/foam/lang/Property.js
+++ b/src/foam/lang/Property.js
@@ -327,6 +327,19 @@ foam.CLASS({
 
   methods: [
     /**
+      Properties are singletons, so use reference equality for comparison.
+      This prevents infinite recursion when comparing objects containing
+      Property references (e.g., predicates with __Property__ args).
+    */
+    function compareTo(other) {
+      return this === other ? 0 : this.name.localeCompare(other.name);
+    },
+
+    function equals(other) {
+      return this === other;
+    },
+
+    /**
       Handle overriding of Property definition from parent class by
       copying undefined values from parent Property, if it exists.
     */

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1662,6 +1662,7 @@ foam.CLASS({
       // Without wrapping in a PropertyBorder
       name: '__',
       transient: true,
+      compare: function() { return 0; },
       getter: function() {
         return { __proto__: this, toE: this.toPropertyView };
       }


### PR DESCRIPTION

## Summary

Fixes infinite recursion / stack overflow when comparing FObjects that contain Property references (e.g., predicates with `__Property__` serialized args).

## Problem

When saving or comparing objects containing Property references, the UI throws:
```
Uncaught (in promise) RangeError: Maximum call stack size exceeded
```

### Root Cause Analysis

The comparison flow was:
1. Compare FObject containing a predicate
2. Predicate contains `arg1` with `__Property__` reference
3. `__Property__` deserializes to actual Property axiom object
4. Comparing Property objects triggers `FObject.compareTo()` which compares ALL properties
5. Property has a `__` property (from Element2.js refinement) with getter: `{ __proto__: this }`
6. This object inherits `cls_` from prototype, making `foam.typeOf` think it's an FObject
7. Comparing `__` values recurses back to comparing Property → infinite loop

Stack trace pattern:
```
foam.lang.String → __ → foam.lang.String → __ → foam.lang.String → ...
```

## Solution

### 1. Property.js - Singleton Reference Equality

Properties are singletons (each property axiom is created once and shared). Comparison should use `===` instead of recursively comparing all fields.

```javascript
// foam3/src/foam/lang/Property.js

function compareTo(other) {
  return this === other ? 0 : this.name.localeCompare(other.name);
}

function equals(other) {
  return this === other;
}
```

### 2. Element2.js - Skip `__` Property Comparison

The `__` property is a helper that returns `{ __proto__: this }` for view rendering. It should never be compared.

```javascript
// foam3/src/foam/u2/Element2.js

{
  name: '__',
  transient: true,
  compare: function() { return 0; },  // Added
  getter: function() {
    return { __proto__: this, toE: this.toPropertyView };
  }
}
```

## Why Both Fixes?

| Fix | Purpose |
|-----|---------|
| Property.compareTo | Handles direct Property-to-Property comparison |
| `__` compare | Prevents the `__` getter's object from being compared at all |

Together they provide defense in depth against comparison issues with Property objects.

## Testing

1. Create an object with a predicate containing `__Property__` references
2. Compare or save the object through the UI
3. Verify no stack overflow error occurs

## Files Changed

```
foam3/src/foam/lang/Property.js
foam3/src/foam/u2/Element2.js
```

## Impact

- **Low risk**: Changes are isolated to Property comparison behavior
- **No breaking changes**: Properties that were `===` equal before will still be equal
- **Performance improvement**: Avoids unnecessary deep comparison of singleton objects
