### PR TITLE
fix(reflow): prevent double execution on load by awaiting initial execution

### DIFF
--- a/src/foam/core/reflow/DAOPrompt.js
+++ b/src/foam/core/reflow/DAOPrompt.js
@@ -485,13 +485,17 @@ foam.CLASS({
     },
 
     async function addToE(e) {
-      this.onDetach(this.dao.listen(this.rerun));
       this.onDetach(this.filteredDAO.listen(this.updateRowCount));
       this.updateRowCount_();
 
       // TODO: name current block
       e.tag(this.DAOPromptView, {data: this, label: this.label});
 //      e.tag(this.DAOPromptView.create({data: this, label: this.label}, this));
+
+      // Wait for initial execution to complete before enabling live DAO updates
+      // This prevents double execution on load (dynamic() handles initial render)
+      await this.readyLatch_;
+      this.onDetach(this.dao.listen(this.rerun));
     },
 
     function onLoad() {


### PR DESCRIPTION
## Summary
- Fix bug where GroupBy DAO agent was executing twice on initial load
- Defer DAO listener setup until after initial execution completes

## Problem
When a DAOPrompt loads, the agent executes twice due to two separate trigger paths firing simultaneously.

### Call Chain - Path 1 (Initial Render)
```
Commands.js:261          execute()
  └─> DAOPrompt.js:493   addToE() -> e.tag(DAOPromptView)
      └─> Element2.js    load/render
          └─> DAOPrompt.js:44   DAOPromptView.render() -> dynamic()
              └─> Slot.js:698   init -> factory
                  └─> DAOPrompt.js:50   select.execute()  ← FIRST EXECUTION
```

### Call Chain - Path 2 (DAO Listener)
```
DAOPrompt.js:490         this.dao.listen(this.rerun)
  └─> AbstractDAO.js:241 listen_() fires immediately with current state
      └─> ProxyDAO.js:71 update/reset event
          └─> DAOPrompt.js:563  rerun listener (merged, 100ms delay)
              └─> DAOPrompt.js:530  run() -> version++
                  └─> DAOPrompt.js:39   version$.sub(onUpdate)
                      └─> DAOPrompt.js:72   onUpdate -> DAOPromptView.version++
                          └─> Slot.js:729   invalidate
                              └─> DAOPrompt.js:50   select.execute()  ← SECOND EXECUTION
```

### Root Cause
In `DAOPrompt.addToE()` (line 487-499):
- `this.dao.listen(this.rerun)` was set up BEFORE the view rendered
- DAO's `listen()` fires immediately with current state on subscription
- This triggered `rerun` -> `run()` -> `version++` -> dynamic re-execution
- Meanwhile, `dynamic()` in `DAOPromptView.render()` already handles initial execution

## Solution
Defer the DAO listener setup until after initial execution completes using the existing `readyLatch_`:

**File:** `foam3/src/foam/core/reflow/DAOPrompt.js`

**Before (line 487-492):**
```javascript
async function addToE(e) {
  this.onDetach(this.dao.listen(this.rerun));  // ← Fires immediately!
  this.onDetach(this.filteredDAO.listen(this.updateRowCount));
  this.updateRowCount_();
  e.tag(this.DAOPromptView, {data: this, label: this.label});
},
```

**After (line 487-499):**
```javascript
async function addToE(e) {
  this.onDetach(this.filteredDAO.listen(this.updateRowCount));
  this.updateRowCount_();
  e.tag(this.DAOPromptView, {data: this, label: this.label});

  // Wait for initial execution to complete before enabling live DAO updates
  // This prevents double execution on load (dynamic() handles initial render)
  await this.readyLatch_;
  this.onDetach(this.dao.listen(this.rerun));
},
```

### Why This Works
1. `readyLatch_` resolves after first execution completes (line 51)
2. DAO listener is only set up AFTER initial render is done
3. No new flags needed - uses existing infrastructure
4. Future DAO changes still trigger re-execution correctly


