### PR TITLE
PT-FIXES: DOS-2019, DOS-2008, DOS-2007 : enhance timestamp handling and validation in date parser

### DIFF
--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -32,12 +32,24 @@ foam.CLASS({
         // Main entry point - try all formats including unambiguous month names
         // NOTE: Month name formats go FIRST because they contain letters (unambiguous!)
         // Once the parser sees letters, it knows it's not a numeric format
+        // Timestamps (10-13 digits) go LAST to avoid matching date formats like YYYYMMDDHH
         dateOrDatetime: alt(
           sym('datemonthname'),  // All month name formats (with or without separators)
           sym('yyyymmdd'),
           sym('mmddyyyy'),
-          sym('mmddyy')
+          sym('mmddyy'),
+          sym('timestamp')       // Unix/JS timestamps (10-13 digits, must not match date formats)
         ),
+
+        // Unix timestamp (10 digits, seconds) or JavaScript timestamp (13 digits, milliseconds)
+        // Placed LAST in dateOrDatetime to avoid matching date formats like YYYYMMDDHH
+        // Note: 10-digit timestamps will only match if they don't match any other format
+        timestamp: alt(
+          sym('timestamp13'),  // 13-digit JavaScript millisecond timestamp (always safe)
+          sym('timestamp10')   // 10-digit Unix second timestamp (checked after date formats fail)
+        ),
+        timestamp13: str(repeat(range('0', '9'), null, 13, 13)),
+        timestamp10: str(repeat(range('0', '9'), null, 10, 10)),
 
         // Date with month names - ALL completely unambiguous (contain letters!)
         // DD-MMM-YYYY, DD/MMM/YYYY, DDMMMYYYY, YYYY-DD-MMM, YYYY/DD/MMM, YYYYDDMMM
@@ -175,23 +187,23 @@ foam.CLASS({
           )
         ),
 
-        // MMDDYYYY compact: 8 digits (that don't match YYYY 1900-2999 pattern) with optional space-separated time
+        // MMDDYYYY compact: 8 digits with validated month (01-12), day (01-31), year
         mmddyyyycompact: alt(
           // With space and compact time (HHMMSS - no colons)
           seq(
-            str(repeat(range('0', '9'), null, 8, 8)),
+            str(seq(sym('month2'), sym('day2'), sym('year4'))),
             sym('datetimesep'),
             sym('hour2'), sym('minute2'), sym('second2')
           ),
           // With space and time with colons
           seq(
-            str(repeat(range('0', '9'), null, 8, 8)),
+            str(seq(sym('month2'), sym('day2'), sym('year4'))),
             sym('datetimesep'),
             sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
             optional(sym('timezone'))
           ),
           // Date only
-          str(repeat(range('0', '9'), null, 8, 8))
+          str(seq(sym('month2'), sym('day2'), sym('year4')))
         ),
 
         // YYMMDD - tries all variants (compact, separated)
@@ -229,8 +241,8 @@ foam.CLASS({
           )
         ),
 
-        // YYMMDD compact: 6 digits
-        yymmddcompact: str(repeat(range('0', '9'), null, 6, 6)),
+        // YYMMDD compact: 6 digits with validated year, month (01-12), day (01-31)
+        yymmddcompact: str(seq(sym('year2'), sym('month2'), sym('day2'))),
 
         // MMDDYY - tries all variants (compact, separated)
         // Covers: MMDDYY, MM-DD-YY, MM/DD/YY with optional time
@@ -267,8 +279,8 @@ foam.CLASS({
           )
         ),
 
-        // MMDDYY compact: 6 digits
-        mmddyycompact: str(repeat(range('0', '9'), null, 6, 6)),
+        // MMDDYY compact: 6 digits with validated month (01-12), day (01-31), year
+        mmddyycompact: str(seq(sym('month2'), sym('day2'), sym('year2'))),
 
         // DDMMYYYY - NOT in main dateOrDatetime, accessible via opt_name only
         // Covers: DD-MM-YYYY, DD/MM/YYYY, DDMMYYYY, DD-MM-YY, DD/MM/YY, DDMMYY with optional time
@@ -309,23 +321,23 @@ foam.CLASS({
           )
         ),
 
-        // DDMMYYYY compact: 8 digits (that don't match YYYY 1900-2999 pattern) with optional space-separated time
+        // DDMMYYYY compact: 8 digits with validated day (01-31), month (01-12), year
         ddmmyyyycompact: alt(
           // With space and compact time (HHMMSS - no colons)
           seq(
-            str(repeat(range('0', '9'), null, 8, 8)),
+            str(seq(sym('day2'), sym('month2'), sym('year4'))),
             sym('datetimesep'),
             sym('hour2'), sym('minute2'), sym('second2')
           ),
           // With space and time with colons
           seq(
-            str(repeat(range('0', '9'), null, 8, 8)),
+            str(seq(sym('day2'), sym('month2'), sym('year4'))),
             sym('datetimesep'),
             sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
             optional(sym('timezone'))
           ),
           // Date only
-          str(repeat(range('0', '9'), null, 8, 8))
+          str(seq(sym('day2'), sym('month2'), sym('year4')))
         ),
 
         // DDMMYY with separators and optional time (2-digit year)
@@ -357,8 +369,8 @@ foam.CLASS({
           )
         ),
 
-        // DDMMYY compact: 6 digits
-        ddmmyycompact: str(repeat(range('0', '9'), null, 6, 6)),
+        // DDMMYY compact: 6 digits with validated day (01-31), month (01-12), year
+        ddmmyycompact: str(seq(sym('day2'), sym('month2'), sym('year2'))),
 
         // YYYYDDMM - NOT in main dateOrDatetime, accessible via opt_name only
         // Covers: YYYY-DD-MM, YYYY/DD/MM, YYYYDDMM, YY-DD-MM, YY/DD/MM, YYDDMM with optional time
@@ -398,23 +410,23 @@ foam.CLASS({
           )
         ),
 
-        // YYYYDDMM compact: 8 digits with optional space-separated time
+        // YYYYDDMM compact: 8 digits with validated year, day (01-31), month (01-12)
         yyyyddmmcompact: alt(
           // With space and compact time (HHMMSS - no colons)
           seq(
-            str(repeat(range('0', '9'), null, 8, 8)),
+            str(seq(sym('year4'), sym('day2'), sym('month2'))),
             sym('datetimesep'),
             sym('hour2'), sym('minute2'), sym('second2')
           ),
           // With space and time with colons
           seq(
-            str(repeat(range('0', '9'), null, 8, 8)),
+            str(seq(sym('year4'), sym('day2'), sym('month2'))),
             sym('datetimesep'),
             sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
             optional(sym('timezone'))
           ),
           // Date only
-          str(repeat(range('0', '9'), null, 8, 8))
+          str(seq(sym('year4'), sym('day2'), sym('month2')))
         ),
 
         // YYDDMM - 2-digit year, day, month (6 digits)
@@ -452,8 +464,8 @@ foam.CLASS({
           )
         ),
 
-        // YYDDMM compact: 6 digits
-        yyddmmcompact: str(repeat(range('0', '9'), null, 6, 6)),
+        // YYDDMM compact: 6 digits with validated year, day (01-31), month (01-12)
+        yyddmmcompact: str(seq(sym('year2'), sym('day2'), sym('month2'))),
 
         // YYYYDDMMM with separators: YYYY-DD-MMM, YYYY/DD/MMM
         // Supports single-digit days (e.g., 2025-5-JAN)
@@ -496,7 +508,11 @@ foam.CLASS({
           seq('2', range('0', '9'), range('0', '9'), range('0', '9'))
         )),
         year2: str(seq(range('0', '9'), range('0', '9'))),
-        month2: str(seq(range('0', '1'), range('0', '9'))),  // Used in compact formats (without separators)
+        // Month (01-12) for compact formats - strict validation to prevent timestamp mismatches
+        month2: str(alt(
+          seq('0', range('1', '9')),      // 01-09
+          seq('1', range('0', '2'))       // 10-12
+        )),
 
         // Flexible parsers to support single digits (e.g. 7/2/2025) in formats with separators
         // Allows slightly out-of-range values for JavaScript Date normalization:
@@ -529,7 +545,12 @@ foam.CLASS({
           literalIC('NOV'),
           literalIC('DEC')
         ),
-        day2: str(seq(range('0', '3'), range('0', '9'))),  // Used in compact formats (without separators)
+        // Day (01-31) for compact formats - strict validation to prevent timestamp mismatches
+        day2: str(alt(
+          seq('0', range('1', '9')),           // 01-09
+          seq(range('1', '2'), range('0', '9')), // 10-29
+          seq('3', range('0', '1'))            // 30-31
+        )),
         hour2: str(seq(range('0', '2'), range('0', '9'))),
         minute2: str(seq(range('0', '5'), range('0', '9'))),
         second2: str(seq(range('0', '5'), range('0', '9'))),

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -607,6 +607,22 @@ foam.CLASS({
       };
     },
 
+    // Timestamp actions - convert timestamp strings directly to Date objects
+    // These return Date objects directly (not {year, month, day} objects) because
+    // timestamps are already a complete date representation
+
+    // 13-digit JavaScript timestamp (milliseconds since epoch)
+    // v = "1754308800000" (string)
+    function timestamp13Action(v) {
+      return new Date(parseInt(v, 10));
+    },
+
+    // 10-digit Unix timestamp (seconds since epoch)
+    // v = "1754308800" (string)
+    function timestamp10Action(v) {
+      return new Date(parseInt(v, 10) * 1000);
+    },
+
     function flattenTimezone(tzArray) {
       if ( ! tzArray ) return null;
       if ( tzArray === 'Z' ) return 'Z';
@@ -725,6 +741,11 @@ foam.CLASS({
         return this.validateDate(this.INVALID_DATE, str);
       }
 
+      // Check if result is already a Date object (from timestamp actions)
+      if ( result instanceof Date ) {
+        return this.validateDate(result, str);
+      }
+
       // Determine if this is a datetime or date-only result based on presence of time components
       var ret;
       if ( result.hour !== undefined || result.minute !== undefined || result.second !== undefined ) {
@@ -777,6 +798,11 @@ foam.CLASS({
         return this.validateDate(this.INVALID_DATE, str);
       }
 
+      // Check if result is already a Date object (from timestamp actions)
+      if ( result instanceof Date ) {
+        return this.validateDate(result, str);
+      }
+
       // Always return date at noon UTC, ignoring time even if present
       var ret = new Date(Date.UTC(result.year, result.month, result.day, 12, 0, 0, 0));
 
@@ -814,6 +840,11 @@ foam.CLASS({
       if ( ! result ) {
         // Unparseable format - return MAX_DATE
         return this.validateDate(this.INVALID_DATE, str);
+      }
+
+      // Check if result is already a Date object (from timestamp actions)
+      if ( result instanceof Date ) {
+        return this.validateDate(result, str);
       }
 
       // Validate time components if present
@@ -893,6 +924,11 @@ foam.CLASS({
       if ( ! result ) {
         // Unparseable format - return MAX_DATE
         return this.validateDateUTC(this.INVALID_DATE, str);
+      }
+
+      // Check if result is already a Date object (from timestamp actions)
+      if ( result instanceof Date ) {
+        return this.validateDateUTC(result, str);
       }
 
       // Validate time components if present

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -38,6 +38,7 @@ foam.CLASS({
       this.testWithAndWithoutZ(x);
       this.testInvalidLeapYearDates(x);
       this.testAllParseMethodsExample(x);
+      this.testTimestampStrings(x);
     },
 
     function testYYYYMMDDFormats(x) {
@@ -1976,6 +1977,93 @@ foam.CLASS({
         console.error(`Test datetime error:`, e);
         return false;
       }
+    },
+
+    /**
+     * Test that timestamp strings don't conflict with date parsing.
+     * Tests foam.lang.Date and foam.lang.DateTime adapt functions handle:
+     * - 13-digit JavaScript millisecond timestamps (always treated as timestamps)
+     * - 10-digit Unix timestamps starting with '1' (treated as seconds since epoch)
+     * - 10-digit strings starting with '2' should still parse as dates (YYYYMMDDHH)
+     */
+    function testTimestampStrings(x) {
+      // Test 13-digit millisecond timestamps (should be treated as timestamps)
+      let msTimestamps = [
+        { input: '1754308800000', expectedDate: new Date(1754308800000), desc: '13-digit ms timestamp (2025-08-04)' },
+        { input: '1000000000000', expectedDate: new Date(1000000000000), desc: '13-digit ms timestamp (2001-09-09)' },
+        { input: '1609459200000', expectedDate: new Date(1609459200000), desc: '13-digit ms timestamp (2021-01-01)' }
+      ];
+
+      // Test 10-digit Unix second timestamps starting with '1' (should be treated as timestamps)
+      let secTimestamps = [
+        { input: '1754308800', expectedDate: new Date(1754308800 * 1000), desc: '10-digit sec timestamp starting with 1' },
+        { input: '1000000000', expectedDate: new Date(1000000000 * 1000), desc: '10-digit sec timestamp (2001-09-09)' },
+        { input: '1609459200', expectedDate: new Date(1609459200 * 1000), desc: '10-digit sec timestamp (2021-01-01)' }
+      ];
+
+      // Test 10-digit strings starting with '2' should NOT be treated as timestamps
+      // They should be parsed as YYYYMMDDHH format
+      let dateStrings = [
+        { input: '2025011512', desc: '10-digit starting with 2 (YYYYMMDDHH format)', expectedYear: 2025, expectedMonth: 0, expectedDay: 15 },
+        { input: '2024123123', desc: '10-digit date format', expectedYear: 2024, expectedMonth: 11, expectedDay: 31 }
+      ];
+
+      // Test 13-digit timestamps via foam.lang.Date adapt
+      msTimestamps.forEach((testCase, i) => {
+        try {
+          let dateProp = foam.lang.Date.create();
+          let result = dateProp.adapt.call({}, null, testCase.input);
+          // Compare timestamps (allow 1 day tolerance for Date noon UTC normalization)
+          let timeDiff = Math.abs(result.getTime() - testCase.expectedDate.getTime());
+          let pass = timeDiff < 86400000; // Within 24 hours
+          x.test(pass, `Timestamp-13digit Test${i + 1}: ${testCase.desc} - expected ~${testCase.expectedDate.toISOString()}, got ${result.toISOString()}`);
+        } catch (e) {
+          x.test(false, `Timestamp-13digit Test${i + 1}: ${testCase.desc} - Error: ${e.message}`);
+        }
+      });
+
+      // Test 10-digit timestamps starting with '1' via foam.lang.Date adapt
+      secTimestamps.forEach((testCase, i) => {
+        try {
+          let dateProp = foam.lang.Date.create();
+          let result = dateProp.adapt.call({}, null, testCase.input);
+          // Compare timestamps (allow 1 day tolerance for Date noon UTC normalization)
+          let timeDiff = Math.abs(result.getTime() - testCase.expectedDate.getTime());
+          let pass = timeDiff < 86400000; // Within 24 hours
+          x.test(pass, `Timestamp-10digit Test${i + 1}: ${testCase.desc} - expected ~${testCase.expectedDate.toISOString()}, got ${result.toISOString()}`);
+        } catch (e) {
+          x.test(false, `Timestamp-10digit Test${i + 1}: ${testCase.desc} - Error: ${e.message}`);
+        }
+      });
+
+      // Test that 10-digit strings starting with '2' are still parsed as dates (not timestamps)
+      dateStrings.forEach((testCase, i) => {
+        try {
+          let dateProp = foam.lang.Date.create();
+          let result = dateProp.adapt.call({}, null, testCase.input);
+          // Should be parsed as a date, not a timestamp from 1970
+          let isReasonableYear = result.getFullYear() >= 2000 && result.getFullYear() <= 2100;
+          x.test(isReasonableYear, `DateString-10digit Test${i + 1}: ${testCase.desc} - year should be 2000-2100, got ${result.getFullYear()}`);
+          if ( testCase.expectedYear ) {
+            let yearMatch = result.getUTCFullYear() === testCase.expectedYear;
+            x.test(yearMatch, `DateString-10digit Test${i + 1}: ${testCase.desc} - expected year ${testCase.expectedYear}, got ${result.getUTCFullYear()}`);
+          }
+        } catch (e) {
+          x.test(false, `DateString-10digit Test${i + 1}: ${testCase.desc} - Error: ${e.message}`);
+        }
+      });
+
+      // Test foam.lang.DateTime adapt with 13-digit timestamps
+      msTimestamps.forEach((testCase, i) => {
+        try {
+          let dateTimeProp = foam.lang.DateTime.create();
+          let result = dateTimeProp.adapt.call({}, null, testCase.input);
+          let pass = result.getTime() === testCase.expectedDate.getTime();
+          x.test(pass, `DateTime-Timestamp Test${i + 1}: ${testCase.desc} - expected ${testCase.expectedDate.toISOString()}, got ${result.toISOString()}`);
+        } catch (e) {
+          x.test(false, `DateTime-Timestamp Test${i + 1}: ${testCase.desc} - Error: ${e.message}`);
+        }
+      });
     }
   ]
 });


### PR DESCRIPTION


## Problem

Timestamp strings like `"1754308800000"` (13-digit JS timestamp) were being incorrectly parsed as dates. The grammar's compact date formats (e.g., `mmddyycompact`) matched ANY 6/8 digits without validation. So `"175430"` matched as MMDDYY with month=17, day=54, which JavaScript normalized to 2031-06-23 instead of the correct 2025-08-04.

## Fix

1. Made `month2` strictly match 01-12 and `day2` strictly match 01-31
2. Updated all compact date formats to use validated components
3. Added `timestamp13` and `timestamp10` grammar symbols with actions to properly handle timestamps

## Why

Strict validation prevents invalid date components from matching, forcing timestamps to fall through to the dedicated timestamp patterns.
