### PR TITLE
Fix scroll animation glitch with code editor

### DIFF
--- a/src/io/c9/ace/Editor.js
+++ b/src/io/c9/ace/Editor.js
@@ -123,6 +123,7 @@ foam.CLASS({
       self.editor.session.on('change', self.editorToData);
       self.updateEditor();
       self.dataToEditor();
+      self.editor.setAnimatedScroll(false);
       self.editor.resize();
     },
     {


### PR DESCRIPTION
## Fix annoying horizontal scrolling in Ace editor when clicking on long lines
### Problem
When clicking inside the Ace editor on a line containing a lot of text, the horizontal scrollbar scrolls very fast (almost jumping) to the cursor position, making it disorienting and difficult to work with long lines.
Interestingly, this behavior disappears when the page is zoomed in or out, suggesting the issue is related to **devicePixelRatio** calculations in Ace's scroll animation logic.

### Solution
Disable animated scrolling by calling `editor.setAnimatedScroll(false)` during editor initialization. This makes the editor jump instantly to the cursor position rather than animating, which bypasses the problematic scroll velocity calculation.
Changes

src/io/c9/ace/Editor.js: Added self.editor.setAnimatedScroll(false) in the renderEditor() listener