### PR TITLE
Fix: Safari Invalid Date error in DashboardCalendarSink

### DIFF
--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -1970,8 +1970,9 @@ foam.CLASS({
     function put(obj) {
       let d = this.dateProp.f(obj);
       let c = this.categoryProp ? this.categoryProp.f(obj) : 'default';
-      if (!d || !c) return;
-      let key = new Date(d).toISOString().slice(0, 10);
+      if ( ! d || ! c ) return;
+      // Use d directly - it's either a Date or already a formatted string from transformation
+      let key = d instanceof Date ? d.toISOString().slice(0, 10) : String(d);
       if (!this.map_[key]) this.map_[key] = {};
       let v = 1;
       if (this.valueSink && this.valueSink.put) {


### PR DESCRIPTION

### Problem
`DashboardCalendarSink.put()` was failing in Safari with `RangeError: Invalid Date` when the date property used a transformation expression.

### Root Cause
The code was doing unnecessary date re-parsing:
```javascript
let d = this.dateProp.f(obj);  // Returns "2025-01" from DateToYYYYMMExpr
let key = new Date(d).toISOString().slice(0, 10);  // Fails in Safari
```

Safari's `Date` constructor doesn't parse partial date strings like `"2025-01"` or `"2025/07"`, while Chrome is more lenient. When `dateProp` is a transformation expression (e.g., `DateToYYYYMMExpr`), `d` is already a formatted string that doesn't need re-parsing.

### Fix
Skip parsing if the value is already a string:
```javascript
let key = d instanceof Date ? d.toISOString().slice(0, 10) : String(d);
```

### Browser Behavior
| Input | Chrome | Safari |
|-------|--------|--------|
| `new Date("2025-01")` | Valid | Invalid Date |
| `new Date("2025/07")` | Valid | Invalid Date |
| `new Date("2025-01-15")` | Valid | Valid |
