### PR TITLE
Use full auth chain for CHECK_USER_PERMISSION

### DIFF
--- a/src/foam/core/auth/UserAndGroupAuthService.js
+++ b/src/foam/core/auth/UserAndGroupAuthService.js
@@ -36,6 +36,7 @@ foam.CLASS({
   javaImports: [
     'foam.lang.X',
     'foam.dao.DAO',
+    'foam.core.auth.AuthService',
     'foam.core.auth.LifecycleState',
     'foam.core.auth.ServiceProvider',
     'foam.core.auth.Subject',
@@ -160,7 +161,10 @@ foam.CLASS({
       name: 'checkGroup',
       javaCode: `
         // check whether user has permission to check group permissions
-        if ( ! check(x, CHECK_USER_PERMISSION) ) throw new AuthorizationException();
+        // Use full auth chain (from context) so capabilities/other grants can satisfy this permission
+        AuthService auth = (AuthService) x.get("auth");
+        if ( auth == null ) throw new AuthorizationException("Fishy Auth missing");
+        if ( ! auth.check(x, CHECK_USER_PERMISSION) ) throw new AuthorizationException("Not allowed to check user permissions.");
         try {
           Permission p = new AuthPermission(permission);
           while ( ! SafetyUtil.isEmpty(groupId) ) {


### PR DESCRIPTION
when doing auth.checkUser you get to UserGroupAuth and hit a check to see if you are allowed to check user permissions. The issue is that the check only considers group permissions.