### PR TITLE
Flow access updates

### DIFF
--- a/src/foam/core/menu/LimitedEditFlowMenu.js
+++ b/src/foam/core/menu/LimitedEditFlowMenu.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.menu',
+  name: 'LimitedEditFlowMenu',
+  extends: 'foam.core.menu.ViewMenu',
+
+  documentation: 'Menu item that opens a flow in limited-edit mode (presentation with edit affordance).',
+
+  imports: [
+    'currentMenu?'
+  ],
+
+  properties: [
+    {
+      class: 'Reference',
+      of: 'foam.core.reflow.Flow',
+      name: 'flow',
+    }
+  ],
+
+  methods: [
+    function select(X, menu) {
+      /** Include flowMode in route to enable limited edit presentation. **/
+      if ( this.currentMenu?.id === menu.id ) return;
+      X.routeTo(menu.id + '?flowMode=LIMIT_EDIT');
+    },
+    function createView(X) {
+      return {
+        class: "foam.core.reflow.Console",
+        route: this.flow,
+        flowMode: "LIMIT_EDIT"
+      };
+    }
+  ]
+});

--- a/src/foam/core/menu/Menu.js
+++ b/src/foam/core/menu/Menu.js
@@ -77,7 +77,8 @@
           [ 'foam.core.menu.TabsMenu',         'Tabs' ],
           [ 'foam.core.menu.ViewMenu',         'View' ],
           [ 'foam.core.menu.SeparatorMenu',    'Separator' ],
-          [ 'foam.core.menu.FlowMenu',         'Flow' ]
+          [ 'foam.core.menu.FlowMenu',         'Flow' ],
+          [ 'foam.core.menu.LimitedEditFlowMenu', 'Flow (Limited Edit)' ]
         ]
       }
     },

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -143,6 +143,7 @@ foam.POM({
     { name: "menu/DAOMenu2",                                                              flags: "web" },
     { name: "menu/DocumentMenu",                                                          flags: "js" },
     { name: "menu/FlowMenu",                                                              flags: "js" },
+    { name: "menu/LimitedEditFlowMenu",                                                     flags: "js" },
     { name: "menu/SeparatorMenu",                                                         flags: "js" },
     { name: "menu/DocumentFileMenu",                                                      flags: "js|java" },
     { name: "menu/LinkMenu",                                                              flags: "js" },

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -198,6 +198,7 @@ foam.CLASS({
   methods: [
     function render() {
       let self = this;
+      const isLimitedEditConsole = this.data.flowMode === this.FlowMode.LIMIT_EDIT_CONSOLE;
 
       var fullVersion = this.data.value.dynamic(function(version, revision) {
         this.add(`v${version}.${revision}`);
@@ -207,7 +208,9 @@ foam.CLASS({
         .start()
           .addClass(this.myClass('header-container'))
           .start().addClass(this.myClass('navigator'))
-            .tag(this.HOME)
+            .callIf(! isLimitedEditConsole, function() {
+              this.tag(self.HOME);
+            })
             .start(foam.u2.tag.Image, {
               glyph: 'rightChevron',
               embedSVG: true
@@ -235,7 +238,7 @@ foam.CLASS({
               .tag(this.SAVE)
               .tag(this.OverlayActionListView, {
                 label: 'More',
-                data: [this.RESET, this.CANCEL, this.CLEAR],
+                data: isLimitedEditConsole ? [this.CANCEL] : [this.RESET, this.CANCEL, this.CLEAR],
                 obj: this,
                 buttonStyle: 'SECONDARY',
                 size: 'SMALL',
@@ -244,9 +247,11 @@ foam.CLASS({
                 showDropdownIcon: false,
                 horizontal: false
               })
-              .start('span').addClass(this.myClass('separator')).end()
-              .tag(this.FULL_SCREEN, { themeIcon$: self.data.flowMode$.map(c => c == self.FlowMode.CONSOLE ? 'fullScreen' : 'minimize') })
             .endContext()
+            .callIf(! isLimitedEditConsole, function() {
+              this.start('span').addClass(self.myClass('separator')).end()
+                .tag(self.FULL_SCREEN, { themeIcon$: self.data.flowMode$.map(c => c == self.FlowMode.CONSOLE ? 'fullScreen' : 'minimize') });
+            })
             // callIf(this.data.showPrompts$, function() {
             //   this.start().addClass(self.myClass('save-text'))
             //     .add('The Flow is saved automatically')
@@ -278,6 +283,9 @@ foam.CLASS({
         return ! showPrompts;
       },
       code: function() {
+        if ( this.data.flowMode == this.data.FlowMode.LIMIT_EDIT ) {
+          this.data.flowMode = this.data.FlowMode.CONSOLE;
+        }
         this.data.showPrompts = true;
       }
     },
@@ -378,15 +386,72 @@ foam.CLASS({
       label: '',
       buttonStyle: foam.u2.ButtonStyle.SECONDARY,
       isAvailable: function(data$flowMode) {
-        // Hide toggle button in PRESENTATION_ONLY mode
-        return data$flowMode != this.FlowMode.PRESENTATION_ONLY;
+        // Hide toggle button in PRESENTATION_ONLY and limited edit modes
+        return data$flowMode != this.FlowMode.PRESENTATION_ONLY &&
+               data$flowMode != this.FlowMode.LIMIT_EDIT &&
+               data$flowMode != this.FlowMode.LIMIT_EDIT_CONSOLE;
       },
       code: function() {
         if ( this.data.flowMode == this.FlowMode.CONSOLE ) {
           this.data.flowMode = this.FlowMode.PRESENTATION;
         } else if ( this.data.flowMode == this.FlowMode.PRESENTATION ) {
           this.data.flowMode = this.FlowMode.CONSOLE;
+        } else if ( this.data.flowMode == this.FlowMode.LIMIT_EDIT ) {
+          this.data.flowMode = this.FlowMode.LIMIT_EDIT_CONSOLE;
+        } else if ( this.data.flowMode == this.FlowMode.LIMIT_EDIT_CONSOLE ) {
+          this.data.flowMode = this.FlowMode.LIMIT_EDIT;
         }
+      }
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.reflow',
+  name: 'LimitEditHeader',
+  extends: 'foam.u2.View',
+
+  requires: [
+    'foam.core.reflow.FlowMode'
+  ],
+
+  css: `
+    ^container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+    }
+    ^title {
+      font-weight: $font-medium;
+      color: $textDefault;
+    }
+  `,
+
+  methods: [
+    function render() {
+      this.
+        addClass().
+        start().addClass(this.myClass('container'))
+          .start('span').addClass(this.myClass('title'))
+            .add(this.data.value.name$.map(n => n || 'Unnamed'))
+          .end()
+          .startContext({ data: this })
+            .tag(this.EDIT_LIMITED)
+          .endContext()
+        .end();
+    }
+  ],
+
+  actions: [
+    {
+      name: 'editLimited',
+      label: 'Edit',
+      buttonStyle: foam.u2.ButtonStyle.PRIMARY,
+      size: 'SMALL',
+      code: function() {
+        this.data.flowMode = this.FlowMode.LIMIT_EDIT_CONSOLE;
       }
     }
   ]
@@ -887,7 +952,7 @@ foam.CLASS({
 foam.ENUM({
   package: 'foam.core.reflow',
   name: 'FlowMode',
-  values: [ 'CONSOLE', 'PRESENTATION', 'PRESENTATION_ONLY' ]
+  values: [ 'CONSOLE', 'PRESENTATION', 'PRESENTATION_ONLY', 'LIMIT_EDIT', 'LIMIT_EDIT_CONSOLE' ]
 });
 
 
@@ -914,6 +979,7 @@ foam.CLASS({
     'foam.core.reflow.ToolbarControl',
     'foam.core.reflow.Block',
     'foam.core.reflow.Flow',
+    'foam.core.reflow.LimitEditHeader',
     'foam.core.reflow.FlowMode',
     'foam.core.reflow.FlowableTree',
     'foam.core.reflow.Layout',
@@ -1094,7 +1160,7 @@ foam.CLASS({
       name: 'showPrompts',
       value: true,
       expression: function(flowMode) {
-        return flowMode === this.FlowMode.CONSOLE;
+        return flowMode === this.FlowMode.CONSOLE || flowMode === this.FlowMode.LIMIT_EDIT_CONSOLE;
       },
       preSet: function(_, n) { return n === 'false' ? '' : n; },
 //      memorable: true // use flowMode
@@ -1384,9 +1450,13 @@ foam.CLASS({
         });
       }
 
-      layout.header.add(this.dynamic(function(showPrompts) {
-        this.tag(self.ReflowHeader, {data: self, showPrompts: showPrompts, resetFlow: self.clearFlow});
-      }));
+      layout.header.add(this.dynamic(function(flowMode, showPrompts) {
+        if ( flowMode == self.FlowMode.LIMIT_EDIT ) {
+          this.tag(self.LimitEditHeader, { data: self });
+        } else {
+          this.tag(self.ReflowHeader, {data: self, showPrompts: showPrompts, resetFlow: self.clearFlow});
+        }
+      }, self.flowMode$, self.showPrompts$));
 
       await this.eval_('preLoad', null, true);
 
@@ -1793,9 +1863,15 @@ foam.CLASS({
         // Don't allow toggling out of PRESENTATION_ONLY mode
         if ( this.flowMode == this.FlowMode.PRESENTATION_ONLY ) return;
 
-        this.flowMode = this.flowMode == this.FlowMode.CONSOLE ?
-          this.FlowMode.PRESENTATION :
-          this.FlowMode.CONSOLE ;
+        if ( this.flowMode == this.FlowMode.CONSOLE ) {
+          this.flowMode = this.FlowMode.PRESENTATION;
+        } else if ( this.flowMode == this.FlowMode.PRESENTATION ) {
+          this.flowMode = this.FlowMode.CONSOLE;
+        } else if ( this.flowMode == this.FlowMode.LIMIT_EDIT ) {
+          this.flowMode = this.FlowMode.LIMIT_EDIT_CONSOLE;
+        } else if ( this.flowMode == this.FlowMode.LIMIT_EDIT_CONSOLE ) {
+          this.flowMode = this.FlowMode.LIMIT_EDIT;
+        }
 
         // After toggleMode is executed the app may no longer have focus so thee
         // keyboard shortcut won't work. Set focus to something so if you user presses escape again

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -247,11 +247,9 @@ foam.CLASS({
                 showDropdownIcon: false,
                 horizontal: false
               })
+              .start('span').addClass(this.myClass('separator')).end()
+              .tag(this.FULL_SCREEN, { themeIcon$: self.data.flowMode$.map(c => c == self.FlowMode.CONSOLE || c == self.FlowMode.LIMIT_EDIT_CONSOLE  ? 'fullScreen' : 'minimize') })
             .endContext()
-            .callIf(! isLimitedEditConsole, function() {
-              this.start('span').addClass(self.myClass('separator')).end()
-                .tag(self.FULL_SCREEN, { themeIcon$: self.data.flowMode$.map(c => c == self.FlowMode.CONSOLE ? 'fullScreen' : 'minimize') });
-            })
             // callIf(this.data.showPrompts$, function() {
             //   this.start().addClass(self.myClass('save-text'))
             //     .add('The Flow is saved automatically')
@@ -388,8 +386,7 @@ foam.CLASS({
       isAvailable: function(data$flowMode) {
         // Hide toggle button in PRESENTATION_ONLY and limited edit modes
         return data$flowMode != this.FlowMode.PRESENTATION_ONLY &&
-               data$flowMode != this.FlowMode.LIMIT_EDIT &&
-               data$flowMode != this.FlowMode.LIMIT_EDIT_CONSOLE;
+               data$flowMode != this.FlowMode.LIMIT_EDIT;
       },
       code: function() {
         if ( this.data.flowMode == this.FlowMode.CONSOLE ) {

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -428,16 +428,25 @@ foam.CLASS({
 
   methods: [
     function render() {
+      var self = this;
       this.
         addClass().
-        start().addClass(this.myClass('container'))
-          .start('span').addClass(this.myClass('title'))
-            .add(this.data.value.name$.map(n => n || 'Unnamed'))
-          .end()
-          .startContext({ data: this })
-            .tag(this.EDIT_LIMITED)
-          .endContext()
-        .end();
+        add(this.slot(function(flow, permission) {
+          var e = self.E().start().addClass(self.myClass('container'));
+
+          if ( permission ) {
+            var action = self.EDIT_LIMITED.clone();
+            action.availablePermissions = [ permission ];
+            action.availablePermissionsSlot_ = null; // reset permission cache
+
+            e.startContext({ data: self })
+              .tag(action)
+            .endContext();
+          }
+
+          return e.end();
+        }, this.data.value$, this.data.value$.dot('limitedEditPermission')))
+        ;
     }
   ],
 

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -556,6 +556,11 @@ foam.CLASS({
       hidden: false
     },
     {
+      class: 'Boolean',
+      name: 'allowLimitedEdit',
+      documentation: 'When true, Block configuration remains accessible in LIMIT_EDIT_CONSOLE mode.'
+    },
+    {
       class: 'foam.u2.ViewSpec',
       name: 'border',
       label: 'Border Properties',
@@ -1436,7 +1441,7 @@ foam.CLASS({
       let setupEditMode = () => {
         this.deepSub(this.onFlowChildrenChange, [this.FLOW_CHILDREN, this.VALUE]);
         layout.left.tag(this.FlowableTree, {data: this, selected$: this.selected$, isMenuOpen$: layout.isMenuOpen$});
-        layout.right.tag(this.ReflowConfigView, { data$: this.selected$});
+        layout.right.tag(this.ReflowConfigView, { data$: this.selected$, flowMode$: this.flowMode$});
       };
 
       if ( this.showPrompts ) {

--- a/src/foam/core/reflow/Flow.js
+++ b/src/foam/core/reflow/Flow.js
@@ -75,6 +75,12 @@ foam.CLASS({
     },
     {
       class: 'String',
+      name: 'limitedEditPermission',
+      hidden: true,
+      documentation: 'Permission id required to access limited-edit controls; hidden from standard UI.'
+    },
+    {
+      class: 'String',
       name: 'description',
       section: 'general',
       width: 80

--- a/src/foam/core/reflow/ReflowConfigView.js
+++ b/src/foam/core/reflow/ReflowConfigView.js
@@ -11,7 +11,8 @@ foam.CLASS({
   //TODO: reactions dont work for block properties
   requires: [
     'foam.core.reflow.ReactiveSectionedDetailView',
-    'foam.core.reflow.Block'
+    'foam.core.reflow.Block',
+    'foam.core.reflow.FlowMode'
   ],
   css:` 
     ^ {
@@ -26,6 +27,12 @@ foam.CLASS({
   properties: [
     {
       name: 'data'
+    },
+    {
+      class: 'Enum',
+      of: 'foam.core.reflow.FlowMode',
+      name: 'flowMode',
+      value: 'CONSOLE'
     },
     {
       name: 'selectedValue',
@@ -44,7 +51,16 @@ foam.CLASS({
             self.selected = this;
           }));
         })
-        .add(this.dynamic(function(data$configViewSpec, selectedValue) {
+        .add(this.dynamic(function(data$configViewSpec, selectedValue, flowMode, data) {
+          var limitedBlocked = flowMode == self.FlowMode.LIMIT_EDIT_CONSOLE &&
+            self.Block.isInstance(data) &&
+            data.allowLimitedEdit !== true;
+
+          if ( limitedBlocked ) {
+            this.add('Access Denied');
+            return;
+          }
+
           if ( ! selectedValue ) return;
           this.tag(self.ReactiveSectionedDetailView, {
             of: selectedValue.cls_.id ?? '',
@@ -53,21 +69,30 @@ foam.CLASS({
             showActions: true,
             showHeader: true
           });
-        }))
+        }, self.data$configViewSpec$, self.selectedValue$, self.flowMode$, self.data$))
       .end()
       .start(this.Tab, { label: 'Block Properties' })
-        .add(this.dynamic(function(data) {
+        .add(this.dynamic(function(data, flowMode) {
           if ( ! data || data.deleted_ || ! self.Block.isInstance(data) ) {
             this.add('No block selected');
             return;
           }
+
+          var limitedBlocked = flowMode == self.FlowMode.LIMIT_EDIT_CONSOLE &&
+            data.allowLimitedEdit !== true;
+
+          if ( limitedBlocked ) {
+            this.add('Access Denied');
+            return;
+          }
+
           this.tag(self.ReactiveSectionedDetailView, {
             ...(data.configViewSpec || {}),
             data: data,
             showActions: true,
             showHeader: true
           });
-        }))
+        }, self.data$, self.flowMode$))
       .end();;
     }
   ]

--- a/src/foam/core/reflow/ReflowConfigView.js
+++ b/src/foam/core/reflow/ReflowConfigView.js
@@ -12,7 +12,8 @@ foam.CLASS({
   requires: [
     'foam.core.reflow.ReactiveSectionedDetailView',
     'foam.core.reflow.Block',
-    'foam.core.reflow.FlowMode'
+    'foam.core.reflow.FlowMode',
+    'foam.core.reflow.Flow'
   ],
   css:` 
     ^ {
@@ -52,9 +53,10 @@ foam.CLASS({
           }));
         })
         .add(this.dynamic(function(data$configViewSpec, selectedValue, flowMode, data) {
-          var limitedBlocked = flowMode == self.FlowMode.LIMIT_EDIT_CONSOLE &&
-            self.Block.isInstance(data) &&
-            data.allowLimitedEdit !== true;
+          var limitedBlocked = flowMode == self.FlowMode.LIMIT_EDIT_CONSOLE && (
+            ( self.Block.isInstance(data) && data.allowLimitedEdit !== true ) ||
+            ( self.Flow.isInstance(selectedValue) )
+          );
 
           if ( limitedBlocked ) {
             this.add('Access Denied');


### PR DESCRIPTION
src/foam/core/menu/LimitedEditFlowMenu.js
-> flow menu to access LIMIT_EDIT mode

src/foam/core/reflow/Console.js
src/foam/core/reflow/Flow.js
src/foam/core/reflow/ReflowConfigView.js
Contribute too:
-> updates FlowMode to include LIMIT_EDIT && LIMIT_EDIT_CONSOLE
- LIMIT_EDIT is similar to PRESENTATION_ONLY but if a permission is available will include a header action "Edit" which will transition flow to LIMIT_EDIT_CONSOLE.

<img width="1292" height="88" alt="Screenshot 2026-01-09 at 9 07 54 pm" src="https://github.com/user-attachments/assets/f5f77af9-e331-41ca-9fe9-a7691d243331" />

So above image is the LIMIT_EDIT with no permission set on flow or if user has flow permission.

<img width="739" height="46" alt="Screenshot 2026-01-09 at 9 08 18 pm" src="https://github.com/user-attachments/assets/fd9033c3-71e8-494b-8a7d-4c37d956bb4e" />

This image is header hidden in LIMIT_EDIT - user does not have flow permission see or configure anything related to this flow.

- LIMIT_EDIT_CONSOLE is similar to CONSOLE but limits block properties. Defaults all blocks to 'access denied' but can configure blocks to show properties if you so wish.
<img width="1064" height="102" alt="Screenshot 2026-01-09 at 9 08 31 pm" src="https://github.com/user-attachments/assets/6084295d-bafe-440c-b721-4cb5f60dc5c3" />


Example flow with a permission set and blocks setup:
p({
	"class": "foam.core.reflow.Flow",
	"name": "Test",
	"accessLevel": 3,
	**"limitedEditPermission": "permission.test.edit",**
	"script": `[
	{
		"flowName": "something_control",
		"cmd": "something",
		**"allowLimitedEdit": true,**
		....


limitEditPermission is hidden ... questionable whether we want UI to set this...