### PR TITLE
Display form validation errors when hovering the create button

### DIFF
--- a/src/foam/comics/v3/CreateView.js
+++ b/src/foam/comics/v3/CreateView.js
@@ -86,6 +86,16 @@ foam.CLASS({
         }
         return enabled;
       },
+      toolTipFn: function(data$errors_) {
+        let hasErrors = !! data$errors_;
+        if ( hasErrors ) {
+          function printErrors(errors_) {
+            return errors_.map(e => `<li><b>${e[0].label}</b>: ${e[1]}</li>`).join('');
+          }
+          return 'Save is disabled due to the following validation errors:<br /><ul>' + printErrors(data$errors_) + '</ul>';
+        }
+        return '';
+      },
       code: function() {
         var cData = this.data;
 

--- a/src/foam/lang/Action.js
+++ b/src/foam/lang/Action.js
@@ -64,10 +64,16 @@ foam.CLASS({
       expression: function(name) { return this.label || foam.String.labelize(name); }
     },
     {
-      documentation: 'displayed on :hover',
+      documentation: 'displayed on :hover (Overridden by toolTipFn if provided)',
       generateJava: false,
       class: 'String',
       name: 'toolTip'
+    },
+    {
+      documentation: 'Function to determine the tooltip text. If not provided, the toolTip property is used.',
+      generateJava: false,
+      class: 'Function',
+      name: 'toolTipFn'
     },
     {
       name: 'icon',
@@ -253,7 +259,15 @@ If empty then no permissions are required.`
         data.slot(expression) :
         foam.lang.ConstantSlot.create({ value: true });
 
-      return this.addPermissionsCheck_(x, slot, data, permissionsName);
+      if ( permissionsName ) {
+        return this.addPermissionsCheck_(x, slot, data, permissionsName);
+      }
+      return slot;
+    },
+
+    function createToolTip$(x, data) {
+      // toolTipFnPermissions is not needed, so don't check permissions
+      return this.createSlotFor_(x, data, this.toolTipFn, null);
     },
 
     function createIsEnabled$(x, data) {

--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -158,7 +158,13 @@ foam.CLASS({
 
   methods: [
     function render() {
-      this.tooltip$.follow(this.action.toolTip$);
+
+      if ( this.action.toolTipFn ) {
+        let toolTip$ = this.action.createToolTip$(this.__context__, this.data);
+        this.tooltip$.follow(toolTip$);
+      } else {
+        this.tooltip$.follow(this.action.toolTip$);
+      }
 
       this.SUPER();
 

--- a/src/foam/u2/Tooltip.js
+++ b/src/foam/u2/Tooltip.js
@@ -132,7 +132,15 @@ foam.CLASS({
       this.SUPER();
       this
         .show(this.data$)
-        .add(this.data)
+        .add(this.slot(function(data) {
+          // If data is a string, treat as HTML. If DOM node, add directly.
+          if ( typeof data === 'string' ) {
+            var span = this.E('span');
+            span.element_.innerHTML = data;
+            return span;
+          }
+          return data;
+        }))
         .addClass()
     }
   ]


### PR DESCRIPTION
### Motivation
When the `Create` button is disabled, it's hard to know what the issue is exactly, especially when we have large forms with tabs (Take the User form for example). This PR makes it easy to know what are the validation errors I have simply by hovering on the `Create` button itself.

### Screenshot
<img width="573" height="272" style="border: 2px solid gray; padding: 5px;" alt="Validation Errors Screenshot" src="https://github.com/user-attachments/assets/ead3dcd6-d28f-4e58-b50a-d98e00d7e721" />


### In this PR
  - Add tooltip when create button is disabled containing validation errors
  - Add `toolTipFn` property on Actions that allows tooltips to be calculated from when data changes
  - Implement support for html content on the tooltips.