### PR TITLE
PT-FIXES: DOS-2067 : update memento handling in FilterController and FilterView, improve error logging in DeFeedback

### DIFF
--- a/src/foam/u2/filter/FilterController.js
+++ b/src/foam/u2/filter/FilterController.js
@@ -145,9 +145,8 @@ foam.CLASS({
         args: Object.values(criterias).map((criteria) => { return this.and(criteria.predicates); })
       }).partialEval();
       if ( orPredicate === this.FALSE ) orPredicate = this.TRUE;
-      if ( foam.util.equals(orPredicate, this.finalPredicate) ) return;
 
-      this.mementoPredicate = this.Or.create({
+      var newMementoPredicate = this.Or.create({
         args: Object.values(criterias)
                 .map((criteria) => {
                   let temp = {}
@@ -159,6 +158,14 @@ foam.CLASS({
                 })
       }).partialEval();
 
+      // Check both predicates since finalPredicate can be set externally via FilterView's
+      // data$ binding (from URL memento), which would cause early return before mementoPredicate is updated
+      if ( foam.util.equals(orPredicate, this.finalPredicate) &&
+           foam.util.equals(newMementoPredicate, this.mementoPredicate) ) {
+        return;
+      }
+
+      this.mementoPredicate = newMementoPredicate;
       this.finalPredicate = orPredicate;
     },
 

--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -235,9 +235,9 @@ foam.CLASS({
     },
     async function render() {
       var self = this;
-      this.mementoString$.sub(this.getData);
+      this.onDetach(this.mementoString$.sub(this.getData));
       this.getData();
-      this.filterController.mementoPredicate$.sub(this.updateMementoString);
+      this.onDetach(this.filterController.mementoPredicate$.sub(this.updateMementoString));
 
       await this.updateFilters();
 
@@ -413,7 +413,9 @@ foam.CLASS({
       name: 'updateMementoString',
       code: function() {
         this.deFeedback(() => {
-          var mem = this.filterController.mementoPredicate.toMQL();
+          var pred = this.filterController.mementoPredicate;
+          // TRUE doesn't have toMQL, so check if it exists
+          var mem = pred.toMQL ? pred.toMQL() : '';
           if ( mem ) {
             this.mementoString = '{' + mem + '}';
           } else {
@@ -468,7 +470,8 @@ foam.CLASS({
         // clear all filters
         this.filterController.clearAll();
         if ( this.generalSearchField ) this.generalSearchField.view.data = '';
-        this.mementoString = '';
+        // Use undefined so hasDefaultValue() returns true and memento removes from URL
+        this.mementoString = undefined;
       }
     },
     {

--- a/src/foam/util/DeFeedback.js
+++ b/src/foam/util/DeFeedback.js
@@ -22,8 +22,13 @@ foam.CLASS({
       /** Call the supplied function with feedback elimination. **/
       if ( this.feedback_ ) return;
       this.feedback_ = true;
-      try { fn(); } catch(x) {}
-      this.feedback_ = false;
+      try {
+        fn();
+      } catch(e) {
+        console.error('deFeedback error:', e);
+      } finally {
+        this.feedback_ = false;
+      }
     }
   ]
 });


### PR DESCRIPTION
## Issue

When using FilterView, clearing the last filter did not remove the filter parameter from the URL. The bidirectional sync between the filter state and the URL hash was broken specifically when all filters were cleared.

## Root Cause

The `updateFilterPredicate` method in FilterController had an early return that only checked if `finalPredicate` was unchanged. However, `finalPredicate` is bound bidirectionally to FilterView's `data$` property, which is linked to the URL memento.

When a filter was applied from the URL:
1. `finalPredicate` would be set via the external binding
2. When the UI tried to update, `updateFilterPredicate` would see `finalPredicate` was already set and early return
3. `mementoPredicate` was never updated to reflect the actual filter
4. When the filter was cleared, `mementoPredicate` was already TRUE, so no change was detected

## Fixes

### 1. FilterController - Early Return Logic

Changed the early return check to verify that **both** `finalPredicate` and `mementoPredicate` are unchanged before returning. This ensures `mementoPredicate` is always updated when filters change, even if `finalPredicate` was set externally.

### 2. FilterView - TRUE Predicate Handling

The TRUE constant in FOAM does not have a `toMQL()` method. Added a check before calling `toMQL()` to handle this case gracefully, returning an empty string instead of throwing an error.

### 3. FilterView - Subscription Lifecycle

Added `onDetach` to the `mementoPredicate$` subscription to ensure proper cleanup when the view is destroyed.

### 4. FilterView - Clear All Action

Changed `mementoString` assignment from empty string to `undefined` when clearing all filters. This allows `hasDefaultValue()` to return true, which properly removes the parameter from the URL.

### 5. DeFeedback - Error Logging

Changed DeFeedback to log errors instead of silently swallowing them. Previously, any error inside a `deFeedback` callback would be caught and ignored, making debugging very difficult. Errors are now logged to the console while still preventing feedback loops.
