### PR TITLE
update JSONFObjectFormatter outputProperty to default a class if empty object

### DIFF
--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -215,9 +215,6 @@ public class JSONFObjectFormatter
       // Only do this when OutputDefaultClassNames is true, otherwise preserve
       // original behavior (which may produce invalid JSON for edge cases).
       if ( builder().length() == valueStart ) {
-        setLength(startLen);
-        outputKey(getPropertyName(p));
-        append(':');
         if ( propObj instanceof FObject && outputDefaultClassNames_ ) {
           append('{');
           outputKey("class");

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -212,19 +212,23 @@ public class JSONFObjectFormatter
       p.formatJSON(this, o);
       // If nothing was written for the value (eg: empty/default nested FObject),
       // output a minimal object carrying the class to avoid blank entries.
+      // Only do this when OutputDefaultClassNames is true, otherwise preserve
+      // original behavior (which may produce invalid JSON for edge cases).
       if ( builder().length() == valueStart ) {
         setLength(startLen);
         outputKey(getPropertyName(p));
         append(':');
-        if ( propObj instanceof FObject ) {
+        if ( propObj instanceof FObject && getOutputDefaultClassNames() ) {
           append('{');
           outputKey("class");
           append(':');
           output(((FObject) propObj).getClassInfo().getId());
           append('}');
-        } else {
+        } else if ( ! ( propObj instanceof FObject ) ) {
           append("null");
         }
+        // else: FObject with OutputDefaultClassNames=false - leave empty
+        // (preserves original behavior, produces invalid JSON as expected)
       }
     } catch (Throwable t) {
       System.err.println("***************************************************** error outputting " + getPropertyName(p));

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -212,23 +212,19 @@ public class JSONFObjectFormatter
       p.formatJSON(this, o);
       // If nothing was written for the value (eg: empty/default nested FObject),
       // output a minimal object carrying the class to avoid blank entries.
-      // Only do this when OutputDefaultClassNames is true, otherwise preserve
-      // original behavior (which may produce invalid JSON for edge cases).
       if ( builder().length() == valueStart ) {
         setLength(startLen);
         outputKey(getPropertyName(p));
         append(':');
-        if ( propObj instanceof FObject && getOutputDefaultClassNames() ) {
+        if ( propObj instanceof FObject ) {
           append('{');
           outputKey("class");
           append(':');
           output(((FObject) propObj).getClassInfo().getId());
           append('}');
-        } else if ( ! ( propObj instanceof FObject ) ) {
+        } else {
           append("null");
         }
-        // else: FObject with OutputDefaultClassNames=false - leave empty
-        // (preserves original behavior, produces invalid JSON as expected)
       }
     } catch (Throwable t) {
       System.err.println("***************************************************** error outputting " + getPropertyName(p));

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -204,9 +204,28 @@ public class JSONFObjectFormatter
 
   protected void outputProperty(FObject o, PropertyInfo p) {
     try {
+      int startLen = builder().length();
       outputKey(getPropertyName(p));
       append(':');
+      int valueStart = builder().length();
+      Object propObj = p.get(o);
       p.formatJSON(this, o);
+      // If nothing was written for the value (eg: empty/default nested FObject),
+      // output a minimal object carrying the class to avoid blank entries.
+      if ( builder().length() == valueStart ) {
+        setLength(startLen);
+        outputKey(getPropertyName(p));
+        append(':');
+        if ( propObj instanceof FObject ) {
+          append('{');
+          outputKey("class");
+          append(':');
+          output(((FObject) propObj).getClassInfo().getId());
+          append('}');
+        } else {
+          append("null");
+        }
+      }
     } catch (Throwable t) {
       System.err.println("***************************************************** error outputting " + getPropertyName(p));
       // System.err.println("" + p.get(o));

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -212,19 +212,23 @@ public class JSONFObjectFormatter
       p.formatJSON(this, o);
       // If nothing was written for the value (eg: empty/default nested FObject),
       // output a minimal object carrying the class to avoid blank entries.
+      // Only do this when OutputDefaultClassNames is true, otherwise preserve
+      // original behavior (which may produce invalid JSON for edge cases).
       if ( builder().length() == valueStart ) {
         setLength(startLen);
         outputKey(getPropertyName(p));
         append(':');
-        if ( propObj instanceof FObject ) {
+        if ( propObj instanceof FObject && outputDefaultClassNames_ ) {
           append('{');
           outputKey("class");
           append(':');
           output(((FObject) propObj).getClassInfo().getId());
           append('}');
-        } else {
+        } else if ( ! ( propObj instanceof FObject ) ) {
           append("null");
         }
+        // else: FObject with OutputDefaultClassNames=false - leave empty
+        // (preserves original behavior, produces invalid JSON as expected)
       }
     } catch (Throwable t) {
       System.err.println("***************************************************** error outputting " + getPropertyName(p));

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -137,17 +137,20 @@ foam.CLASS({
         test ( false, testId+" Error parsing: "+t.getMessage());
       }
 
-      testId = "EmptyFObjectProperty-OutputDefaultClassNames:false";
+      // Test with OutputDefaultValues=false (JRL default) - the actual use case from PR
+      // When OutputDefaultValues=false, the empty Address outputs nothing except the class
+      testId = "EmptyFObjectProperty-JRLDefaults";
       formatter = new JSONFObjectFormatter();
-      formatter.setOutputDefaultClassNames(false);
-      formatter.setOutputDefaultValues(true);
+      // OutputDefaultClassNames=true (default)
+      // OutputDefaultValues=false (default) - mimics JRL behavior
       user = new User();
       user.setId(12345L);
       user.setAddress(new Address()); // Empty/default address
       formatter.output(user);
       json = formatter.builder().toString();
-      // With OutputDefaultClassNames=false, empty FObject produces invalid JSON (original behavior)
-      test ( ! SafetyUtil.isEmpty(json) && json.contains(":,"), testId+" produces invalid json as expected: "+json);
+      // With default settings (JRL-like), empty Address should still have class output
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated");
+      test ( json.contains("address") && json.contains("foam.core.auth.Address"), testId+" address with class present: "+json);
       `
     }
   ]

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -12,6 +12,8 @@ foam.CLASS({
   documentation: 'Test formatting and parsing json',
 
   javaImports: [
+    'foam.core.auth.Address',
+    'foam.core.auth.User',
     'foam.lib.formatter.JSONFObjectFormatter',
     'foam.lib.json.JSONParser',
     'foam.util.SafetyUtil'
@@ -105,6 +107,47 @@ foam.CLASS({
       } catch ( Throwable t ) {
         test ( false, testId+" Error parsing: "+t.getMessage());
       }
+
+      // ============================================================
+      // Test empty/default FObjectProperty (like User.address)
+      // When OutputDefaultClassNames=true, empty FObjects should output {class:"..."}
+      // ============================================================
+
+      testId = "EmptyFObjectProperty-OutputDefaultClassNames:true";
+      formatter = new JSONFObjectFormatter();
+      // formatter.setOutputDefaultClassNames(true); - default
+      formatter.setOutputDefaultValues(true);
+      var user = new User();
+      user.setId(12345L);
+      user.setAddress(new Address()); // Empty/default address
+      formatter.output(user);
+      json = formatter.builder().toString();
+      // Should contain address with at least the class
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated (no empty values)");
+      test ( json.contains("address") && json.contains("foam.core.auth.Address"), testId+" address with class present: "+json);
+      parser = new JSONParser();
+      try {
+        Object o = parser.parseString(json);
+        test ( o != null, testId+" json parsed successfully");
+        if ( o instanceof User ) {
+          User parsedUser = (User) o;
+          test ( parsedUser.getAddress() != null, testId+" parsed user has address object");
+        }
+      } catch ( Throwable t ) {
+        test ( false, testId+" Error parsing: "+t.getMessage());
+      }
+
+      testId = "EmptyFObjectProperty-OutputDefaultClassNames:false";
+      formatter = new JSONFObjectFormatter();
+      formatter.setOutputDefaultClassNames(false);
+      formatter.setOutputDefaultValues(true);
+      user = new User();
+      user.setId(12345L);
+      user.setAddress(new Address()); // Empty/default address
+      formatter.output(user);
+      json = formatter.builder().toString();
+      // With OutputDefaultClassNames=false, empty FObject produces invalid JSON (original behavior)
+      test ( ! SafetyUtil.isEmpty(json) && json.contains(":,"), testId+" produces invalid json as expected: "+json);
       `
     }
   ]


### PR DESCRIPTION
SO use case was User.
Specifically address.
Take a user who does not have an address set.
Open this user in a detailView
Edit
save
look at jrls. User would be written with address:,
because:
https://github.com/kgrgreer/foam3/blob/a47773b4a5693c32453dc87912dc68d800231e66/src/foam/core/auth/User.js#L482-L493

the address client has a factory for a default class, but since it is default nothing gets written.

Changes here will write a class if the JSONFormatter does return empty.

Prior this commit we'd get something like this in the jrls.
p({id:26929051,address:,lastModified:1768309920909,group:"admin"})

After this change we get:
p({id:26929051,address:{class:"foam.core.auth.Address"},lastModified:1768309920909,group:"admin"})