### PR TITLE
fix(parse): add '+' to valid characters in QueryParser

### DIFF
--- a/src/foam/parse/QueryParser.java
+++ b/src/foam/parse/QueryParser.java
@@ -589,7 +589,8 @@ public class QueryParser
       Literal.create("_"),
       Literal.create("@"),
       Literal.create("%"),
-      Literal.create(".")
+      Literal.create("."),
+      Literal.create("+")
     ));
 
     grammar.addSymbol("NUMBER", new Repeat(

--- a/src/foam/parse/QueryParser.js
+++ b/src/foam/parse/QueryParser.js
@@ -240,7 +240,7 @@ foam.CLASS({
           word: repeat(sym('char'), null, 1),
 
           char: alt(range('a', 'z'), range('A', 'Z'), range('0', '9'), '-', '^',
-            '_', '@', '%', '.'),
+            '_', '@', '%', '.', '+'),
 
           number: repeat(range('0', '9'), null, 1),
 

--- a/src/foam/parse/test/QueryParserJSTest.js
+++ b/src/foam/parse/test/QueryParserJSTest.js
@@ -12,6 +12,7 @@ foam.CLASS({
     { class: 'Long', name: 'id' },
     { class: 'String', name: 'firstName' },
     { class: 'String', name: 'lastName' },
+    { class: 'String', name: 'email' },
     { class: 'foam.lang.Date', name: 'birthday' },
     { class: 'foam.lang.DateTime', name: 'lastLogin' },
     { class: 'Boolean', name: 'emailVerified' }
@@ -33,6 +34,7 @@ foam.CLASS({
   methods: [
     async function runTest(x) {
       this.testBasicQueries(x);
+      this.testEmailPlusAddressing(x);
       this.testDateParsing(x);
       this.testDateParsingFixes(x);
       this.testTimezoneHandling(x);
@@ -71,6 +73,28 @@ foam.CLASS({
       // Lists
       x.test(this.isValidQuery(parser, "firstName=Simon,John"), "Should parse value list");
       x.test(this.isValidQuery(parser, "firstName:(Simon|John)"), "Should parse OR values");
+    },
+
+    function testEmailPlusAddressing(x) {
+      var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
+
+      // Test emails with + (plus addressing/tagging)
+      x.test(this.isValidQuery(parser, "email=user+tag@example.com"), "Should parse email with + tag");
+      x.test(this.isValidQuery(parser, "email=user+test@example.com,user+other@example.com"), "Should parse multiple emails with +");
+
+      // Verify the full email is captured, not truncated at +
+      var query = parser.parseString("email=user+tag@example.com");
+      if ( query && query.args && query.args[0] ) {
+        var predicate = query.args[0];
+        var value = predicate.arg2;
+        if ( value && value.value ) value = value.value;
+        x.test(value === "user+tag@example.com",
+          "Email with + should not be truncated, got: " + value);
+      }
+
+      // Test + doesn't interfere with other queries
+      x.test(this.isValidQuery(parser, "email=user+tag@example.com AND firstName=John"),
+        "Should parse email with + in AND query");
     },
 
     function testDateParsing(x) {

--- a/src/foam/parse/test/QueryParserJSTest.js
+++ b/src/foam/parse/test/QueryParserJSTest.js
@@ -102,17 +102,19 @@ foam.CLASS({
     },
 
     function extractValues(query) {
-      // Extract values from Or predicate containing Eq predicates
+      // Extract values from In predicate (used for comma-separated values with =)
       var values = [];
-      if ( ! query || ! query.args ) return values;
-      for ( var i = 0 ; i < query.args.length ; i++ ) {
-        var pred = query.args[i];
-        if ( pred && pred.arg2 ) {
-          var val = pred.arg2;
-          values.push(val.value !== undefined ? val.value : val);
-        }
+      if ( ! query ) return values;
+      // Handle And wrapper: query.args[0] is the actual predicate
+      var pred = query.args ? query.args[0] : query;
+      if ( ! pred || ! pred.arg2 ) return values;
+      var arg2 = pred.arg2;
+      // arg2 could be a Constant wrapping an array, or the array directly
+      var arr = arg2.value !== undefined ? arg2.value : arg2;
+      if ( Array.isArray(arr) ) {
+        return arr;
       }
-      return values;
+      return [arr];
     },
 
     function testDateParsing(x) {

--- a/src/foam/parse/test/QueryParserJSTest.js
+++ b/src/foam/parse/test/QueryParserJSTest.js
@@ -78,23 +78,41 @@ foam.CLASS({
     function testEmailPlusAddressing(x) {
       var parser = this.QueryParser.create({ of: this.QueryParserTestUser });
 
-      // Test emails with + (plus addressing/tagging)
-      x.test(this.isValidQuery(parser, "email=user+tag@example.com"), "Should parse email with + tag");
-      x.test(this.isValidQuery(parser, "email=user+test@example.com,user+other@example.com"), "Should parse multiple emails with +");
-
-      // Verify the full email is captured, not truncated at +
+      // Verify the full email with + is captured, not truncated
+      // Without + in char rule, "user+tag@example.com" would parse as just "user"
       var query = parser.parseString("email=user+tag@example.com");
-      if ( query && query.args && query.args[0] ) {
-        var predicate = query.args[0];
-        var value = predicate.arg2;
-        if ( value && value.value ) value = value.value;
-        x.test(value === "user+tag@example.com",
-          "Email with + should not be truncated, got: " + value);
-      }
+      var value = this.extractValue(query);
+      x.test(value === "user+tag@example.com",
+        "Email with + should not be truncated at +, expected 'user+tag@example.com' got: '" + value + "'");
 
-      // Test + doesn't interfere with other queries
-      x.test(this.isValidQuery(parser, "email=user+tag@example.com AND firstName=John"),
-        "Should parse email with + in AND query");
+      // Test multiple emails with +
+      var query2 = parser.parseString("email=a+b@test.com,c+d@test.com");
+      var values = this.extractValues(query2);
+      x.test(values.includes("a+b@test.com") && values.includes("c+d@test.com"),
+        "Multiple emails with + should parse correctly, got: " + JSON.stringify(values));
+    },
+
+    function extractValue(query) {
+      // Extract single value from Eq predicate
+      if ( ! query ) return null;
+      var pred = query.args ? query.args[0] : query;
+      if ( ! pred || ! pred.arg2 ) return null;
+      var val = pred.arg2;
+      return val.value !== undefined ? val.value : val;
+    },
+
+    function extractValues(query) {
+      // Extract values from Or predicate containing Eq predicates
+      var values = [];
+      if ( ! query || ! query.args ) return values;
+      for ( var i = 0 ; i < query.args.length ; i++ ) {
+        var pred = query.args[i];
+        if ( pred && pred.arg2 ) {
+          var val = pred.arg2;
+          values.push(val.value !== undefined ? val.value : val);
+        }
+      }
+      return values;
     },
 
     function testDateParsing(x) {

--- a/src/foam/parse/test/QueryParserUserTest.js
+++ b/src/foam/parse/test/QueryParserUserTest.js
@@ -81,9 +81,11 @@ foam.CLASS({
       test( isValid("has:businessName"," (businessname <> '') is not true ") , "The businessName exist");
       test( isValid("is:emailVerified"," emailverified =  ?  ") , "The emailVerified is equal to true");
 
-      // Email with + (plus addressing)
-      test( isValid("email=user+tag@example.com"," email =  ?  ") , "Email with + should parse correctly");
-      test( isValid("email=user+tag@example.com,user+other@example.com"," ( email =  ?  )  OR  ( email =  ?  ) ") , "Multiple emails with + should parse correctly");
+      // Email with + (plus addressing) - verify full email is captured, not truncated at +
+      var emailUser = new User();
+      emailUser.setEmail("user+tag@example.com");
+      test( evaluate("email=user+tag@example.com", emailUser), "Email with + should match user with that email");
+      test( !evaluate("email=user", emailUser), "Truncated email (without +tag) should NOT match - if this fails, + is not in CHAR rule");
 
       //          {"id=me"," ( ( id =  ?  ) ) "},
       

--- a/src/foam/parse/test/QueryParserUserTest.js
+++ b/src/foam/parse/test/QueryParserUserTest.js
@@ -80,6 +80,11 @@ foam.CLASS({
       
       test( isValid("has:businessName"," (businessname <> '') is not true ") , "The businessName exist");
       test( isValid("is:emailVerified"," emailverified =  ?  ") , "The emailVerified is equal to true");
+
+      // Email with + (plus addressing)
+      test( isValid("email=user+tag@example.com"," email =  ?  ") , "Email with + should parse correctly");
+      test( isValid("email=user+tag@example.com,user+other@example.com"," ( email =  ?  )  OR  ( email =  ?  ) ") , "Multiple emails with + should parse correctly");
+
       //          {"id=me"," ( ( id =  ?  ) ) "},
       
       test( isValid("firstName=Simon,Wassim"," ( firstname =  ?  )  OR  ( firstname =  ?  ) ") , "The firstName is equal to value1 OR to value2");


### PR DESCRIPTION
## Problem
Email addresses with `+` aliases (e.g., `user+tag@example.com`) were not being parsed correctly from URL memento parameters. The QueryParser's `char` rule didn't include `+`, causing the parser to stop at the `+` character and only capture the portion before it (e.g., `user`).

## Solution
Added `+` to the `char` rule in QueryParser, allowing email addresses with plus-addressing to be parsed correctly as unquoted words in MQL filter strings.

## Changes
- Added `+` to the `char` rule in QueryParser.js to support valid email characters
