### PR TITLE
PT-FIXES: DOS-2121 Fix URL search prefilter causing duplicate DAO queries

### DIFF
--- a/src/foam/u2/search/TextSearchView.js
+++ b/src/foam/u2/search/TextSearchView.js
@@ -95,6 +95,14 @@ foam.CLASS({
   ],
 
   methods: [
+    function init() {
+      // If data is pre-populated (e.g., from URL memento), parse it immediately
+      // Don't wait for the 500ms debounced updateValue listener
+      if ( this.data ) {
+        this.predicate = this.queryParser.parseString(this.data) || this.TRUE;
+      }
+    },
+
     function render() {
       this.__subContext__.register(foam.u2.SearchField, 'foam.u2.TextField');
 


### PR DESCRIPTION

## Problem

When navigating to a DAOBrowserView with a URL search parameter (e.g., `#MyMenu?search=status%3DACTIVE`), the system was making two DAO queries instead of one:

1. First query with no filter (wasteful)
2. Second query with the actual filter from the URL

This happened because TextSearchView has a 500ms debounced `updateValue` listener. When `data` was pre-populated from the URL memento, it wasn't parsed into a predicate until 500ms later - after the initial DAO query had already fired with a `TRUE` predicate.

## Solution

Added an `init()` method to TextSearchView that checks if `data` is pre-populated (e.g., from URL memento) and parses it immediately into a predicate. The 500ms debounce delay now only applies to subsequent user typing, not to initial values.

## Changes

- **TextSearchView.js**: Added `init()` method that immediately parses pre-populated `data` into `predicate`, bypassing the 500ms debounce delay for initial values
