### PR TITLE
PT-FIXES: DOS-2126 Fix Table Row Actions for Multipart Key Models

### DIFF
--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -257,7 +257,14 @@ foam.CLASS({
 
       if ( ! this.obj && this.dao ) {
         foam.assert(this.id, 'Id must be provided when obj needs to be fetched in OverlayActionListView');
-        this.obj = await this.dao.inX(this.__context__).find(this.id);
+        var id = this.id;
+        // Handle multipart keys - convert string ID back to ID object
+        var of = this.dao.of;
+        if ( of && foam.lang.MultiPartID.isInstance(of.ID) && typeof id === 'string' ) {
+          id = of.ID.of.FROM_STRING(id);
+        }
+        this.obj = await this.dao.inX(this.__context__).find(id);
+        foam.assert(this.obj, 'Failed to find object with id: ' + this.id + ' in OverlayActionListView');
       }
 
       self.availabilities_$.follow(self.createAvailabilitySlotArray())


### PR DESCRIPTION

## Problem
Table row actions failed to receive object data for models using multipart/composite keys (`ids: ['field1', 'field2']`). When `OverlayActionListView` tried to fetch the full object using `DAO.find(id)`, the string representation of multipart IDs was not being converted back to the proper ID object, causing the lookup to fail silently. This resulted in `X.data` being `null` in action handlers when triggered from table views.

## Solution
Added multipart key detection and conversion in `OverlayActionListView`. Before calling `DAO.find()`, the code now checks if the model uses `MultiPartID` and if the ID is a string. If so, it converts the string back to the proper ID object using the generated `FROM_STRING` method.

## Changes
- Added multipart key detection using `foam.lang.MultiPartID.isInstance(of.ID)`
- Added string ID conversion using `of.ID.of.FROM_STRING(id)` for multipart keys
- Added assertion to catch lookup failures with descriptive error message
