### PR TITLE
PT-FIXES: DOS-2080 Fix filter state loss when navigating to detail view and back

### DIFF
--- a/src/foam/u2/memento/Memento.js
+++ b/src/foam/u2/memento/Memento.js
@@ -210,10 +210,12 @@ foam.CLASS({
         in the parent, even if it is the default value, otherwise it would
         cause ambiguity as to which level the binding applied.
       **/
-      var ret = ( this.tail && opt_untilObj !== this.obj ) ? this.tail.encode() : { route: '', params: '', bound: {} };
+      var tailRet = ( this.tail && opt_untilObj !== this.obj ) ? this.tail.encode() : null;
+      var ret = tailRet ? { route: tailRet.route, params: tailRet.params, bound: Object.assign({}, tailRet.bound) } : { route: '', params: '', bound: {} };
 
       this.props.forEach(p => {
         var val = this.obj[p.name] === undefined ? '' : this.obj[p.name];
+
         if ( p.name === 'route' || p.shortName === 'route' ) {
           if ( ret.route ) ret.route = '/' + ret.route;
           ret.route = encodeURIComponent(val) + ret.route;
@@ -221,20 +223,32 @@ foam.CLASS({
           var name = p.shortName || p.name;
 
           // If the name is bound in the tail, then output to avoid ambiguity
-          if ( ! this.obj.hasDefaultValue(p.name) || ret.bound[name] ) {
+          var hasDefault = this.obj.hasDefaultValue(p.name);
+
+          if ( ! hasDefault || ret.bound[name] ) {
             if ( ret.params ) ret.params = '&' + ret.params;
             // ???: What is this used for?
             if ( val && this.cls_.isInstance(val) ) debugger;
             // if ( val && this.cls_.isInstance(val) ) val = `{${val.usedStr}}`;
             // if ( val === undefined ) val = '';
-            ret.params = name + '=' + encodeURIComponent(val) + ret.params;
-            // console.log('***', name, val);
+            var encodedVal = encodeURIComponent(val);
+            ret.params = name + '=' + encodedVal + ret.params;
             ret.bound[name] = true;
           }
         }
       });
 
-      if ( ! opt_untilObj ) this.usedStr = this.toString(ret);
+      var resultStr = this.toString(ret);
+
+      if ( ! opt_untilObj ) {
+        this.usedStr = resultStr;
+
+        // Also update tailStr to keep it in sync with usedStr.
+        // This prevents stale tailStr from being passed to newly created child mementos.
+        if ( tailRet ) {
+          this.tailStr = this.toString(tailRet);
+        }
+      }
 
       return ret;
     }
@@ -258,7 +272,6 @@ foam.CLASS({
       code: function(slot) {
         if ( this.feedback_ ) return;
         if ( this.parent && this.parent.tail !== this ) {
-          // console.log('***************** update() of orphaned Memento');
           // Update received from a child
           if ( slot ) {
             slot.detach();
@@ -267,7 +280,6 @@ foam.CLASS({
           }
           return;
         }
-// console.log('*** update() objClass:', this.obj && this.obj.cls_.name, 'property:', arguments[2], 'value:', arguments[3]?.get());
         this.update_();
       }
     },
@@ -276,7 +288,6 @@ foam.CLASS({
       isMerged: true,
       mergeDelay: 32,
       code: function() {
-        // console.log('*** update_(): ', this.$UID, this.cls_.name, 'objClass:', this.obj.cls_.name, 'tail:', this.tail && (this.tail.$UID + ' ' + this.tail.usedStr), 'usedStr:', this.usedStr);
         if ( this.parent ) {
           this.parent.update();
         } else {
@@ -326,7 +337,6 @@ foam.CLASS({
       // Not framed or merged so can detect hashFeedback_ properly
       documentation: 'Called when the window hash is updated, causes update to memento.',
       code: function() {
-        // console.log('onHashChange', this.hashFeedback_, this.window.location.hash);
         if ( this.hashFeedback_ ) return;
         this.str = this.window.location.hash.substring(1);
       }
@@ -339,11 +349,13 @@ foam.CLASS({
         let route    = this.usedStr.split('?')[0];
         let winRoute = this.window.location.hash.substring(1).split('?')[0];
         let self = this;
+
         if ( route == winRoute ) {
           this.window.history.replaceState(null,'','#' + this.usedStr)
         } else {
           this.window.history.pushState(null, '', '#' + this.usedStr)
         }
+
         // Title needs to be set here otherwise title changes before the memento does and we get incorrect document titles
         if ( this.breadcrumbs ) {
           if ( this.detacher_ ) this.detacher_.detach();


### PR DESCRIPTION
## Problem
Filter state was being lost when navigating from a DAO browse view to a detail view and back. For example, selecting 6 email filters, clicking a row to view details, then clicking the breadcrumb to return would result in only 4 filters remaining. The `tailStr` property (which passes memento state to child views) was only updated when parsing incoming URL strings, not when encoding outgoing state changes. This caused newly created child mementos to receive stale filter state.

## Solution
Update `tailStr` in the `encode()` method to keep it synchronized with `usedStr`. When the memento chain encodes its current state to the URL, it now also updates `tailStr` with the tail's encoded value. This ensures that when a new child memento is created (e.g., when navigating to a detail view), it receives the current up-to-date state rather than a cached stale value.

## Changes
- Modified `encode()` to save tail's encoding result before modifying the return object
- Added logic to update `tailStr` after setting `usedStr` to keep them in sync
- Removed commented-out debug logging that was no longer needed
