### PR TITLE
PT-FIXES: DOS-2125 Fix memento navigation for multipart ID records

### DIFF
--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1574,7 +1574,8 @@ foam.CLASS({
   methods: [
     function toE(args, X) {
       return foam.u2.ViewSpec.createView(
-        { class: 'foam.u2.DetailView', showActions: true, data: this },
+        // Mark as inline view so it doesn't participate in navigation memento chain
+        { class: 'foam.u2.DetailView', showActions: true, data: this, isInlineView_: true },
         args, this, X);
     }
   ]

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1573,10 +1573,14 @@ foam.CLASS({
   refines: 'foam.lang.FObject',
   methods: [
     function toE(args, X) {
+      var ctx = X?.__context__ || this.__context__ || foam.__context__;
+      // Create isolated memento so inline views don't participate in navigation chain
+      var isolatedCtx = ctx.createSubContext({
+        memento_: foam.u2.memento.Memento.create({obj: this}, ctx)
+      });
       return foam.u2.ViewSpec.createView(
-        // Mark as inline view so it doesn't participate in navigation memento chain
-        { class: 'foam.u2.DetailView', showActions: true, data: this, isInlineView_: true },
-        args, this, X);
+        { class: 'foam.u2.DetailView', showActions: true, data: this },
+        args, this, isolatedCtx);
     }
   ]
 });

--- a/src/foam/u2/memento/Memento.js
+++ b/src/foam/u2/memento/Memento.js
@@ -389,24 +389,11 @@ foam.CLASS({
 
   properties: [
     {
-      class: 'Boolean',
-      name: 'isInlineView_',
-      documentation: 'If true, this view was created inline (via toE) and should not participate in navigation memento chain.',
-      hidden: true,
-      transient: true
-    },
-    {
       name: 'memento_',
       documentation: 'Memento bound to this object.',
       hidden: true,
       transient: true,
       factory: function() {
-        // Inline views (created via toE for property display) should not participate
-        // in the navigation memento chain - they would incorrectly overwrite the
-        // navigation tail and orphan the real navigation views.
-        if ( this.isInlineView_ ) {
-          return this.Memento.create({obj: this}, this); // No parent = isolated memento
-        }
         // If no top-level Memento found, then create a WindowHashMemento to be
         // the top-level one.
         return this.parentMemento_ ?
@@ -419,11 +406,6 @@ foam.CLASS({
   methods: [
     function initArgs(args, opt_parent) {
       this.SUPER(null, opt_parent);
-      // Set isInlineView_ from args BEFORE memento_ factory runs
-      // because memento_ factory needs to check this flag
-      if ( args && args.isInlineView_ ) {
-        this.isInlineView_ = args.isInlineView_;
-      }
       this.memento_;
       // Copy args again cause context was needed for mementos
       this.SUPER(args);

--- a/src/foam/u2/memento/Memento.js
+++ b/src/foam/u2/memento/Memento.js
@@ -391,11 +391,24 @@ foam.CLASS({
 
   properties: [
     {
+      class: 'Boolean',
+      name: 'isInlineView_',
+      documentation: 'If true, this view was created inline (via toE) and should not participate in navigation memento chain.',
+      hidden: true,
+      transient: true
+    },
+    {
       name: 'memento_',
       documentation: 'Memento bound to this object.',
       hidden: true,
       transient: true,
       factory: function() {
+        // Inline views (created via toE for property display) should not participate
+        // in the navigation memento chain - they would incorrectly overwrite the
+        // navigation tail and orphan the real navigation views.
+        if ( this.isInlineView_ ) {
+          return this.Memento.create({obj: this}, this); // No parent = isolated memento
+        }
         // If no top-level Memento found, then create a WindowHashMemento to be
         // the top-level one.
         return this.parentMemento_ ?
@@ -408,6 +421,11 @@ foam.CLASS({
   methods: [
     function initArgs(args, opt_parent) {
       this.SUPER(null, opt_parent);
+      // Set isInlineView_ from args BEFORE memento_ factory runs
+      // because memento_ factory needs to check this flag
+      if ( args && args.isInlineView_ ) {
+        this.isInlineView_ = args.isInlineView_;
+      }
       this.memento_;
       // Copy args again cause context was needed for mementos
       this.SUPER(args);

--- a/src/foam/u2/memento/Memento.js
+++ b/src/foam/u2/memento/Memento.js
@@ -52,15 +52,37 @@ foam.CLASS({
       documentation: 'Set to true when "str" is being set to prevent feedback.'
     },
     {
+      class: 'Boolean',
+      name: 'parentInitiated_',
+      documentation: 'Set to true when str is being set from parent postSet.'
+    },
+    {
       name: 'parent',
       postSet: function(_, p) {
+        // Don't overwrite an existing routed tail with an embedded/inline view.
+        // Embedded views (like foam.u2.DetailView created via FObject.toE) shouldn't
+        // affect the navigation chain. Only views with a 'route' property (routers)
+        // should be able to set themselves as tail.
+        var childHasRoute = this.obj?.cls_?.getAxiomByName?.('route')?.memorable;
+        var existingTailHasRoute = p.tail?.obj?.cls_?.getAxiomByName?.('route')?.memorable;
+
+        if ( p.tail && existingTailHasRoute && ! childHasRoute ) {
+          // Don't overwrite a router's tail with a non-router view
+          this.parentInitiated_ = true;
+          this.str = p.tailStr;
+          this.parentInitiated_ = false;
+          return;
+        }
+
         p.tail   = this;
         // Should this be done? Maybe only for something like AltView, so it
         // should do it.
         // If the child is created after the parent (which is usual), then we
         // need to keep the tailStr around until then. But if something like
         // a menu is switched, don't want to keep orphaned bindings.
+        this.parentInitiated_ = true;
         this.str = p.tailStr;
+        this.parentInitiated_ = false;
       },
       documentation: 'The parent Memento for this Memento (parent.tail == this).'
     },
@@ -110,7 +132,7 @@ foam.CLASS({
             var value = consumeBinding(p.shortName || p.name);
             // Remove the tail memento if the route changes to prevent retaining stale parameters.
             if ( ( p.name === 'route' || p.shortName === 'route' ) && this.obj[p.name] !== value && this.tail ) {
-              // this.detachTail();
+              this.detachTail();
             }
             // Even if value doesn't exist, then still set, to revert to default value
             value = value && decodeURIComponent(value);
@@ -121,6 +143,9 @@ foam.CLASS({
         } finally {
           this.feedback_ = false;
         }
+        // Trigger update to propagate changes to root (was blocked during parsing by feedback_)
+        // Don't update if str was set from parent postSet (parent chain handles that)
+        if ( ! this.parentInitiated_ ) this.update();
       }
     },
     {
@@ -151,7 +176,6 @@ foam.CLASS({
     },
 
     function detachTail() {
-      // console.log('detaching tail', this.tailStr)
       this.tail?.detach();
       this.tail = null;
       this.tailStr = '';
@@ -234,7 +258,9 @@ foam.CLASS({
         }
       });
 
-      if ( ! opt_untilObj ) this.usedStr = this.toString(ret);
+      if ( ! opt_untilObj ) {
+        this.usedStr = this.toString(ret);
+      }
 
       return ret;
     }
@@ -258,8 +284,7 @@ foam.CLASS({
       code: function(slot) {
         if ( this.feedback_ ) return;
         if ( this.parent && this.parent.tail !== this ) {
-          // console.log('***************** update() of orphaned Memento');
-          // Update received from a child
+          // Orphaned memento - parent's tail was changed to something else
           if ( slot ) {
             slot.detach();
           } else {
@@ -267,7 +292,6 @@ foam.CLASS({
           }
           return;
         }
-// console.log('*** update() objClass:', this.obj && this.obj.cls_.name, 'property:', arguments[2], 'value:', arguments[3]?.get());
         this.update_();
       }
     },
@@ -276,7 +300,6 @@ foam.CLASS({
       isMerged: true,
       mergeDelay: 32,
       code: function() {
-        // console.log('*** update_(): ', this.$UID, this.cls_.name, 'objClass:', this.obj.cls_.name, 'tail:', this.tail && (this.tail.$UID + ' ' + this.tail.usedStr), 'usedStr:', this.usedStr);
         if ( this.parent ) {
           this.parent.update();
         } else {
@@ -306,6 +329,12 @@ foam.CLASS({
       name: 'hashFeedback_',
       hidden: true
     },
+    {
+      class: 'Boolean',
+      name: 'initializing_',
+      documentation: 'True during initial URL parse to prevent premature URL updates.',
+      hidden: true
+    },
     'detacher_'
   ],
 
@@ -313,10 +342,18 @@ foam.CLASS({
     function init() {
       this.SUPER();
 
+      // Set initializing flag to prevent URL updates during initial parse
+      this.initializing_ = true;
       this.onHashChange();
       this.window.onpopstate = this.onHashChange;
       this.usedStr$.sub(this.onMementoChange);
-      this.window.history.replaceState({},'',this.window.location.href)
+      this.window.history.replaceState({},'',this.window.location.href);
+      // Clear initializing flag after merge delay (32ms) + buffer to allow chain to establish
+      // Then trigger update to sync URL with established chain
+      this.window.setTimeout(() => {
+        this.initializing_ = false;
+        this.update();
+      }, 100);
     }
   ],
 
@@ -326,7 +363,6 @@ foam.CLASS({
       // Not framed or merged so can detect hashFeedback_ properly
       documentation: 'Called when the window hash is updated, causes update to memento.',
       code: function() {
-        // console.log('onHashChange', this.hashFeedback_, this.window.location.hash);
         if ( this.hashFeedback_ ) return;
         this.str = this.window.location.hash.substring(1);
       }
@@ -335,6 +371,8 @@ foam.CLASS({
       name: 'onMementoChange',
       documentation: 'Called when the memento changes, causes update to hash.',
       code: function() {
+        // Skip URL updates during initial parse - chain not yet established
+        if ( this.initializing_ ) return;
         this.hashFeedback_ = true;
         let route    = this.usedStr.split('?')[0];
         let winRoute = this.window.location.hash.substring(1).split('?')[0];
@@ -391,11 +429,24 @@ foam.CLASS({
 
   properties: [
     {
+      class: 'Boolean',
+      name: 'isInlineView_',
+      documentation: 'If true, this view was created inline (via toE) and should not participate in navigation memento chain.',
+      hidden: true,
+      transient: true
+    },
+    {
       name: 'memento_',
       documentation: 'Memento bound to this object.',
       hidden: true,
       transient: true,
       factory: function() {
+        // Inline views (created via toE for property display) should not participate
+        // in the navigation memento chain - they would incorrectly overwrite the
+        // navigation tail and orphan the real navigation views.
+        if ( this.isInlineView_ ) {
+          return this.Memento.create({obj: this}, this); // No parent = isolated memento
+        }
         // If no top-level Memento found, then create a WindowHashMemento to be
         // the top-level one.
         return this.parentMemento_ ?
@@ -408,6 +459,11 @@ foam.CLASS({
   methods: [
     function initArgs(args, opt_parent) {
       this.SUPER(null, opt_parent);
+      // Set isInlineView_ from args BEFORE memento_ factory runs
+      // because memento_ factory needs to check this flag
+      if ( args && args.isInlineView_ ) {
+        this.isInlineView_ = args.isInlineView_;
+      }
       this.memento_;
       // Copy args again cause context was needed for mementos
       this.SUPER(args);

--- a/src/foam/u2/memento/Memento.js
+++ b/src/foam/u2/memento/Memento.js
@@ -52,37 +52,15 @@ foam.CLASS({
       documentation: 'Set to true when "str" is being set to prevent feedback.'
     },
     {
-      class: 'Boolean',
-      name: 'parentInitiated_',
-      documentation: 'Set to true when str is being set from parent postSet.'
-    },
-    {
       name: 'parent',
       postSet: function(_, p) {
-        // Don't overwrite an existing routed tail with an embedded/inline view.
-        // Embedded views (like foam.u2.DetailView created via FObject.toE) shouldn't
-        // affect the navigation chain. Only views with a 'route' property (routers)
-        // should be able to set themselves as tail.
-        var childHasRoute = this.obj?.cls_?.getAxiomByName?.('route')?.memorable;
-        var existingTailHasRoute = p.tail?.obj?.cls_?.getAxiomByName?.('route')?.memorable;
-
-        if ( p.tail && existingTailHasRoute && ! childHasRoute ) {
-          // Don't overwrite a router's tail with a non-router view
-          this.parentInitiated_ = true;
-          this.str = p.tailStr;
-          this.parentInitiated_ = false;
-          return;
-        }
-
         p.tail   = this;
         // Should this be done? Maybe only for something like AltView, so it
         // should do it.
         // If the child is created after the parent (which is usual), then we
         // need to keep the tailStr around until then. But if something like
         // a menu is switched, don't want to keep orphaned bindings.
-        this.parentInitiated_ = true;
         this.str = p.tailStr;
-        this.parentInitiated_ = false;
       },
       documentation: 'The parent Memento for this Memento (parent.tail == this).'
     },
@@ -132,7 +110,7 @@ foam.CLASS({
             var value = consumeBinding(p.shortName || p.name);
             // Remove the tail memento if the route changes to prevent retaining stale parameters.
             if ( ( p.name === 'route' || p.shortName === 'route' ) && this.obj[p.name] !== value && this.tail ) {
-              this.detachTail();
+              // this.detachTail();
             }
             // Even if value doesn't exist, then still set, to revert to default value
             value = value && decodeURIComponent(value);
@@ -143,9 +121,6 @@ foam.CLASS({
         } finally {
           this.feedback_ = false;
         }
-        // Trigger update to propagate changes to root (was blocked during parsing by feedback_)
-        // Don't update if str was set from parent postSet (parent chain handles that)
-        if ( ! this.parentInitiated_ ) this.update();
       }
     },
     {
@@ -329,12 +304,6 @@ foam.CLASS({
       name: 'hashFeedback_',
       hidden: true
     },
-    {
-      class: 'Boolean',
-      name: 'initializing_',
-      documentation: 'True during initial URL parse to prevent premature URL updates.',
-      hidden: true
-    },
     'detacher_'
   ],
 
@@ -342,18 +311,10 @@ foam.CLASS({
     function init() {
       this.SUPER();
 
-      // Set initializing flag to prevent URL updates during initial parse
-      this.initializing_ = true;
       this.onHashChange();
       this.window.onpopstate = this.onHashChange;
       this.usedStr$.sub(this.onMementoChange);
-      this.window.history.replaceState({},'',this.window.location.href);
-      // Clear initializing flag after merge delay (32ms) + buffer to allow chain to establish
-      // Then trigger update to sync URL with established chain
-      this.window.setTimeout(() => {
-        this.initializing_ = false;
-        this.update();
-      }, 100);
+      this.window.history.replaceState({},'',this.window.location.href)
     }
   ],
 
@@ -363,6 +324,7 @@ foam.CLASS({
       // Not framed or merged so can detect hashFeedback_ properly
       documentation: 'Called when the window hash is updated, causes update to memento.',
       code: function() {
+        // console.log('onHashChange', this.hashFeedback_, this.window.location.hash);
         if ( this.hashFeedback_ ) return;
         this.str = this.window.location.hash.substring(1);
       }
@@ -371,8 +333,6 @@ foam.CLASS({
       name: 'onMementoChange',
       documentation: 'Called when the memento changes, causes update to hash.',
       code: function() {
-        // Skip URL updates during initial parse - chain not yet established
-        if ( this.initializing_ ) return;
         this.hashFeedback_ = true;
         let route    = this.usedStr.split('?')[0];
         let winRoute = this.window.location.hash.substring(1).split('?')[0];


### PR DESCRIPTION

## Problem
When navigating to detail views of records with multipart IDs (composite keys), the URL would fail to update correctly after the first navigation. Inline views created via `FObject.toE()` (for displaying properties) were connecting to the navigation memento chain, orphaning the DAOController and breaking subsequent URL updates.

## Solution
Create an isolated memento context for inline views in `FObject.toE()`. By passing a pre-created isolated Memento in the context, inline DetailViews no longer participate in the navigation chain, preventing them from disrupting the memento hierarchy.

## Changes
- Modified `FObject.toE()` to create an isolated context with its own Memento
