### PR TITLE
Enable NDiff on Flow DAO and Improve Compare UI

### DIFF
--- a/src/foam/core/ndiff/NDiff.js
+++ b/src/foam/core/ndiff/NDiff.js
@@ -10,7 +10,14 @@ foam.CLASS({
   documentation: `Tracks changes to cSpecs. Used for debugging`,
   requires: [
     'foam.u2.dialog.Popup',
+    'foam.core.ndiff.NDiffId'
   ],
+
+  css: `
+    .ndiff-compare-modal .foam-u2-dialog-StyledModal-wrapper {
+      width: min(95vw, 1200px);
+    }
+  `,
   tableColumns: [
     'cSpecName',
     'objectId',
@@ -50,9 +57,10 @@ foam.CLASS({
       class: 'FObjectProperty',
       visibility: 'HIDDEN',
       documentation: `
-        The object as it was loaded from the runtime journals
+        The current runtime state of the object (fetched on-the-fly during select)
       `,
       storageTransient: true,
+      networkTransient: false,
     },
     {
       name: 'applyOriginal',
@@ -65,6 +73,7 @@ foam.CLASS({
         The flag will then automatically be set to false.
         `,
       storageTransient: true,
+      networkTransient: false
     }
   ],
 
@@ -76,18 +85,65 @@ foam.CLASS({
       confirmationRequired: function() {
         return true;
       },
-      code: function(X) {
-        this.applyOriginal = true;
-        X.dao.put(this);
+      code: async function(X) {
+        var self = this;
+
+        // Fetch full NDiff to get complete initialFObject (projection may have filtered fields)
+        var fullNdiff = await X.ndiffDAO.find(foam.core.ndiff.NDiffId.create({
+          cSpecName: self.cSpecName,
+          objectId: self.objectId
+        }));
+
+        if ( ! fullNdiff || ! fullNdiff.initialFObject ) {
+          console.warn('NDiff.apply: Could not fetch full NDiff or initialFObject');
+          return;
+        }
+
+        fullNdiff.applyOriginal = true;
+        await X.ndiffDAO.put(fullNdiff);
       }
     },
     {
       name: 'compare',
       label: 'Compare Changes',
       tableWidth: 25,
-      code: function(X) {
-        X.ctrl.add(foam.u2.dialog.StyledModal.create({ title: 'Comparison' }, this)
-          .tag({class: 'foam.u2.view.ComparisonView', left: this.initialFObject, right: this.runtimeFObject})
+      code: async function(X) {
+        var self = this;
+
+        // Fetch full NDiff to get complete initialFObject (projection may have filtered fields)
+        var fullNdiff = await X.ndiffDAO.find(foam.core.ndiff.NDiffId.create({
+          cSpecName: self.cSpecName,
+          objectId: self.objectId
+        }));
+
+        if ( ! fullNdiff || ! fullNdiff.initialFObject ) {
+          console.warn('NDiff.compare: Could not fetch full NDiff or initialFObject');
+          return;
+        }
+
+        var initialFObject = fullNdiff.initialFObject;
+
+        // Fetch runtime object from the target DAO
+        var targetDAO = X[self.cSpecName];
+        var runtimeFObject = null;
+
+        if ( targetDAO ) {
+          var id = initialFObject.id;
+          runtimeFObject = await targetDAO.find(id);
+        }
+
+        // Create comparison modal - ComparisonView handles all the diff logic and UI
+        X.ctrl.add(
+          foam.u2.dialog.StyledModal.create({
+            title: 'Comparison: ' + self.objectId,
+            maxWidth: 'min(95vw, 1200px)'
+          }, self)
+            .addClass('ndiff-compare-modal')
+            .tag({
+              class: 'foam.u2.view.ComparisonView',
+              left: initialFObject,
+              right: runtimeFObject
+            })
         );
       }
     }

--- a/src/foam/core/ndiff/NDiff.js
+++ b/src/foam/core/ndiff/NDiff.js
@@ -34,6 +34,7 @@ foam.CLASS({
     {
       name: 'objectId',
       class: 'String',
+      projectionSafe: false
     },
     {
       name: 'deletedAtRuntime',

--- a/src/foam/core/ndiff/NDiff.js
+++ b/src/foam/core/ndiff/NDiff.js
@@ -9,8 +9,7 @@ foam.CLASS({
   name: 'NDiff',
   documentation: `Tracks changes to cSpecs. Used for debugging`,
   requires: [
-    'foam.u2.dialog.Popup',
-    'foam.core.ndiff.NDiffId'
+    'foam.u2.dialog.Popup'
   ],
 
   css: `
@@ -48,18 +47,20 @@ foam.CLASS({
       name: 'initialFObject',
       class: 'FObjectProperty',
       visibility: 'HIDDEN',
+      projectionSafe: false,
       documentation: `
         The object as it was loaded from the repo journals (".0 file")
-        `,
+        `
     },
     {
       name: 'runtimeFObject',
       class: 'FObjectProperty',
       visibility: 'HIDDEN',
+      projectionSafe: false,
+      storageTransient: true,
       documentation: `
         The current runtime state of the object (fetched on-the-fly during select)
-      `,
-      storageTransient: true
+      `
     },
     {
       name: 'applyOriginal',
@@ -84,21 +85,8 @@ foam.CLASS({
         return true;
       },
       code: async function(X) {
-        var self = this;
-
-        // Fetch full NDiff to get complete initialFObject (projection may have filtered fields)
-        var fullNdiff = await X.ndiffDAO.find(foam.core.ndiff.NDiffId.create({
-          cSpecName: self.cSpecName,
-          objectId: self.objectId
-        }));
-
-        if ( ! fullNdiff || ! fullNdiff.initialFObject ) {
-          console.warn('NDiff.apply: Could not fetch full NDiff or initialFObject');
-          return;
-        }
-
-        fullNdiff.applyOriginal = true;
-        await X.ndiffDAO.put(fullNdiff);
+        this.applyOriginal = true;
+        await X.ndiffDAO.put(this);
       }
     },
     {
@@ -108,26 +96,12 @@ foam.CLASS({
       code: async function(X) {
         var self = this;
 
-        // Fetch full NDiff to get complete initialFObject (projection may have filtered fields)
-        var fullNdiff = await X.ndiffDAO.find(foam.core.ndiff.NDiffId.create({
-          cSpecName: self.cSpecName,
-          objectId: self.objectId
-        }));
-
-        if ( ! fullNdiff || ! fullNdiff.initialFObject ) {
-          console.warn('NDiff.compare: Could not fetch full NDiff or initialFObject');
-          return;
-        }
-
-        var initialFObject = fullNdiff.initialFObject;
-
-        // Fetch runtime object from the target DAO
+        // Fetch latest runtime object from target DAO for accurate comparison
         var targetDAO = X[self.cSpecName];
         var runtimeFObject = null;
 
-        if ( targetDAO ) {
-          var id = initialFObject.id;
-          runtimeFObject = await targetDAO.find(id);
+        if ( targetDAO && self.initialFObject ) {
+          runtimeFObject = await targetDAO.find(self.initialFObject.id);
         }
 
         // Create comparison modal - ComparisonView handles all the diff logic and UI
@@ -139,7 +113,7 @@ foam.CLASS({
             .addClass('ndiff-compare-modal')
             .tag({
               class: 'foam.u2.view.ComparisonView',
-              left: initialFObject,
+              left: self.initialFObject,
               right: runtimeFObject
             })
         );

--- a/src/foam/core/ndiff/NDiff.js
+++ b/src/foam/core/ndiff/NDiff.js
@@ -59,8 +59,7 @@ foam.CLASS({
       documentation: `
         The current runtime state of the object (fetched on-the-fly during select)
       `,
-      storageTransient: true,
-      networkTransient: false,
+      storageTransient: true
     },
     {
       name: 'applyOriginal',
@@ -72,8 +71,7 @@ foam.CLASS({
         the initialFObject to its respective DAO.
         The flag will then automatically be set to false.
         `,
-      storageTransient: true,
-      networkTransient: false
+      storageTransient: true
     }
   ],
 

--- a/src/foam/core/ndiff/NDiffRuntimeDAO.js
+++ b/src/foam/core/ndiff/NDiffRuntimeDAO.js
@@ -36,15 +36,17 @@ foam.CLASS({
 
           String cSpecName = ndiff.getCSpecName();
           DAO dao = (DAO)x.get(cSpecName);
-          if ( dao != null ) {  
+
+          if ( dao != null ) {
             // the dao is almost certainly being decorated by NDiffDAO.
             // this put_ will recursively call this function and we
-            // won't be able to restore the result. 
-            dao.put_(x, ndiff.getInitialFObject()); 
-        
+            // won't be able to restore the result.
+            FObject initialFObject = ndiff.getInitialFObject();
+            dao.put_(x, initialFObject);
+
             var newNdiff = (NDiff) this.find_(x, new NDiffId(ndiff.getCSpecName(),
                                              ndiff.getObjectId()));
-            
+
             ndiff = newNdiff != null ? (NDiff)newNdiff.fclone() : ndiff;
 
             ndiff.setDeletedAtRuntime(false);
@@ -110,15 +112,15 @@ foam.CLASS({
             // we have to call the DAO to get the runtime object
             // and to set the deletedAtRuntime flag.
             // looks slow, but the predicate filters out unchanged
-            // ndiffs ahead of time. 
+            // ndiffs ahead of time.
             // (important: predicate MUST be applied or problems happen)
 
             NDiff ndiff = (NDiff)( ((NDiff)obj).fclone() );
             FObject initialFObject = ndiff.getInitialFObject();
-          
+
             String cSpecName = ndiff.getCSpecName();
             DAO dao = (DAO)x.get(cSpecName);
-            Object id = initialFObject.getProperty("id");    
+            Object id = initialFObject.getProperty("id");
             FObject runtimeFObject = dao.find_(x, id);
 
             var deletedAtRuntime = runtimeFObject == null;
@@ -126,7 +128,7 @@ foam.CLASS({
             if ( ! deletedAtRuntime ) {
               ndiff.setRuntimeFObject(runtimeFObject);
             }
-            
+
             super.put(ndiff,sub);
           }
         };

--- a/src/foam/core/ndiff/menus.jrl
+++ b/src/foam/core/ndiff/menus.jrl
@@ -7,6 +7,7 @@ p({
     "config":{
       "class":"foam.comics.v2.DAOControllerConfig",
       "daoKey":"ndiffDAO",
+      "disableSelection": true,
       "summaryView": {
         "class": "foam.u2.table.TableView",
         "editColumnsEnabled": true,

--- a/src/foam/core/reflow/services.jrl
+++ b/src/foam/core/reflow/services.jrl
@@ -27,6 +27,7 @@ p({
   """
     return new foam.dao.EasyDAO.Builder(x)
       .setPm(true)
+      .setNdiff(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("flows")
       .setOf(foam.core.reflow.Flow.getOwnClassInfo())

--- a/src/foam/u2/view/ComparisonView.js
+++ b/src/foam/u2/view/ComparisonView.js
@@ -8,6 +8,8 @@
   package: 'foam.u2.view',
   name: 'ComparisonView',
   extends: 'foam.u2.View',
+  documentation: 'Displays a side-by-side comparison of two FObjects with a summary of changes.',
+
   requires: [
     'foam.lang.FObject',
     'foam.u2.ModalHeader',
@@ -16,41 +18,157 @@
     'foam.u2.layout.Cols'
   ],
 
+  css: `
+    ^summary-box {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      border-radius: 6px;
+      margin-bottom: 16px;
+    }
+    ^summary-deleted {
+      background-color: $destructive50;
+      border: 1px solid $destructive200;
+    }
+    ^summary-changed {
+      background-color: transparent;
+      border: none;
+      padding-left: 0;
+      padding-right: 0;
+    }
+    ^summary-unchanged {
+      background-color: $success50;
+      border: 1px solid $success200;
+    }
+    ^summary-label {
+      font-weight: $font-medium;
+      color: $textSecondary;
+    }
+    ^field-chip {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 12px;
+      font-size: 0.85em;
+      background-color: $warn100;
+      color: $warn700;
+    }
+    ^columns {
+      display: flex;
+      gap: 24px;
+    }
+    ^column {
+      flex: 1;
+      min-width: 0;
+    }
+    ^column-header {
+      font-weight: $font-medium;
+      padding-bottom: 8px;
+      margin-bottom: 8px;
+      border-bottom: 1px solid $borderLight;
+    }
+  `,
+
   properties: [
     {
       name: 'left',
-      type: 'FObject'
+      type: 'FObject',
+      documentation: 'The "before" object (original/initial state)'
     },
     {
       name: 'right',
-      type: 'FObject'
+      type: 'FObject',
+      documentation: 'The "after" object (current/runtime state). Null if deleted.'
+    },
+    {
+      name: 'changedFields',
+      class: 'StringArray',
+      documentation: 'List of field names that differ between left and right objects.',
+      factory: function() {
+        return this.calculateChangedFields();
+      }
     }
   ],
+
   methods: [
+    function calculateChangedFields() {
+      var changed = [];
+      if ( ! this.left || ! this.right ) return changed;
+
+      var keys = Object.keys(this.left.instance_ || {});
+      for ( var i = 0 ; i < keys.length ; i++ ) {
+        var key = keys[i];
+        if ( key.endsWith('$') ) continue; // Skip slot properties
+        var leftValue = this.left[key];
+        var rightValue = this.right[key];
+        if ( ! foam.util.equals(leftValue, rightValue) ) {
+          changed.push(key);
+        }
+      }
+      return changed;
+    },
+
     function render() {
       this.SUPER();
+      var self = this;
 
-      this.addClass()
-      .startContext({controllerMode: foam.u2.ControllerMode.VIEW})
-      .start()
-        .start(this.Cols)
-          .start()
-            .addClass('h500')
-            .add('Before')
-            .tag(this.VerticalDetailView, { showTitle: true, title: 'Before', data: this.left })
+      this.addClass();
+
+      // Render summary section
+      this.renderSummary();
+
+      // Render comparison columns
+      this
+        .startContext({ controllerMode: foam.u2.ControllerMode.VIEW })
+        .start().addClass(this.myClass('columns'))
+          .start().addClass(this.myClass('column'))
+            .start('div').addClass(this.myClass('column-header')).add('Before').end()
+            .tag(this.VerticalDetailView, { data: this.left })
           .end()
-          .start()
-            .addClass('h500')
-            .add('After')
-            .tag(this.VerticalDetailView, { showTitle: true, title: 'After', data: this.right })
+          .start().addClass(this.myClass('column'))
+            .start('div').addClass(this.myClass('column-header')).add('After').end()
+            .call(function() {
+              if ( self.right ) {
+                this.tag(self.VerticalDetailView, { data: self.right });
+              } else {
+                this.start('div')
+                  .style({ color: '$textTertiary', 'font-style': 'italic', padding: '16px' })
+                  .add('Object has been deleted')
+                .end();
+              }
+            })
           .end()
         .end()
-      .end()
-      .endContext();
+        .endContext();
+    },
 
-      // this.tag(this.DetailView, { data: this.left });
-      // this.tag(this.DetailView, { data: this.right });
+    function renderSummary() {
+      var summaryBox = this.start('div').addClass(this.myClass('summary-box'));
+
+      if ( this.right == null ) {
+        // Object was deleted
+        summaryBox
+          .addClass(this.myClass('summary-deleted'))
+          .start('span').addClass(this.myClass('summary-label')).add('Status:').end()
+          .add(' Object was deleted at runtime');
+      } else if ( this.changedFields.length > 0 ) {
+        // Object has changes
+        summaryBox
+          .addClass(this.myClass('summary-changed'))
+          .start('span').addClass(this.myClass('summary-label')).add('Changed fields:').end();
+        for ( var i = 0 ; i < this.changedFields.length ; i++ ) {
+          summaryBox.start('span').addClass(this.myClass('field-chip')).add(this.changedFields[i]).end();
+        }
+      } else {
+        // No changes
+        summaryBox
+          .addClass(this.myClass('summary-unchanged'))
+          .start('span').addClass(this.myClass('summary-label')).add('Status:').end()
+          .add(' No changes detected');
+      }
+
+      summaryBox.end();
     }
   ]
-
 });

--- a/src/foam/u2/view/ComparisonView.js
+++ b/src/foam/u2/view/ComparisonView.js
@@ -96,16 +96,24 @@
       var changed = [];
       if ( ! this.left || ! this.right ) return changed;
 
-      var keys = Object.keys(this.left.instance_ || {});
-      for ( var i = 0 ; i < keys.length ; i++ ) {
-        var key = keys[i];
-        if ( key.endsWith('$') ) continue; // Skip slot properties
-        var leftValue = this.left[key];
-        var rightValue = this.right[key];
-        if ( ! foam.util.equals(leftValue, rightValue) ) {
-          changed.push(key);
+      // Use the model's properties (axioms) to compare
+      var cls = this.left.cls_;
+      if ( ! cls || ! cls.getAxiomsByClass ) return changed;
+
+      try {
+        var props = cls.getAxiomsByClass(foam.lang.Property);
+        for ( var i = 0 ; i < props.length ; i++ ) {
+          var prop = props[i];
+          var leftValue = prop.get(this.left);
+          var rightValue = prop.get(this.right);
+          if ( ! foam.util.equals(leftValue, rightValue) ) {
+            changed.push(prop.label || prop.name);
+          }
         }
+      } catch ( e ) {
+        console.warn('ComparisonView: Error calculating changed fields', e);
       }
+
       return changed;
     },
 


### PR DESCRIPTION

## Problem
The NDiff "Compare Changes" and "Apply Original" actions were not working correctly:
1. Table projections filtered out FObjectProperty fields like `initialFObject`, causing actions to receive incomplete data
2. Clicking on table rows opened detail view, but NDiff `find_()` doesn't work correctly for detail editing
3. ComparisonView had no visual summary of what changed between objects
4. The comparison modal was too narrow to display side-by-side comparisons effectively

## Solution
1. Added `projectionSafe: false` to visible columns to force full object fetch in table views
2. Added `disableSelection: true` to prevent row click from opening detail view
3. Enhanced ComparisonView with automatic change detection using model axioms
4. Added responsive modal width CSS

## Changes
- Enable NDiff tracking on flowDAO via `.setNdiff(true)` in services.jrl
- Added `projectionSafe: false` to `objectId`, `initialFObject`, and `runtimeFObject` properties
- Added `disableSelection: true` to menus.jrl to prevent row click to detail view
- ComparisonView now calculates changed fields using `cls.getAxiomsByClass(foam.lang.Property)`
- Added status-based styling: red for deleted, yellow chips for changed fields, green for unchanged
- Added responsive modal width (95vw up to 1200px max)
- Improved column layout with styled headers
- Minor whitespace cleanup in NDiffRuntimeDAO.js
