### PR TITLE
fix(choice-view): prevent auto-selection of single choice when placeholder is set

### DIFF
--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -251,7 +251,8 @@ foam.CLASS({
       this.SUPER();
       var self = this;
 
-      if ( ! this.choice && this.choices.length == 1 ) this.data = this.choices[0][0];
+      // Only auto-select single choice if no placeholder is set
+      if ( ! this.choice && this.choices.length == 1 && ! this.placeholder ) this.data = this.choices[0][0];
 
       // If no item is selected, and data has not been provided, select the 0th
       // entry.


### PR DESCRIPTION
## Problem
When a ChoiceView had exactly one choice and a placeholder was configured, it would still auto-select the single choice, ignoring the placeholder. This made it impossible to have an optional FObjectProperty default to "empty/none" when there was only one strategy available.

## Solution
Added a check for `this.placeholder` to the single-choice auto-select condition in ChoiceView's render method. Now when a placeholder is set, the single choice won't be automatically selected, allowing the placeholder to be displayed as expected.

## Changes
- Added `&& ! this.placeholder` condition to the single-choice auto-select logic in ChoiceView.render()
- Added comment explaining the behavior
