### PR TITLE
Fix GroupBy dynamic model naming conflicts

### DIFF
--- a/src/foam/mlang/sink/GroupBy.js
+++ b/src/foam/mlang/sink/GroupBy.js
@@ -264,11 +264,27 @@ for (Object key : getGroups().keySet()) {
         expr = expr.delegate || expr.arg1;
       }
 
-      // Generate deterministic name based on source class, property name, and sink type
-      // This prevents conflicts in chained GroupBy operations
+      // Generate deterministic name based on source class, property name, sink type, AND property names
+      // This ensures:
+      // 1. Same GroupBy structure always gets the same model name (needed for reload/persistence)
+      // 2. Different internal sink structures get different model names (prevents property conflicts)
+      //
+      // Example: GroupBy(Transaction.currency, Sequence[LabeledSink('debit', Sum), LabeledSink('credit', Sum)])
+      //   => 'GroupBy_Transaction_currency_Sequence_debit_credit'
+      //
       var sinkName = this.arg2.cls_?.name || 'Count';
       var sourceClassName = sourceClass.split('.').pop(); // Get last part of class name
-      var modelName = 'GroupBy_' + sourceClassName + '_' + exprName + '_' + sinkName;
+
+      // Include property names from nested sinks to differentiate structures with same outer shape
+      var nestedPropNames = '';
+      if ( this.arg2.toProperties ) {
+        var props = this.arg2.toProperties();
+        if ( props && Array.isArray(props) ) {
+          nestedPropNames = '_' + props.filter(p => p && p.name).map(p => p.name).join('_');
+        }
+      }
+
+      var modelName = 'GroupBy_' + sourceClassName + '_' + exprName + '_' + sinkName + nestedPropNames;
 
       const model = {
         package: 'foam.tmp',

--- a/src/foam/u2/table/UnstyledTableRow.js
+++ b/src/foam/u2/table/UnstyledTableRow.js
@@ -155,6 +155,9 @@ foam.CLASS({
         }));
       }
 
+      foam.assert(prop && prop.tableCellFormatter,
+        'Missing prop or tableCellFormatter for column:', this.col, 'propName:', this.propName, 'cls:', this.data?.cls_?.id);
+
       this
         .startContext({ controllerMode: 'VIEW' })
         .addClass(this.table.myClass('td'))
@@ -163,6 +166,7 @@ foam.CLASS({
           })
         })
         .call(function() {
+          if ( ! prop || ! prop.tableCellFormatter ) return;
           prop.tableCellFormatter.format(
             this,
             prop.f ? prop.f(objReturned) : null,


### PR DESCRIPTION
## Problem
GroupBy's deterministic model naming used only sourceClass, exprName, and sinkName. When multiple GroupBys had the same outer structure but different internal sinks (e.g., different LabeledSink labels), they generated identical model names, causing property conflicts where properties from one GroupBy would be missing or overwritten by another.

## Solution
Include nested property names in the model name generation. This ensures:
1. Same GroupBy structure always gets the same model name (needed for reload/persistence)
2. Different internal sink structures get different model names (prevents property conflicts)

## Changes
- Include nested property names from `toProperties()` in GroupBy model name generation
- Add assertion in UnstyledTableRow to help debug missing tableCellFormatter issues
- Add guard in UnstyledTableRow.call() to prevent errors when prop is missing
