### PR TITLE
Revert " PT-FIXES: DOS-1370 generate deterministic model names to prevent conflicts in chained operations"

### DIFF
--- a/src/foam/mlang/sink/GroupBy.js
+++ b/src/foam/mlang/sink/GroupBy.js
@@ -252,27 +252,19 @@ for (Object key : getGroups().keySet()) {
       // Determine property class by traversing expressions to find underlying property
       var exprClass = 'String';
       var expr = this.arg1;
-      var sourceClass = 'Unknown';
       while ( expr ) {
         if ( foam.lang.Property.isInstance(expr) ) {
           exprClass = expr.cls_?.id || 'String';
-          // Get the source class name from the property's forClass_
-          sourceClass = expr.forClass_ || sourceClass;
           break;
         }
         // Try delegate, then arg1, then stop
         expr = expr.delegate || expr.arg1;
       }
 
-      // Generate deterministic name based on source class, property name, and sink type
-      // This prevents conflicts in chained GroupBy operations
-      var sinkName = this.arg2.cls_?.name || 'Count';
-      var sourceClassName = sourceClass.split('.').pop(); // Get last part of class name
-      var modelName = 'GroupBy_' + sourceClassName + '_' + exprName + '_' + sinkName;
 
       const model = {
         package: 'foam.tmp',
-        name: modelName,
+        name: 'GroupBy' + foam.next$UID(),
         ids: [ 'row' ],
         properties: [
           { class: 'Long', name: 'row' },


### PR DESCRIPTION
Reverts kgrgreer/foam3#4553


since it breaks if the user made two groupbys that are simliar they override each other

this can improve it https://github.com/kgrgreer/foam3/pull/4742, but will think/implement something safer