### PR TITLE
PT-FIXES: DOS-1998, DOS-2007, DOS-2008, DOS-2019, DOS-2198  Add Julian date format support to DateParser

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -47,6 +47,11 @@ foam.ENUM({
       name: 'YYYYDDMM',
       label: 'yyyy/dd/mm',
       documentation: 'Numeric only: yyyy-dd-mm, yyyyddmm, yy-dd-mm, yyddmm'
+    },
+    {
+      name: 'JULIANDATE',
+      label: 'Julian Date',
+      documentation: 'Julian date format: YYDDD (5 digits like 25216) or YDDD (4 digits like 5216) where YY/Y is year and DDD is day of year (001-366). Example: 25216 = August 4, 2025 (day 216 of 2025)'
     }
   ],
 
@@ -322,7 +327,7 @@ foam.CLASS({
        * Maps DateFormat enum to DateParser grammar symbol name.
        * This is used when calling DateUtil parsing methods with format hints.
        *
-       * @returns {string} Parser grammar symbol name ('START', 'ddmmyyyy', 'yyyyddmm')
+       * @returns {string} Parser grammar symbol name ('START', 'ddmmyyyy', 'yyyyddmm', 'juliandate')
        */
       if ( ! this.dateFormat ) return 'START';
 
@@ -332,6 +337,8 @@ foam.CLASS({
           return 'ddmmyyyy';
         case 'YYYYDDMM':
           return 'yyyyddmm';
+        case 'JULIANDATE':
+          return 'juliandate';
         case 'STANDARD':
         default:
           return 'START';

--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -42,6 +42,42 @@ foam.CLASS({
           sym('timestamp')       // Unix/JS timestamps (10-13 digits, must not match date formats)
         ),
 
+        // Julian date formats (YYDDD and YDDD) - day-of-year formats
+        // These are NOT in main dateOrDatetime to avoid ambiguity with other formats.
+        // Use opt_name='juliandate' for auto-detection, or 'yyddd'/'yddd' for explicit format.
+        //
+        // Combined Julian date parser - tries YYDDD first (5 digits), then YDDD (4 digits)
+        // Use this in mapping configurations: opt_name='juliandate'
+        juliandate: alt(
+          sym('yyddd'),   // Try 5-digit format first (more specific)
+          sym('yddd')     // Fall back to 4-digit format
+        ),
+
+        // YYDDD format: 5-digit Julian date (2-digit year + 3-digit day of year)
+        // e.g., "25216" = Year 2025, Day 216 = August 4, 2025
+        // Year cutoff: 00-49 = 2000-2049, 50-99 = 1950-1999
+        yyddd: str(seq(
+          sym('year2'),                                    // YY: 2-digit year (00-99)
+          sym('dayOfYear')                                 // DDD: day of year (001-366)
+        )),
+
+        // YDDD format: 4-digit Julian date (1-digit year + 3-digit day of year)
+        // e.g., "5216" = Year 2025, Day 216 = August 4, 2025
+        // Year mapping: Sliding window based on current year (decade + digit, with 5-year future limit)
+        yddd: str(seq(
+          range('0', '9'),                                 // Y: 1-digit year (sliding window)
+          sym('dayOfYear')                                 // DDD: day of year (001-366)
+        )),
+
+        // Day of year (001-366) - used for Julian date formats
+        // Wrapped in str() to ensure it returns a string, not an array
+        dayOfYear: str(alt(
+          seq('3', '6', range('0', '6')),                  // 360-366
+          seq('3', range('0', '5'), range('0', '9')),      // 300-359
+          seq(range('1', '2'), range('0', '9'), range('0', '9')),  // 100-299
+          seq('0', range('0', '9'), range('0', '9'))       // 000-099
+        )),
+
         // Unix timestamp (10 digits, seconds) or JavaScript timestamp (13 digits, milliseconds)
         // Placed LAST in dateOrDatetime to avoid matching date formats like YYYYMMDDHH
         // Note: 10-digit timestamps will only match if they don't match any other format

--- a/src/foam/parse/DateParser.java
+++ b/src/foam/parse/DateParser.java
@@ -1028,6 +1028,39 @@ public class DateParser {
     // YYDDMM compact: 6 digits with validated year, day (01-31), month (01-12)
     grammar.addSymbol("yyddmm-compact", new Join(new Seq(grammar.sym("year2"), grammar.sym("day2"), grammar.sym("month2"))));
 
+    // ========== Julian Date Formats ==========
+
+    // Combined Julian date parser - tries YYDDD first (5 digits), then YDDD (4 digits)
+    // Use opt_name='juliandate' in mapping configurations
+    grammar.addSymbol("juliandate", new Alt(
+      grammar.sym("yyddd"),   // Try 5-digit format first (more specific)
+      grammar.sym("yddd")     // Fall back to 4-digit format
+    ));
+
+    // YYDDD format: 5-digit Julian date (2-digit year + 3-digit day of year)
+    // e.g., "25216" = Year 2025, Day 216 = August 4, 2025
+    // Year cutoff: 00-50 = 2000-2050, 51-99 = 1951-1999
+    grammar.addSymbol("yyddd", new Join(new Seq(
+      grammar.sym("year2"),      // YY: 2-digit year (00-99)
+      grammar.sym("dayOfYear")   // DDD: day of year (001-366)
+    )));
+
+    // YDDD format: 4-digit Julian date (1-digit year + 3-digit day of year)
+    // e.g., "5216" = Year 2025, Day 216 = August 4, 2025
+    // Year mapping: 0-9 = 2020-2029
+    grammar.addSymbol("yddd", new Join(new Seq(
+      Range.create('0', '9'),    // Y: 1-digit year (0-9 → 2020-2029)
+      grammar.sym("dayOfYear")   // DDD: day of year (001-366)
+    )));
+
+    // Day of year (001-366) - used for Julian date formats
+    grammar.addSymbol("dayOfYear", new Alt(
+      new Seq(Literal.create("3"), Literal.create("6"), Range.create('0', '6')),  // 360-366
+      new Seq(Literal.create("3"), Range.create('0', '5'), Range.create('0', '9')),  // 300-359
+      new Seq(Range.create('1', '2'), Range.create('0', '9'), Range.create('0', '9')),  // 100-299
+      new Seq(Literal.create("0"), Range.create('0', '9'), Range.create('0', '9'))   // 000-099
+    ));
+
     // ========== Month Name Formats ==========
 
     // YYYYDDMMM with separators - supports single-digit days (e.g., 2025-5-JAN)
@@ -1416,6 +1449,62 @@ public class DateParser {
         self.convertTwoDigitYear(twoDigitYear),
         Integer.parseInt(v.substring(0, 2)) - 1,
         Integer.parseInt(v.substring(2, 4)),
+        -1, -1, -1, -1, null);
+    });
+
+    // YYDDD Julian date action: "25216" (5 digits)
+    // 2-digit year + 3-digit day of year
+    grammar.addAction("yyddd", (val, x) -> {
+      String v = (String) val;
+      DateParseMode mode = (DateParseMode) x.get("dateParseMode");
+      int twoDigitYear = Integer.parseInt(v.substring(0, 2));
+      int dayOfYear = Integer.parseInt(v.substring(2));
+      int year = self.convertTwoDigitYear(twoDigitYear);
+
+      // Convert day-of-year to month and day using Calendar
+      Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+      cal.clear();
+      cal.set(Calendar.YEAR, year);
+      cal.set(Calendar.DAY_OF_YEAR, dayOfYear);
+
+      return self.buildDate(mode,
+        cal.get(Calendar.YEAR),
+        cal.get(Calendar.MONTH),
+        cal.get(Calendar.DAY_OF_MONTH),
+        -1, -1, -1, -1, null);
+    });
+
+    // YDDD Julian date action: "5216" (4 digits)
+    // 1-digit year + 3-digit day of year
+    // Year mapping: Sliding window based on current year
+    // - Uses current decade as base (e.g., 2020 in 2025, 2030 in 2035)
+    // - If result is more than 5 years in future, assumes previous decade
+    grammar.addAction("yddd", (val, x) -> {
+      String v = (String) val;
+      DateParseMode mode = (DateParseMode) x.get("dateParseMode");
+      int oneDigitYear = Integer.parseInt(v.substring(0, 1));
+      int dayOfYear = Integer.parseInt(v.substring(1));
+
+      // Sliding window: calculate year based on current decade
+      int currentYear = Calendar.getInstance(TimeZone.getTimeZone("GMT")).get(Calendar.YEAR);
+      int decade = (currentYear / 10) * 10;
+      int year = decade + oneDigitYear;
+
+      // If calculated year is more than 5 years in future, assume previous decade
+      if ( year > currentYear + 5 ) {
+        year -= 10;
+      }
+
+      // Convert day-of-year to month and day using Calendar
+      Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+      cal.clear();
+      cal.set(Calendar.YEAR, year);
+      cal.set(Calendar.DAY_OF_YEAR, dayOfYear);
+
+      return self.buildDate(mode,
+        cal.get(Calendar.YEAR),
+        cal.get(Calendar.MONTH),
+        cal.get(Calendar.DAY_OF_MONTH),
         -1, -1, -1, -1, null);
     });
   }

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -562,6 +562,57 @@ foam.CLASS({
         -1, -1, -1, -1, null);
     },
 
+    // YYDDD Julian date format: 5-digit (2-digit year + 3-digit day of year)
+    // v = "25216" (string) where 25=year 2025, 216=day of year (August 4)
+    // Year cutoff: 00-49 = 2000-2049, 50-99 = 1950-1999 (uses convertTwoDigitYear)
+    function yydddAction(v) {
+      var twoDigitYear = parseInt(v.substring(0, 2), 10);
+      var dayOfYear = parseInt(v.substring(2), 10);
+      var year = this.convertTwoDigitYear(twoDigitYear);
+
+      // Convert day-of-year to month and day using UTC to avoid timezone issues
+      // Create Jan 1 of the year at noon UTC, then add (dayOfYear - 1) days
+      var date = new Date(Date.UTC(year, 0, 1, 12, 0, 0));
+      date.setUTCDate(dayOfYear);
+
+      return this.buildDate(this.dateParseMode,
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+        -1, -1, -1, -1, null);
+    },
+
+    // YDDD Julian date format: 4-digit (1-digit year + 3-digit day of year)
+    // v = "5216" (string) where 5=year 2025, 216=day of year (August 4)
+    // Year mapping: Sliding window based on current year
+    // - Uses current decade as base (e.g., 2020 in 2025, 2030 in 2035)
+    // - If result is more than 5 years in future, assumes previous decade
+    function ydddAction(v) {
+      var oneDigitYear = parseInt(v.substring(0, 1), 10);
+      var dayOfYear = parseInt(v.substring(1), 10);
+
+      // Sliding window: calculate year based on current decade
+      var currentYear = new Date().getUTCFullYear();
+      var decade = Math.floor(currentYear / 10) * 10;
+      var year = decade + oneDigitYear;
+
+      // If calculated year is more than 5 years in future, assume previous decade
+      if ( year > currentYear + 5 ) {
+        year -= 10;
+      }
+
+      // Convert day-of-year to month and day using UTC to avoid timezone issues
+      // Create Jan 1 of the year at noon UTC, then add (dayOfYear - 1) days
+      var date = new Date(Date.UTC(year, 0, 1, 12, 0, 0));
+      date.setUTCDate(dayOfYear);
+
+      return this.buildDate(this.dateParseMode,
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+        -1, -1, -1, -1, null);
+    },
+
     // Timestamp actions - convert timestamp strings directly to Date objects
     // These return Date objects directly (not {year, month, day} objects) because
     // timestamps are already a complete date representation

--- a/src/foam/parse/test/DateParserJavaTest.js
+++ b/src/foam/parse/test/DateParserJavaTest.js
@@ -84,6 +84,9 @@ foam.CLASS({
 
         // Unix/Java Date.toString() format tests
         DateParserTest_UnixDateToString();
+
+        // Julian Date Format Tests
+        DateParserTest_JulianDate();
       `
     },
 
@@ -1193,6 +1196,132 @@ foam.CLASS({
         Calendar calOffset4 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
         calOffset4.setTime(dateOffset4);
         test(calOffset4.get(Calendar.HOUR_OF_DAY) == 5, "Unix Date.toString() +05:00: hour 5 UTC (10 - 5)");
+      `
+    },
+
+    // ========== Julian Date Format Tests ==========
+
+    {
+      name: 'DateParserTest_JulianDate',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // ========== YYDDD Format Tests (5-digit: 2-digit year + 3-digit day of year) ==========
+        // Uses fixed pivot: 00-49 -> 2000-2049, 50-99 -> 1950-1999
+
+        // Test "25216" = August 4, 2025 (day 216 of 2025)
+        Date date1 = parser.parseDateString("25216", "yyddd");
+        Calendar cal1 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal1.setTime(date1);
+        test(cal1.get(Calendar.YEAR) == 2025, "YYDDD 25216: year 2025");
+        test(cal1.get(Calendar.MONTH) == 7, "YYDDD 25216: month 7 (Aug)");
+        test(cal1.get(Calendar.DAY_OF_MONTH) == 4, "YYDDD 25216: day 4");
+
+        // Test "24341" = December 6, 2024 (day 341 of 2024)
+        Date date2 = parser.parseDateString("24341", "yyddd");
+        Calendar cal2 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal2.setTime(date2);
+        test(cal2.get(Calendar.YEAR) == 2024, "YYDDD 24341: year 2024");
+        test(cal2.get(Calendar.MONTH) == 11, "YYDDD 24341: month 11 (Dec)");
+        test(cal2.get(Calendar.DAY_OF_MONTH) == 6, "YYDDD 24341: day 6");
+
+        // Test "25001" = January 1, 2025 (day 1)
+        Date date3 = parser.parseDateString("25001", "yyddd");
+        Calendar cal3 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal3.setTime(date3);
+        test(cal3.get(Calendar.YEAR) == 2025, "YYDDD 25001: year 2025");
+        test(cal3.get(Calendar.MONTH) == 0, "YYDDD 25001: month 0 (Jan)");
+        test(cal3.get(Calendar.DAY_OF_MONTH) == 1, "YYDDD 25001: day 1");
+
+        // Test "25365" = December 31, 2025 (day 365, non-leap year)
+        Date date4 = parser.parseDateString("25365", "yyddd");
+        Calendar cal4 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal4.setTime(date4);
+        test(cal4.get(Calendar.YEAR) == 2025, "YYDDD 25365: year 2025");
+        test(cal4.get(Calendar.MONTH) == 11, "YYDDD 25365: month 11 (Dec)");
+        test(cal4.get(Calendar.DAY_OF_MONTH) == 31, "YYDDD 25365: day 31");
+
+        // Test "24366" = December 31, 2024 (day 366, leap year)
+        Date date5 = parser.parseDateString("24366", "yyddd");
+        Calendar cal5 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal5.setTime(date5);
+        test(cal5.get(Calendar.YEAR) == 2024, "YYDDD 24366 leap year: year 2024");
+        test(cal5.get(Calendar.MONTH) == 11, "YYDDD 24366 leap year: month 11 (Dec)");
+        test(cal5.get(Calendar.DAY_OF_MONTH) == 31, "YYDDD 24366 leap year: day 31");
+
+        // Test 2-digit year pivot: 49 → 2049
+        Date date6 = parser.parseDateString("49001", "yyddd");
+        Calendar cal6 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal6.setTime(date6);
+        test(cal6.get(Calendar.YEAR) == 2049, "YYDDD year pivot: 49 → 2049");
+
+        // Test 2-digit year pivot: 50 → 1950
+        Date date7 = parser.parseDateString("50001", "yyddd");
+        Calendar cal7 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal7.setTime(date7);
+        test(cal7.get(Calendar.YEAR) == 1950, "YYDDD year pivot: 50 → 1950");
+
+        // ========== YDDD Format Tests (4-digit: 1-digit year + 3-digit day of year) ==========
+        // Uses sliding window logic based on current year:
+        //   decade = floor(currentYear / 10) * 10
+        //   year = decade + oneDigitYear
+        //   if year > currentYear + 5 then year = year - 10
+
+        int currentYear = Calendar.getInstance(TimeZone.getTimeZone("GMT")).get(Calendar.YEAR);
+        int decade = (currentYear / 10) * 10;
+
+        // Calculate expected years using sliding window
+        int expectedYear0 = decade + 0;
+        if ( expectedYear0 > currentYear + 5 ) expectedYear0 -= 10;
+        int expectedYear5 = decade + 5;
+        if ( expectedYear5 > currentYear + 5 ) expectedYear5 -= 10;
+        int expectedYear9 = decade + 9;
+        if ( expectedYear9 > currentYear + 5 ) expectedYear9 -= 10;
+
+        // Test "5216" = August 4 (year 5 with sliding window, day 216)
+        Date date8 = parser.parseDateString("5216", "yddd");
+        Calendar cal8 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal8.setTime(date8);
+        test(cal8.get(Calendar.YEAR) == expectedYear5, "YDDD 5216: year " + expectedYear5);
+        test(cal8.get(Calendar.MONTH) == 7, "YDDD 5216: month 7 (Aug)");
+        test(cal8.get(Calendar.DAY_OF_MONTH) == 4, "YDDD 5216: day 4");
+
+        // Test "0001" = January 1 (year 0 with sliding window)
+        Date date9 = parser.parseDateString("0001", "yddd");
+        Calendar cal9 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal9.setTime(date9);
+        test(cal9.get(Calendar.YEAR) == expectedYear0, "YDDD 0001: year " + expectedYear0 + " (0 → " + expectedYear0 + ")");
+        test(cal9.get(Calendar.MONTH) == 0, "YDDD 0001: month 0 (Jan)");
+        test(cal9.get(Calendar.DAY_OF_MONTH) == 1, "YDDD 0001: day 1");
+
+        // Test "9365" = December 31 (year 9 with sliding window)
+        Date date10 = parser.parseDateString("9365", "yddd");
+        Calendar cal10 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal10.setTime(date10);
+        test(cal10.get(Calendar.YEAR) == expectedYear9, "YDDD 9365: year " + expectedYear9 + " (9 → " + expectedYear9 + ")");
+        test(cal10.get(Calendar.MONTH) == 11, "YDDD 9365: month 11 (Dec)");
+        test(cal10.get(Calendar.DAY_OF_MONTH) == 31, "YDDD 9365: day 31");
+
+        // ========== Combined juliandate Format Tests ==========
+        // Auto-detects YYDDD (5 digits) or YDDD (4 digits)
+        // 5-digit: Uses fixed 2-digit year pivot
+        // 4-digit: Uses sliding window based on current year
+
+        // Test 5-digit with juliandate opt_name (uses fixed pivot)
+        Date date11 = parser.parseDateString("25216", "juliandate");
+        Calendar cal11 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal11.setTime(date11);
+        test(cal11.get(Calendar.YEAR) == 2025, "juliandate 25216 (5-digit): year 2025");
+        test(cal11.get(Calendar.MONTH) == 7, "juliandate 25216 (5-digit): month 7 (Aug)");
+        test(cal11.get(Calendar.DAY_OF_MONTH) == 4, "juliandate 25216 (5-digit): day 4");
+
+        // Test 4-digit with juliandate opt_name (uses sliding window)
+        Date date12 = parser.parseDateString("5216", "juliandate");
+        Calendar cal12 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal12.setTime(date12);
+        test(cal12.get(Calendar.YEAR) == expectedYear5, "juliandate 5216 (4-digit): year " + expectedYear5);
+        test(cal12.get(Calendar.MONTH) == 7, "juliandate 5216 (4-digit): month 7 (Aug)");
+        test(cal12.get(Calendar.DAY_OF_MONTH) == 4, "juliandate 5216 (4-digit): day 4");
       `
     }
   ]

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -43,6 +43,7 @@ foam.CLASS({
       this.testStrictValidationMode(x);
       this.testLenientValidationMode(x);
       this.testInvalidMonthNameValidation(x);
+      this.testJulianDateFormats(x);
     },
 
     function testYYYYMMDDFormats(x) {
@@ -2335,6 +2336,138 @@ foam.CLASS({
       parser.strictValidation = false;
       let result = parser.parseString('15-XYZ-2025');
       x.test(result.getTime() === foam.Date.MAX_DATE.getTime(), 'LenientMode: unparseable returns MAX_DATE');
+    },
+
+    function testJulianDateFormats(x) {
+      let parser = this.DateParser.create();
+
+      // ============================================================
+      // YYDDD format tests (5-digit: 2-digit year + 3-digit day of year)
+      // ============================================================
+      let yydddTestCases = [
+        { input: '25216', year: 2025, month: 7, day: 4, desc: 'day 216 of 2025 = Aug 4, 2025' },
+        { input: '24341', year: 2024, month: 11, day: 6, desc: 'day 341 of 2024 = Dec 6, 2024' },
+        { input: '25001', year: 2025, month: 0, day: 1, desc: 'day 1 of 2025 = Jan 1, 2025' },
+        { input: '25365', year: 2025, month: 11, day: 31, desc: 'day 365 of 2025 = Dec 31, 2025' },
+        // 2-digit year pivot tests: 00-49 -> 2000-2049, 50-99 -> 1950-1999
+        { input: '49365', year: 2049, month: 11, day: 31, desc: 'day 365 of 2049 (year pivot: 49 -> 2049)' },
+        { input: '50001', year: 1950, month: 0, day: 1, desc: 'day 1 of 1950 (year pivot: 50 -> 1950)' }
+      ];
+
+      yydddTestCases.forEach((testCase, i) => {
+        try {
+          let result = parser.parseDateString(testCase.input, 'yyddd');
+          if ( ! result || isNaN(result.getTime()) ) {
+            x.test(false, `YYDDD Test${i + 1}: ${testCase.input} - ${testCase.desc}. Got: null/invalid`);
+            return;
+          }
+          let actualYear = result.getUTCFullYear();
+          let actualMonth = result.getUTCMonth();
+          let actualDay = result.getUTCDate();
+          let pass = actualYear === testCase.year &&
+                     actualMonth === testCase.month &&
+                     actualDay === testCase.day;
+          if ( pass ) {
+            x.test(true, `YYDDD Test${i + 1}: ${testCase.input} - ${testCase.desc}`);
+          } else {
+            x.test(false, `YYDDD Test${i + 1}: ${testCase.input} - Expected: ${testCase.year}-${testCase.month + 1}-${testCase.day}, Got: ${actualYear}-${actualMonth + 1}-${actualDay}`);
+          }
+        } catch (e) {
+          x.test(false, `YYDDD Test${i + 1}: ${testCase.input} - Error: ${e.message}`);
+        }
+      });
+
+      // ============================================================
+      // YDDD format tests (4-digit: 1-digit year + 3-digit day of year)
+      // Uses sliding window logic based on current year:
+      //   decade = floor(currentYear / 10) * 10
+      //   year = decade + oneDigitYear
+      //   if year > currentYear + 5 then year = year - 10
+      // ============================================================
+
+      // Calculate expected years using sliding window
+      let currentYear = new Date().getUTCFullYear();
+      let decade = Math.floor(currentYear / 10) * 10;
+
+      // Helper to calculate expected year for a single digit
+      function calcExpectedYear(digit) {
+        let yr = decade + digit;
+        if ( yr > currentYear + 5 ) yr -= 10;
+        return yr;
+      }
+
+      let expectedYear0 = calcExpectedYear(0);
+      let expectedYear5 = calcExpectedYear(5);
+      let expectedYear9 = calcExpectedYear(9);
+
+      let ydddTestCases = [
+        { input: '5216', year: expectedYear5, month: 7, day: 4, desc: `day 216 of ${expectedYear5} = Aug 4, ${expectedYear5} (year 5 = ${expectedYear5})` },
+        { input: '0001', year: expectedYear0, month: 0, day: 1, desc: `day 1 of ${expectedYear0} = Jan 1, ${expectedYear0} (year 0 = ${expectedYear0})` },
+        { input: '9365', year: expectedYear9, month: 11, day: 31, desc: `day 365 of ${expectedYear9} = Dec 31, ${expectedYear9} (year 9 = ${expectedYear9})` }
+      ];
+
+      ydddTestCases.forEach((testCase, i) => {
+        try {
+          let result = parser.parseDateString(testCase.input, 'yddd');
+          if ( ! result || isNaN(result.getTime()) ) {
+            x.test(false, `YDDD Test${i + 1}: ${testCase.input} - ${testCase.desc}. Got: null/invalid`);
+            return;
+          }
+          let actualYear = result.getUTCFullYear();
+          let actualMonth = result.getUTCMonth();
+          let actualDay = result.getUTCDate();
+          let pass = actualYear === testCase.year &&
+                     actualMonth === testCase.month &&
+                     actualDay === testCase.day;
+          if ( pass ) {
+            x.test(true, `YDDD Test${i + 1}: ${testCase.input} - ${testCase.desc}`);
+          } else {
+            x.test(false, `YDDD Test${i + 1}: ${testCase.input} - Expected: ${testCase.year}-${testCase.month + 1}-${testCase.day}, Got: ${actualYear}-${actualMonth + 1}-${actualDay}`);
+          }
+        } catch (e) {
+          x.test(false, `YDDD Test${i + 1}: ${testCase.input} - Error: ${e.message}`);
+        }
+      });
+
+      // ============================================================
+      // Combined juliandate format tests (auto-detects 4 or 5 digit)
+      // 5-digit: Uses fixed 2-digit year pivot (00-49 -> 2000-2049, 50-99 -> 1950-1999)
+      // 4-digit: Uses sliding window based on current year
+      // ============================================================
+      let juliandateTestCases = [
+        // 5-digit format (YYDDD) - uses fixed pivot
+        { input: '25216', year: 2025, month: 7, day: 4, desc: '5-digit: day 216 of 2025 = Aug 4, 2025' },
+        { input: '24341', year: 2024, month: 11, day: 6, desc: '5-digit: day 341 of 2024 = Dec 6, 2024' },
+        { input: '25001', year: 2025, month: 0, day: 1, desc: '5-digit: day 1 of 2025 = Jan 1, 2025' },
+        { input: '25365', year: 2025, month: 11, day: 31, desc: '5-digit: day 365 of 2025 = Dec 31, 2025' },
+        // 4-digit format (YDDD) - uses sliding window (expectedYear vars calculated above)
+        { input: '5216', year: expectedYear5, month: 7, day: 4, desc: `4-digit: day 216 of ${expectedYear5} = Aug 4, ${expectedYear5}` },
+        { input: '0001', year: expectedYear0, month: 0, day: 1, desc: `4-digit: day 1 of ${expectedYear0} = Jan 1, ${expectedYear0}` },
+        { input: '9365', year: expectedYear9, month: 11, day: 31, desc: `4-digit: day 365 of ${expectedYear9} = Dec 31, ${expectedYear9}` }
+      ];
+
+      juliandateTestCases.forEach((testCase, i) => {
+        try {
+          let result = parser.parseDateString(testCase.input, 'juliandate');
+          if ( ! result || isNaN(result.getTime()) ) {
+            x.test(false, `JulianDate Test${i + 1}: ${testCase.input} - ${testCase.desc}. Got: null/invalid`);
+            return;
+          }
+          let actualYear = result.getUTCFullYear();
+          let actualMonth = result.getUTCMonth();
+          let actualDay = result.getUTCDate();
+          let pass = actualYear === testCase.year &&
+                     actualMonth === testCase.month &&
+                     actualDay === testCase.day;
+          if ( pass ) {
+            x.test(true, `JulianDate Test${i + 1}: ${testCase.input} - ${testCase.desc}`);
+          } else {
+            x.test(false, `JulianDate Test${i + 1}: ${testCase.input} - Expected: ${testCase.year}-${testCase.month + 1}-${testCase.day}, Got: ${actualYear}-${actualMonth + 1}-${actualDay}`);
+          }
+        } catch (e) {
+          x.test(false, `JulianDate Test${i + 1}: ${testCase.input} - Error: ${e.message}`);
+        }
+      });
     }
   ]
 });


### PR DESCRIPTION

## Problem
The DateParser did not support Julian date formats (YYDDD and YDDD) which represent dates as a year plus day-of-year (1-366). These formats are commonly used in financial data files where dates like "25216" represent August 4, 2025 (day 216 of year 2025). Without this support, users had to implement custom parsing logic outside the standard date parser.

## Solution
Added Julian date parsing support to DateParser with two formats:
- **YYDDD** (5-digit): 2-digit year + 3-digit day-of-year with standard year pivot (00-49 → 2000-2049, 50-99 → 1950-1999)
- **YDDD** (4-digit): 1-digit year + 3-digit day-of-year with sliding window logic to avoid Y2030-style issues

The sliding window for YDDD uses the current decade as base and limits future dates to 5 years ahead, automatically rolling back to the previous decade if needed.

## Changes
- Add `juliandate`, `yyddd`, `yddd`, and `dayOfYear` grammar rules to DateGrammar.js
- Add `yydddAction` and `ydddAction` to DateParser.js with UTC timezone handling
- Add equivalent grammar rules and actions to DateParser.java
- Add `JULIANDATE` option to DateFormat enum in Mapping.js for mapping UI support
- Add comprehensive tests for both JS and Java implementations
