### PR TITLE
ArrayView automatic view selection for primitive types

### DIFF
--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -180,7 +180,7 @@ foam.CLASS({
               .addClass('p')
               .forEach(data || [], function(e, i) {
                 var row = self.Row.create({ index: i, value: e });
-                e && e.sub(self.updateDataWithoutFeedback);
+                e && e.sub && e.sub(self.updateDataWithoutFeedback);
                 this
                   .startContext({ data: row })
                     .start(self.Cols)

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -30,7 +30,18 @@ foam.CLASS({
     {
       class: 'foam.u2.ViewSpec',
       name: 'valueView',
-      value: { class: 'foam.u2.view.AnyView' }
+      factory: function() {
+        // Get the 'of' type from the property and use its default view
+        var prop = this.prop;
+        if ( prop && prop.of ) {
+          var typeCls = foam.lookup('foam.lang.' + prop.of, true);
+          if ( typeCls && typeCls.VIEW ) {
+            return typeCls.VIEW.value;
+          }
+        }
+        // Default to AnyView for FObjects and unknown types
+        return { class: 'foam.u2.view.AnyView' };
+      }
     },
     {
       name: 'defaultNewItem',

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -29,19 +29,8 @@ foam.CLASS({
     },
     {
       class: 'foam.u2.ViewSpec',
-      name: 'valueView',
-      factory: function() {
-        // Get the 'of' type from the property and use its default view
-        var prop = this.prop;
-        if ( prop && prop.of ) {
-          var typeCls = foam.lookup('foam.lang.' + prop.of, true);
-          if ( typeCls && typeCls.VIEW ) {
-            return typeCls.VIEW.value;
-          }
-        }
-        // Default to AnyView for FObjects and unknown types
-        return { class: 'foam.u2.view.AnyView' };
-      }
+      name: 'valueView'
+      // Set dynamically in fromProperty() based on the 'of' type
     },
     {
       name: 'defaultNewItem',
@@ -175,6 +164,27 @@ foam.CLASS({
   `,
 
   methods: [
+    function fromProperty(prop) {
+      /**
+       * Set valueView based on the property's 'of' type.
+       * For primitive types (Int, Long, String, etc.), use their default view.
+       * For FObjects or unknown types, fall back to AnyView.
+       */
+      if ( ! this.valueView && prop && prop.of ) {
+        // Try to find the type class (e.g., 'Long' -> foam.lang.Long)
+        var typeCls = foam.lookup('foam.lang.' + prop.of, true);
+        if ( typeCls && typeCls.VIEW ) {
+          this.valueView = typeCls.VIEW.value;
+          return;
+        }
+      }
+
+      // Default to AnyView for FObjects and unknown types
+      if ( ! this.valueView ) {
+        this.valueView = { class: 'foam.u2.view.AnyView' };
+      }
+    },
+
     function render() {
       this.SUPER();
       var self = this;


### PR DESCRIPTION

## Problem
ArrayView always used AnyView as the default valueView, showing a type picker dropdown even for simple primitive arrays like `Array` with `of: 'Long'` or `of: 'String'`. This required creating separate view classes (StringArrayView, IntegerArrayView, etc.) for each primitive type, which is not scalable.

Additionally, calling `e.sub()` on primitive values (numbers, strings) caused errors since primitives don't have a `sub` method.

## Solution
Enhanced ArrayView to automatically detect primitive types and use their default views:
- Added `fromProperty()` method that looks up `foam.lang.<type>.VIEW` for the property's `of` type
- Primitive types (Int, Long, String, Float, etc.) have VIEW refinements in Element2.js
- Falls back to AnyView for FObjects and unknown types
- Added null check for `e.sub` to handle primitive array elements

## Changes
- Moved valueView initialization from static value to dynamic `fromProperty()` method
- Added lookup of `foam.lang.<of>.VIEW` to get type-appropriate view
- Added `e.sub &&` guard before calling subscription on array elements
