### PR TITLE
v2: ArrayView automatic view selection for primitive array types

### DIFF
--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1834,36 +1834,21 @@ foam.CLASS({
   properties: [
     {
       name: 'view',
-      expression: function(of) {
-        // Determine element type from 'of' or 'javaType'
-        var elementType = of;
-
-        if ( ! elementType && this.javaType ) {
-          // Extract type from javaType (e.g., 'Long[]' -> 'Long', 'int[]' -> 'int')
+      factory: function() {
+        // Extract element type from javaType (e.g., 'Long[]' -> 'Long')
+        if ( this.javaType ) {
           var match = this.javaType.match(/^(\w+)\[\]$/);
           if ( match ) {
-            elementType = match[1];
             // Map Java primitives to FOAM types
-            var javaToFoam = {
-              'int': 'Int', 'long': 'Long', 'float': 'Float',
-              'double': 'Double', 'boolean': 'Boolean'
-            };
-            elementType = javaToFoam[elementType] || elementType;
+            var javaToFoam = { 'int': 'Int', 'long': 'Long', 'float': 'Float', 'double': 'Double', 'boolean': 'Boolean' };
+            var elementType = javaToFoam[match[1]] || match[1];
+            var typeCls     = foam.lookup(elementType);
+
+            if ( typeCls && typeCls.VIEW ) {
+              return { class: 'foam.u2.view.ArrayView', valueView: typeCls.VIEW.value };
+            }
           }
         }
-
-        // For primitive types, use their default view as valueView
-        if ( elementType ) {
-          var typeCls = foam.lookup(elementType);
-          if ( typeCls && typeCls.VIEW ) {
-            return {
-              class: 'foam.u2.view.ArrayView',
-              valueView: typeCls.VIEW.value
-            };
-          }
-        }
-
-        // Default to ArrayView with AnyView
         return { class: 'foam.u2.view.ArrayView' };
       }
     }

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1832,7 +1832,41 @@ foam.CLASS({
   refines: 'foam.lang.Array',
   requires: [ 'foam.u2.view.ArrayView' ],
   properties: [
-    [ 'view', { class: 'foam.u2.view.ArrayView' } ]
+    {
+      name: 'view',
+      expression: function(of) {
+        // Determine element type from 'of' or 'javaType'
+        var elementType = of;
+
+        if ( ! elementType && this.javaType ) {
+          // Extract type from javaType (e.g., 'Long[]' -> 'Long', 'int[]' -> 'int')
+          var match = this.javaType.match(/^(\w+)\[\]$/);
+          if ( match ) {
+            elementType = match[1];
+            // Map Java primitives to FOAM types
+            var javaToFoam = {
+              'int': 'Int', 'long': 'Long', 'float': 'Float',
+              'double': 'Double', 'boolean': 'Boolean'
+            };
+            elementType = javaToFoam[elementType] || elementType;
+          }
+        }
+
+        // For primitive types, use their default view as valueView
+        if ( elementType ) {
+          var typeCls = foam.lookup('foam.lang.' + elementType, true);
+          if ( typeCls && typeCls.VIEW ) {
+            return {
+              class: 'foam.u2.view.ArrayView',
+              valueView: typeCls.VIEW.value
+            };
+          }
+        }
+
+        // Default to ArrayView with AnyView
+        return { class: 'foam.u2.view.ArrayView' };
+      }
+    }
   ]
 });
 

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1854,7 +1854,7 @@ foam.CLASS({
 
         // For primitive types, use their default view as valueView
         if ( elementType ) {
-          var typeCls = foam.lookup('foam.lang.' + elementType, true);
+          var typeCls = foam.lookup(elementType);
           if ( typeCls && typeCls.VIEW ) {
             return {
               class: 'foam.u2.view.ArrayView',

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -180,7 +180,7 @@ foam.CLASS({
               .addClass('p')
               .forEach(data || [], function(e, i) {
                 var row = self.Row.create({ index: i, value: e });
-                e && e.sub(self.updateDataWithoutFeedback);
+                e && e.sub && e.sub(self.updateDataWithoutFeedback);
                 this
                   .startContext({ data: row })
                     .start(self.Cols)

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -30,7 +30,18 @@ foam.CLASS({
     {
       class: 'foam.u2.ViewSpec',
       name: 'valueView',
-      value: { class: 'foam.u2.view.AnyView' }
+      factory: function() {
+        // Get the 'of' type from the property and use its default view
+        var prop = this.prop;
+        if ( prop && prop.of ) {
+          var typeCls = foam.lookup('foam.lang.' + prop.of, true);
+          if ( typeCls && typeCls.VIEW ) {
+            return typeCls.VIEW.value;
+          }
+        }
+        // Default to AnyView for FObjects and unknown types
+        return { class: 'foam.u2.view.AnyView' };
+      }
     },
     {
       name: 'defaultNewItem',

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -29,8 +29,8 @@ foam.CLASS({
     },
     {
       class: 'foam.u2.ViewSpec',
-      name: 'valueView'
-      // Set dynamically in fromProperty() based on the 'of' type
+      name: 'valueView',
+      value: { class: 'foam.u2.view.AnyView' }
     },
     {
       name: 'defaultNewItem',
@@ -164,27 +164,6 @@ foam.CLASS({
   `,
 
   methods: [
-    function fromProperty(prop) {
-      /**
-       * Set valueView based on the property's 'of' type.
-       * For primitive types (Int, Long, String, etc.), use their default view.
-       * For FObjects or unknown types, fall back to AnyView.
-       */
-      if ( ! this.valueView && prop && prop.of ) {
-        // Try to find the type class (e.g., 'Long' -> foam.lang.Long)
-        var typeCls = foam.lookup('foam.lang.' + prop.of, true);
-        if ( typeCls && typeCls.VIEW ) {
-          this.valueView = typeCls.VIEW.value;
-          return;
-        }
-      }
-
-      // Default to AnyView for FObjects and unknown types
-      if ( ! this.valueView ) {
-        this.valueView = { class: 'foam.u2.view.AnyView' };
-      }
-    },
-
     function render() {
       this.SUPER();
       var self = this;

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -29,19 +29,8 @@ foam.CLASS({
     },
     {
       class: 'foam.u2.ViewSpec',
-      name: 'valueView',
-      factory: function() {
-        // Get the 'of' type from the property and use its default view
-        var prop = this.prop;
-        if ( prop && prop.of ) {
-          var typeCls = foam.lookup('foam.lang.' + prop.of, true);
-          if ( typeCls && typeCls.VIEW ) {
-            return typeCls.VIEW.value;
-          }
-        }
-        // Default to AnyView for FObjects and unknown types
-        return { class: 'foam.u2.view.AnyView' };
-      }
+      name: 'valueView'
+      // Set dynamically in fromProperty() based on the 'of' type
     },
     {
       name: 'defaultNewItem',
@@ -175,6 +164,27 @@ foam.CLASS({
   `,
 
   methods: [
+    function fromProperty(prop) {
+      /**
+       * Set valueView based on the property's 'of' type.
+       * For primitive types (Int, Long, String, etc.), use their default view.
+       * For FObjects or unknown types, fall back to AnyView.
+       */
+      if ( ! this.valueView && prop && prop.of ) {
+        // Try to find the type class (e.g., 'Long' -> foam.lang.Long)
+        var typeCls = foam.lookup('foam.lang.' + prop.of, true);
+        if ( typeCls && typeCls.VIEW ) {
+          this.valueView = typeCls.VIEW.value;
+          return;
+        }
+      }
+
+      // Default to AnyView for FObjects and unknown types
+      if ( ! this.valueView ) {
+        this.valueView = { class: 'foam.u2.view.AnyView' };
+      }
+    },
+
     function render() {
       this.SUPER();
       var self = this;


### PR DESCRIPTION
Another approach for https://github.com/kgrgreer/foam3/pull/4750


## Problem
ArrayView always used AnyView as the default valueView, showing a type picker dropdown even for simple primitive arrays like `Array` with `javaType: 'Long[]'`. This required creating separate view classes (StringArrayView, IntegerArrayView, etc.) for each primitive type, which is not scalable.


## Solution
Enhanced the ArrayViewRefinement to automatically detect primitive element types and configure the appropriate view:
- Added expression-based `view` property that checks both `of` and `javaType`
- Extracts element type from `javaType` (e.g., `'Long[]'` → `'Long'`)
- Maps Java primitives to FOAM types (`int` → `Int`, `long` → `Long`, etc.)
- Looks up the FOAM type's VIEW and passes it as `valueView` to ArrayView

## Changes
- Modified ArrayViewRefinement in Element2.js to use expression-based view with type detection
