### PR TITLE
PT-FIXES: DOS-2182 Fix FOAM constant name collisions in dynamic Mapping

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -196,31 +196,24 @@ foam.CLASS({
       hidden: true,
       transient: true,
       expression: function(fileHeaders) {
-        // Create a temporary model with the current file headers as properties
-        if ( ! fileHeaders || fileHeaders.length === 0 ) {
-          return null;
-        }
+        if ( ! fileHeaders || fileHeaders.length === 0 ) return null;
 
-        // Create mapping of original headers to normalized names
-        var headerMap = {};
-        var props = [];
+        var headerMap   = {};
+        var constantMap = {};
+        var props       = [];
 
-        for ( var i = 0; i < fileHeaders.length; i++ ) {
-          var original = fileHeaders[i];
-          var normalized = original.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^[0-9]+/, '');
+        for ( var i = 0 ; i < fileHeaders.length ; i++ ) {
+          var original   = fileHeaders[i];
+          var normalized = this.normalizeHeader(original);
+          normalized     = this.resolveConstantCollision(normalized, constantMap);
+
           headerMap[normalized] = original;
-
-          props.push({
-            class: 'String',
-            name: normalized,
-            label: original
-          });
+          props.push({ class: 'String', name: normalized, label: original });
         }
 
-        // Check if model already exists, if so, reuse it
-        var modelName = 'DynamicExpressionModel';
-        var fullName = 'foam.core.reflow.temp.' + modelName;
-
+        var propKey   = props.map(p => p.name).sort().join('_');
+        var modelName = 'DynamicExpressionModel_' + Math.abs(foam.String.hashCode(propKey));
+        var fullName  = 'foam.core.reflow.temp.' + modelName;
         var TempModel = foam.maybeLookup(fullName);
 
         if ( ! TempModel ) {
@@ -337,6 +330,34 @@ foam.CLASS({
   ],
 
   methods: [
+    function normalizeHeader(header) {
+      /** Normalize a header string to a valid property name. */
+      return header.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^[0-9]+/, '');
+    },
+
+    function resolveConstantCollision(normalized, constantMap) {
+      /**
+       * Resolve FOAM constant name collisions by appending a numeric suffix.
+       * Returns the resolved property name.
+       */
+      var constantName = foam.String.constantize(normalized);
+
+      if ( ! constantMap[constantName] || constantMap[constantName] === normalized ) {
+        constantMap[constantName] = normalized;
+        return normalized;
+      }
+
+      // Collision detected - append suffix to make unique
+      var suffix = 2;
+      var newNormalized = normalized + '_' + suffix;
+      while ( constantMap[foam.String.constantize(newNormalized)] ) {
+        suffix++;
+        newNormalized = normalized + '_' + suffix;
+      }
+      constantMap[foam.String.constantize(newNormalized)] = newNormalized;
+      return newNormalized;
+    },
+
     function formatToParserName() {
       /**
        * Maps DateFormat enum to DateParser grammar symbol name.


### PR DESCRIPTION
## Problem
When creating dynamic models from file headers, headers like `StartDate` and `Start_date` would both normalize to the same FOAM constant `START_DATE`, causing a "Class constant conflict" error. This prevented file uploads with similar header naming patterns.

Additionally, the dynamic model was using a fixed name which caused property redefinition errors when headers changed between uploads.

## Solution
Added collision detection when normalizing headers to property names. When two headers would produce the same FOAM constant, append a numeric suffix to make it unique. Also generate unique model names based on a hash of property names.

## Changes
- Added `normalizeHeader()` method for consistent header-to-property name conversion
- Added `resolveConstantCollision()` method to detect and resolve FOAM constant conflicts
- Generate unique dynamic model names using `foam.String.hashCode()` to avoid redefinition errors
- Refactored expressionParser_ for better readability
