### PR TITLE
PT-FIXES: DOS-2182 Add exact match priority to ColumnParser

### DIFF
--- a/src/foam/core/reflow/ColumnParser.js
+++ b/src/foam/core/reflow/ColumnParser.js
@@ -60,30 +60,56 @@ foam.CLASS({
       var self = this;
       var ps = this.of.getAxiomsByClass(foam.lang.Property);
 
-      // Build normalized lookup map: normalized identifier → property
-      // Normalizes both property names and input for consistent matching
-      var propertyMap = {};
+      // Build two lookup maps:
+      // 1. Exact match map (case-insensitive) - for aliases and exact property names
+      // 2. Normalized match map - for fuzzy matching
+      var exactMap      = {};
+      var normalizedMap = {};
+
       ps.forEach(function(p) {
-        // Store by normalized name (handles non-standard property names)
-        propertyMap[self.normalizeToPropertyName(p.name).toLowerCase()] = p;
-        if ( p.shortName ) {
-          propertyMap[self.normalizeToPropertyName(p.shortName).toLowerCase()] = p;
+        var normalizedKey;
+
+        // Exact match: property name as-is (case-insensitive)
+        exactMap[p.name.toLowerCase()] = p;
+
+        // Normalized match - don't overwrite existing (first match wins)
+        normalizedKey = self.normalizeToPropertyName(p.name).toLowerCase();
+        if ( ! normalizedMap[normalizedKey] ) {
+          normalizedMap[normalizedKey] = p;
         }
+
+        if ( p.shortName ) {
+          exactMap[p.shortName.toLowerCase()] = p;
+          normalizedKey = self.normalizeToPropertyName(p.shortName).toLowerCase();
+          if ( ! normalizedMap[normalizedKey] ) {
+            normalizedMap[normalizedKey] = p;
+          }
+        }
+
+        // Aliases get exact match priority
         p.aliases.forEach(function(a) {
-          propertyMap[self.normalizeToPropertyName(a).toLowerCase()] = p;
+          exactMap[a.toLowerCase()] = p;
+          normalizedKey = self.normalizeToPropertyName(a).toLowerCase();
+          if ( ! normalizedMap[normalizedKey] ) {
+            normalizedMap[normalizedKey] = p;
+          }
         });
       });
 
-      // Single parser: normalize input and lookup in map
+      // Single parser: try exact match first, then normalized match
       var fieldNameParser = action(
         seq1(0, str(plus(notChars(',\t\n\r'))), sym('end')),
         function(input) {
           input = input.trim();
           if ( ! input ) return foam.parse.ParserWithAction.NO_PARSE;
 
-          // Normalize input and lookup
+          // Try exact match first (case-insensitive)
+          var prop = exactMap[input.toLowerCase()];
+          if ( prop ) return prop;
+
+          // Fall back to normalized match
           var normalized = self.normalizeToPropertyName(input);
-          var prop = propertyMap[normalized.toLowerCase()];
+          prop = normalizedMap[normalized.toLowerCase()];
           return prop || foam.parse.ParserWithAction.NO_PARSE;
         }
       );

--- a/src/foam/core/reflow/test/ColumnParserTest.js
+++ b/src/foam/core/reflow/test/ColumnParserTest.js
@@ -609,6 +609,131 @@ foam.CLASS({
         list8[2]?.name === 'CONSTANT_STYLE',
         'NonStandard List: Mixed input formats for non-standard properties'
       );
+
+      // ============================================
+      // EXACT MATCH PRIORITY TESTS
+      // Tests that exact aliases take priority over normalized matches
+      // This prevents collision when headers normalize to same value
+      // ============================================
+
+      // Create model with properties that would collide after normalization
+      // e.g., StartDate and Start_date both normalize to startDate
+      foam.CLASS({
+        package: 'foam.core.reflow.test',
+        name: 'CollisionModel',
+        properties: [
+          {
+            name: 'startDate',
+            aliases: ['StartDate', 'start_date']
+          },
+          {
+            name: 'startAttrDate',
+            aliases: ['Start_date']
+          },
+          {
+            name: 'endDate',
+            aliases: ['EndDate', 'end_date']
+          },
+          {
+            name: 'endAttrDate',
+            aliases: ['End_date']
+          },
+          {
+            name: 'createdDate',
+            aliases: ['CreatedDate']
+          },
+          {
+            name: 'createdAttrDate',
+            aliases: ['Created_date']
+          }
+        ]
+      });
+
+      var parser3 = this.ColumnParser.create({
+        of: foam.core.reflow.test.CollisionModel
+      });
+
+      // 6.1 Exact alias match takes priority
+      x.test(
+        parser3.parseString('StartDate')?.name === 'startDate',
+        'ExactPriority: StartDate matches startDate via exact alias'
+      );
+      x.test(
+        parser3.parseString('Start_date')?.name === 'startAttrDate',
+        'ExactPriority: Start_date matches startAttrDate via exact alias'
+      );
+
+      // 6.2 Case insensitive exact match
+      x.test(
+        parser3.parseString('startdate')?.name === 'startDate',
+        'ExactPriority: startdate (lowercase) matches startDate'
+      );
+      x.test(
+        parser3.parseString('start_date')?.name === 'startAttrDate',
+        'ExactPriority: start_date (lowercase) matches startAttrDate'
+      );
+      x.test(
+        parser3.parseString('STARTDATE')?.name === 'startDate',
+        'ExactPriority: STARTDATE (uppercase) matches startDate'
+      );
+      x.test(
+        parser3.parseString('START_DATE')?.name === 'startAttrDate',
+        'ExactPriority: START_DATE (uppercase) matches startAttrDate'
+      );
+
+      // 6.3 Another collision pair - EndDate vs End_date
+      x.test(
+        parser3.parseString('EndDate')?.name === 'endDate',
+        'ExactPriority: EndDate matches endDate via exact alias'
+      );
+      x.test(
+        parser3.parseString('End_date')?.name === 'endAttrDate',
+        'ExactPriority: End_date matches endAttrDate via exact alias'
+      );
+      x.test(
+        parser3.parseString('enddate')?.name === 'endDate',
+        'ExactPriority: enddate (lowercase) matches endDate'
+      );
+      x.test(
+        parser3.parseString('end_date')?.name === 'endAttrDate',
+        'ExactPriority: end_date (lowercase) matches endAttrDate'
+      );
+
+      // 6.4 Third collision pair - CreatedDate vs Created_date
+      x.test(
+        parser3.parseString('CreatedDate')?.name === 'createdDate',
+        'ExactPriority: CreatedDate matches createdDate via exact alias'
+      );
+      x.test(
+        parser3.parseString('Created_date')?.name === 'createdAttrDate',
+        'ExactPriority: Created_date matches createdAttrDate via exact alias'
+      );
+
+      // 6.5 Normalized fallback still works when no exact match
+      x.test(
+        parser3.parseString('START DATE')?.name === 'startDate',
+        'ExactPriority: START DATE falls back to normalized match for startDate'
+      );
+
+      // 6.6 Column list with collision-prone headers
+      var list9 = parser3.parseString('StartDate, Start_date, EndDate, End_date', 'columnList');
+      x.test(
+        list9?.length === 4 &&
+        list9[0]?.name === 'startDate' &&
+        list9[1]?.name === 'startAttrDate' &&
+        list9[2]?.name === 'endDate' &&
+        list9[3]?.name === 'endAttrDate',
+        'ExactPriority List: All collision-prone headers match correctly'
+      );
+
+      // 6.7 Mixed case in list
+      var list10 = parser3.parseString('startdate, start_date', 'columnList');
+      x.test(
+        list10?.length === 2 &&
+        list10[0]?.name === 'startDate' &&
+        list10[1]?.name === 'startAttrDate',
+        'ExactPriority List: Lowercase collision headers match correctly'
+      );
     }
   ]
 });

--- a/src/foam/parse/SimpleJavaScriptParser.js
+++ b/src/foam/parse/SimpleJavaScriptParser.js
@@ -165,6 +165,10 @@ foam.CLASS({
   ],
 
   methods: [
+    function parse(ps, x, opt_name) {
+      return this.grammar_.parse(ps, x, opt_name);
+    },
+
     function parseString(str, opt_name, opt_apply) {
       return this.grammar_.parseString(str, opt_name, opt_apply);
     }


### PR DESCRIPTION
## Problem
When parsing file headers with similar names that normalize to the same value (e.g., `StartDate` and `Start_date` both normalizing to `startDate`), the ColumnParser would incorrectly match headers to the wrong properties. This caused auto-mapping failures when properties had distinct aliases that should match exactly.

Additionally, SmartView threw an error when using dynamic mappings because SimpleJavaScriptParser was missing the `parse()` method required by the view.

## Solution
Implemented a two-phase matching strategy in ColumnParser:
1. First try exact case-insensitive match against property names, shortNames, and aliases
2. Fall back to normalized matching only if no exact match found
3. Use "first match wins" semantics for normalized matches to prevent collisions

Also added the missing `parse()` method to SimpleJavaScriptParser.

## Changes
- Split ColumnParser lookup into exactMap and normalizedMap for two-phase matching
- Added exact match priority for aliases to distinguish similar header names
- Implemented first-match-wins for normalized lookups to prevent overwrites
- Added parse() method to SimpleJavaScriptParser for SmartView compatibility
- Added comprehensive tests for exact match priority scenarios
