### PR TITLE
PT-FIXES:DOS-2203 fix(mlang): add missing outputType to DateToYYYYMMExpr

### DIFF
--- a/src/foam/mlang/expr/DateToYYYYMMExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMExpr.js
@@ -15,6 +15,11 @@ foam.CLASS({
     {
       class: 'foam.mlang.ExprProperty',
       name: 'delegate'
+    },
+    {
+      name: 'outputType',
+      value: 'String',
+      documentation: 'Output type is String (YYYY/MM format)'
     }
   ],
 


### PR DESCRIPTION

## Problem
When using GroupBy with a date field and selecting the YYYY/MM date format option, the date was not being parsed correctly. The GroupBy sink's `genModel()` method checks for an `outputType` property on expressions to determine the property class for the generated model. Without this property, it falls back to traversing to the underlying DateTime type, which doesn't correctly handle the YYYY/MM string format.

## Solution
Added the missing `outputType: 'String'` property to `DateToYYYYMMExpr`. This tells GroupBy that the expression outputs a String value, not a DateTime, allowing proper parsing and display of the YYYY/MM formatted values.

## Changes
- Added `outputType` property with value `'String'` to `DateToYYYYMMExpr.js`
