### PR TITLE
PT-FIXES: DOS-2199: add precision support to numeric aggregation sinks

### DIFF
--- a/src/foam/core/bench/BenchmarkRunner.js
+++ b/src/foam/core/bench/BenchmarkRunner.js
@@ -416,7 +416,7 @@ foam.CLASS({
           // print out transactions per second
           long endTime = System.currentTimeMillis();
 
-          Average avg = new Average(x, PMInfo.TOTAL_TIME, 0.0, 0L);
+          Average avg = new Average(x, PMInfo.TOTAL_TIME, 0.0, 0L, -1);
           ((DAO) x.get("pmInfoDAO"))
             .where(
               AND(

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -231,16 +231,27 @@ foam.CLASS({
       view: function(_, X) {
        return { class: 'foam.core.reflow.PropertyChoiceView', forCls: X.data.of };
       }
+    },
+    {
+      class: 'Int',
+      name: 'precision',
+      value: -1,
+      help: 'Number of decimal places for numeric results. -1 means no rounding.'
     }
   ],
 
   methods: [
     function value(s) { return s; },
-    function createSink() { return this.MIN(this.prop); },
+    function createSink() {
+      var sink = this.MIN(this.prop);
+      sink.precision = this.precision;
+      return sink;
+    },
     function addToE(e) {
       e.startContext({data: this}).start().
         style({display: 'flex'}).
-        add(this.PROP);
+        add(this.PROP).
+        add(this.PRECISION.__);
     }
   ]
 });
@@ -251,7 +262,11 @@ foam.CLASS({
   name: 'MaxDAOAgent',
   extends: 'foam.core.reflow.MinDAOAgent',
   methods: [
-    function createSink() { return this.MAX(this.prop); }
+    function createSink() {
+      var sink = this.MAX(this.prop);
+      sink.precision = this.precision;
+      return sink;
+    }
   ]
 });
 
@@ -278,7 +293,11 @@ foam.CLASS({
   ],
 
   methods: [
-    function createSink() { return this.AVG(this.prop); }
+    function createSink() {
+      var sink = this.AVG(this.prop);
+      sink.precision = this.precision;
+      return sink;
+    }
   ]
 });
 
@@ -288,7 +307,11 @@ foam.CLASS({
   name: 'SumDAOAgent',
   extends: 'foam.core.reflow.AvgDAOAgent',
   methods: [
-    function createSink() { return this.SUM(this.prop); }
+    function createSink() {
+      var sink = this.SUM(this.prop);
+      sink.precision = this.precision;
+      return sink;
+    }
   ]
 });
 

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -36,8 +36,7 @@ foam.CLASS({
 
     function applyPrecision(val) {
       if ( this.precision < 0 || typeof val !== 'number' ) return val;
-      var factor = Math.pow(10, this.precision);
-      return Math.round(val * factor) / factor;
+     return Number(val).toFixed(precision);
     }
   ]
 });

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -36,7 +36,7 @@ foam.CLASS({
     },
 
     function applyPrecision(val) {
-      if ( this.precision < 0 ) return val;
+      if ( this.precision < 0 || typeof val !== 'number' ) return val;
       var factor = Math.pow(10, this.precision);
       return Math.round(val * factor) / factor;
     }

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -19,27 +19,14 @@ foam.CLASS({
     {
       class: 'foam.mlang.ExprProperty',
       name: 'arg1',
-      hidden: true,
-      postSet: function(o, n) {
-        console.log('arg1 postSet:', n, n?.cls_?.id);
-      }
+      hidden: true
     },
     {
       class: 'Int',
       name: 'precision',
       value: -1,
       generateJava: false,
-      documentation: 'Number of decimal places for numeric results. -1 means no rounding (default behavior).',
-      visibility: function(arg1) {
-        console.log('precision visibility check:', arg1, arg1?.cls_?.id);
-        if ( ! arg1 ) return foam.u2.DisplayMode.HIDDEN;
-        var isNumeric = foam.lang.Int.isInstance(arg1) ||
-                        foam.lang.Long.isInstance(arg1) ||
-                        foam.lang.Float.isInstance(arg1) ||
-                        foam.lang.Double.isInstance(arg1);
-        console.log('isNumeric:', isNumeric);
-        return isNumeric ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
-      }
+      documentation: 'Number of decimal places for numeric results. -1 means no rounding (default behavior).'
     }
   ],
 

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -25,6 +25,7 @@ foam.CLASS({
       class: 'Int',
       name: 'precision',
       value: -1,
+      generateJava: false,
       documentation: 'Number of decimal places for numeric results. -1 means no rounding (default behavior).',
       visibility: function(arg1) {
         if ( ! arg1 ) return foam.u2.DisplayMode.HIDDEN;
@@ -42,20 +43,10 @@ foam.CLASS({
       return foam.String.constantize(this.cls_.name) + '(' + this.arg1.toString() + ')';
     },
 
-    {
-      name: 'applyPrecision',
-      args: 'Double val',
-      type: 'Double',
-      code: function applyPrecision(val) {
-        if ( this.precision < 0 ) return val;
-        var factor = Math.pow(10, this.precision);
-        return Math.round(val * factor) / factor;
-      },
-      javaCode: `
-if ( getPrecision() < 0 ) return val;
-double factor = Math.pow(10, getPrecision());
-return Math.round(val * factor) / factor;
-      `
+    function applyPrecision(val) {
+      if ( this.precision < 0 ) return val;
+      var factor = Math.pow(10, this.precision);
+      return Math.round(val * factor) / factor;
     }
   ]
 });

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -19,7 +19,10 @@ foam.CLASS({
     {
       class: 'foam.mlang.ExprProperty',
       name: 'arg1',
-      hidden: true
+      hidden: true,
+      postSet: function(o, n) {
+        console.log('arg1 postSet:', n, n?.cls_?.id);
+      }
     },
     {
       class: 'Int',
@@ -28,11 +31,13 @@ foam.CLASS({
       generateJava: false,
       documentation: 'Number of decimal places for numeric results. -1 means no rounding (default behavior).',
       visibility: function(arg1) {
+        console.log('precision visibility check:', arg1, arg1?.cls_?.id);
         if ( ! arg1 ) return foam.u2.DisplayMode.HIDDEN;
         var isNumeric = foam.lang.Int.isInstance(arg1) ||
                         foam.lang.Long.isInstance(arg1) ||
                         foam.lang.Float.isInstance(arg1) ||
                         foam.lang.Double.isInstance(arg1);
+        console.log('isNumeric:', isNumeric);
         return isNumeric ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
     }

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -25,7 +25,6 @@ foam.CLASS({
       class: 'Int',
       name: 'precision',
       value: -1,
-      generateJava: false,
       documentation: 'Number of decimal places for numeric results. -1 means no rounding (default behavior).'
     }
   ],

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -20,12 +20,42 @@ foam.CLASS({
       class: 'foam.mlang.ExprProperty',
       name: 'arg1',
       hidden: true
+    },
+    {
+      class: 'Int',
+      name: 'precision',
+      value: -1,
+      documentation: 'Number of decimal places for numeric results. -1 means no rounding (default behavior).',
+      visibility: function(arg1) {
+        if ( ! arg1 ) return foam.u2.DisplayMode.HIDDEN;
+        var isNumeric = foam.lang.Int.isInstance(arg1) ||
+                        foam.lang.Long.isInstance(arg1) ||
+                        foam.lang.Float.isInstance(arg1) ||
+                        foam.lang.Double.isInstance(arg1);
+        return isNumeric ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      }
     }
   ],
 
   methods: [
     function toString() {
       return foam.String.constantize(this.cls_.name) + '(' + this.arg1.toString() + ')';
+    },
+
+    {
+      name: 'applyPrecision',
+      args: 'Double val',
+      type: 'Double',
+      code: function applyPrecision(val) {
+        if ( this.precision < 0 ) return val;
+        var factor = Math.pow(10, this.precision);
+        return Math.round(val * factor) / factor;
+      },
+      javaCode: `
+if ( getPrecision() < 0 ) return val;
+double factor = Math.pow(10, getPrecision());
+return Math.round(val * factor) / factor;
+      `
     }
   ]
 });

--- a/src/foam/mlang/sink/Average.js
+++ b/src/foam/mlang/sink/Average.js
@@ -19,13 +19,11 @@ foam.CLASS({
     },
     {
       class: 'Double',
-      name: 'value',
-      value: 0
+      name: 'value'
     },
     {
       class: 'Long',
-      name: 'count',
-      value: 0
+      name: 'count'
     }
   ],
 

--- a/src/foam/mlang/sink/Average.js
+++ b/src/foam/mlang/sink/Average.js
@@ -69,8 +69,8 @@ if (other instanceof foam.mlang.sink.Average) {
       javaCode: 'setValue(0); setCount(0);',
       swiftCode: 'value = 0; count = 0'
     },
-    function toSummary() { return this.value; },
-    function valueOf() { return this.value; },
-    function addToE(e) { e.add(this.value); }
+    function toSummary() { return this.applyPrecision(this.value); },
+    function valueOf() { return this.applyPrecision(this.value); },
+    function addToE(e) { e.add(this.applyPrecision(this.value)); }
   ]
 });

--- a/src/foam/mlang/sink/Average.js
+++ b/src/foam/mlang/sink/Average.js
@@ -15,11 +15,7 @@ foam.CLASS({
   properties: [
     {
       class: 'foam.mlang.ExprProperty',
-      name: 'arg1',
-      hidden: false,
-      postSet: function(o, n) {
-        console.log('Average arg1 postSet:', n, n?.cls_?.id);
-      }
+      name: 'arg1'
     },
     {
       class: 'Double',

--- a/src/foam/mlang/sink/Average.js
+++ b/src/foam/mlang/sink/Average.js
@@ -15,7 +15,11 @@ foam.CLASS({
   properties: [
     {
       class: 'foam.mlang.ExprProperty',
-      name: 'arg1'
+      name: 'arg1',
+      hidden: false,
+      postSet: function(o, n) {
+        console.log('Average arg1 postSet:', n, n?.cls_?.id);
+      }
     },
     {
       class: 'Double',

--- a/src/foam/mlang/sink/Max.js
+++ b/src/foam/mlang/sink/Max.js
@@ -85,9 +85,14 @@ if (other instanceof foam.mlang.sink.Max) {
       code: function() { this.value = 0; },
       swiftCode: 'value = 0'
     },
-    function toSummary() { return this.value; },
-    function valueOf() { return this.value; },
-    function addToE(e) { e.add(this.value); },
+    function formatValue(val) {
+      if ( this.precision < 0 || typeof val !== 'number' ) return val;
+      return this.applyPrecision(val);
+    },
+
+    function toSummary() { return this.formatValue(this.value); },
+    function valueOf() { return this.formatValue(this.value); },
+    function addToE(e) { e.add(this.formatValue(this.value)); },
 
     function toProperties() {
       var name = 'max_' + this.arg1.name;
@@ -96,7 +101,7 @@ if (other instanceof foam.mlang.sink.Max) {
     },
 
     function setPropertyValues(o, sink, ps) {
-      ps[0].set(o, sink.value);
+      ps[0].set(o, sink.formatValue(sink.value));
     }
   ]
 });

--- a/src/foam/mlang/sink/Max.js
+++ b/src/foam/mlang/sink/Max.js
@@ -85,14 +85,9 @@ if (other instanceof foam.mlang.sink.Max) {
       code: function() { this.value = 0; },
       swiftCode: 'value = 0'
     },
-    function formatValue(val) {
-      if ( this.precision < 0 || typeof val !== 'number' ) return val;
-      return this.applyPrecision(val);
-    },
-
-    function toSummary() { return this.formatValue(this.value); },
-    function valueOf() { return this.formatValue(this.value); },
-    function addToE(e) { e.add(this.formatValue(this.value)); },
+    function toSummary() { return this.applyPrecision(this.value); },
+    function valueOf() { return this.applyPrecision(this.value); },
+    function addToE(e) { e.add(this.applyPrecision(this.value)); },
 
     function toProperties() {
       var name = 'max_' + this.arg1.name;
@@ -101,7 +96,7 @@ if (other instanceof foam.mlang.sink.Max) {
     },
 
     function setPropertyValues(o, sink, ps) {
-      ps[0].set(o, sink.formatValue(sink.value));
+      ps[0].set(o, sink.applyPrecision(sink.value));
     }
   ]
 });

--- a/src/foam/mlang/sink/Min.js
+++ b/src/foam/mlang/sink/Min.js
@@ -79,14 +79,9 @@ if (other instanceof foam.mlang.sink.Min) {
       code: function() { this.value = 0; },
       swiftCode: 'value = 0'
     },
-    function formatValue(val) {
-      if ( this.precision < 0 || typeof val !== 'number' ) return val;
-      return this.applyPrecision(val);
-    },
-
-    function toSummary() { return this.formatValue(this.value); },
-    function valueOf() { return this.formatValue(this.value); },
-    function addToE(e) { e.add(this.formatValue(this.value)); },
+    function toSummary() { return this.applyPrecision(this.value); },
+    function valueOf() { return this.applyPrecision(this.value); },
+    function addToE(e) { e.add(this.applyPrecision(this.value)); },
 
     function toProperties() {
       var name = 'min_' + this.arg1.name;
@@ -95,7 +90,7 @@ if (other instanceof foam.mlang.sink.Min) {
     },
 
     function setPropertyValues(o, sink, ps) {
-      ps[0].set(o, sink.formatValue(sink.value));
+      ps[0].set(o, sink.applyPrecision(sink.value));
     }
   ]
 });

--- a/src/foam/mlang/sink/Min.js
+++ b/src/foam/mlang/sink/Min.js
@@ -79,9 +79,14 @@ if (other instanceof foam.mlang.sink.Min) {
       code: function() { this.value = 0; },
       swiftCode: 'value = 0'
     },
-    function toSummary() { return this.value; },
-    function valueOf() { return this.value; },
-    function addToE(e) { e.add(this.value); },
+    function formatValue(val) {
+      if ( this.precision < 0 || typeof val !== 'number' ) return val;
+      return this.applyPrecision(val);
+    },
+
+    function toSummary() { return this.formatValue(this.value); },
+    function valueOf() { return this.formatValue(this.value); },
+    function addToE(e) { e.add(this.formatValue(this.value)); },
 
     function toProperties() {
       var name = 'min_' + this.arg1.name;
@@ -90,7 +95,7 @@ if (other instanceof foam.mlang.sink.Min) {
     },
 
     function setPropertyValues(o, sink, ps) {
-      ps[0].set(o, sink.value);
+      ps[0].set(o, sink.formatValue(sink.value));
     }
   ]
 });

--- a/src/foam/mlang/sink/Sum.js
+++ b/src/foam/mlang/sink/Sum.js
@@ -50,19 +50,19 @@ if (other instanceof foam.mlang.sink.Sum) {
       swiftCode: 'value = 0'
     },
 
-    function toSummary() { return this.value; },
+    function toSummary() { return this.applyPrecision(this.value); },
 
-    function addToE(e) { e.add(this.value); },
+    function addToE(e) { e.add(this.applyPrecision(this.value)); },
 
     function toProperties() {
       var name = 'sum_' + this.arg1.name;
       return [ { class: 'Double', name: name , label: 'SUM(' + foam.String.labelize(name) + ')' } ];
     },
 
-    function valueOf() { return this.value; },
+    function valueOf() { return this.applyPrecision(this.value); },
 
     function setPropertyValues(o, sink, ps) {
-      ps[0].set(o, sink.value);
+      ps[0].set(o, sink.applyPrecision(sink.value));
     }
   ]
 });

--- a/src/foam/mlang/sink/Sum.js
+++ b/src/foam/mlang/sink/Sum.js
@@ -15,7 +15,11 @@ foam.CLASS({
   properties: [
     {
       class: 'foam.mlang.ExprProperty',
-      name: 'arg1'
+      name: 'arg1',
+      hidden: false,
+      postSet: function(o, n) {
+        console.log('Sum arg1 postSet:', n, n?.cls_?.id);
+      }
     },
     {
       class: 'Double',

--- a/src/foam/mlang/sink/Sum.js
+++ b/src/foam/mlang/sink/Sum.js
@@ -15,11 +15,7 @@ foam.CLASS({
   properties: [
     {
       class: 'foam.mlang.ExprProperty',
-      name: 'arg1',
-      hidden: false,
-      postSet: function(o, n) {
-        console.log('Sum arg1 postSet:', n, n?.cls_?.id);
-      }
+      name: 'arg1'
     },
     {
       class: 'Double',

--- a/src/foam/mlang/sink/Sum.js
+++ b/src/foam/mlang/sink/Sum.js
@@ -19,8 +19,7 @@ foam.CLASS({
     },
     {
       class: 'Double',
-      name: 'value',
-      value: 0
+      name: 'value'
     }
   ],
 


### PR DESCRIPTION

## Problem
Numeric aggregation sinks (Sum, Average, Min, Max) displayed raw floating-point values with excessive decimal places, causing readability issues in dashboards and reports.

## Solution
Added a configurable `precision` property to control decimal place rounding. The precision is exposed in the reflow DAOAgent UI, allowing users to configure it per-sink. The value is serialized to Java so it persists through server round-trips.

## Changes
- Added `precision` property to `AbstractUnarySink` with `applyPrecision()` method
- Updated Sum, Average, Min, Max sinks to apply precision in `toSummary()`, `valueOf()`, `addToE()`, and `setPropertyValues()`
- Added precision config to MinDAOAgent (inherited by Max, Avg, Sum agents) with UI field
- Updated `createSink()` methods in DAOAgents to pass precision to sinks
- Fixed BenchmarkRunner Average constructor call for new precision parameter
