### PR TITLE
fix CSV download

### DIFF
--- a/src/foam/core/dig/drivers/DigCsvDriver.js
+++ b/src/foam/core/dig/drivers/DigCsvDriver.js
@@ -21,6 +21,14 @@ foam.CLASS({
     'foam.core.boot.CSpec',
     'foam.core.dig.*',
     'foam.core.dig.exception.*',
+    'foam.dao.AbstractSink',
+    'foam.dao.AbstractDAO',
+    'foam.lang.Detachable',
+    'foam.mlang.predicate.Predicate',
+    'foam.mlang.MLang',
+    'foam.core.auth.AuthService',
+    'foam.core.http.Command',
+    'foam.core.http.HttpParameters',
     'foam.core.http.*',
     'foam.core.logger.Logger',
     'foam.core.logger.PrefixLogger',
@@ -90,6 +98,127 @@ foam.CLASS({
       // Output the formatted data
       out.append(csv.getSb());
       out.println();
+      `
+    },
+    {
+      // Stream CSV rows directly to the response instead of buffering the
+      // entire dataset into memory. This keeps large exports from blowing up
+      // either the server or the browser when the DAO is big.
+      name: 'select',
+      args: 'X x',
+      javaCode: `
+      HttpParameters    p        = x.get(HttpParameters.class);
+      HttpServletResponse resp   = x.get(HttpServletResponse.class);
+      Command           command  = (Command) p.get(Command.class);
+      String            id       = p.getParameter("id");
+      String            q        = p.getParameter("q");
+      String            cols     = p.getParameter("columns");
+      String            limit    = p.getParameter("limit");
+      String            skip     = p.getParameter("skip");
+      String            daoName  = p.getParameter("dao");
+      String[]          outputCols = null;
+
+      if ( SafetyUtil.isEmpty(daoName) ) return;
+
+      DAO dao = getDAO(x);
+      if ( dao == null ) return;
+
+      ClassInfo cInfo = dao.getOf();
+      try {
+        String className = p.getParameter("of");
+        if ( ! SafetyUtil.isEmpty(className) ) {
+          cInfo = ((FObject) Class.forName(className).newInstance()).getClassInfo();
+        }
+      } catch ( Throwable t ) {
+        getLogger().warning("Failed to override class info", t);
+      }
+      final ClassInfo cInfoFinal = cInfo;
+
+      Predicate pred = new WebAgentQueryParser(cInfo).parse(x, q);
+      dao = dao.where(pred);
+
+      if ( ! SafetyUtil.isEmpty(cols) ) {
+        String[] cs = cols.split(",");
+        if ( cs.length > 0 ) {
+          outputCols = Arrays.asList(cs).stream().filter(pn -> {
+            try {
+              PropertyInfo pi = (PropertyInfo) cInfoFinal.getAxiomByName(pn);
+              return pi != null && ! pi.getNetworkTransient();
+            } catch (Throwable t) {
+              return false;
+            }
+          }).toArray(String[]::new);
+        }
+      }
+
+      PropertyInfo idProp = (PropertyInfo) cInfo.getAxiomByName("id");
+      dao = ! SafetyUtil.isEmpty(id) ? dao.where(MLang.EQ(idProp, id)) : dao;
+
+      if ( ! SafetyUtil.isEmpty(skip) ) {
+        long s = Long.valueOf(skip);
+        if ( s > 0 && s != AbstractDAO.MAX_SAFE_INTEGER ) {
+          dao = dao.skip(s);
+        }
+      }
+
+      long pageSize = DigFormatDriver.MAX_PAGE_SIZE;
+      if ( ! SafetyUtil.isEmpty(limit) ) {
+        AuthService auth = (AuthService) x.get("auth");
+        long l = Long.valueOf(limit);
+        if ( l == 0 ) {
+          if ( auth.check(x, "service.dig.read-all-records") ) {
+            pageSize = AbstractDAO.MAX_SAFE_INTEGER;
+          }
+        } else if ( l != AbstractDAO.MAX_SAFE_INTEGER && l < pageSize && l > 0 ) {
+          pageSize = l;
+        }
+      }
+      dao = dao.limit(pageSize);
+
+      // Prepare CSV outputter and response headers
+      CSVOutputterImpl csv = new CSVOutputterImpl.Builder(x)
+        .setOf(cInfo)
+        .build();
+      if ( outputCols != null && outputCols.length > 0 ) csv.setProps(outputCols);
+
+      resp.setContentType("text/csv");
+      resp.setHeader("Content-Disposition", "attachment; filename=\\"" + daoName + ".csv\\"");
+
+      PrintWriter out = x.get(PrintWriter.class);
+      final boolean[] wroteRows = { false };
+
+      dao.select(new AbstractSink() {
+        @Override
+        public void put(Object obj, Detachable sub) {
+          csv.outputFObject(x, (FObject) obj);
+          wroteRows[0] = true;
+
+          // Flush in manageable chunks to avoid large buffers.
+          if ( csv.getSb().length() >= 8192 ) {
+            out.append(csv.getSb());
+            csv.getSb().setLength(0);
+            out.flush();
+          }
+
+          if ( sub != null ) sub.detach();
+        }
+      });
+
+      if ( ! wroteRows[0] ) {
+        // Emit just the header so the downloaded file is still valid CSV.
+        csv.outputHeader(x);
+      }
+
+      if ( csv.getSb().length() > 0 ) {
+        out.append(csv.getSb());
+        csv.getSb().setLength(0);
+      }
+
+      out.println();
+      out.flush();
+      getLogger().debug("select.success", daoName, id);
+
+      resp.setStatus(HttpServletResponse.SC_OK);
       `
     }
   ]

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -988,12 +988,23 @@ foam.CLASS({
   imports: [ 'block', 'sessionID', 'window' ],
 
   requires: [
+    'foam.dao.ArrayDAO',
     'foam.core.export.CSVTableExportDriver',
     'foam.core.export.JSONDriver',
     'foam.core.export.JSONJDriver',
     'foam.core.export.XMLDriver'
   ],
-
+  css: `
+  ^basicLink {
+    border:none;
+    background:none;
+    padding:0;
+    margin:0;
+    cursor:pointer;
+    color:#0066cc;
+    text-decoration:underline;
+  }
+  `,
   properties: [
     {
       name: 'formats',
@@ -1043,13 +1054,22 @@ foam.CLASS({
     async function renderServiceDownloads(dao, serviceName) {
       var location = this.window.location.origin;
       var daoKey   = serviceName.substring(8);
-      var url      = `${location}/service/dig?dao=${daoKey}&cmd=select&sessionId=${this.sessionID}&limit=${this.block.value.limit}`;
+      // Build base POST payload instead of a GET query string. Keeping the
+      // body small avoids URL-length limits and prevents putting session
+      // identifiers or predicates into the address bar (which some proxies
+      // flag as policy violations).
+      var baseParams = {
+        dao:  daoKey,
+        cmd:  'select',
+        limit: this.block.value.limit
+      };
+      if ( this.sessionID ) baseParams.sessionId = this.sessionID;
 
       // Probe DAO to find the actual full query being used
       try {
         var sink = foam.dao.ArraySink.create();
         sink.setPredicate = function(p) {
-          url = url + '&q=' + encodeURIComponent(p.toMQL());
+          baseParams.q = p.toMQL();
           throw "just probing";
         };
         await dao.select(sink);
@@ -1057,22 +1077,55 @@ foam.CLASS({
       }
 
       if ( this.block.value.columns ) {
-        url = url + '&columns=' + encodeURIComponent(this.block.value.columns);
+        baseParams.columns = this.block.value.columns;
       }
 
       this.add('Download As: ');
       this.formats.forEach((fmt, idx) => {
         if ( idx > 0 ) this.add(', ');
-        this.
-          start('a').
-            attrs({
-              href: url + '&format=' + fmt.format,
-              rel: 'noopener noreferrer',
-              download: daoKey + fmt.extension,
-              target: '_blank'
-            }).
-            add(fmt.label).
-          end();
+
+        // Render a tiny form per format so we can POST and let the browser
+        // handle STREAMING the response directly to disk.
+        var form = this.start('form').attrs({
+          method: 'POST',
+          action: `${location}/service/dig`,
+          target: '_blank',
+          style: 'display:inline'
+        });
+
+        Object.keys(baseParams).forEach(k => {
+          form.start('input').attrs({ type: 'hidden', name: k, value: baseParams[k] }).end();
+        });
+
+        form.start('input').attrs({ type: 'hidden', name: 'format', value: fmt.format }).end();
+
+        form.start('button').
+          attrs({
+            type: 'submit',
+            style: 'border:none;background:none;padding:0;margin:0;cursor:pointer;color:#0066cc;text-decoration:underline'
+          }).
+          add(fmt.label).
+        end();
+
+        form.end(); // form
+      });
+
+      // FALLBACK for strict enterprise DLP: fetch data via the service API,
+      // then export client-side as a Blob (no direct file response for DLP to
+      // intercept). This preserves fixes for large files but gives an escape hatch.
+      this.start('div').style({ marginTop: '12px', color: '#555' })
+        .add('Blocked by a download proxy? Use client-side export: ')
+        .end();
+
+      this.formats.forEach((fmt, idx) => {
+        if ( idx > 0 ) this.add(', ');
+        this.start('a')
+          .style({ cursor: 'pointer', color: '#0066cc', 'text-decoration': 'underline' })
+          .on('click', async () => {
+            await this.downloadServiceClientSide(dao, daoKey, fmt, baseParams);
+          })
+          .add(fmt.label + ' (local fetch)')
+          .end();
       });
     },
 
@@ -1105,6 +1158,23 @@ foam.CLASS({
       } catch (error) {
         console.error('Export failed:', error);
         alert('Export failed: ' + (error?.message ?? error));
+      }
+    },
+
+    async function downloadServiceClientSide(remoteDAO, daoKey, format, baseParams) {
+      try {
+        // Pull data over the existing DAO API (respects predicates/columns/limit),
+        // accumulate locally, then reuse the client export path.
+        var sink = await remoteDAO.select();
+
+        var arrayDAO = this.ArrayDAO.create({
+          of: remoteDAO.of,
+          array: sink.array
+        }, this);
+
+        await this.downloadLocal(arrayDAO, daoKey || 'data', format);
+      } catch (error) {
+        console.error('Client-side export failed:', error);
       }
     }
   ]


### PR DESCRIPTION
In the Download of DAOAgents we have 3 possibilities for all format types.
**1)** we have local dao downloads
**2)** we have large file server downloads
**3)** we have DLP blocked client server downloads.

**Download Path 1** unchanged - if on browser then download is fine.
**Download Path 2**: 
Switch DIG downloads to POST forms so params aren’t in the URL and large files stream directly to the browser.
**Download Path 3**:
Add a client-side “local fetch” export fallback to bypass strict DLP environments while keeping the streaming path for scale.
Stream CSV rows in DigCsvDriver instead of buffering, set download filename, and emit headers for empty results.