### PR TITLE
Improve NumberFormat enum naming and structure

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -90,16 +90,36 @@ foam.ENUM({
   package: 'foam.core.reflow',
   name: 'NumberFormat',
 
+  properties: [
+    {
+      class: 'String',
+      name: 'parserSymbol',
+      documentation: 'The number parser grammar symbol name for this format'
+    },
+    {
+      name: 'id',
+      getter: function() { return this.ordinal; }
+    }
+  ],
+
   values: [
     {
-      name: 'STANDARD',
-      label: 'Standard (1,000.00)',
-      documentation: 'US/UK format: comma for thousands, period for decimal'
+      name: 'US_UK',
+      label: 'US/UK Style (1,000.00)',
+      parserSymbol: 'START',
+      documentation: 'Period as decimal separator, comma for thousands: 1,234.56'
     },
     {
       name: 'EUROPEAN',
-      label: 'European (1.000,00)',
-      documentation: 'European format: period for thousands, comma for decimal'
+      label: 'European / Continental (1.000,00)',
+      parserSymbol: 'european',
+      documentation: 'Comma as decimal separator, period for thousands: 1.234,56'
+    }
+  ],
+
+  methods: [
+    function toSummary() {
+      return this.label;
     }
   ]
 });
@@ -310,8 +330,8 @@ foam.CLASS({
       of: 'foam.core.reflow.NumberFormat',
       name: 'numberFormat',
       label: '',
-      value: 'STANDARD',
-      help: 'Standard format uses comma for thousands and period for decimal (1,000.00). European format uses period for thousands and comma for decimal (1.000,00).',
+      value: 'US_UK',
+      help: 'US/UK Style uses period for decimal (1,000.00). European uses comma for decimal (1.000,00).',
       documentation: 'Number format for this field (only applies to numeric properties)',
       view: {
         class: 'foam.core.reflow.NumberFormatRichChoiceView'
@@ -471,18 +491,10 @@ foam.CLASS({
        * Maps NumberFormat enum to NumberParser grammar symbol name.
        * This is used when calling fromCSV with format hints.
        *
-       * @returns {string} Parser grammar symbol name (undefined for standard, 'european' for European)
+       * @returns {string} Parser grammar symbol name ('START' or 'european')
        */
-      if ( ! this.numberFormat ) return undefined;
-
-      // Map enum values to parser symbol names
-      switch ( this.numberFormat.name ) {
-        case 'EUROPEAN':
-          return 'european';
-        case 'STANDARD':
-        default:
-          return undefined;
-      }
+      if ( ! this.numberFormat ) return 'START';
+      return this.numberFormat.parserSymbol || 'START';
     },
 
     function evaluateExpression(expression, rowData) {

--- a/src/foam/core/reflow/Upload.js
+++ b/src/foam/core/reflow/Upload.js
@@ -94,7 +94,7 @@ foam.CLASS({
         start('th').addClass('col-type').add('Type').end().
         start('th').addClass('col-value').add('Value').end().
         start('th').addClass('col-sample').add('Sample').end().
-        start('th').addClass('col-dateformat').add('Date Format').end().
+        start('th').addClass('col-dateformat').add('Format').end().
         start('th').addClass('col-required').add('Required').end().
       end().
       add(this.dynamic(function(data) {


### PR DESCRIPTION
## Problem
The NumberFormat enum used ambiguous naming ("STANDARD") that could be confused with DateFormat's "STANDARD" value. The enum also lacked the parserSymbol property pattern used by DateFormat, requiring a switch statement to map enum values to parser symbols.

## Solution
Renamed enum values to use clearer financial terminology (US_UK, EUROPEAN) and added parserSymbol property to match the DateFormat pattern, simplifying the parser mapping logic.

## Changes
- Renamed `STANDARD` to `US_UK` with label "US/UK Style (1,000.00)"
- Updated `EUROPEAN` label to "European / Continental (1.000,00)"
- Added `parserSymbol` property to NumberFormat enum (matching DateFormat pattern)
- Added `id` getter and `toSummary()` method for consistency with DateFormat
- Simplified `numberFormatToParserName()` to use parserSymbol directly instead of switch statement
- Renamed "Date Format" column header to "Format" in Upload view

<img width="255" height="219" alt="image" src="https://github.com/user-attachments/assets/5161434e-ee7a-4a42-a700-7ad00f63afea" />

