### PR TITLE
Add a DoubleUnitValue type and appropriate views and formatters | Use…

### DIFF
--- a/src/foam/lang/Currency.js
+++ b/src/foam/lang/Currency.js
@@ -28,6 +28,10 @@ foam.CLASS({
     'emoji'
   ],
 
+  constants: {
+    FORMATTER_CACHE: {}
+  },
+
   axioms: [
     {
       buildJavaClass: function(cls) {
@@ -156,6 +160,28 @@ foam.CLASS({
          * is not equal to the homeDenomination
          *
          */
+        // Not using foam locale as foam locale can be reset to a different value mid-session based on translation available
+        // using browser default formatting when available 
+        if ( navigator.language ) {
+          amount = Number(amount);
+          let opts = {
+            minimumFractionDigits: this.precision,
+            maximumFractionDigits: this.precision
+          }
+          if ( ! hideSymbol ) {
+            opts.style = 'currency';
+            opts.currency = this.id;
+          }
+          let formatterId = navigator.language + '-' + this.id;
+          if ( this.FORMATTER_CACHE[formatterId] ) {
+            return this.FORMATTER_CACHE[formatterId].format(amount);
+          } else {
+            let formatter = new Intl.NumberFormat(navigator.language, opts);
+            this.FORMATTER_CACHE[formatterId] = formatter;
+            return formatter.format(amount);
+          }
+        }
+        // TODO: Maybe consider deleting the custom formatting logic below
         amount = Math.round(amount);
         var isNegative = amount < 0;
         amount = amount.toString();

--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -909,6 +909,52 @@ foam.CLASS({
       `
     },
     {
+      class: 'Boolean',
+      name: 'hideId',
+      documentation: `
+        If true, the unit id will be excluded when formatting the value by default.
+        NOTE: This only affects formatting when using the unitPropValueToString method using the default view and tableCellFormatter.
+      `
+    },
+    {
+      name: 'unitPropValueToString',
+      value: async function(x, val, unitPropName, excludeUnit) {
+        if ( unitPropName ) {
+          const unitProp = await x.currencyDAO.find(unitPropName);
+          if ( unitProp )
+            return unitProp.format(val, excludeUnit, false);
+        }
+        return val;
+      }
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'DoubleUnitValue',
+  extends: 'Double',
+  documentation: `
+    A Double value with an associated unit property for formatting.
+  `,
+  properties: [
+    {
+      class: 'String',
+      name: 'unitPropName',
+      documentation: `
+        The name of the property of a model that contains the denomination String.
+      `
+    },
+    {
+      class: 'Boolean',
+      name: 'hideId',
+      documentation: `
+        If true, the unit id will be excluded when formatting the value by default.
+        NOTE: This only affects formatting when using the unitPropValueToString method using the default view and tableCellFormatter.
+      `,
+      value: true
+    },
+    {
       name: 'unitPropValueToString',
       value: async function(x, val, unitPropName, excludeUnit) {
         if ( unitPropName ) {

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1934,6 +1934,17 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'DoubleUnitValueViewRefinement',
+  refines: 'foam.lang.DoubleUnitValue',
+  requires: [ 'foam.u2.view.CurrencyView' ],
+  properties: [
+    [ 'displayWidth', 15 ],
+    [ 'view', { class: 'foam.u2.view.CurrencyView', onKey: false } ]
+  ]
+});
+
 
 foam.CLASS({
   package: 'foam.u2',

--- a/src/foam/u2/table/UnstyledTableView.js
+++ b/src/foam/u2/table/UnstyledTableView.js
@@ -483,13 +483,13 @@ foam.CLASS({
           var buttonStyle = { label: '', buttonStyle: 'TERTIARY', size: 'SMALL' };
           return showPagination ?
           this.E().start(view.Cols).addClass(view.myClass('nav')).style({ 'justify-content': 'flex-end'}). // Have to do this here because Cols CSS is installed after nav. Investigate later
-            startContext({ data: view.scrollEl_ }).
+            startContext({ data: view.scrollEl_, controllerMode: foam.u2.ControllerMode.VIEW }).
               start(view.Cols).
                 style({ gap: '4px', 'box-sizing': 'border-box' }).
-                start('').add(view.scrollEl_$.dot('topRow')).addClass(this.myClass('counters')).end().
+                start('').tag(view.scrollEl_.TOP_ROW).addClass(this.myClass('counters')).end().
                 add('-').
-                start('').add(view.scrollEl_$.dot('bottomRow')).addClass(this.myClass('counters')).end().
-                start().addClass(view.myClass('separator')).translate(this.cls_.id + '.MESSAGE_OF', this.MESSAGE_OF).end().add(view.scrollEl_.daoCount$).
+                start('').tag(view.scrollEl_.BOTTOM_ROW).addClass(this.myClass('counters')).end().
+                start().addClass(view.myClass('separator')).translate(this.cls_.id + '.MESSAGE_OF', this.MESSAGE_OF).end().tag(view.scrollEl_.DAO_COUNT).
               end().
               start(view.scrollEl_.FIRST_PAGE, { ...buttonStyle, themeIcon: 'first' }).
               addClass(view.myClass('buttons')).end().

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -62,7 +62,7 @@ foam.CLASS({
           class: 'foam.u2.view.FnFormatter',
           f: function(value, obj, axiom) {
             if ( foam.Number.isInstance(value) ) {
-              return Number(value).toLocaleString(navigator.locale);
+              value = Number(value).toLocaleString(navigator.locale);
             }
             this.add(value);
           }

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -253,6 +253,30 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'DoubleUnitValueTableCellFormatterRefinement',
+  refines: 'foam.lang.DoubleUnitValue',
+
+  properties: [
+    {
+      class: 'foam.u2.view.TableCellFormatter',
+      name: 'tableCellFormatter',
+      value: function(value, obj, axiom) {
+        var unitProp = obj.cls_.getAxiomByName(axiom.unitPropName);
+        if ( ! unitProp ) {
+          console.warn(obj.cls_.name, ' does not have the property: ', axiom.unitPropName);
+          this.add(value);
+          return;
+        }
+        var self = this;
+        this.startContext({objData: obj}).tag(foam.u2.view.ValueView, {prop: axiom, data: value}).endContext();
+      }
+    },
+    ['projectionSafe', false]
+  ]
+});
+
 
 foam.CLASS({
   package: 'foam.u2.view',

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -61,6 +61,9 @@ foam.CLASS({
         return foam.u2.view.FnFormatter.create({
           class: 'foam.u2.view.FnFormatter',
           f: function(value, obj, axiom) {
+            if ( foam.Number.isInstance(value) ) {
+              return Number(value).toLocaleString(navigator.locale);
+            }
             this.add(value);
           }
         });

--- a/src/foam/u2/view/ValueView.js
+++ b/src/foam/u2/view/ValueView.js
@@ -49,7 +49,12 @@ foam.CLASS({
           })
         );
       } else {
-        this.add(this.data$);
+        this.add(this.data$.map(v => {
+          if ( foam.Number.isInstance(v) ) {
+            return Number(v).toLocaleString(navigator.locale);
+          }
+          return v;
+        }));
       }
     }
   ]

--- a/src/foam/u2/view/ValueView.js
+++ b/src/foam/u2/view/ValueView.js
@@ -42,10 +42,10 @@ foam.CLASS({
         this.add(
           unitPropSlot ?
           this.slot(function(data, unitProp) {
-            return prop.unitPropValueToString.call(self.__subContext__.objData, self.__subContext__, data, unitProp);
+            return prop.unitPropValueToString.call(self.__subContext__.objData, self.__subContext__, data, unitProp, prop.hideId);
           }, this.data$, unitPropSlot) :
           this.slot(function(data) {
-            return prop.unitPropValueToString.call(self.__subContext__.objData, self.__subContext__, data, self.__subContext__.objData[prop.unitPropName]);
+            return prop.unitPropValueToString.call(self.__subContext__.objData, self.__subContext__, data, self.__subContext__.objData[prop.unitPropName], prop.hideId);
           })
         );
       } else {


### PR DESCRIPTION
- Add a DoubleUnitValue type and appropriate views and formatters
- Use the browser formatting for currency when available based on navigator locale
- For all numbers, format based on locale adding delimiters and decimal as needed

Merge with caution, changes a lot of basic views 