### PR TITLE
Fix UploadSink semaphore usage to prevent upload hangs

### DIFF
--- a/src/foam/core/reflow/UploadSink.js
+++ b/src/foam/core/reflow/UploadSink.js
@@ -146,14 +146,14 @@ foam.CLASS({
     
     async function put(o) {
       var self = this;
-      
+
       // Apply object adaptation callback
       try {
         this.adaptObject(o);
       } catch (e) {
         console.warn('Object adaptation callback failed:', e);
       }
-      
+
       // Increment processing counter (totalRows should be set by parser upfront)
       this.processing++;
       this.updateStatus();
@@ -239,14 +239,15 @@ foam.CLASS({
           if ( this.bulkUpload ) {
             if ( ! this.agent_ ) this.agent_ = this.UploadAgent.create();
             this.agent_.data.push(o);
-            
+
             if ( this.matchedRows && this.matchedRows % 2000 === 0 ) {
               var oldAgent = this.agent_;
               this.agent_ = undefined;
               await new Promise(r => self.setTimeout(r, 0));
-              // Only allow a fixed number of outstanding cmd() calls
-              await this.semaphore_;
-              this.dao.cmd(oldAgent).then(() => self.semaphore_.decr());
+              // Limit concurrent batch uploads using semaphore
+              this.semaphore_.then(async () => {
+                await this.dao.cmd(oldAgent);
+              });
             }
           } else {
             await this.dao.put(o);

--- a/src/foam/lang/CountingSemaphore.js
+++ b/src/foam/lang/CountingSemaphore.js
@@ -67,7 +67,7 @@ foam.CLASS({
     },
 
     function drain() {
-      if ( this.count_ == 0 ) return Promise.resolve();
+      if ( this.count_ <= 0 ) return Promise.resolve();
       return this.drainLatch_ = this.Latch.create();
     }
   ],


### PR DESCRIPTION

## Problem
File uploads could hang at the end when using bulk upload with batching. The UploadSink was using the CountingSemaphore incorrectly:

- `await this.semaphore_` was used, which doesn't actually wait - it just awaits the object itself and resolves immediately
- `decr()` was called without matching `then()` calls, causing the internal count to go negative
- `drain()` checked `count_ == 0`, but with a negative count it would create a latch that never resolved, causing the upload to hang

## Solution
Use the CountingSemaphore correctly following the established pattern (as seen in Transform.js):

- Use `semaphore_.then(block)` which properly increments count, executes the block, and decrements when done
- Change `drain()` to check `count_ <= 0` as a safety measure for edge cases where count could be negative

## Changes
- **UploadSink.js**: Replace incorrect `await this.semaphore_` + manual `decr()` with proper `semaphore_.then(async () => { ... })` pattern
- **CountingSemaphore.js**: Change `drain()` condition from `count_ == 0` to `count_ <= 0` to handle edge cases
