### PR TITLE
PT-FIXES: DOS-2199 Remove hardcoded precision from Cells

### DIFF
--- a/src/foam/core/reflow/cells/Cells.js
+++ b/src/foam/core/reflow/cells/Cells.js
@@ -200,10 +200,6 @@ foam.CLASS({
         },
         {
           name: 'data',
-          adapt: function(_, v) {
-            var ret = parseFloat(v);
-            return ret && ! Number.isInteger(ret) ? ret.toFixed(2) : v;
-          },
           displayWidth: 12
         },
         {


### PR DESCRIPTION
## Problem
The `Cells.Cell.data` property had a hardcoded `adapt` function that forced all non-integer numeric values to 2 decimal places using `toFixed(2)`. This caused data loss for values that needed more precision, and was redundant since the aggregate DAOAgents (Min, Max, Avg, Sum) now have configurable `precision` properties that allow users to control decimal formatting.

## Solution
Removed the `adapt` function from `Cells.Cell.data` so values display as-is without forced rounding. Users who need specific precision can use the configurable precision property on aggregate agents.

## Changes
- Removed hardcoded 2-decimal `adapt` function from `Cells.Cell.data` property in `Cells.js`
