### PR TITLE
Remove javax.json library as it has been replaced by jakarta.json

### DIFF
--- a/pom.js
+++ b/pom.js
@@ -37,7 +37,6 @@ foam.POM({
     'jakarta.mail:jakarta.mail-api:2.1.2',
     'jakarta.activation:jakarta.activation-api:2.1.2',
     'jakarta.websocket:jakarta.websocket-api:2.0.0',
-    'javax.json:javax.json-api:1.1.4',
     'jakarta.json:jakarta.json-api:2.1.3',
     'javax.ws.rs:javax.ws.rs-api:2.1.1',
     'jstl:jstl:1.2',
@@ -65,7 +64,6 @@ foam.POM({
     'org.eclipse.jetty.http2:http2-server:11.0.26',
     'org.eclipse.jetty.websocket:websocket-jetty-server:11.0.26',
     'org.eclipse.parsson:parsson:1.1.7',
-    'org.glassfish:javax.json:1.1.4',
     'org.jsoup:jsoup:1.15.1', // HTML Parser
     'org.jtwig:jtwig-core:5.87.0.RELEASE',
     'org.postgresql:postgresql:42.3.8',

--- a/src/foam/core/oauth/OAuthProvider.js
+++ b/src/foam/core/oauth/OAuthProvider.js
@@ -119,8 +119,8 @@ if (responseCode != 200) {
 
 // Read the response body into a JsonObject
 java.io.InputStream is = connection.getInputStream();
-javax.json.JsonReader jsonReader = javax.json.Json.createReader(is);
-javax.json.JsonObject responseJson = jsonReader.readObject(); 
+jakarta.json.JsonReader jsonReader = jakarta.json.Json.createReader(is);
+jakarta.json.JsonObject responseJson = jsonReader.readObject(); 
 return responseJson.getString("access_token");
 } catch (Exception e) {
     throw new RuntimeException("Failed to refresh token", e);

--- a/src/foam/core/oauth/OAuthWebAgent.java
+++ b/src/foam/core/oauth/OAuthWebAgent.java
@@ -118,7 +118,7 @@ public class OAuthWebAgent implements WebAgent {
 
             sendResponse(x, state, resp);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("OAuthWebAgent", e);
             try {
                 resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 resp.getWriter().write("Server error: " + e.getMessage());

--- a/src/foam/core/oauth/OAuthWebAgent.java
+++ b/src/foam/core/oauth/OAuthWebAgent.java
@@ -11,9 +11,9 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import foam.core.logger.Logger;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 
 // Generic OAuth Web Agent for handling oauth redirects
 // can be used for login and for storing oauth credentials for users
@@ -175,7 +175,7 @@ public class OAuthWebAgent implements WebAgent {
         }
     }
 
-    protected foam.core.auth.User loginWithIdToken(foam.lang.X x, javax.json.JsonObject state, foam.core.oauth.OAuthProvider provider, String idToken) {
+    protected foam.core.auth.User loginWithIdToken(foam.lang.X x, jakarta.json.JsonObject state, foam.core.oauth.OAuthProvider provider, String idToken) {
         Logger logger = (Logger) x.get("logger");
         String parts[] = idToken.split("\\.");
         String bodyb64 = parts[1];
@@ -183,8 +183,8 @@ public class OAuthWebAgent implements WebAgent {
         byte[] bodyBytes = java.util.Base64.getUrlDecoder().decode(bodyb64);
         String body = new String(bodyBytes, java.nio.charset.StandardCharsets.UTF_8);
 
-        javax.json.JsonReader reader = javax.json.Json.createReader(new java.io.StringReader(body));
-        javax.json.JsonObject bodyObject = reader.readObject();
+        jakarta.json.JsonReader reader = jakarta.json.Json.createReader(new java.io.StringReader(body));
+        jakarta.json.JsonObject bodyObject = reader.readObject();
         reader.close();
 
         if (!bodyObject.getBoolean("email_verified")) {


### PR DESCRIPTION
It caused CCE when calling `Json.createReader()`.

    Server error: Provider org.glassfish.json.JsonProviderImpl could not be instantiated: java.lang.ClassCastException: class org.glassfish.json.JsonProviderImpl cannot be cast to class javax.json.spi.JsonProvider (org.glassfish.json.JsonProviderImpl and javax.json.spi.JsonProvider are in unnamed module of loader 'app')

```
javax.json.JsonException: Provider org.glassfish.json.JsonProviderImpl could not be instantiated: java.lang.ClassCastException: class org.glassfish.json.JsonProviderImpl cannot be cast to class javax.json.spi.JsonProvider (org.glassfish.json.JsonProviderImpl and javax.json.spi.JsonProvider are in unnamed module of loader 'app')
        at javax.json.spi.JsonProvider.provider(JsonProvider.java:102)
        at javax.json.Json.createReader(Json.java:213)
        at foam.core.oauth.OAuthWebAgent.execute(OAuthWebAgent.java:45)
        at foam.core.pm.PMWebAgent.execute(PMWebAgent.java:34)
        at foam.core.http.NanoRouter.service(NanoRouter.java:125)
        at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1665)
        at foam.core.http.csp.CSPFilter.doFilter(CSPFilter.java:242)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:170)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:527)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1381)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1303)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)
        at org.eclipse.jetty.server.handler.InetAccessHandler.handle(InetAccessHandler.java:228)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
        at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:822)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
        at org.eclipse.jetty.server.Server.handle(Server.java:563)
        at org.eclipse.jetty.server.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1598)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:753)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:501)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:287)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
        at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:558)
        at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:379)
        at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:146)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
        at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:421)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:390)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:277)
        at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:199)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:411)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:969)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1194)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1149)
        at java.base/java.lang.Thread.run(Thread.java:1583)

```