### PR TITLE
Fix CSSAuditTest failures in markdown components

### DIFF
--- a/src/foam/u2/markdown/Glossary.js
+++ b/src/foam/u2/markdown/Glossary.js
@@ -155,7 +155,7 @@ foam.CLASS({
     }
 
     ^term {
-      color: #0066cc;
+      color: $textBrand;
       text-decoration: underline;
       text-decoration-style: dotted;
       cursor: pointer;
@@ -163,14 +163,14 @@ foam.CLASS({
     }
 
     ^term:hover {
-      color: #004499;
+      color: $primary500;
     }
 
     ^popup {
       position: absolute;
       z-index: 1000;
-      background: #fff;
-      border: 1px solid #ccc;
+      background: $white;
+      border: 1px solid $borderDefault;
       border-radius: 6px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.15);
       padding: 12px 16px;
@@ -181,21 +181,21 @@ foam.CLASS({
     }
 
     ^popup-header {
-      font-weight: 600;
-      color: #333;
+      font-weight: $font-medium;
+      color: $textDefault;
       margin-bottom: 8px;
       padding-bottom: 6px;
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid $borderLight;
     }
 
     ^popup-definition {
-      color: #555;
+      color: $textSecondary;
     }
 
     ^popup-source {
       margin-top: 8px;
       font-size: 12px;
-      color: #888;
+      color: $textTertiary;
       font-style: italic;
     }
 
@@ -204,13 +204,13 @@ foam.CLASS({
       top: 8px;
       right: 10px;
       cursor: pointer;
-      color: #999;
+      color: $grey400;
       font-size: 16px;
       line-height: 1;
     }
 
     ^popup-close:hover {
-      color: #333;
+      color: $textDefault;
     }
   `,
 
@@ -367,9 +367,9 @@ foam.CLASS({
 
   css: `
     ^entry { margin-bottom: 16px; }
-    ^entry dt { font-weight: 600; color: #333; }
-    ^entry dd { margin-left: 0; margin-top: 4px; color: #555; }
-    ^source { font-size: 0.9em; color: #888; font-style: italic; }
+    ^entry dt { font-weight: $font-medium; color: $textDefault; }
+    ^entry dd { margin-left: 0; margin-top: 4px; color: $textSecondary; }
+    ^source { font-size: 0.9em; color: $textTertiary; font-style: italic; }
   `,
 
   methods: [

--- a/src/foam/u2/markdown/Search.js
+++ b/src/foam/u2/markdown/Search.js
@@ -369,7 +369,7 @@ foam.CLASS({
   css: `
     ^ {
       font-size: 14px;
-      color: #666;
+      color: $textSecondary;
       margin: 8px 0;
     }
   `,

--- a/src/foam/u2/markdown/TOC.js
+++ b/src/foam/u2/markdown/TOC.js
@@ -300,12 +300,12 @@ foam.CLASS({
 
   css: `
     ^ { margin: 20px 0; }
-    ^title { font-size: 1.25em; font-weight: 600; margin-bottom: 12px; }
+    ^title { font-size: 1.25em; font-weight: $font-medium; margin-bottom: 12px; }
     ^list { list-style: none; padding: 0; margin: 0; }
     ^item { margin: 4px 0; }
-    ^item a { color: #0066cc; text-decoration: none; }
+    ^item a { color: $textBrand; text-decoration: none; }
     ^item a:hover { text-decoration: underline; }
-    ^level-1 { margin-left: 0; font-weight: 500; }
+    ^level-1 { margin-left: 0; font-weight: $font-regular; }
     ^level-2 { margin-left: 20px; }
     ^level-3 { margin-left: 40px; }
     ^level-4 { margin-left: 60px; }


### PR DESCRIPTION

## Problem
The CSSAuditTest was failing because markdown components (TOC.js, Glossary.js, Search.js) used hardcoded hex colors and font-weight values instead of semantic CSS tokens from CSSTokens.js. This violated the style guidelines and prevented proper theming support.

## Solution
Replaced all hardcoded colors and font-weight values with their corresponding CSS token equivalents defined in foam.u2.CSSTokens.

## Changes
- **TOC.js**: Replaced link colors (`#0066cc` → `$textBrand`) and font-weights (`600` → `$font-medium`, `500` → `$font-regular`)
- **Glossary.js**: Replaced all hardcoded colors in TermReference and Glossary components:
  - Link colors: `#0066cc` → `$textBrand`, `#004499` → `$primary500`
  - Text colors: `#333` → `$textDefault`, `#555` → `$textSecondary`, `#888`/`#999` → `$textTertiary`/`$grey400`
  - Background/borders: `#fff` → `$white`, `#ccc` → `$borderDefault`, `#eee` → `$borderLight`
  - Font weights: `600` → `$font-medium`
- **Search.js**: Replaced text color (`#666` → `$textSecondary`)
