### PR TITLE
 PT-FIXES:DOS-2328 Fix CountPlan returning wrong count for indexed predicates

### DIFF
--- a/src/foam/dao/index/TreeIndex.java
+++ b/src/foam/dao/index/TreeIndex.java
@@ -186,10 +186,12 @@ public class TreeIndex
 
     Object   originalState  = state;
     Object[] statePredicate = simplifyPredicate(state, predicate);
-    long     size           = state == null ? 0 : ((TreeNode) state).size;
 
     state     = statePredicate[0];
     predicate = (Predicate) statePredicate[1];
+
+    // Calculate size AFTER state is potentially narrowed by simplifyPredicate
+    long     size           = state == null ? 0 : ((TreeNode) state).size;
 
     // Treat as "no limit" if limit >= the size of the collection
     if ( limit >= size ) limit = AbstractDAO.MAX_SAFE_INTEGER;


### PR DESCRIPTION

## Problem

When using `Count` sink with a predicate that matches a secondary index (e.g., `Eq(programId, 157)`), `TreeIndex.planSelect()` returned incorrect counts. The count returned the total table size instead of the filtered count.

The issue was in the order of operations in `planSelect()`:
1. `simplifyPredicate()` narrows the state based on indexed predicates
2. `size` was calculated from the **original** state (before narrowing)
3. When `CountPlan` was created, it used this incorrect size

## Solution

Moved the `size` calculation to occur **after** the state is updated from `simplifyPredicate()`. This ensures `CountPlan` uses the size of the narrowed state, which correctly reflects the filtered record count.

## Changes

- Moved `size` calculation in `TreeIndex.planSelect()` to after state assignment
- Added comment explaining why size must be calculated after state narrowing
