### PR TITLE
PT-FIXES:DOS-2207 Fix format field description missing in production bundles

### DIFF
--- a/src/foam/core/reflow/DateFormatCitationView.js
+++ b/src/foam/core/reflow/DateFormatCitationView.js
@@ -43,7 +43,7 @@ foam.CLASS({
         .end()
         .start('div')
           .addClass(this.myClass('documentation'))
-          .add(this.data.documentation || '')
+          .add(this.data.help || '')
         .end();
     }
   ]
@@ -93,6 +93,11 @@ foam.CLASS({
 
   documentation: 'Custom RichChoiceView for enum values that stores the full enum object',
 
+  requires: [
+    'foam.dao.ArrayDAO',
+    'foam.core.reflow.DateFormat'
+  ],
+
   properties: [
     {
       name: 'selectionView',
@@ -111,9 +116,9 @@ foam.CLASS({
       factory: function() {
         return [
           {
-            dao: foam.dao.ArrayDAO.create({
-              of: foam.core.reflow.DateFormat,
-              array: foam.core.reflow.DateFormat.VALUES
+            dao: this.ArrayDAO.create({
+              of: this.DateFormat,
+              array: this.DateFormat.VALUES
             })
           }
         ];

--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -39,6 +39,10 @@ foam.ENUM({
       documentation: 'The DateParser grammar symbol name for this format'
     },
     {
+      class: 'String',
+      name: 'help'
+    },
+    {
       // Add an 'id' property that returns the ordinal for DAO compatibility
       name: 'id',
       getter: function() { return this.ordinal; }
@@ -50,31 +54,31 @@ foam.ENUM({
       name: 'STANDARD',
       label: 'Standard',
       parserSymbol: 'START',
-      documentation: 'Standard formats: yyyy-mm-dd, yyyy/mm/dd, yyyymmdd, mm/dd/yyyy, mm-dd-yyyy, mmddyyyy, mm/dd/yy, mm-dd-yy, mmddyy, plus ALL month name formats (unambiguous!): 31-JAN-2025, 31JAN2025, 2025-31-JAN, 202531JAN, Jan 02 2025'
+      help: 'yyyy-mm-dd, mm/dd/yyyy, 31-JAN-2025, Jan 02 2025'
     },
     {
       name: 'DDMMYYYY',
       label: 'dd/mm/yyyy',
       parserSymbol: 'ddmmyyyy',
-      documentation: 'Day-Month-Year format for NUMERIC dates: dd/mm/yyyy, dd-mm-yyyy, ddmmyyyy, dd/mm/yy, dd-mm-yy, ddmmyy (month names work automatically in STANDARD)'
+      help: 'dd/mm/yyyy, dd-mm-yyyy, ddmmyyyy'
     },
     {
       name: 'YYYYDDMM',
       label: 'yyyy/dd/mm',
       parserSymbol: 'yyyyddmm',
-      documentation: 'Numeric only: yyyy-dd-mm, yyyyddmm, yy-dd-mm, yyddmm'
+      help: 'yyyy-dd-mm, yyyyddmm'
     },
     {
       name: 'JULIANDATE',
       label: 'Julian Date',
       parserSymbol: 'juliandate',
-      documentation: 'Julian date format: YYDDD (5 digits like 25216) or YDDD (4 digits like 5216) where YY/Y is year and DDD is day of year (001-366). Example: 25216 = August 4, 2025 (day 216 of 2025)'
+      help: 'YYDDD or YDDD (e.g. 25216 = Aug 4, 2025)'
     },
     {
       name: 'YYMMDD',
       label: 'yy/mm/dd',
       parserSymbol: 'yymmdd',
-      documentation: 'Year-Month-Day with 2-digit year: yymmdd (compact 6-digit), yy-mm-dd, yy/mm/dd. Example: 250325 = March 25, 2025. Year pivot: 00-49 → 2000-2049, 50-99 → 1950-1999'
+      help: 'yymmdd, yy-mm-dd (e.g. 250325 = Mar 25, 2025)'
     }
   ],
 
@@ -97,6 +101,10 @@ foam.ENUM({
       documentation: 'The number parser grammar symbol name for this format'
     },
     {
+      class: 'String',
+      name: 'help'
+    },
+    {
       name: 'id',
       getter: function() { return this.ordinal; }
     }
@@ -105,15 +113,15 @@ foam.ENUM({
   values: [
     {
       name: 'US_UK',
-      label: 'US/UK Style (1,000.00)',
+      label: 'US/UK (1,000.00)',
       parserSymbol: 'START',
-      documentation: 'Period as decimal separator, comma for thousands: 1,234.56'
+      help: '1,234.56'
     },
     {
       name: 'EUROPEAN',
-      label: 'European / Continental (1.000,00)',
+      label: 'European (1.000,00)',
       parserSymbol: 'european',
-      documentation: 'Comma as decimal separator, period for thousands: 1.234,56'
+      help: '1.234,56'
     }
   ],
 

--- a/src/foam/core/reflow/NumberFormatCitationView.js
+++ b/src/foam/core/reflow/NumberFormatCitationView.js
@@ -43,7 +43,7 @@ foam.CLASS({
         .end()
         .start('div')
           .addClass(this.myClass('documentation'))
-          .add(this.data.documentation || '')
+          .add(this.data.help || '')
         .end();
     }
   ]
@@ -93,6 +93,11 @@ foam.CLASS({
 
   documentation: 'Custom RichChoiceView for NumberFormat enum values',
 
+  requires: [
+    'foam.dao.ArrayDAO',
+    'foam.core.reflow.NumberFormat'
+  ],
+
   properties: [
     {
       name: 'selectionView',
@@ -111,9 +116,9 @@ foam.CLASS({
       factory: function() {
         return [
           {
-            dao: foam.dao.ArrayDAO.create({
-              of: foam.core.reflow.NumberFormat,
-              array: foam.core.reflow.NumberFormat.VALUES
+            dao: this.ArrayDAO.create({
+              of: this.NumberFormat,
+              array: this.NumberFormat.VALUES
             })
           }
         ];


### PR DESCRIPTION

## Problem
The format field description (showing supported date/number formats) was missing on the file upload screen in production builds. The `documentation` property on enum values gets stripped during bundle builds with the `-a` flag, causing the help text to disappear.

Additionally, the RichChoiceView factories were using direct class references (`foam.core.reflow.DateFormat`) instead of properly required classes, which could fail in bundled mode.

## Solution
Changed DateFormat and NumberFormat enums to use the `help` property instead of `documentation`, which is preserved in production bundles. Added proper `requires` declarations to ensure classes are available when factories execute. Also simplified the help text to be more concise.

## Changes
- Added `help` property to DateFormat and NumberFormat enum definitions in Mapping.js
- Changed enum values to use `help` instead of `documentation`
- Simplified help text for better readability (e.g., "yyyy-mm-dd, mm/dd/yyyy" instead of verbose descriptions)
- Added `requires` for ArrayDAO and format enums in DateFormatRichChoiceView
- Added `requires` for ArrayDAO and format enums in NumberFormatRichChoiceView
- Changed factories to use `this.ArrayDAO` and `this.DateFormat`/`this.NumberFormat` instead of direct references
- Updated citation views to read `this.data.help` instead of `this.data.documentation`
