### PR TITLE
Fix Node.js HTTPRequest blob payload streaming

### DIFF
--- a/src/foam/blob/BlobBlob.js
+++ b/src/foam/blob/BlobBlob.js
@@ -26,9 +26,17 @@ foam.CLASS({
 
   methods: [
     function read(out, offset, length) {
-      var reader = new FileReader();
-
       var b = this.blob.slice(offset, offset + length);
+
+      // Node.js: use blob.arrayBuffer() API (Node.js 18+)
+      if ( typeof FileReader === 'undefined' ) {
+        return b.arrayBuffer().then(function(arrayBuffer) {
+          out(arrayBuffer);
+        });
+      }
+
+      // Browser: use FileReader API
+      var reader = new FileReader();
 
       return new Promise(function(resolve, reject) {
         reader.onload = function(e) {

--- a/src/foam/net/node/HTTPRequest.js
+++ b/src/foam/net/node/HTTPRequest.js
@@ -127,13 +127,36 @@ foam.CLASS({
         });
 
         if ( this.payload && this.Blob.isInstance(this.payload) ) {
-          this.payload.pipe(function(buf) {
-            if ( req.write(buf) ) {
-              return new Promise(function(resolve) { req.once('drain', resolve); });
+          // Stream blob data in chunks using read()
+          var blob = this.payload;
+          var chunkSize = 1024 * 1024; // 1MB chunks
+          var offset = 0;
+          var size = blob.size;
+
+          function writeNextChunk() {
+            if ( offset >= size ) {
+              req.end();
+              return;
             }
-          }).then(function() {
-            req.end();
-          });
+
+            var length = Math.min(chunkSize, size - offset);
+            var currentOffset = offset;
+            offset += length;
+
+            blob.read(function(buf) {
+              // req.write() returns false if buffer is full, true if ok to continue
+              if ( ! req.write(buf) ) {
+                // Buffer full, wait for drain before continuing
+                req.once('drain', writeNextChunk);
+              } else {
+                writeNextChunk();
+              }
+            }, currentOffset, length).catch(function(err) {
+              reject(err);
+            });
+          }
+
+          writeNextChunk();
           return;
         } else if ( this.payload ) {
           req.write(buf);

--- a/src/foam/net/node/HTTPRequest.js
+++ b/src/foam/net/node/HTTPRequest.js
@@ -144,8 +144,10 @@ foam.CLASS({
             offset += length;
 
             blob.read(function(buf) {
+              // Convert ArrayBuffer to Node.js Buffer for req.write()
+              var chunk = Buffer.from(buf);
               // req.write() returns false if buffer is full, true if ok to continue
-              if ( ! req.write(buf) ) {
+              if ( ! req.write(chunk) ) {
                 // Buffer full, wait for drain before continuing
                 req.once('drain', writeNextChunk);
               } else {


### PR DESCRIPTION

## Problem
Node.js HTTPRequest failed when uploading blobs because:
1. It called `blob.pipe()` which doesn't exist on the Blob interface (only `read()` and `getSize()` exist)
2. BlobBlob.read() used FileReader which is browser-only, causing "FileReader is not defined" errors in Node.js
3. Node.js `req.write()` received ArrayBuffer but only accepts Buffer/Uint8Array

## Solution
- Replace non-existent `pipe()` with chunked `read()` calls in node HTTPRequest
- Add runtime environment detection in BlobBlob to use `blob.arrayBuffer()` (Node.js 18+) when FileReader is unavailable
- Convert ArrayBuffer to Node.js Buffer before passing to `req.write()`

## Changes
- `foam/net/node/HTTPRequest.js`: Replace `blob.pipe()` with chunked `blob.read()` streaming with backpressure handling
- `foam/blob/BlobBlob.js`: Add Node.js compatibility using `blob.arrayBuffer()` when FileReader is undefined
- `foam/net/node/HTTPRequest.js`: Convert ArrayBuffer to Buffer for `req.write()`

