### PR TITLE
PT-FIXES:DOS-2365 Add Equal option to DateFilterView

### DIFF
--- a/src/foam/u2/filter/properties/DateFilterView.js
+++ b/src/foam/u2/filter/properties/DateFilterView.js
@@ -20,11 +20,12 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'LABEL_ALL',    message: 'All Time' },
-    { name: 'LABEL_AFTER',    message: 'After' },
+    { name: 'LABEL_ALL',       message: 'All Time' },
+    { name: 'LABEL_EQUAL',     message: 'Equal' },
+    { name: 'LABEL_AFTER',     message: 'After' },
     { name: 'LABEL_BEFORE',    message: 'Before' },
-    { name: 'LABEL_BETWEEN',    message: 'Between' },
-    { name: 'LABEL_INCLUSIVE',    message: 'Inclusive' }
+    { name: 'LABEL_BETWEEN',   message: 'Between' },
+    { name: 'LABEL_INCLUSIVE',  message: 'Inclusive' }
   ],
 
   css: `
@@ -147,9 +148,10 @@ foam.CLASS({
               data$: this.qualifier$,
               choices: [
                 ['True', this.LABEL_ALL],
-                ['Gt', this.LABEL_AFTER],
-                ['Lt', this.LABEL_BEFORE],
-                ['Bt', this.LABEL_BETWEEN]
+                ['Eq',   this.LABEL_EQUAL],
+                ['Gt',   this.LABEL_AFTER],
+                ['Lt',   this.LABEL_BEFORE],
+                ['Bt',   this.LABEL_BETWEEN]
               ],
               defaultValue: 'True'
             })


### PR DESCRIPTION
## Problem
The DateFilterView only offered "All Time", "After", "Before", and "Between" as filter qualifiers. Users needed the ability to filter by an exact date match (e.g., settlement date equals a specific day).

## Solution
Added an "Equal" choice to the DateFilterView qualifier dropdown. The existing generic predicate handling (`foam.mlang.predicate.Eq`) and single-date-input rendering already support this — no new logic was needed beyond the choice entry and message label.

## Changes
- Added `LABEL_EQUAL` message for the "Equal" label
- Added `['Eq', this.LABEL_EQUAL]` to the qualifier choices
- Aligned whitespace in messages and choices arrays for consistency
