### PR TITLE
Fix MultiChoiceView to respect controller display mode

### DIFF
--- a/src/foam/u2/view/DayChoiceView.js
+++ b/src/foam/u2/view/DayChoiceView.js
@@ -19,6 +19,9 @@ foam.CLASS({
   ^:hover {
     cursor: pointer;
   }
+  ^disabled:hover {
+    cursor: default;
+  }
   ^selected {
     background-color: $backgroundBrand;
     border-color: $backgroundBrand;

--- a/src/foam/u2/view/MultiChoiceView.js
+++ b/src/foam/u2/view/MultiChoiceView.js
@@ -279,8 +279,10 @@ foam.CLASS({
                   return false;
                 }
               });
-              var isDisabledSlot = self.slot(function(choices, data, maxSelected) {
+              var isDisabledSlot = self.slot(function(choices, data, maxSelected, mode) {
                 try {
+                    if ( mode !== foam.u2.DisplayMode.RW ) return true;
+
                     if ( isFinal ) {
                       return true;
                     }
@@ -305,6 +307,8 @@ foam.CLASS({
                 })
                   .call(function() {
                     self.onDetach(this.clicked.sub(() => {
+                      if ( self.mode !== foam.u2.DisplayMode.RW ) return;
+
                       let indexDataToAdd = self.getIndexOfChoice(self.data, valueSimpSlot.get());
                       let array = [
                         ...self.data
@@ -330,8 +334,8 @@ foam.CLASS({
       };
 
       this
-        .add(this.dynamic(function(showMinMaxHelper) {
-          if ( ! showMinMaxHelper ) return;
+        .add(this.dynamic(function(showMinMaxHelper, mode) {
+          if ( ! showMinMaxHelper || mode !== foam.u2.DisplayMode.RW ) return;
           this
           .start(foam.u2.layout.Rows)
             .start()


### PR DESCRIPTION

## Problem
MultiChoiceView (and its subclasses like DayOfWeekView) always rendered fully interactive choices regardless of the display mode. When a property using MultiChoiceView was set to read-only or disabled, users could still click choices to toggle selections. Other FOAM choice views (e.g., ChoiceView) properly check `mode` and render differently in RO/DISABLED modes.

## Solution
Added display mode awareness to MultiChoiceView's render method, following the same pattern used by ChoiceView and other FOAM views. When mode is not RW, all choices appear disabled and clicks are ignored. The min/max helper text is also hidden since selections cannot be changed.

## Changes
- **MultiChoiceView**: `isDisabledSlot` now includes `mode` — returns disabled for all choices when mode is not RW
- **MultiChoiceView**: Click handler guards against non-RW mode as a second line of defense
- **MultiChoiceView**: Min/max helper text hidden in non-RW mode
- **DayChoiceView**: Override cursor to `default` on disabled hover to avoid misleading pointer cursor
