### PR TITLE
Add accounting format for negative currency values

### DIFF
--- a/src/foam/lang/Currency.js
+++ b/src/foam/lang/Currency.js
@@ -166,7 +166,8 @@ foam.CLASS({
           amount = Number(amount);
           let opts = {
             minimumFractionDigits: this.precision,
-            maximumFractionDigits: this.precision
+            maximumFractionDigits: this.precision,
+            currencySign: 'accounting'
           }
           if ( ! hideSymbol ) {
             opts.style = 'currency';


### PR DESCRIPTION

## Problem
Negative currency amounts were displayed with a minus sign (e.g., `-$123.45`), which is not the standard accounting convention. In financial and accounting contexts, negative values are expected to be shown in parentheses (e.g., `($123.45)`).

## Solution
Added `currencySign: 'accounting'` to the `Intl.NumberFormat` options in `Currency.format()`. This uses the browser's built-in accounting format, which wraps negative values in parentheses instead of prefixing with a minus sign.

## Changes
- Added `currencySign: 'accounting'` option to `Intl.NumberFormat` configuration in `Currency.js`
