### PR TITLE
No need to generate javaCode property on enum

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1405,7 +1405,8 @@ foam.CLASS({
   properties: [
     {
       class: 'String',
-      name: 'javaCode'
+      name: 'javaCode',
+      generateJava: false
     }
   ],
 


### PR DESCRIPTION
Enum value can have javaCode but there is no need to store javaCode as a property in the generated java class.