### PR TITLE
Fix NPE when comparing canonical name for anonymous classes

### DIFF
--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -442,7 +442,7 @@ public class JSONFObjectFormatter
         } else {
           if ( calculateDeltaForNestedFObjects_ &&
                prop.get(newFObject) != null && prop.get(oldFObject) != null &&
-               prop.get(newFObject).getClass().getCanonicalName().equals(prop.get(oldFObject).getClass().getCanonicalName()) ) {
+               SafetyUtil.classEquals(prop.get(newFObject), prop.get(oldFObject)) ) {
             if ( maybeOutputFObjectProperty(newFObject, oldFObject, prop) ) {
               delta += 1;
               if ( optionalPredicate_.propertyPredicateCheck(getX(), of, prop) ) {

--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -413,4 +413,20 @@ public class SafetyUtil {
     v.validate(x);
   }
 
+  public static boolean classEquals(Object o1, Object o2) {
+    if ( o1 == null ) return o2 == null;
+
+    Class c1 = o1.getClass();
+    Class c2 = o2.getClass();
+
+    if ( c1 == c2 ) return true;
+
+    // Enum value with javaCode is being treated as anonymous class by the compiler
+    // e.g. MyEnum$1, which doesn't have canonical name so comparing on enclosing class.
+    if ( c1.isAnonymousClass() )
+      return c2.isAnonymousClass() && c1.getEnclosingClass() == c2.getEnclosingClass();
+
+    String canonicalName = c1.getCanonicalName();
+    return canonicalName != null && canonicalName.equals(c2.getCanonicalName());
+  }
 }


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "java.lang.Class.getCanonicalName()" is null
	at foam.lib.formatter.JSONFObjectFormatter.maybeOutputDelta(JSONFObjectFormatter.java:445)
	at foam.dao.AbstractF3FileJournal$15.executeJob(AbstractF3FileJournal.java:626)
	at foam.util.concurrent.SyncAssemblyLine.enqueue(SyncAssemblyLine.java:69)
	at foam.dao.AbstractF3FileJournal.put(AbstractF3FileJournal.java:611)
	at foam.dao.java.JDAO.put_(JDAO.java:469)
	at foam.dao.SequenceNumberDAO.put_(SequenceNumberDAO.java:187)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:198)
        ...
```