### PR TITLE
Fix CurrencyView to support DoubleUnitValue properties

### DIFF
--- a/src/foam/u2/CurrencyView.js
+++ b/src/foam/u2/CurrencyView.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'CurrencyView',
   extends: 'foam.u2.FloatView',
 
-  documentation: 'View for formatting cents into dollars.',
+  documentation: 'View for formatting currency values. Supports both UnitValue (Long/cents) and DoubleUnitValue (Double/dollars).',
 
   properties: [
     ['precision', 2],
@@ -22,7 +22,13 @@ foam.CLASS({
       value: 'CAD'
     },
     'curr_',
-    ['hideSymbol', true]
+    ['hideSymbol', true],
+    {
+      class: 'Boolean',
+      name: 'useMinorUnits',
+      documentation: 'When true, converts between major and minor units (e.g. dollars to cents). Set to false for DoubleUnitValue properties that store values in major units.',
+      value: true
+    }
   ],
 
   methods: [
@@ -40,7 +46,8 @@ foam.CLASS({
         ! this.hideSymbol && this.curr_.symbol && plainText.startsWith(this.curr_.symbol) ?
         plainText.substring(1) :
         plainText;
-      return Math.round(this.SUPER(plainText) * 100);
+      var val = this.SUPER(plainText);
+      return this.useMinorUnits ? Math.round(val * 100) : val;
     },
 
     function formatNumber(val) {

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1941,7 +1941,7 @@ foam.CLASS({
   requires: [ 'foam.u2.view.CurrencyView' ],
   properties: [
     [ 'displayWidth', 15 ],
-    [ 'view', { class: 'foam.u2.view.CurrencyView', onKey: false } ]
+    [ 'view', { class: 'foam.u2.view.CurrencyView', onKey: false, useMinorUnits: false } ]
   ]
 });
 


### PR DESCRIPTION

## Problem
`CurrencyView.textToData()` unconditionally multiplied user input by 100 (`Math.round(val * 100)`), converting dollars to cents for `UnitValue` (Long-based) storage. When `DoubleUnitValue` was introduced — which stores actual dollar amounts as Double — the same view was assigned via the refinement in Element2.js. This caused user input to be multiplied by 100 incorrectly (e.g., entering 1 stored 100).

## Solution
Added a `useMinorUnits` boolean property to `CurrencyView` (defaults `true` for backward compatibility with `UnitValue`). When `false`, `textToData` skips the ×100 conversion. Updated the `DoubleUnitValueViewRefinement` in Element2.js to pass `useMinorUnits: false`.

## Changes
- Added `useMinorUnits` boolean property to `foam.u2.CurrencyView` with default `true`
- Made `textToData` conditionally apply the ×100 conversion based on `useMinorUnits`
- Updated `DoubleUnitValueViewRefinement` in Element2.js to set `useMinorUnits: false`
