### PR TITLE
Fix Attribute linking in element, adds a new attribute mode that keeps attributes synced with model props

### DIFF
--- a/src/foam/core/reflow/Image.js
+++ b/src/foam/core/reflow/Image.js
@@ -88,14 +88,15 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.core.reflow',
-  name: 'ImageTagRefine',
-  refines: 'foam.u2.tag.ImageTag',
-
+  name: 'ImageTag',
+  extends: 'foam.u2.Element',
   imports: [ 'scope?' ],
 
   properties: [
+    ['nodeName', 'img'],
     {
       name: 'src',
+      attribute: 'BOTH',
       preSet: function(o, n) {
         if ( ! this.scope ) return n;
         // If the src is the name of a value from the scope (probably from reflow) then
@@ -108,4 +109,12 @@ foam.CLASS({
       }
     }
   ]
+});
+
+foam.SCRIPT({
+  package: 'foam.core.reflow',
+  name: 'ImageScript',
+  code: function() {
+    foam.__context__.registerElement(foam.u2.tag.ImageTag, 'img');
+  }
 });

--- a/src/foam/core/reflow/Image.js
+++ b/src/foam/core/reflow/Image.js
@@ -34,12 +34,29 @@ foam.CLASS({
       hidden: true
     },
     {
-      class: 'Int',
-      name: 'maxWidth'
+      class: 'String',
+      name: 'sizingStrategy',
+      value: 'Auto',
+      view: {
+        class: 'foam.u2.view.ChoiceView',
+        choices: ['Auto', 'Manual', 'Maintain-Ratio']
+      }
     },
     {
       class: 'Int',
-      name: 'maxHeight'
+      name: 'width',
+      value: 100,
+      visibility: function(sizingStrategy) {
+        return sizingStrategy === 'Auto' ? 'HIDDEN' : 'RW'
+      }
+    },
+    {
+      class: 'Int',
+      name: 'height',
+      value: 100,
+      visibility: function(sizingStrategy) {
+        return sizingStrategy === 'Auto' || sizingStrategy === 'Maintain-Ratio' ? 'HIDDEN' : 'RW'
+      }
     },
     {
       class: 'String',
@@ -49,47 +66,36 @@ foam.CLASS({
 
   methods: [
     function addToE(e) {
-      e.tag(foam.core.reflow.ImageView, {data: this});
+      e.start('img')
+        .attrs({
+          src: this.imageData$,
+          alt: this.alt$,
+          width: this.slot(function(sizingStrategy, width) {
+            if ( sizingStrategy === 'Auto') return 'auto';
+            return width;
+          }),
+          height: this.slot(function(sizingStrategy, height) {
+            if ( sizingStrategy === 'Auto') return 'auto';
+            if ( sizingStrategy === 'Maintain-Ratio') return 'auto';
+            return height;
+          })
+        })
+        .style({ 'aspect-ratio': this.imageData$.map(v => v ? 1 : 'auto') })
+      .end();
     }
   ]
 });
 
-
 foam.CLASS({
   package: 'foam.core.reflow',
-  name: 'ImageView',
-  extends: 'foam.u2.View',
-
-  documentation: 'Display view for reflow Image. Uses base64 data URL stored inline.',
-
-  methods: [
-    function render() {
-      this.add(this.data.dynamic(function(imageData, alt, maxWidth, maxHeight) {
-        if ( ! imageData ) return;
-
-        var style = {};
-        if ( maxWidth )  style['max-width']  = maxWidth + 'px';
-        if ( maxHeight ) style['max-height'] = maxHeight + 'px';
-
-        this.start('img').attrs({ src: imageData, alt: alt || '' }).style(style).end();
-      }));
-    }
-  ]
-});
-
-
-// TODO: it should be possible to simplify this and only handle 'src' and let everything else pass through
-foam.CLASS({
-  package: 'foam.core.reflow',
-  name: 'ImageTag',
-  extends: 'foam.u2.Element',
+  name: 'ImageTagRefine',
+  refines: 'foam.u2.tag.ImageTag',
 
   imports: [ 'scope?' ],
 
   properties: [
     {
       name: 'src',
-      attribute: true,
       preSet: function(o, n) {
         if ( ! this.scope ) return n;
         // If the src is the name of a value from the scope (probably from reflow) then
@@ -100,38 +106,6 @@ foam.CLASS({
         }
         return n;
       }
-    },
-    { class: 'String', name: 'title', attribute: true },
-    { class: 'String', name: 'alt',   attribute: true },
-    { class: 'Int',    name: 'width'  },
-    { class: 'Int',    name: 'height' }
-  ],
-
-  methods: [
-    function render() {
-      this.dynamic(function(src, title, alt, width, height) {
-        if ( ! src ) return;
-
-        let style = {};
-        if ( width  ) style.width  = width;
-        if ( height ) style.height = height;
-
-        // We create an Element() instead of doing start('img') to avoid in infinite loop
-        // where the 'img' element gets replaced by this view.
-        this.start(foam.u2.Element.create({nodeName: 'img'}, this))
-          .attrs({ src: src, title: title, alt: alt })
-          .style(style)
-        .end();
-      });
     }
   ]
-});
-
-
-foam.SCRIPT({
-  package: 'foam.core.reflow',
-  name: 'ImageScript',
-  code: function() {
-    foam.__context__.registerElement(foam.core.reflow.ImageTag, 'img');
-  }
 });

--- a/src/foam/core/reflow/Link.js
+++ b/src/foam/core/reflow/Link.js
@@ -50,7 +50,7 @@ foam.CLASS({
 
 foam.SCRIPT({
   package: 'foam.core.reflow',
-  name: 'ImageScript',
+  name: 'LinkScript',
   code: function() {
     foam.__context__.registerElement(foam.core.reflow.Link, 'a');
   }

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1557,13 +1557,13 @@ foam.CLASS({
        * Find an axiom by the specified domName from either this class or an
        * ancestor.
        */
-      let cache = this.DOM_NAME_CACHE;
+      let cache = this.DOM_NAME_CACHE[this.cls_.id] ?? {};
       if ( ! Object.keys(cache).length ) {
         let props = this.cls_.getAxiomsByClass(foam.lang.Property);
         for ( var prop of props ) {
           cache[prop.domName] = prop;
         }
-        this.DOM_NAME_CACHE = cache;
+        this.DOM_NAME_CACHE[this.cls_.id] = cache;
       }
       return cache[name];
     },

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -513,6 +513,10 @@ foam.CLASS({
         '112': 'f1',
         '127': 'delete'
       }
+    },
+    {
+      name: 'DOM_NAME_CACHE',
+      value: {}
     }
   ],
 
@@ -1553,19 +1557,15 @@ foam.CLASS({
        * Find an axiom by the specified domName from either this class or an
        * ancestor.
        */
-      let cache = this.getPrivate_('domNameCache') || {};
-      let val = cache[name];
-      if ( ! val ) {
+      let cache = this.DOM_NAME_CACHE;
+      if ( ! Object.keys(cache).length ) {
         let props = this.cls_.getAxiomsByClass(foam.lang.Property);
         for ( var prop of props ) {
-          if ( prop.domName === name ) {
-            val = cache[name] = prop;
-            break;
-          }
+          cache[prop.domName] = prop;
         }
-        this.setPrivate_('domNameCache', cache);
+        this.DOM_NAME_CACHE = cache;
       }
-      return val;
+      return cache[name];
     },
   ],
 

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1004,19 +1004,22 @@ foam.CLASS({
         return;
       }
 
-      var prop = this.cls_.getAxiomByName(name);
+      const AttributeType = foam.u2.AttributeType;
+      let prop = this.getPropertyByDOMName(name);
 
-      if ( prop &&
-           foam.lang.Property.isInstance(prop) &&
-           prop.attribute )
-      {
+      if ( prop && prop.attribute !== AttributeType.DOM ) {
         if ( typeof value === 'string' ) {
           // TODO: remove check when all properties have fromString()
-          this[name] = prop.fromString ? prop.fromString(value) : value;
+          this[name] = prop.fromString(value);
         } else if ( foam.lang.Slot.isInstance(value) ) {
           this.onDetach(this.slot(name).follow(value));
         } else {
           this[name] = value;
+        }
+        // When setting a non slotted value, refetch value from the model in case
+        // an adapt/preset/postset changes it
+        if ( ! foam.lang.Slot.isInstance(value) ) {
+          value = this[name];
         }
       } else {
         if ( value === undefined || value === null || value === false ) {
@@ -1543,7 +1546,27 @@ foam.CLASS({
       this.css[key] = value;
       this.element_.style[key] = value;
       return this;
-    }
+    },
+
+    function getPropertyByDOMName(name) {
+      /**
+       * Find an axiom by the specified domName from either this class or an
+       * ancestor.
+       */
+      let cache = this.getPrivate_('domNameCache') || {};
+      let val = cache[name];
+      if ( ! val ) {
+        let props = this.cls_.getAxiomsByClass(foam.lang.Property);
+        for ( var prop of props ) {
+          if ( prop.domName === name ) {
+            val = cache[name] = prop;
+            break;
+          }
+        }
+        this.setPrivate_('domNameCache', cache);
+      }
+      return val;
+    },
   ],
 
   listeners: [
@@ -1587,6 +1610,14 @@ foam.CLASS({
   ]
 });
 
+foam.ENUM({
+  package: 'foam.u2',
+  name: 'AttributeType',
+  values: [
+    'DOM', 'MODEL', 'BOTH'
+  ]
+})
+
 
 foam.CLASS({
   package: 'foam.u2',
@@ -1594,14 +1625,51 @@ foam.CLASS({
   refines: 'foam.lang.Property',
 
   requires: [
-    'foam.u2.TextField'
+    'foam.u2.TextField',
+    'foam.u2.AttributeType'
   ],
 
   properties: [
     {
+      name: 'postSet',
+      factory: function() {
+        let self = this;
+        if ( this.attribute != 'BOTH' ) return undefined;
+        return function(o, n) {
+          if ( ! self.isDefaultValue(n) ) {
+            this.element_?.setAttribute?.(self.domName, this[self.name]);
+          }
+        }
+      },
+      adapt: function(oFn, nFn, prop) {
+        let self = this;
+        if ( self.attribute != 'BOTH' ) return nFn;
+        let fn = function(o, n) {
+          if ( ! self.isDefaultValue(n) ) {
+            this.element_.setAttribute(self.domName, this[self.name]);
+          }
+          nFn?.call(this, o, n);
+        }
+        return fn;
+      }
+    },
+    {
       // If true, this property is treated as a psedo-U2 attribute.
+      class: 'Enum',
+      of: 'foam.u2.AttributeType',
       name: 'attribute',
-      value: false
+      adapt: function(o, n, prop) {
+        if ( n === true ) return this.AttributeType.MODEL;
+        if ( n === false ) return this.AttributeType.DOM;
+        return foam.lang.Enum.ADAPT.value.call(this, o, n, prop);
+      }
+    },
+    {
+      class: 'String',
+      name: 'domName',
+      factory: function() {
+        return this.name
+      }
     },
     {
       class: 'String',

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -1613,8 +1613,23 @@ foam.CLASS({
 foam.ENUM({
   package: 'foam.u2',
   name: 'AttributeType',
+  documentation: 'Defines how a property attribute is synchronized between the model and the DOM.',
   values: [
-    'DOM', 'MODEL', 'BOTH'
+    {
+      name: 'DOM',
+      documentation: `Property is only reflected to the DOM as an attribute. 
+      The model property is not updated when the DOM attribute changes.`
+    },
+    {
+      name: 'MODEL',
+      documentation: `Property is only stored in the model.
+      It is not synchronized with the DOM as an HTML attribute.`
+    },
+    {
+      name: 'BOTH',
+      documentation: `Property is kept in sync between the model and DOM. 
+      When the model property changes, it updates the DOM attribute.`
+    }
   ]
 })
 

--- a/src/foam/u2/TextField.js
+++ b/src/foam/u2/TextField.js
@@ -60,10 +60,6 @@ foam.CLASS({
         this.displayWidth = prop.displayWidth;
       }
 
-      if ( ! this.size ) {
-        this.size = this.displayWidth;
-      }
-
       if ( ! this.units ) {
         this.units = prop.units;
       }

--- a/src/foam/u2/tag/Image.js
+++ b/src/foam/u2/tag/Image.js
@@ -170,7 +170,7 @@ foam.CLASS({
 
 
 foam.SCRIPT({
-  package: 'foam.core.reflow',
+  package: 'foam.u2.tag',
   name: 'ImageScript',
   code: function() {
     foam.__context__.registerElement(foam.u2.tag.ImageTag, 'img');

--- a/src/foam/u2/tag/Image.js
+++ b/src/foam/u2/tag/Image.js
@@ -153,11 +153,26 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2.tag',
+  name: 'ImageTag',
+  extends: 'foam.u2.Element',
+
+  properties: [
+    { name: 'nodeName', value: 'img' },
+    { class: 'String', name: 'src', attribute: 'BOTH' },
+    { class: 'String', name: 'title', attribute: 'BOTH' },
+    { class: 'String', name: 'alt', attribute: 'BOTH' },
+    { class: 'String', name: 'width', attribute: 'BOTH' },
+    { class: 'String', name: 'height', attribute: 'BOTH' }
+  ]
+});
+
 
 foam.SCRIPT({
-  package: 'foam.u2.tag',
+  package: 'foam.core.reflow',
   name: 'ImageScript',
   code: function() {
-    foam.__context__.registerElement(foam.u2.tag.Image);
+    foam.__context__.registerElement(foam.u2.tag.ImageTag, 'img');
   }
 });

--- a/src/foam/u2/tag/Image.js
+++ b/src/foam/u2/tag/Image.js
@@ -152,27 +152,3 @@ foam.CLASS({
     }
   ]
 });
-
-foam.CLASS({
-  package: 'foam.u2.tag',
-  name: 'ImageTag',
-  extends: 'foam.u2.Element',
-
-  properties: [
-    { name: 'nodeName', value: 'img' },
-    { class: 'String', name: 'src', attribute: 'BOTH' },
-    { class: 'String', name: 'title', attribute: 'BOTH' },
-    { class: 'String', name: 'alt', attribute: 'BOTH' },
-    { class: 'String', name: 'width', attribute: 'BOTH' },
-    { class: 'String', name: 'height', attribute: 'BOTH' }
-  ]
-});
-
-
-foam.SCRIPT({
-  package: 'foam.u2.tag',
-  name: 'ImageScript',
-  code: function() {
-    foam.__context__.registerElement(foam.u2.tag.ImageTag, 'img');
-  }
-});

--- a/src/foam/u2/tag/Input.js
+++ b/src/foam/u2/tag/Input.js
@@ -49,31 +49,61 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'onKey',
-      attribute: true,
+      attribute: 'MODEL',
       // documentation: 'When true, $$DOC{ref:".data"} is updated on every keystroke, rather than on blur.'
     },
     {
       class: 'Boolean',
       name: 'autofocus',
-      attribute: true,
+      attribute: 'BOTH',
       documentation: 'If enabled, field gains focus when added to screen.'
     },
     {
       class: 'Int',
-      name: 'size'
+      name: 'size',
+      attribute: 'BOTH'
     },
     {
       class: 'Int',
       name: 'maxLength',
-      attribute: true,
-      // documentation: 'When set, will limit the length of the input to a certain number'
+      domName: 'maxlength',
+      attribute: 'BOTH',
+      documentation: 'When set, will limit the length of the input to a certain number'
     },
-    'type',
-    'placeholder',
-    'ariaLabel',
-    [ 'autocomplete', true ],
+    {
+      class: 'String',
+      name: 'type',
+      attribute: 'BOTH'
+    },
+    {
+      class: 'String',
+      name:'placeholder',
+      attribute: 'BOTH'
+    },
+    {
+      class: 'String',
+      name: 'ariaLabel',
+      domName: 'aria-label',
+      attribute: 'BOTH'
+    },
+    {
+      class: 'String',
+      name: 'autocomplete',
+      attribute: 'BOTH',
+      adapt: function(o,n) {
+        if ( n === true ) return 'on';
+        if ( n === false ) return 'off';
+        return n;
+      }
+    },
 //    'autocompleter',
-    'inputMode', // Allows a browser to display an appropriate virtual keyboard
+    {
+      class: 'String',
+      name: 'inputMode',
+      domName: 'inputmode',
+      documentation: 'Allows a browser to display an appropriate virtual keyboard',
+      attribute: 'BOTH'
+    },
     {
       class: 'Array',
       name: 'choices',
@@ -114,18 +144,6 @@ foam.CLASS({
       this.SUPER();
       var self = this;
 
-      if ( this.size          ) this.setAttribute('size',        this.size);
-      if ( this.type          ) this.setAttribute('type',        this.type$);
-      if ( this.placeholder   ) this.setAttribute('placeholder', this.placeholder$);
-      if ( this.ariaLabel     ) this.setAttribute('aria-label',  this.ariaLabel);
-      if ( this.maxLength > 0 ) this.setAttribute('maxlength',   this.maxLength);
-      if ( this.inputMode     ) this.setAttribute('inputmode',   this.inputMode);
-
-      this.setAttribute('autocomplete', this.autocomplete ?
-        (foam.String.isInstance(this.autocomplete) ? this.autocomplete : 'on') :
-        'off'
-      );
-
       if ( this.choices && this.choices.length ) {
         var cid = self.$UID + '-choices';
 
@@ -156,12 +174,6 @@ foam.CLASS({
 
       this.initCls();
       this.link();
-
-      if ( this.autofocus ) {
-        window.setTimeout(() => {
-          this.focus();
-        }, 0);
-      }
     },
 
     function initCls() {

--- a/src/foam/u2/view/MarkdownView.js
+++ b/src/foam/u2/view/MarkdownView.js
@@ -438,11 +438,11 @@ foam.CLASS({
         function image(v) {
           let alt = v[1], url = v[3], title = v[4] || '';
           return function() {
-            this.start('img').attrs( {
+            this.start('img').attrs({
               src: url,
               alt: alt,
               title: title
-            });
+            }).end();
           };
         },
 

--- a/src/foam/u2/view/MarkdownView.js
+++ b/src/foam/u2/view/MarkdownView.js
@@ -303,7 +303,7 @@ foam.CLASS({
               this.tag(tagName);
             } else {
               let content = closing[1];
-              let e = this.start(tagName, attributes).call(content);
+              let e = this.start(tagName).attrs(attributes).call(content);
               if ( attributes.style ) {
                 let style = {};
                 attributes.style.split(';').forEach(s => {


### PR DESCRIPTION
- Added `AttributeType` enum with three modes: `DOM`, `MODEL`, and `BOTH` for bidirectional sync
- Implemented `getPropertyByDOMName()` to look up properties by DOM attribute name
- Added `domName` property for mapping different DOM and model property names
- Enhanced automatic postSet/adapt handlers to sync non-slot values to DOM
- **Input.js**: Refactored attributes to use `BOTH` mode; removed manual setAttribute calls
- **Image.js**: Added sizing strategy with Auto/Manual/Maintain-Ratio options; replaced maxWidth/maxHeight
- **Image.js (foam.u2.tag)**: Created new ImageTag element with synced attributes
- **TextField.js**: Removed automatic size calculation
- **MarkdownView.js**: Fixed image tag rendering