### PR TITLE
Migrate SimpleDateFormat to DateTimeformat

### DIFF
--- a/src/foam/core/er/EventRecordNotificationRuleAction.js
+++ b/src/foam/core/er/EventRecordNotificationRuleAction.js
@@ -27,7 +27,8 @@ foam.CLASS({
     'foam.log.LogLevel',
     'foam.util.SafetyUtil',
     'foam.util.StringUtil',
-    'java.text.SimpleDateFormat',
+    'java.time.ZoneOffset',
+    'java.time.format.DateTimeFormatter',
     'java.util.Date',
     'java.util.HashMap',
     'java.util.Map'
@@ -42,14 +43,8 @@ foam.CLASS({
   ],
 
   javaCode: `
-  protected static ThreadLocal<SimpleDateFormat> sdf_ = new ThreadLocal<SimpleDateFormat>() {
-    @Override
-    protected SimpleDateFormat initialValue() {
-      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-      df.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
-      return df;
-    }
-  };
+    protected static DateTimeFormatter sdf_ = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                                              .withZone(ZoneOffset.UTC);
   `,
 
   methods: [
@@ -90,7 +85,7 @@ foam.CLASS({
       if ( er instanceof CreatedAware ) {
         Date date = ((CreatedAware)er).getCreated();
         if ( date != null ) {
-          args.put("created", sdf_.get().format(date));
+          args.put("created", sdf_.format(date.toInstant()));
         }
       }
       if ( er instanceof CreatedByAware ) {
@@ -105,7 +100,7 @@ foam.CLASS({
       if ( er instanceof LastModifiedAware ) {
         Date date = ((LastModifiedAware)er).getLastModified();
         if ( date != null ) {
-          args.put("lastModified", sdf_.get().format(date));
+          args.put("lastModified", sdf_.format(date.toInstant()));
         }
       }
       if ( er instanceof LastModifiedByAware ) {

--- a/src/foam/core/notification/DAONotificationRuleAction.js
+++ b/src/foam/core/notification/DAONotificationRuleAction.js
@@ -21,7 +21,8 @@ foam.CLASS({
     'foam.core.auth.LastModifiedAware',
     'foam.core.auth.LastModifiedByAware',
     'foam.util.StringUtil',
-    'java.text.SimpleDateFormat',
+    'java.time.ZoneOffset',
+    'java.time.format.DateTimeFormatter',
     'java.util.Date',
     'java.util.HashMap',
     'java.util.Map'
@@ -44,14 +45,8 @@ foam.CLASS({
   ],
 
   javaCode: `
-  protected static ThreadLocal<SimpleDateFormat> sdf_ = new ThreadLocal<SimpleDateFormat>() {
-    @Override
-    protected SimpleDateFormat initialValue() {
-      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-      df.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
-      return df;
-    }
-  };
+    protected static DateTimeFormatter sdf_ = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                                                .withZone(ZoneOffset.UTC);
   `,
   
   methods: [
@@ -81,7 +76,7 @@ foam.CLASS({
       if ( obj instanceof CreatedAware ) {
         Date date = ((CreatedAware)obj).getCreated();
         if ( date != null ) {
-          args.put("created", sdf_.get().format(date));
+          args.put("created", sdf_.format(date.toInstant()));
         }
       }
       if ( obj instanceof CreatedByAware ) {
@@ -96,7 +91,7 @@ foam.CLASS({
       if ( obj instanceof LastModifiedAware ) {
         Date date = ((LastModifiedAware)obj).getLastModified();
         if ( date != null ) {
-          args.put("lastModified", sdf_.get().format(date));
+          args.put("lastModified", sdf_.format(date.toInstant()));
         }
       }
       if ( obj instanceof LastModifiedByAware ) {

--- a/src/foam/lib/html/Outputter.java
+++ b/src/foam/lib/html/Outputter.java
@@ -14,7 +14,8 @@ import foam.dao.AbstractSink;
 import foam.lib.json.OutputterMode;
 import foam.util.SafetyUtil;
 import java.io.*;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -25,15 +26,8 @@ public class Outputter
   extends AbstractSink
   implements foam.lib.Outputter
 {
-
-  protected ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<SimpleDateFormat>() {
-    @Override
-    protected SimpleDateFormat initialValue() {
-      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-      df.setTimeZone(TimeZone.getTimeZone("UTC"));
-      return df;
-    }
-  };
+  protected static DateTimeFormatter sdf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                                              .withZone(ZoneOffset.UTC);
 
   protected ClassInfo          of_           = null;
   protected List<PropertyInfo> props_        = null;
@@ -122,7 +116,7 @@ public class Outputter
   }
 
   protected void outputDate(Date value) {
-    outputString(sdf.get().format(value));
+    outputString(sdf.format(value.toInstant()));
   }
 
   public void outputStartHtml() {

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -16,7 +16,8 @@ import foam.lib.PropertyPredicate;
 import foam.util.SafetyUtil;
 import java.io.*;
 import java.lang.reflect.Array;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.*;
@@ -27,15 +28,8 @@ public class Outputter
   extends    AbstractSink
   implements foam.lib.Outputter
 {
-
-  protected static ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<SimpleDateFormat>() {
-    @Override
-    protected SimpleDateFormat initialValue() {
-      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-      df.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
-      return df;
-    }
-  };
+  protected static DateTimeFormatter sdf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                                            .withZone(ZoneOffset.UTC);
 
   protected foam.lang.X       x_;
   public    PrintWriter       writer_;
@@ -309,7 +303,7 @@ public class Outputter
 
   public void outputDateValue(java.util.Date date) {
     if ( outputReadableDates_ ) {
-      outputString(sdf.get().format(date));
+      outputString(sdf.format(date.toInstant()));
     } else {
       outputNumber(date.getTime());
     }

--- a/src/foam/lib/xml/Outputter.java
+++ b/src/foam/lib/xml/Outputter.java
@@ -14,7 +14,8 @@ import foam.lib.PropertyPredicate;
 import foam.lib.json.OutputterMode;
 import foam.util.SafetyUtil;
 import java.io.*;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,14 +24,8 @@ import org.apache.commons.io.IOUtils;
 public class Outputter
   implements foam.lib.Outputter
 {
-  protected static ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<SimpleDateFormat>() {
-    @Override
-    protected SimpleDateFormat initialValue() {
-      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-      df.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
-      return df;
-    }
-  };
+  protected static DateTimeFormatter sdf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                                              .withZone(ZoneOffset.UTC);
 
   protected PrintWriter       writer_;
   protected OutputterMode     mode_;
@@ -145,7 +140,7 @@ public class Outputter
   }
 
   protected void outputDate(Date value) {
-    writer_.append(sdf.get().format(value));
+    writer_.append(sdf.format(value.toInstant()));
   }
 
   protected void outputEnum(Enum<?> value) {

--- a/src/foam/parse/test/QueryParserUserTest.js
+++ b/src/foam/parse/test/QueryParserUserTest.js
@@ -19,16 +19,15 @@ foam.CLASS({
   'foam.mlang.predicate.Predicate',
   'foam.parse.*',
   'java.util.Date',
-  'java.text.SimpleDateFormat',
+  'java.time.ZoneOffset',
+  'java.time.format.DateTimeFormatter',
   'java.util.TimeZone'
   ],
 
   javaCode: `
-  protected final static ThreadLocal<SimpleDateFormat> dateFormat_ = ThreadLocal.withInitial(() -> {
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm");
-    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-    return sdf;
-  });`,
+    protected static DateTimeFormatter dateFormat_ = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")
+                                                      .withZone(ZoneOffset.UTC);
+  `,
 
   methods: [
     {
@@ -103,7 +102,7 @@ foam.CLASS({
       Date noon = new Date(2289600000L);
 
       // test user's birthday is between two timestamps
-      test(evaluate("birthday=" + dateFormat_.get().format(noon), user), user.getBirthday() + " = "+noon.toString());
+      test(evaluate("birthday=" + dateFormat_.format(noon.toInstant()), user), user.getBirthday() + " = "+noon.toString());
       `
     },
     {


### PR DESCRIPTION
DateTimeformat is threadsafe. Using it instead of ThreadLocal<SimpleDateFormat> will bring some performance benefit.