### PR TITLE
 PT-FIXES:DOS-2199 Pivot table now respects sink precision setting

### DIFF
--- a/src/foam/core/reflow/PivotTableView.js
+++ b/src/foam/core/reflow/PivotTableView.js
@@ -228,7 +228,7 @@ foam.CLASS({
 
     // convert the nested groupbys into a simpler nested dictionary
     function makeDictionary(data) {
-      if ( ! foam.mlang.sink.GroupBy.isInstance(data) ) return data?.value || data;
+      if ( ! foam.mlang.sink.GroupBy.isInstance(data) ) return data?.valueOf() ?? data;
       var ret = {};
       var keys = data.sortedKeys();
       for ( var i = 0; i < keys.length; i++ ) {

--- a/src/foam/core/reflow/PivotTableView.js
+++ b/src/foam/core/reflow/PivotTableView.js
@@ -228,7 +228,7 @@ foam.CLASS({
 
     // convert the nested groupbys into a simpler nested dictionary
     function makeDictionary(data) {
-      if ( ! foam.mlang.sink.GroupBy.isInstance(data) ) return data?.valueOf() ?? data;
+      if ( ! foam.mlang.sink.GroupBy.isInstance(data) ) return data?.valueOf() || data;
       var ret = {};
       var keys = data.sortedKeys();
       for ( var i = 0; i < keys.length; i++ ) {


### PR DESCRIPTION

## Problem
Pivot table cells displayed raw floating-point values (e.g. `401.70000000000005`) instead of honoring the precision configured on the accumulator sink (Sum, Avg, Min, Max). This happened because `makeDictionary()` accessed the sink's `.value` property directly, bypassing `applyPrecision()` formatting.

## Solution
Changed `makeDictionary()` to call `valueOf()` instead of reading `.value` directly. Each sink's `valueOf()` method already applies precision formatting (e.g. `Sum.valueOf()` calls `this.applyPrecision(this.value)`). The existing `||` fallback to the sink object is preserved, so falsy values (like Count of 0) still render correctly via `addToE()`.

## Changes
- `PivotTableView.js`: Use `data?.valueOf()` instead of `data?.value` in `makeDictionary()`
