### PR TITLE
 Add 2-digit year variants to DDMMYYYY date format help text

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -60,7 +60,7 @@ foam.ENUM({
       name: 'DDMMYYYY',
       label: 'dd/mm/yyyy',
       parserSymbol: 'ddmmyyyy',
-      help: 'dd/mm/yyyy, dd-mm-yyyy, ddmmyyyy'
+      help: 'dd/mm/yyyy, dd-mm-yyyy, ddmmyyyy, dd/mm/yy, dd-mm-yy, ddmmyy'
     },
     {
       name: 'YYYYDDMM',


### PR DESCRIPTION

## Problem
The `DateFormat.DDMMYYYY` enum's help text only listed 4-digit year formats (`dd/mm/yyyy, dd-mm-yyyy, ddmmyyyy`), even though the underlying `DateGrammar` already supports 2-digit year variants (`dd/mm/yy`, `dd-mm-yy`, `ddmmyy`). Users had no way to discover that 2-digit years were supported under this format option.

## Solution
Updated the help text to include all six supported variants, covering both 4-digit and 2-digit year forms.

## Changes
- Updated `DateFormat.DDMMYYYY.help` in `Mapping.js` to include `dd/mm/yy, dd-mm-yy, ddmmyy`
