### PR TITLE
Fix json output for enum with custom java code

### DIFF
--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -287,10 +287,13 @@ public class JSONFObjectFormatter
 
 
   public void outputEnumValue(FEnum value) {
+    String className = value.getClass().isAnonymousClass()
+                      ? value.getClass().getEnclosingClass().getCanonicalName()
+                      : value.getClass().getCanonicalName();
     append('{');
     outputKey("class");
     append(':');
-    output(value.getClass().getName());
+    output(className);
     append(COMMA);
     outputKey("ordinal");
     append(':');

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -151,6 +151,13 @@ foam.CLASS({
       // With default settings (JRL-like), empty Address should still have class output
       test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated");
       test ( json.contains("address") && json.contains("foam.core.auth.Address"), testId+" address with class present: "+json);
+
+      // Test outputting enum with custom javaCode
+      testId = "EnumWithCustomJavaCode";
+      formatter = new JSONFObjectFormatter();
+      formatter.output(foam.test.TestEnum.CUSTOM);
+      json = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" valid json generated: " + json);
       `
     }
   ]

--- a/src/foam/test/TestEnum.js
+++ b/src/foam/test/TestEnum.js
@@ -24,6 +24,10 @@ foam.ENUM({
     },
     {
       name: 'BAR'
+    },
+    {
+      name: 'CUSTOM',
+      javaCode: '/* CODE */'
     }
   ]
 });


### PR DESCRIPTION
Before the json output for enum with custom java code contains anonymous class name, eg. foam.test.TestEnum$1 and failed on the client because client doesn't know how to parse the anonymous java type.