### PR TITLE
PT-FIXES:DOS-2290 Fix journal compaction and add reporting

### DIFF
--- a/deployment/compaction/scripts.jrl
+++ b/deployment/compaction/scripts.jrl
@@ -40,7 +40,11 @@ for ( n : daos ) {
         c = new CompactionDAO(x, n);
         print("INFO: Compacting: "+n);
         c.execute(x);
-        print("INFO: Compaction complete: "+n+", System OK");
+        print("");
+        print("=== " + n + " ===");
+        print(c.getReport());
+        print("");
+        print("OK: Compaction complete: "+n);
     } catch (IllegalStateException e) {
         print(e.getMessage());
         print("WARNING: Compaction aborted: "+n+", System OK");

--- a/doc/guides/Compaction.md
+++ b/doc/guides/Compaction.md
@@ -1,53 +1,364 @@
 # Journal Compaction
 
-Each DAO operation on the same object generates a journal entry containing just the change on the object.  Over time there are many entries for the same object, slowing **replay** since replay time is propotional to the number of lines in a journal file.  **Compaction** writes out each object to a new journal file in it's entirety, thus reducing the multiple entries to just one, and in turn reducing replay time. 
+## Table of Contents
+1. [Overview](#overview)
+2. [How It Works](#how-it-works)
+3. [Default Behavior](#default-behavior)
+4. [Configuration](#configuration)
+5. [Invoking Compaction](#invoking-compaction)
+6. [Running Programmatically](#running-programmatically)
+7. [Filtering and Archiving](#filtering-and-archiving)
+8. [Custom Compaction Sinks](#custom-compaction-sinks)
+9. [Rollback](#rollback)
+10. [Monitoring](#monitoring)
+11. [Gotchas](#gotchas)
+12. [Key Files](#key-files)
 
-Used in conjuction with a custom compaction sink, the compaction process can facilitate archiving with only recent or active objects written to the new journal.
+---
 
-## Considerations
+## Overview
 
-- Compaction can be run concurrently with live traffic, but it is recommended to run compaction at a low traffic period.  Also, compaction can fail requiring system halt and manual intervention, so a Maintenance Window should be scheduled.
-- Compaction filters out many archive or history operations. See `deployment/compaction/compactions.jrl`.
-- The **select** for compaction is performed on the DAO returned from the context using CSpecname. If the DAO stack contains a FixedSizedDAO then only those records retained by the FixedSizedDAO will be compacted into the new journal.
+Each DAO operation on the same object generates a journal entry containing just the changed fields. Over time a single object may have hundreds of entries, slowing **replay** since replay time is proportional to journal line count. **Compaction** writes each object to a new journal file in its entirety, reducing many entries to one and dramatically improving replay time.
 
-## Invocation
+Used in conjunction with custom compaction sinks, the compaction process can also facilitate **archiving** by only writing recent or active objects to the new journal.
 
-Compaction is controlled by Script `DAOCompaction` and scriptParameter `DAOCompaction`.  The ScriptParameter lists the DAOs to compact.
+---
 
-Once script execution reports completion, check:
+## How It Works
 
-1. ScriptEvents for an 'OK' message.
-1. EventRecords for a compaction summary.  Open the reponse message to see the statistics.
+Compaction follows a five-step process:
 
-## Compaction, Major steps
+```
++--------------------------------------------------------------------+
+|                    CompactionDAO.execute()                          |
+|                                                                    |
+|  1. BLOCK         All DAO operations are paused                    |
+|       |                                                            |
+|  2. ROLL          Journal copied to backup (.1, .2, etc.)          |
+|       |           Original truncated (new empty journal)           |
+|       |                                                            |
+|  3. UNBLOCK       DAO operations resume                            |
+|       |           New traffic writes to the new empty journal      |
+|       |                                                            |
+|  4. COMPACT       Read all objects from MDAO (in-memory)           |
+|       |           Write full copies through sink chain             |
+|       |           to the new journal (concurrent with traffic)     |
+|       |                                                            |
+|  5. COMPLETE      Log statistics, record EventRecord               |
++--------------------------------------------------------------------+
+```
 
-1. Start blocking DAO operations.
-1. Roll the journal.  journal becomes journal.1 on the first invocation. Next will rename journal to journal.2 
-1. Unblock DAO operations. At this point live traffic is processed during compaction and written to the new journal file.
-1. Start compacting.
-1. End
+**Journal files after compaction:**
+```
+Before:                     After first compaction:
+  users (large, many        users (compacted + new traffic)
+   delta entries)            users.1 (backup of original)
+```
+
+The roll step uses **copy + truncate** (not rename) because on Linux, renaming only updates the inode. The JVM file operations continue against the original inode, so a rename would leave the writer pointing at the backup file.
+
+**Key point:** Live traffic continues during step 4. New writes go to the new journal alongside compacted entries. This is why compaction should run during low-traffic periods.
+
+---
+
+## Default Behavior
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `compactible` | `true` | All DAOs are compacted by default |
+| `discardLifecycleDeleted` | `true` | Objects marked DELETED are not written to the new journal |
+| `predicate` | none | No filtering -- all objects are compacted |
+| `createdSince` | none | No date filter on creation time |
+| `lastModifiedSince` | none | No date filter on modification time |
+
+If no `Compaction` record exists for a DAO, default settings are used: the DAO is compacted with lifecycle-deleted objects discarded.
+
+---
+
+## Setup
+
+Compaction requires the `deployment/compaction` journals to be included in your build. Add them to the `-J` flag:
+
+```
+./build.sh -J../foam3/deployment/compaction,...
+```
+
+The compaction deployment provides:
+
+| File | Purpose |
+|------|---------|
+| `services.jrl` | Registers the `compactionDAO` service for storing per-DAO configuration |
+| `compactions.jrl` | Per-DAO compaction configuration entries |
+| `scripts.jrl` | The `DAOCompaction` BeanShell script |
+| `scriptparameters.jrl` | Script parameter with the `daos` list |
+
+Without these journals, the compaction script and `compactionDAO` service will not be available.
+
+---
+
+## Configuration
+
+Compaction is configured per-DAO in `deployment/compaction/compactions.jrl`.
+
+### Enable compaction (default)
+
+A DAO is compactible by default. To explicitly configure it:
+
+```
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "userDAO"
+})
+```
+
+### Disable compaction for a DAO
+
+Set `compactible: false`. The journal is still rolled, but **no data is written** to the new journal from the old data. Only new live traffic after the roll goes to the new journal.
+
+```
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "alarmDAO",
+  compactible: false
+})
+```
+
+### Compaction Model Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `cSpec` | Reference | (required) | CSpec ID of the DAO to configure |
+| `compactible` | Boolean | `true` | If true, objects are compacted to new journal. If false, entries are discarded |
+| `discardLifecycleDeleted` | Boolean | `true` | Discard objects with lifecycleState=DELETED |
+| `predicate` | Predicate | null | Custom filter -- only matching objects are compacted |
+| `createdSince` | DateTime | null | Only compact objects created on/after this date |
+| `lastModifiedSince` | DateTime | null | Only compact objects modified on/after this date |
+| `journalName` | String | auto | Journal filename. Defaults to CSpec name with "DAO" removed + "s" |
+
+---
+
+## Invoking Compaction
+
+Compaction is controlled by the `DAOCompaction` Script and its `ScriptParameter`.
+
+1. Configure which DAOs to compact in the `DAOCompaction` ScriptParameter:
+   - Set `parameters.daos` to a comma-separated list of DAO service names
+   - Enable the parameter
+
+2. Run the `DAOCompaction` script from the Scripts admin menu
+
+3. After completion, check:
+   - **ScriptEvents** for an 'OK' message
+   - **EventRecords** for a compaction summary with statistics
+
+### Considerations
+
+- Schedule compaction during a **maintenance window** with low traffic
+- Compaction can fail, requiring manual intervention (see Rollback)
+- If the DAO stack contains a `FixedSizedDAO`, only retained records are compacted
+
+---
+
+## Running Programmatically
+
+### Full compaction (roll + rewrite)
+
+```java
+import foam.dao.compaction.CompactionDAO;
+
+CompactionDAO compactor = new CompactionDAO(x, "myDAO");
+compactor.execute(x);
+```
+
+### Roll only (no compaction)
+
+If you only need to back up the current journal and start a fresh one:
+
+```java
+import foam.dao.FileRollCmd;
+
+DAO dao = (DAO) x.get("myDAO");
+FileRollCmd cmd = new FileRollCmd();
+cmd = (FileRollCmd) dao.cmd_(x, cmd);
+// cmd.getRolledFilename() = "mymodel.1"
+```
+
+**Warning:** Roll-only does NOT compact. The backup retains all delta entries. The new journal only contains writes after the roll.
+
+---
+
+## Filtering and Archiving
+
+Compaction sinks allow filtering which objects are written to the new journal. Objects not matching the filter are discarded, effectively archiving them.
+
+### Sink Chain
+
+```
++-------------------+     +----------------------+     +-------------+
+| CompactionSink    |---->| Filter Sink(s)       |---->| JournalSink |
+| (faceted lookup)  |     | (optional per config)|     | (writes)    |
++-------------------+     +----------------------+     +-------------+
+```
+
+### Filter options
+
+**1. By predicate** -- Only objects matching the predicate are kept:
+
+```
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "approvalRequestDAO",
+  compactible: true,
+  predicate: {
+    class: "foam.mlang.predicate.FScriptPredicate",
+    query: 'status == foam.core.approval.ApprovalStatus.REQUESTED'
+  }
+})
+```
+
+**2. By creation date** -- Only objects created after the date are kept:
+
+```
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "transactionDAO",
+  compactible: true,
+  createdSince: "2024-01-01T00:00:00.000Z"
+})
+```
+
+**3. By last modified date** -- Only recently modified objects are kept:
+
+```
+p({
+  class: "foam.dao.compaction.Compaction",
+  cSpec: "logDAO",
+  compactible: true,
+  lastModifiedSince: "2024-06-01T00:00:00.000Z"
+})
+```
+
+**Note:** Predicate, createdSince, and lastModifiedSince are mutually exclusive. Only one is used (checked in that order).
+
+---
+
+## Custom Compaction Sinks
+
+For per-model filtering logic, create a faceted sink class. The system auto-discovers classes named `{ModelClassId}CompactionSink` via FacetManager.
+
+```javascript
+foam.CLASS({
+  package: 'com.example',
+  name: 'MyModelCompactionSink',
+  extends: 'foam.dao.ProxySink',
+  implements: ['foam.lang.ContextAware'],
+
+  methods: [
+    {
+      name: 'put',
+      javaCode: `
+      MyModel model = (MyModel) obj;
+      if ( model.getStatus() == Status.ACTIVE ) {
+        getDelegate().put(obj, sub);  // Keep: forward to journal
+      }
+      // Discard: don't forward
+      `
+    }
+  ]
+});
+```
+
+See `deployment/compaction/compactions.jrl` for working examples including `TicketCompactionSink` and `ApprovalRequestCompactionSink`.
+
+---
 
 ## Rollback
 
-Should compaction fail for any reason, a rollback is required.
+Should compaction fail, the system should be considered in an **unknown state**. Live traffic must be halted immediately. Operations that occurred during compaction will be lost.
 
-When compaction fails the system should be considered invalid. Live traffic must be halted immediately.  Any operations which occured during compaction will be lost on rollback.
+### Rollback Steps
 
-To rollback:
+1. **Halt the system** -- Stop all traffic
+2. **Restore the journal** -- Discard the new journal file and rename the highest-numbered backup back to the original name:
+   ```
+   rm journals/users
+   mv journals/users.1 journals/users
+   ```
+3. **Restart the system** -- The restored journal will replay on startup
 
-1. Halt the system.
-1. Undo the rolled journal.  Discard the unnumbered journal file and remove the number postfix from the highest number journal.  journal.1 -> journal
-1. Start the system
+### Data loss
 
+Any writes that occurred between the roll and the failure are lost. This is why compaction should be scheduled during maintenance windows with minimal traffic.
 
-## Controlling Compaction via the Compaction model
+---
 
-Compaction model properties:
-    `foam.dao.compaction.Compaction`,
-- compactable :: By default a DAO is compactable, meaning it's entries will be reduced. If compaction is disabled (false), then the DAO's entries will be discarded - they will not be compacted into a new journal.
-- reducible :: By default a DAO is reducible, meaning multiple CRUD operations are reduced to one. If *reducible* is false, then all entries are transfered the new ledger.
-- compactLifecycleDeleted :: LifecycleAware objects which are deleted/removed are set to state DELETED, an r() journal entry is not created.  This option allows to compact DELETED entries.
-- clearable :: Not used outside of [Medusa](https://github.com/kgrgreer/foam-medusa).
-- **sink** :: Custom sinks can be registered for per entry control during compaction.
-See localTicketCommentDAO for an example of inline sink Predicate controlling Ticket Comment compaction based on Ticket Status.
-    see `deployment/compaction/compactions.jrl` ticketDAO for an example. 
+## Monitoring
+
+### EventRecords
+
+Each compaction run creates EventRecords tracking progress:
+- **Start**: Records compaction initiation
+- **Complete**: Includes a CSV summary report
+
+### Report Format
+
+```
+instance,processed,compacted,duration s,reduced,date
+localhost,50000,12000,125,76.00%,2024-12-01
+```
+
+| Field | Description |
+|-------|-------------|
+| instance | Server hostname |
+| processed | Total objects read from MDAO |
+| compacted | Objects written to new journal |
+| duration s | Total time in seconds |
+| reduced | Percentage of entries eliminated |
+| date | When compaction started |
+
+### Progress Logging
+
+During compaction, progress is logged every 5 seconds:
+```
+[INFO] CompactionDAO compaction progress processed=25000 50%
+```
+
+---
+
+## Gotchas
+
+1. **Roll-only does NOT compact** -- `FileRollCmd` only copies the journal and truncates. Use `CompactionDAO.execute()` for full compaction.
+
+2. **ProxyDAO requirement** -- `CompactionDAO.roll()` casts `x.get(serviceName)` to `ProxyDAO`. The DAO must be wrapped in a ProxyDAO or roll will fail.
+
+3. **Compaction is async** -- The compaction step runs on the thread pool. `execute()` polls for completion every 5 seconds.
+
+4. **Live traffic during compaction** -- After the roll, DAO operations resume. New writes go to the new journal. If compaction fails, these writes are lost on rollback.
+
+5. **MDAO is the source** -- Compaction reads from MDAO, not the journal file. The in-memory state is what gets written.
+
+6. **FixedSizedDAO interaction** -- If the DAO stack includes a FixedSizedDAO, only objects retained by it are compacted.
+
+7. **eventRecordDAO required** -- `execute()` writes to `eventRecordDAO`. Must be available in context.
+
+8. **Filter mutual exclusivity** -- Only one of predicate/createdSince/lastModifiedSince is applied (checked in that order as if/else if).
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `foam/dao/compaction/Compaction.js` | Configuration model |
+| `foam/dao/compaction/CompactionDAO.js` | Orchestrator (roll + compact) |
+| `foam/dao/compaction/BlockingDAO.js` | Thread synchronization during roll |
+| `foam/dao/compaction/CompactionSink.js` | Faceted sink discovery |
+| `foam/dao/compaction/LifecycleDeletedCompactionSink.js` | Filter deleted objects |
+| `foam/dao/compaction/PredicateCompactionSink.js` | Filter by predicate |
+| `foam/dao/compaction/CreatedCompactionSink.js` | Filter by creation date |
+| `foam/dao/compaction/LastModifiedCompactionSink.js` | Filter by modification date |
+| `foam/dao/FileRollCmd.js` | Command to trigger journal roll |
+| `foam/dao/AbstractF3FileJournal.js` | Journal roll implementation |
+| `deployment/compaction/compactions.jrl` | Per-DAO compaction configuration |
+| `deployment/compaction/scripts.jrl` | DAOCompaction script |
+| `deployment/compaction/scriptparameters.jrl` | Script parameters |

--- a/pom.js
+++ b/pom.js
@@ -12,6 +12,7 @@ foam.POM({
     { name: 'src/pom' },
     { name: 'src/foam/core/pom' },
     { name: 'src/foam/core/analytics/mixpanel/pom' },
+    { name: 'src/foam/dao/compaction/pom' },
     { name: 'src/foam/net/ipgeo/pom' },
     { name: 'src/foam/u2/wizard/pom' },
     { name: 'src/foam/u2/address/pom' },

--- a/src/foam/dao/compaction/Compaction.js
+++ b/src/foam/dao/compaction/Compaction.js
@@ -40,7 +40,7 @@ Used in conjuction with a custom compaction sink, the compaction process can fac
       documentation: `DAO is eligible for compaction, meaning it's entries will be reduced. If compaction is disabled (false), then the DAO's entries will be discarded - they will not be compacted into a new ledger.`,
       name: 'compactible',
       class: 'Boolean',
-      value: false
+      value: true
     },
     {
       name: 'predicate',

--- a/src/foam/dao/compaction/CompactionDAO.js
+++ b/src/foam/dao/compaction/CompactionDAO.js
@@ -40,6 +40,10 @@ select from mdao and write full records to new empty journal
     'foam.log.LogLevel',
     'foam.mlang.sink.Count',
     'foam.mlang.sink.Sequence',
+    'foam.core.fs.Storage',
+    'java.io.BufferedReader',
+    'java.io.File',
+    'java.io.FileReader',
     'java.time.Duration'
   ],
 
@@ -67,6 +71,11 @@ select from mdao and write full records to new empty journal
       name: 'eventRecord',
       class: 'FObjectProperty',
       of: 'foam.core.er.EventRecord'
+    },
+    {
+      name: 'report',
+      class: 'String',
+      documentation: 'Human-readable compaction report populated after execute()'
     }
   ],
 
@@ -210,6 +219,31 @@ select from mdao and write full records to new empty journal
 
       final DAO sourceDAO = (MDAO) mdao;
 
+      // Capture backup file stats before compaction
+      Storage storage = (Storage) x.get(Storage.class);
+      String filename = jdao.getFilename();
+      long originalEntries = 0;
+      long originalSize = 0;
+      // Find the most recent backup (.1, .2, etc.)
+      for ( int i = 1 ; ; i++ ) {
+        File f = storage.get(filename + "." + (i + 1));
+        if ( f == null || ! f.exists() ) {
+          File backup = storage.get(filename + "." + i);
+          if ( backup != null && backup.exists() ) {
+            originalSize = backup.length();
+            try ( BufferedReader br = new BufferedReader(new FileReader(backup)) ) {
+              while ( br.readLine() != null ) originalEntries++;
+            } catch (Exception e) {
+              logger.warning("could not read backup file", e.getMessage());
+            }
+          }
+          break;
+        }
+      }
+
+      final long backupEntries = originalEntries;
+      final long backupSize = originalSize;
+
       final Count total = (Count) dao.select(new Count());
       final Count processed = new Count();
       CompactionSink compactionSink = new CompactionSink(x, getServiceName(), null);
@@ -272,8 +306,25 @@ select from mdao and write full records to new empty journal
       double seconds = compactionTime / 1000.0;
       double minutes = compactionTime / 60000.0;
       double min100K = minutes / ( (Long) processed.getValue() / 100000.0 );
+
+      // Capture new journal stats
+      long newEntries = 0;
+      long newSize = 0;
+      File journalFile = storage.get(filename);
+      if ( journalFile != null && journalFile.exists() ) {
+        newSize = journalFile.length();
+        try ( BufferedReader br = new BufferedReader(new FileReader(journalFile)) ) {
+          while ( br.readLine() != null ) newEntries++;
+        } catch (Exception e) {
+          logger.warning("could not read journal file", e.getMessage());
+        }
+      }
+
+      double entryReduction = backupEntries > 0 ? ((backupEntries - newEntries) / (double) backupEntries) * 100.0 : 0;
+      double sizeReduction = backupSize > 0 ? ((backupSize - newSize) / (double) backupSize) * 100.0 : 0;
+
       StringBuilder report = new StringBuilder();
-      report.append("instance,processed,compacted,duration s,reduced,date");
+      report.append("instance,processed,compacted,duration s,objects filtered,date,original entries,new entries,entry reduction,original size,new size,size reduction");
       report.append("\\n");
       report.append(System.getProperty("hostname", "localhost"));
       report.append(",");
@@ -286,11 +337,46 @@ select from mdao and write full records to new empty journal
       report.append(String.format("%.2f%%", reduced));
       report.append(",");
       report.append(new java.util.Date(startTime));
+      report.append(",");
+      report.append(backupEntries);
+      report.append(",");
+      report.append(newEntries);
+      report.append(",");
+      report.append(String.format("%.2f%%", entryReduction));
+      report.append(",");
+      report.append(formatSize(backupSize));
+      report.append(",");
+      report.append(formatSize(newSize));
+      report.append(",");
+      report.append(String.format("%.2f%%", sizeReduction));
 
       logger.info("compactionComplete", "report", "\\n"+report.toString());
 
+      StringBuilder readable = new StringBuilder();
+      readable.append("Compaction Report");
+      readable.append("\\n  Instance:          " + System.getProperty("hostname", "localhost"));
+      readable.append("\\n  Date:              " + new java.util.Date(startTime));
+      readable.append("\\n  Duration:          " + Math.round(seconds) + "s");
+      readable.append("\\n  Objects processed:  " + processed.getValue());
+      readable.append("\\n  Objects compacted:  " + compacted);
+      readable.append("\\n  Objects filtered:   " + String.format("%.2f%%", reduced));
+      readable.append("\\n  Journal entries:    " + backupEntries + " -> " + newEntries + " (" + String.format("%.2f%%", entryReduction) + " reduction)");
+      readable.append("\\n  Journal size:       " + formatSize(backupSize) + " -> " + formatSize(newSize) + " (" + String.format("%.2f%%", sizeReduction) + " reduction)");
+      setReport(readable.toString());
+
       EventRecord er = getEventRecord();
       er.setResponseMessage(report.toString());
+      `
+    },
+    {
+      name: 'formatSize',
+      args: 'long bytes',
+      type: 'String',
+      javaCode: `
+      if ( bytes < 1024 ) return bytes + " B";
+      if ( bytes < 1024 * 1024 ) return String.format("%.1f KB", bytes / 1024.0);
+      if ( bytes < 1024 * 1024 * 1024 ) return String.format("%.1f MB", bytes / (1024.0 * 1024));
+      return String.format("%.1f GB", bytes / (1024.0 * 1024 * 1024));
       `
     }
   ],

--- a/src/foam/dao/compaction/CompactionDAO.js
+++ b/src/foam/dao/compaction/CompactionDAO.js
@@ -108,13 +108,18 @@ select from mdao and write full records to new empty journal
       er.clearId();
       setEventRecord(er);
       Compaction compaction = (Compaction) ((DAO) x.get("compactionDAO")).find(getServiceName());
+      if ( compaction == null ) {
+        compaction = new Compaction();
+        compaction.setCSpec(getServiceName());
+        logger.info("no compaction config found, using defaults");
+      }
 
       try {
         roll(x);
         if ( compaction.getCompactible() ) {
           compaction(x);
         } else {
-          logger.warning(getServiceName(), "not compactibe");
+          logger.warning(getServiceName(), "not compactible");
         }
 
         logger.info("end");
@@ -172,6 +177,10 @@ select from mdao and write full records to new empty journal
       javaCode: `
       final Logger logger = Loggers.logger(x, this, "compaction", getServiceName());
       Compaction compaction = (Compaction) ((DAO) x.get("compactionDAO")).find(getServiceName());
+      if ( compaction == null ) {
+        compaction = new Compaction();
+        compaction.setCSpec(getServiceName());
+      }
 
       DAO dao = (DAO) x.get(getServiceName());
       MDAO mdao = null;
@@ -261,12 +270,12 @@ select from mdao and write full records to new empty journal
       double reduced = ((((Long) processed.getValue()) - compacted) / ((Long) processed.getValue()).doubleValue()) * 100.0;
       long compactionTime = System.currentTimeMillis() - startTime;
       double seconds = compactionTime / 1000.0;
-      double minutes = compactionTime / 60;
+      double minutes = compactionTime / 60000.0;
       double min100K = minutes / ( (Long) processed.getValue() / 100000.0 );
       StringBuilder report = new StringBuilder();
       report.append("instance,processed,compacted,duration s,reduced,date");
       report.append("\\n");
-      report.append(System.getProperty("hostname", "loalhost"));
+      report.append(System.getProperty("hostname", "localhost"));
       report.append(",");
       report.append(processed.getValue());
       report.append(",");

--- a/src/foam/dao/compaction/pom.js
+++ b/src/foam/dao/compaction/pom.js
@@ -7,6 +7,10 @@
 foam.POM({
   name: "compaction",
 
+  projects: [
+    { name: 'test/pom', flags: 'test' }
+  ],
+
   files: [
     { name: 'BlockingDAO',                                       flags: 'js|java'},
     { name: 'Compaction',                                        flags: 'js|java'},

--- a/src/foam/dao/compaction/test/CompactionDAOTest.js
+++ b/src/foam/dao/compaction/test/CompactionDAOTest.js
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.compaction.test',
+  name: 'CompactionDAOTest',
+  extends: 'foam.core.test.Test',
+
+  javaImports: [
+    'foam.lang.X',
+    'foam.dao.*',
+    'foam.dao.compaction.*',
+    'foam.dao.java.JDAO',
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.auth.User',
+    'foam.mlang.sink.Count',
+    'java.io.File'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+      x = x.put(Storage.class, x.get(FileSystemStorage.class));
+      setX(x);
+      String serviceName = "compactionTestDAO";
+
+      // Provide a compactionDAO in context for CompactionSink
+      DAO compactionDAO = new MDAO(Compaction.getOwnClassInfo());
+      x = x.put("compactionDAO", compactionDAO);
+
+      // 1. Create a JDAO with User model
+      JDAO jdao = new JDAO(x, User.getOwnClassInfo(), "compactiontest");
+      MDAO mdao = (MDAO) jdao.getDelegate();
+
+      // Wrap in ProxyDAO (CompactionDAO.roll() casts to ProxyDAO)
+      ProxyDAO proxyDAO = new ProxyDAO.Builder(x).setDelegate(jdao).build();
+
+      // Register the DAO in context so CompactionDAO can find it
+      x = x.put(serviceName, proxyDAO);
+
+      // 2. Put multiple updates to the same objects (creates many journal entries)
+      for ( int i = 1 ; i <= 5 ; i++ ) {
+        User u = new User();
+        u.setId(i);
+        u.setFirstName("First" + i);
+        u.setLastName("Last" + i);
+        jdao.put_(x, u);
+      }
+      // Update the same objects 3 more times (creates delta entries in journal)
+      for ( int j = 0 ; j < 3 ; j++ ) {
+        for ( int i = 1 ; i <= 5 ; i++ ) {
+          User u = (User) jdao.find_(x, (long) i);
+          u = (User) u.fclone();
+          u.setFirstName("Updated" + j + "_" + i);
+          jdao.put_(x, u);
+        }
+      }
+
+      // Verify MDAO has 5 objects
+      Count count = (Count) mdao.select(new Count());
+      test( ((Long) count.getValue()) == 5, "MDAO has 5 objects before compaction");
+
+      // Verify original journal file exists and has content
+      File originalFile = x.get(Storage.class).get("compactiontest");
+      test( originalFile.exists(), "Original journal file exists");
+      long originalSize = originalFile.length();
+      test( originalSize > 0, "Original journal has content");
+
+      // 3. Run CompactionDAO (which handles roll + compaction)
+      try {
+        CompactionDAO compactor = new CompactionDAO(x, serviceName);
+        compactor.execute(x);
+        test( true, "CompactionDAO.execute() completed without error");
+      } catch (Throwable t) {
+        test( false, "CompactionDAO.execute() failed: " + t.getMessage());
+        return;
+      }
+
+      // 4. Verify: rolled backup file exists
+      File rolledFile = x.get(Storage.class).get("compactiontest.1");
+      test( rolledFile.exists(), "Rolled backup file (compactiontest.1) exists");
+      test( rolledFile.length() > 0, "Rolled backup file has content");
+
+      // 5. Verify: new journal has content (compacted entries written)
+      File newJournal = x.get(Storage.class).get("compactiontest");
+      test( newJournal.exists(), "New journal file exists after compaction");
+      long newSize = newJournal.length();
+      test( newSize > 0, "New journal has compacted entries");
+
+      // 6. Verify: MDAO still has all 5 objects with correct data
+      count = (Count) mdao.select(new Count());
+      test( ((Long) count.getValue()) == 5, "MDAO still has 5 objects after compaction");
+      User u1 = (User) mdao.find_(x, 1L);
+      test( u1 != null, "Object 1 still exists in MDAO");
+      test( u1.getFirstName().startsWith("Updated"), "Object 1 has latest updated value");
+
+      // 7. Verify: new entries go to the new journal after compaction
+      long sizeBeforeNewPut = newJournal.length();
+      User newUser = new User();
+      newUser.setId(100);
+      newUser.setFirstName("PostCompaction");
+      newUser.setLastName("User");
+      jdao.put_(x, newUser);
+      long sizeAfterNewPut = newJournal.length();
+      test( sizeAfterNewPut > sizeBeforeNewPut, "New entries written to journal after compaction");
+      User fetched = (User) jdao.find_(x, 100L);
+      test( fetched != null, "New entry is findable after compaction");
+      test( "PostCompaction".equals(fetched.getFirstName()), "New entry has correct data");
+      `
+    }
+  ]
+});

--- a/src/foam/dao/compaction/test/pom.js
+++ b/src/foam/dao/compaction/test/pom.js
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.POM({
+  name: "compaction-test",
+
+  files: [
+    { name: 'CompactionDAOTest', flags: 'js&test|java&test' }
+  ]
+});

--- a/src/foam/dao/compaction/test/tests.jrl
+++ b/src/foam/dao/compaction/test/tests.jrl
@@ -1,0 +1,5 @@
+p({
+  class:"foam.dao.compaction.test.CompactionDAOTest",
+  id:"CompactionDAOTest",
+  description:"Tests CompactionDAO roll and compaction of journal files"
+})


### PR DESCRIPTION

## Problem
Journal compaction was not working end-to-end. The `Compaction.compactible` property defaulted to `false`, causing the compact step to be skipped after roll — only a backup was created but no entries were consolidated. Additionally, missing `Compaction` config records caused NPEs, the duration calculation was wrong (dividing milliseconds by 60 instead of 60000), and the compaction report only tracked objects filtered by sinks (showing 0% when no filters were configured), giving no visibility into the actual journal entry reduction.

## Solution
Fixed the bugs preventing compaction from running, added an end-to-end test, enhanced the compaction report to show journal entry count and file size before/after, and rewrote the documentation.

## Changes
- Fix `Compaction.compactible` default from `false` to `true` to match documented behavior
- Add null checks for missing Compaction config in `execute()` and `compaction()` to prevent NPE
- Fix duration math (`/ 60` -> `/ 60000.0` for ms to minutes conversion)
- Fix typos: "compactibe" -> "compactible", "loalhost" -> "localhost"
- Add `CompactionDAOTest` verifying roll, compaction, data integrity, and post-compaction writes
- Add compaction pom to `foam-full` projects for build discovery
- Capture backup file entry count/size before compaction and new journal stats after
- Add `report` property to CompactionDAO with human-readable summary
- Update DAOCompaction script to print readable report via `getReport()`
- Rewrite `Compaction.md` with setup instructions, configuration, usage guide, and architecture docs
