### PR TITLE
PT-FIXES:DOS-2546,DOS-2547,DOS-2414,DOS-2381 Fix CurrencyCode async race condition in initObject

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -1447,9 +1447,16 @@ foam.CLASS({
     {
       name: 'initObject',
       value: async function(obj) {
-        let c = await this.normalize(this.f(obj), this, obj);
+        var value = this.f(obj);
+        // Skip normalization for empty/default values — the value will be
+        // set later by mappings or other code. Without this guard, the async
+        // DAO lookup races with synchronous property setters: initObject
+        // reads the empty default, starts an async query, then overwrites
+        // the already-set value when the query resolves.
+        if ( ! value ) return;
+        let c = await this.normalize(value, this, obj);
         this.set(obj, c);
-      } 
+      }
     },
     {
       name: 'normalize',


### PR DESCRIPTION

## Problem

`CurrencyCode.initObject` has an async race condition that silently overwrites currency values set by synchronous code (mappings, adapters, direct setters).

When an object is created with `create(null, ctx)`, `initObject` fires immediately and reads the empty default value (`""`). It then starts an async `currencyDAO.find(EQ(NUMERIC_CODE, 0))` lookup. Meanwhile, synchronous code (e.g., upload mappings) sets the currency to a valid value like `"USD"`. When the async DAO query resolves (~6 microtask cycles later), `initObject` calls `this.set(obj, "")`, overwriting the already-set value with the empty default.

This causes currency fields to silently lose their values during bulk operations like file uploads, where objects are created and populated synchronously but the async `initObject` resolves later and overwrites the correct values.

## Solution

Added an early return guard in `CurrencyCode.initObject` that skips normalization when the property value is empty/falsy. The `normalize` method only serves to convert numeric currency codes (e.g., `"840"` → `"USD"`) via a DAO lookup — there is nothing to normalize for empty strings. This eliminates the race without affecting the intended numeric-to-string conversion behavior.

## Changes

- Guard `CurrencyCode.initObject` with `if ( ! value ) return` to skip async normalization for empty/default values
