### PR TITLE
PT-FIXES:DOS-2546,DOS-2547,DOS-2414,DOS-2381 Fix CurrencyCode async race condition in initObject

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -1447,9 +1447,16 @@ foam.CLASS({
     {
       name: 'initObject',
       value: async function(obj) {
-        let c = await this.normalize(this.f(obj), this, obj);
+        var value = this.f(obj);
+        // Skip normalization for empty/default values — the value will be
+        // set later by mappings or other code. Without this guard, the async
+        // DAO lookup races with synchronous property setters: initObject
+        // reads the empty default, starts an async query, then overwrites
+        // the already-set value when the query resolves.
+        if ( ! value ) return;
+        let c = await this.normalize(value, this, obj);
         this.set(obj, c);
-      } 
+      }
     },
     {
       name: 'normalize',

--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -1445,17 +1445,32 @@ foam.CLASS({
       }
     },
     {
+      name: 'postSet',
+      value: function(oldValue, newValue, prop) {
+        // Increment the generation counter so any in-flight async initObject
+        // normalization knows it's been superseded by a direct setter.
+        var key = prop.name + '$gen_';
+        this[key] = ( this[key] || 0 ) + 1;
+      }
+    },
+    {
       name: 'initObject',
       value: async function(obj) {
         var value = this.f(obj);
-        // Skip normalization for empty/default values — the value will be
-        // set later by mappings or other code. Without this guard, the async
-        // DAO lookup races with synchronous property setters: initObject
-        // reads the empty default, starts an async query, then overwrites
-        // the already-set value when the query resolves.
         if ( ! value ) return;
+
+        // Capture the current generation before async work. If a setter fires
+        // while the DAO lookup is in flight, the generation will change and
+        // we discard the stale result instead of overwriting.
+        var key = this.name + '$gen_';
+        var gen = obj[key] || 0;
+
         let c = await this.normalize(value, this, obj);
-        this.set(obj, c);
+
+        // Only apply the normalized value if no setter has fired since we started.
+        if ( ( obj[key] || 0 ) === gen ) {
+          this.set(obj, c);
+        }
       }
     },
     {


### PR DESCRIPTION

## Problem

`CurrencyCode.initObject` has an async race condition that silently overwrites currency values set by synchronous code (mappings, adapters, direct setters).

When an object is created with `create(null, ctx)`, `initObject` fires immediately and reads the current value. It then starts an async `currencyDAO.find()` lookup. Meanwhile, synchronous code (e.g., upload mappings) sets the currency to a valid value like `"USD"`. When the async DAO query resolves (~6 microtask cycles later), `initObject` calls `this.set(obj, ...)`, overwriting the already-set value with the stale lookup result.

This causes currency fields to silently lose their values during bulk operations like file uploads, where objects are created and populated synchronously but the async `initObject` resolves later.

## Solution

Two-layer defense against the async race:

1. **Early return for empty values**: Skip normalization entirely when the property value is empty/falsy — there's nothing to normalize for empty strings, and this avoids a pointless `currencyDAO.find(NUMERIC_CODE, 0)` query.

2. **Generation counter via `postSet`**: A `postSet` handler on CurrencyCode increments a per-property generation counter (`propName$gen_`) on the object each time the value is explicitly set. `initObject` captures the generation before starting the async DAO lookup and checks it after the lookup resolves. If the generation changed (meaning a setter fired during the async window), the stale result is discarded.

This approach is safe for all scenarios:
- Empty default → early return, no async work
- Value set before async resolves → generation mismatch, stale result dropped
- No setter fired → generation matches, normalized value applied normally

## Changes

- Add `postSet` handler to `CurrencyCode` that increments a generation counter on the object instance
- Guard `initObject` with early return for empty values and generation check after async normalization
