### PR TITLE
Fix handling empty FObjectProperty in JSONFObjectFormatter 

### DIFF
--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -213,10 +213,18 @@ public class JSONFObjectFormatter
       p.formatJSON(this, o);
 
       // handle empty property value output:
-      //   - for FObjectProperty returns empty json: {}
+      //   - for FObjectProperty returns {class:"..."}
       //   - Otherwise returns null
       if ( builder().length() == startLen ) {
-        append( p.get(o) instanceof FObject ? "{}" : "null" );
+        if ( p.get(o) instanceof FObject fo ) {
+          append('{');
+          outputKey("class");
+          append(':');
+          output(fo.getClassInfo());
+          append('}');
+        } else {
+          append("null");
+        }
       }
     } catch (Throwable t) {
       System.err.println("***************************************************** error outputting " + getPropertyName(p));
@@ -529,7 +537,7 @@ public class JSONFObjectFormatter
       if ( outputProp ) props++;
     }
 
-    if ( props > 0 || outputDefaultClassNames_ || outputDefaultValues_ ) {
+    if ( props > 0 || outputDefaultClassNames_ ) {
       addInnerNewline();
       append('}');
     } else {

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -204,31 +204,19 @@ public class JSONFObjectFormatter
 
   protected void outputProperty(FObject o, PropertyInfo p) {
     try {
-      int startLen = builder().length();
+      // output propertyName:
       outputKey(getPropertyName(p));
       append(':');
-      int valueStart = builder().length();
-      Object propObj = p.get(o);
+
+      // output property value which can be empty. See. output(FObject, ClassInfo, PropertyInfo)
+      int startLen = builder().length();
       p.formatJSON(this, o);
-      // If nothing was written for the value (eg: empty/default nested FObject),
-      // output a minimal object carrying the class to avoid blank entries.
-      // Only do this when OutputDefaultClassNames is true, otherwise preserve
-      // original behavior (which may produce invalid JSON for edge cases).
-      if ( builder().length() == valueStart ) {
-        setLength(startLen);
-        outputKey(getPropertyName(p));
-        append(':');
-        if ( propObj instanceof FObject && outputDefaultClassNames_ ) {
-          append('{');
-          outputKey("class");
-          append(':');
-          output(((FObject) propObj).getClassInfo().getId());
-          append('}');
-        } else if ( ! ( propObj instanceof FObject ) ) {
-          append("null");
-        }
-        // else: FObject with OutputDefaultClassNames=false - leave empty
-        // (preserves original behavior, produces invalid JSON as expected)
+
+      // handle empty property value output:
+      //   - for FObjectProperty returns empty json: {}
+      //   - Otherwise returns null
+      if ( builder().length() == startLen ) {
+        append( p.get(o) instanceof FObject ? "{}" : "null" );
       }
     } catch (Throwable t) {
       System.err.println("***************************************************** error outputting " + getPropertyName(p));
@@ -541,7 +529,7 @@ public class JSONFObjectFormatter
       if ( outputProp ) props++;
     }
 
-    if ( props > 0 || outputDefaultClassNames_ ) {
+    if ( props > 0 || outputDefaultClassNames_ || outputDefaultValues_ ) {
       addInnerNewline();
       append('}');
     } else {

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -23,9 +23,6 @@ foam.CLASS({
     {
       name: 'runTest',
       javaCode: `
-
-      JSONFObjectFormatter formatter = null;
-      JSONParser parser = null;
       String json = null;
       String testId = null;
 
@@ -93,127 +90,10 @@ foam.CLASS({
 
       // test outputting enum with custom javaCode
       testId = "EnumWithCustomJavaCode";
-      formatter = new JSONFObjectFormatter();
+      var formatter = new JSONFObjectFormatter();
       formatter.output(foam.test.TestEnum.CUSTOM);
       json = formatter.builder().toString();
       test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" should not output java anonymous class name: " + json);
-
-      if (true) return;
-
-
-
-
-      parser = new JSONParser();
-      try {
-        Object o = parser.parseString(json);
-        test ( o != null, testId+" valid json generated. " + json);
-      } catch ( Throwable t ) {
-        // Should fail parsing, but not through exception
-        test ( false, testId+" Error parsing: "+t.getMessage());
-      }
-
-      testId = "OutputDefaultClassNames:true-OutputDefaultValues:true";
-      formatter = new JSONFObjectFormatter();
-      // formatter.setOutputDefaultClassNames(true); - default
-      formatter.setOutputDefaultValues(true);
-      rg = new foam.core.ruler.RuleGroup();
-      rg.setId(this.getClass().getSimpleName());
-      // predicate defaults to TRUE
-      formatter.output(rg);
-      json = formatter.builder().toString();
-
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
-      parser = new JSONParser();
-      try {
-        Object o = parser.parseString(json);
-        test ( o != null, testId+" json parsed");
-      } catch ( Throwable t ) {
-        test ( false, testId+" Error parsing: "+t.getMessage());
-      }
-
-      testId = "OutputDefaultClassNames:true-OutputDefaultValues:false";
-      formatter = new JSONFObjectFormatter();
-      // formatter.setOutputDefaultClassNames(true); - default
-      // formatter.setOutputDefaultValues(false); - default
-      rg = new foam.core.ruler.RuleGroup();
-      rg.setId(this.getClass().getSimpleName());
-      // predicate defaults to TRUE
-      formatter.output(rg);
-      json = formatter.builder().toString();
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
-      parser = new JSONParser();
-      try {
-        Object o = parser.parseString(json);
-        test ( o != null, testId+" json parsed");
-      } catch ( Throwable t ) {
-        test ( false, testId+" Error parsing: "+t.getMessage());
-      }
-
-      testId = "OutputDefaultClassNames:false-OutputDefaultValues:false";
-      formatter = new JSONFObjectFormatter();
-      formatter.setOutputDefaultClassNames(false);
-      // formatter.setOutputDefaultValues(false); - default
-      rg = new foam.core.ruler.RuleGroup();
-      rg.setId(this.getClass().getSimpleName());
-      // predicate defaults to TRUE
-      formatter.output(rg);
-      json = formatter.builder().toString();
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
-      parser = new JSONParser();
-      try {
-        Object o = parser.parseString(json);
-        test ( o != null, testId+" json parsed");
-      } catch ( Throwable t ) {
-        test ( false, testId+" Error parsing: "+t.getMessage());
-      }
-
-      // ============================================================
-      // Test empty/default FObjectProperty (like User.address)
-      // When OutputDefaultClassNames=true, empty FObjects should output {class:"..."}
-      // ============================================================
-
-      testId = "EmptyFObjectProperty-OutputDefaultClassNames:true";
-      formatter = new JSONFObjectFormatter();
-      formatter.setOutputDefaultClassNames(true);
-
-      user = new User();
-      user.setId(12345L);
-      user.setAddress(new Address()); // Empty address
-      formatter.output(user);
-      json = formatter.builder().toString();
-      // Should contain address with at least the class
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated (no empty values)");
-      test ( json.contains("address") && json.contains("foam.core.auth.Address"), testId+" address with class present: "+json);
-      parser = new JSONParser();
-      try {
-        Object o = parser.parseString(json);
-        test ( o != null, testId+" json parsed successfully");
-        if ( o instanceof User ) {
-          User parsedUser = (User) o;
-          test ( parsedUser.getAddress() != null, testId+" parsed user has address object");
-        }
-      } catch ( Throwable t ) {
-        test ( false, testId+" Error parsing: "+t.getMessage());
-      }
-
-      // ============================================================
-      // Test empty/default FObjectProperty (like User.address)
-      // When OutputDefaultClassNames=false, empty FObjects should output {}
-      // ============================================================
-      testId = "EmptyFObjectProperty-OutputDefaultClassNames:false";
-      formatter = new JSONFObjectFormatter();
-      formatter.setOutputDefaultClassNames(false);
-
-      formatter.output(user);
-      json = formatter.builder().toString();
-      test ( json.contains("address:{}"), testId+" output address as empty json: "+json);
-
-      // Test outputting enum with custom javaCode
-      testId = "EnumWithCustomJavaCode";
-      formatter = new JSONFObjectFormatter();
-      formatter.output(foam.test.TestEnum.CUSTOM);
-      json = formatter.builder().toString();
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" valid json generated: " + json);
       `
     }
   ],

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -44,11 +44,11 @@ foam.CLASS({
       // predicate defaults to TRUE
       formatter.output(rg);
       json = formatter.builder().toString();
-      test ( ! SafetyUtil.isEmpty(json) && json.contains(":,"), testId+" INVALID json generated "+json.toString());
+      test ( ! SafetyUtil.isEmpty(json) && json.contains("foam.mlang.predicate.True"), testId+" valid json generated "+json.toString());
       parser = new JSONParser();
       try {
         Object o = parser.parseString(json);
-        test ( o == null, testId+" json NOT parsed");
+        test ( SafetyUtil.equals(rg, o), testId+" json parsed");
       } catch ( Throwable t ) {
         // Should fail parsing, but not through exception
         test ( false, testId+" Error parsing: "+t.getMessage());
@@ -115,8 +115,8 @@ foam.CLASS({
 
       testId = "EmptyFObjectProperty-OutputDefaultClassNames:true";
       formatter = new JSONFObjectFormatter();
-      // formatter.setOutputDefaultClassNames(true); - default
-      formatter.setOutputDefaultValues(true);
+      formatter.setOutputDefaultClassNames(true);
+
       var user = new User();
       user.setId(12345L);
       user.setAddress(new Address()); // Empty/default address
@@ -137,20 +137,17 @@ foam.CLASS({
         test ( false, testId+" Error parsing: "+t.getMessage());
       }
 
-      // Test with OutputDefaultValues=false (JRL default) - the actual use case from PR
-      // When OutputDefaultValues=false, the empty Address outputs nothing except the class
-      testId = "EmptyFObjectProperty-JRLDefaults";
+      // ============================================================
+      // Test empty/default FObjectProperty (like User.address)
+      // When OutputDefaultClassNames=false, empty FObjects should output {}
+      // ============================================================
+      testId = "EmptyFObjectProperty-OutputDefaultClassNames:false";
       formatter = new JSONFObjectFormatter();
-      // OutputDefaultClassNames=true (default)
-      // OutputDefaultValues=false (default) - mimics JRL behavior
-      user = new User();
-      user.setId(12345L);
-      user.setAddress(new Address()); // Empty/default address
+      formatter.setOutputDefaultClassNames(false);
+
       formatter.output(user);
       json = formatter.builder().toString();
-      // With default settings (JRL-like), empty Address should still have class output
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated");
-      test ( json.contains("address") && json.contains("foam.core.auth.Address"), testId+" address with class present: "+json);
+      test ( json.contains("address:{}"), testId+" output address as empty json: "+json);
 
       // Test outputting enum with custom javaCode
       testId = "EnumWithCustomJavaCode";

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -35,20 +35,60 @@ foam.CLASS({
       // This combination should produce invalid json.
       // Setting OutputDefaultClassNames(false) will set OutputDefaultValues(false)
       // but this test case explicitly setOutputDefaultValues(true)
-      testId = "OutputDefaultClassNames:false-OutputDefaultValues:true";
-      formatter = new JSONFObjectFormatter();
-      formatter.setOutputDefaultClassNames(false);
-      formatter.setOutputDefaultValues(true);
       var rg = new foam.core.ruler.RuleGroup();
       rg.setId(this.getClass().getSimpleName());
-      // predicate defaults to TRUE
-      formatter.output(rg);
-      json = formatter.builder().toString();
-      test ( ! SafetyUtil.isEmpty(json) && json.contains("foam.mlang.predicate.True"), testId+" valid json generated "+json.toString());
+
+      testId = "OutputDefaultClassNames:true-OutputDefaultValues:false";
+      json = testJSONFObjectFormatter(testId, rg, true, false, rg.getClassInfo());
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
+      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" should not output properties default value");
+
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:false";
+      json = testJSONFObjectFormatter(testId, rg, false, false, rg.getClassInfo());
+      test ( ! json.contains("foam.core.ruler.RuleGroup"), testId+" should not output obj class name");
+      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" should not output properties default value");
+
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:false-DefaultClass:null";
+      json = testJSONFObjectFormatter(testId, rg, false, false, null);
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
+      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" should not output properties default value");
+
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:true";
+      json = testJSONFObjectFormatter(testId, rg, false, true, rg.getClassInfo());
+      test ( ! json.contains("foam.core.ruler.RuleGroup"), testId+" should not output obj class name");
+      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" should output properties default value");
+
+      rg = new foam.core.ruler.RuleGroup(); // initialize new object because properties factory of the old object has already been invoked
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:true-DefaultClass:null";
+      json = testJSONFObjectFormatter(testId, rg, false, true, null);
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
+      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" should output properties default value");
+
+      rg = new foam.core.ruler.RuleGroup();
+      testId = "OutputDefaultClassNames:true-OutputDefaultValues:true";
+      json = testJSONFObjectFormatter(testId, rg, true, true, rg.getClassInfo());
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
+      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" should output properties default value");
+
+      // test outputting property after factory is invoked
+      rg = new foam.core.ruler.RuleGroup();
+      rg.getPredicate();
+      testId = "OutputDefaultClassNames:true-OutputDefaultValues:false-InvokePropertyFactory";
+      json = testJSONFObjectFormatter(testId, rg, false, false, rg.getClassInfo());
+      test ( json.contains("foam.mlang.predicate.True"), testId+" should output properties set by factory");
+      test ( ! json.contains("priority:10"), testId+" should output unset properties");
+
+
+
+      if (true) return;
+
+
+
+
       parser = new JSONParser();
       try {
         Object o = parser.parseString(json);
-        test ( SafetyUtil.equals(rg, o), testId+" json parsed");
+        test ( o != null, testId+" valid json generated. " + json);
       } catch ( Throwable t ) {
         // Should fail parsing, but not through exception
         test ( false, testId+" Error parsing: "+t.getMessage());
@@ -63,6 +103,7 @@ foam.CLASS({
       // predicate defaults to TRUE
       formatter.output(rg);
       json = formatter.builder().toString();
+
       test ( ! SafetyUtil.isEmpty(json) && ! json.contains(":,"), testId+" valid json generated: "+json.toString());
       parser = new JSONParser();
       try {
@@ -157,5 +198,29 @@ foam.CLASS({
       test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" valid json generated: " + json);
       `
     }
-  ]
+  ],
+
+  javaCode: `
+    protected String testJSONFObjectFormatter(String testId, foam.lang.FObject obj, boolean outputDefaultClassNames, boolean outputDefaultValues) {
+      return testJSONFObjectFormatter(testId, obj, outputDefaultClassNames, outputDefaultValues, null);
+    }
+
+    protected String testJSONFObjectFormatter(String testId, foam.lang.FObject obj, boolean outputDefaultClassNames, boolean outputDefaultValues, foam.lang.ClassInfo defaultCls) {
+      var fmt = new JSONFObjectFormatter();
+      fmt.setOutputDefaultClassNames(outputDefaultClassNames);
+      fmt.setOutputDefaultValues(outputDefaultValues);
+      fmt.output(obj, defaultCls);
+
+      String json = fmt.builder().toString();
+
+      var parser = new JSONParser();
+      try {
+        Object o = parser.parseString(json, defaultCls != null ? defaultCls.getObjClass() : null);
+        test( o != null, testId + " generate valid json: " + json );
+      } catch ( Throwable t ) {
+        test( false, testId + " error parsing: " + t.getMessage() );
+      }
+      return json;
+    }
+  `
 })

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -37,43 +37,43 @@ foam.CLASS({
 
       testId = "OutputDefaultClassNames:true-OutputDefaultValues:false";
       json = testJSONFObjectFormatter(testId, rg, true, false, rg.getClassInfo());
-      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
-      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" should not output properties default value");
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" -- output obj class name");
+      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" -- do not output properties default value");
 
       testId = "OutputDefaultClassNames:false-OutputDefaultValues:false";
       json = testJSONFObjectFormatter(testId, rg, false, false, rg.getClassInfo());
-      test ( ! json.contains("foam.core.ruler.RuleGroup"), testId+" should not output obj class name");
-      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" should not output properties default value");
+      test ( ! json.contains("foam.core.ruler.RuleGroup"), testId+" -- do not output obj class name");
+      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" -- do not output properties default value");
 
       testId = "OutputDefaultClassNames:false-OutputDefaultValues:false-DefaultClass:null";
       json = testJSONFObjectFormatter(testId, rg, false, false, null);
-      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
-      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" should not output properties default value");
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" -- output obj class name");
+      test ( ! json.contains("priority:") && ! json.contains("predicate:"), testId+" -- do not output properties default value");
 
       testId = "OutputDefaultClassNames:false-OutputDefaultValues:true";
       json = testJSONFObjectFormatter(testId, rg, false, true, rg.getClassInfo());
-      test ( ! json.contains("foam.core.ruler.RuleGroup"), testId+" should not output obj class name");
-      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" should output properties default value");
+      test ( ! json.contains("foam.core.ruler.RuleGroup"), testId+" -- do not output obj class name");
+      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" -- output properties default value");
 
       rg = new foam.core.ruler.RuleGroup(); // initialize new object because properties factory of the old object has already been invoked
       testId = "OutputDefaultClassNames:false-OutputDefaultValues:true-DefaultClass:null";
       json = testJSONFObjectFormatter(testId, rg, false, true, null);
-      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
-      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" should output properties default value");
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" -- output obj class name");
+      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" -- output properties default value");
 
       rg = new foam.core.ruler.RuleGroup();
       testId = "OutputDefaultClassNames:true-OutputDefaultValues:true";
       json = testJSONFObjectFormatter(testId, rg, true, true, rg.getClassInfo());
-      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" should output obj class name");
-      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" should output properties default value");
+      test ( json.contains("foam.core.ruler.RuleGroup"), testId+" -- output obj class name");
+      test ( json.contains("priority:10") && json.contains("foam.mlang.predicate.True"), testId+" -- output properties default value");
 
       // test outputting property after factory is invoked
       rg = new foam.core.ruler.RuleGroup();
       rg.getPredicate();
       testId = "OutputDefaultClassNames:true-OutputDefaultValues:false-InvokePropertyFactory";
       json = testJSONFObjectFormatter(testId, rg, false, false, rg.getClassInfo());
-      test ( json.contains("foam.mlang.predicate.True"), testId+" should output properties set by factory");
-      test ( ! json.contains("priority:10"), testId+" should output unset properties");
+      test ( json.contains("foam.mlang.predicate.True"), testId+" -- output properties set by factory");
+      test ( ! json.contains("priority:10"), testId+" -- output unset properties");
 
       // test outputting empty fobject property
       var user = new User();
@@ -82,18 +82,18 @@ foam.CLASS({
 
       testId = "OutputDefaultClassNames:true-OutputDefaultValues:false-EmptyFObjectProperty";
       json = testJSONFObjectFormatter(testId, user, true, false, user.getClassInfo());
-      test ( json.contains("address:{class:\\\"foam.core.auth.Address\\\"}"), testId+" should output empty fobject property");
+      test ( json.contains("address:{class:\\\"foam.core.auth.Address\\\"}"), testId+" -- output empty fobject property");
 
       testId = "OutputDefaultClassNames:false-OutputDefaultValues:false-EmptyFObjectProperty";
       json = testJSONFObjectFormatter(testId, user, false, false, user.getClassInfo());
-      test ( json.contains("address:{class:\\\"foam.core.auth.Address\\\"}"), testId+" should output empty fobject property");
+      test ( json.contains("address:{class:\\\"foam.core.auth.Address\\\"}"), testId+" -- output empty fobject property");
 
       // test outputting enum with custom javaCode
       testId = "EnumWithCustomJavaCode";
       var formatter = new JSONFObjectFormatter();
       formatter.output(foam.test.TestEnum.CUSTOM);
       json = formatter.builder().toString();
-      test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" should not output java anonymous class name: " + json);
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" -- do not output java anonymous class name: " + json);
       `
     },
     {

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -95,30 +95,28 @@ foam.CLASS({
       json = formatter.builder().toString();
       test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" should not output java anonymous class name: " + json);
       `
+    },
+    {
+      name: 'testJSONFObjectFormatter',
+      type: 'String',
+      args: 'String testId, FObject obj, Boolean outputDefaultClassNames, Boolean outputDefaultValues, foam.lang.ClassInfo defaultCls',
+      javaCode: `
+        var fmt = new JSONFObjectFormatter();
+        fmt.setOutputDefaultClassNames(outputDefaultClassNames);
+        fmt.setOutputDefaultValues(outputDefaultValues);
+        fmt.output(obj, defaultCls);
+
+        String json = fmt.builder().toString();
+
+        var parser = new JSONParser();
+        try {
+          Object o = parser.parseString(json, defaultCls != null ? defaultCls.getObjClass() : null);
+          test( o != null, testId + " generate valid json: " + json );
+        } catch ( Throwable t ) {
+          test( false, testId + " error parsing: " + t.getMessage() );
+        }
+        return json;
+      `
     }
-  ],
-
-  javaCode: `
-    protected String testJSONFObjectFormatter(String testId, foam.lang.FObject obj, boolean outputDefaultClassNames, boolean outputDefaultValues) {
-      return testJSONFObjectFormatter(testId, obj, outputDefaultClassNames, outputDefaultValues, null);
-    }
-
-    protected String testJSONFObjectFormatter(String testId, foam.lang.FObject obj, boolean outputDefaultClassNames, boolean outputDefaultValues, foam.lang.ClassInfo defaultCls) {
-      var fmt = new JSONFObjectFormatter();
-      fmt.setOutputDefaultClassNames(outputDefaultClassNames);
-      fmt.setOutputDefaultValues(outputDefaultValues);
-      fmt.output(obj, defaultCls);
-
-      String json = fmt.builder().toString();
-
-      var parser = new JSONParser();
-      try {
-        Object o = parser.parseString(json, defaultCls != null ? defaultCls.getObjClass() : null);
-        test( o != null, testId + " generate valid json: " + json );
-      } catch ( Throwable t ) {
-        test( false, testId + " error parsing: " + t.getMessage() );
-      }
-      return json;
-    }
-  `
+  ]
 })

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -73,7 +73,7 @@ foam.CLASS({
       testId = "OutputDefaultClassNames:true-OutputDefaultValues:false-InvokePropertyFactory";
       json = testJSONFObjectFormatter(testId, rg, false, false, rg.getClassInfo());
       test ( json.contains("foam.mlang.predicate.True"), testId+" -- output properties set by factory");
-      test ( ! json.contains("priority:10"), testId+" -- output unset properties");
+      test ( ! json.contains("priority:10"), testId+" -- do not output unset properties");
 
       // test outputting empty fobject property
       var user = new User();

--- a/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
+++ b/src/foam/lib/formatter/test/JSONFObjectFormatterParserTest.js
@@ -78,7 +78,25 @@ foam.CLASS({
       test ( json.contains("foam.mlang.predicate.True"), testId+" should output properties set by factory");
       test ( ! json.contains("priority:10"), testId+" should output unset properties");
 
+      // test outputting empty fobject property
+      var user = new User();
+      user.setId(12345L);
+      user.setAddress(new Address()); // Empty address
 
+      testId = "OutputDefaultClassNames:true-OutputDefaultValues:false-EmptyFObjectProperty";
+      json = testJSONFObjectFormatter(testId, user, true, false, user.getClassInfo());
+      test ( json.contains("address:{class:\\\"foam.core.auth.Address\\\"}"), testId+" should output empty fobject property");
+
+      testId = "OutputDefaultClassNames:false-OutputDefaultValues:false-EmptyFObjectProperty";
+      json = testJSONFObjectFormatter(testId, user, false, false, user.getClassInfo());
+      test ( json.contains("address:{class:\\\"foam.core.auth.Address\\\"}"), testId+" should output empty fobject property");
+
+      // test outputting enum with custom javaCode
+      testId = "EnumWithCustomJavaCode";
+      formatter = new JSONFObjectFormatter();
+      formatter.output(foam.test.TestEnum.CUSTOM);
+      json = formatter.builder().toString();
+      test ( ! SafetyUtil.isEmpty(json) && ! json.contains("$"), testId+" should not output java anonymous class name: " + json);
 
       if (true) return;
 
@@ -158,9 +176,9 @@ foam.CLASS({
       formatter = new JSONFObjectFormatter();
       formatter.setOutputDefaultClassNames(true);
 
-      var user = new User();
+      user = new User();
       user.setId(12345L);
-      user.setAddress(new Address()); // Empty/default address
+      user.setAddress(new Address()); // Empty address
       formatter.output(user);
       json = formatter.builder().toString();
       // Should contain address with at least the class


### PR DESCRIPTION
## Issues
- Create new user without address from the gui is generating invalid json entry in the journal file

## Changes
- Output propName: {class: "..."} for empty FObject property eg. User.address

      p({class:"foam.core.auth.User",id:123,address:{class:"foam.core.auth.Address"}})

- Rewrite JSONFObjectFormatter test cases

## Step to reproduce
- Login as admin
- Goto 'Data Management' > userDAO then create a new user from the gui without filling out address fields
- Check users journal if the address field is populated correctly

## Test outputs
```
JSONFObjectFormatterParserTest
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false generate valid json: {class:"foam.core.ruler.RuleGroup",id:"JSONFObjectFormatterParserTest"}
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false -- output obj class name
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false -- do not output properties default value
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false generate valid json: {id:"JSONFObjectFormatterParserTest"}
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false -- do not output obj class name
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false -- do not output properties default value
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false-DefaultClass:null generate valid json: {class:"foam.core.ruler.RuleGroup",id:"JSONFObjectFormatterParserTest"}
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false-DefaultClass:null -- output obj class name
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false-DefaultClass:null -- do not output properties default value
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:true generate valid json: {id:"JSONFObjectFormatterParserTest",documentation:"",predicate:{class:"foam.mlang.predicate.True"},enabled:true,priority:10}
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:true -- do not output obj class name
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:true -- output properties default value
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:true-DefaultClass:null generate valid json: {class:"foam.core.ruler.RuleGroup",id:"",documentation:"",predicate:{class:"foam.mlang.predicate.True"},enabled:true,priority:10}
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:true-DefaultClass:null -- output obj class name
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:true-DefaultClass:null -- output properties default value
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:true generate valid json: {class:"foam.core.ruler.RuleGroup",id:"",documentation:"",predicate:{class:"foam.mlang.predicate.True"},enabled:true,priority:10}
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:true -- output obj class name
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:true -- output properties default value
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false-InvokePropertyFactory generate valid json: {predicate:{class:"foam.mlang.predicate.True"}}
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false-InvokePropertyFactory -- output properties set by factory
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false-InvokePropertyFactory -- do not output unset properties
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false-EmptyFObjectProperty generate valid json: {class:"foam.core.auth.User",id:12345,address:{class:"foam.core.auth.Address"}}
	 ✓ SUCCESS: OutputDefaultClassNames:true-OutputDefaultValues:false-EmptyFObjectProperty -- output empty fobject property
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false-EmptyFObjectProperty generate valid json: {id:12345,address:{class:"foam.core.auth.Address"}}
	 ✓ SUCCESS: OutputDefaultClassNames:false-OutputDefaultValues:false-EmptyFObjectProperty -- output empty fobject property
	 ✓ SUCCESS: EnumWithCustomJavaCode -- do not output java anonymous class name: {class:"foam.test.TestEnum",ordinal:2}
```