### PR TITLE
refactor(u2): use VerticalDetailView as default for FObjectArrayView

### DIFF
--- a/src/foam/u2/view/FObjectArrayView.js
+++ b/src/foam/u2/view/FObjectArrayView.js
@@ -39,7 +39,7 @@ foam.CLASS({
     {
       name: 'valueView',
       expression: function(of) {
-        return { class: 'foam.u2.DetailView' };
+        return { class: 'foam.u2.detail.VerticalDetailView' };
         /*
         return {
           class: 'foam.u2.view.CollapseableDetailView',


### PR DESCRIPTION
VerticalDetailView provides a more compact layout for inline array item editing, better suited to the typical FObjectArray use case.