### PR TITLE
Add JavaScript Date.toString() Format Support to DateParser

### DIFF
--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -26,7 +26,7 @@ foam.CLASS({
   `,
 
   methods: [
-    function grammar(alt, anyChar, chars, literalIC, optional, range, repeat, seq, str, sym) {
+    function grammar(alt, anyChar, chars, literalIC, notChars, optional, range, repeat, seq, str, sym) {
       return {
         START: sym('dateOrDatetime'),
 
@@ -93,8 +93,10 @@ foam.CLASS({
         // DD MMM YYYY (with spaces)
         // Unix/Java Date.toString() format: DDD MMM DD HH:MM:SS TZ YYYY
         // NOTE: yyyyddmmmcompact must come BEFORE ddmmmyyyycompact to match correctly
-        // NOTE: unixdatetostring must come FIRST because it has the most specific pattern
+        // NOTE: jsdatetostring must come FIRST (year before time), then unixdatetostring
         datemonthname: alt(
+          // Support: DDD MMM DD YYYY HH:MM:SS GMT±HHMM (Timezone Name) (e.g., "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)")
+          sym('jsdatetostring'),
           // Support: DDD MMM DD HH:MM:SS TZ YYYY (e.g., "Tue Apr 01 05:17:59 GMT 2025")
           sym('unixdatetostring'),
           // Support: MMM dd yyyy (e.g., Jan 02 2025)
@@ -543,6 +545,26 @@ foam.CLASS({
         // Supports single-digit days
         ddmmmyyyyspace: seq(
           sym('dayFlexible'), ' ', sym('month3alpha'), ' ', sym('year4')
+        ),
+
+        // JavaScript Date.toString() format: DDD MMM DD YYYY HH:MM:SS GMT±HHMM (Timezone Name)
+        // e.g., "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
+        // The day name (Mon, Tue, etc.) is parsed but ignored for date construction
+        // Year comes BEFORE time (unlike Unix format), timezone is GMT fused with offset
+        jsdatetostring: seq(
+          sym('day3alpha'), ' ',      // Day name (ignored)
+          sym('month3alpha'), ' ',    // Month name
+          sym('dayFlexible'), ' ',    // Day of month (1-31 or 01-31)
+          sym('year4'), ' ',          // Year
+          sym('hour2'), ':', sym('minute2'), ':', sym('second2'), ' ',  // Time HH:MM:SS
+          sym('jsTimezone'),          // Timezone (GMT or GMT±HHMM)
+          optional(seq(' ', '(', str(repeat(notChars(')'), null, 1)), ')'))  // Optional (Timezone Name)
+        ),
+
+        // JS timezone format: GMT optionally followed by ±HHMM offset
+        jsTimezone: seq(
+          literalIC('GMT'),
+          optional(seq(chars('+-'), repeat(range('0', '9'), null, 4, 4)))
         ),
 
         // Unix/Java Date.toString() format: DDD MMM DD HH:MM:SS TZ YYYY

--- a/src/foam/parse/DateParser.java
+++ b/src/foam/parse/DateParser.java
@@ -395,6 +395,19 @@ public class DateParser {
   }
 
   /**
+   * Normalize JS timezone: Seq result [GMT_literal, optional_offset] to standard format.
+   * ['GMT', null] → 'Z', ['GMT', ['+', ['0','4','0','0']]] → '+0400'
+   */
+  private String normalizeJsTimezone(Object tz) {
+    if ( tz == null ) return "Z";
+    if ( ! (tz instanceof Object[]) ) return "Z";
+    Object[] arr = (Object[]) tz;
+    // arr = [GMT_literal, optional_offset]
+    if ( arr.length < 2 || arr[1] == null ) return "Z";
+    return flattenTimezone(arr[1]);
+  }
+
+  /**
    * Parse timezone string and return offset in minutes.
    * Z means UTC (0). +05:30 means +330 minutes.
    */
@@ -618,6 +631,7 @@ public class DateParser {
 
     // Date with month names - ALL completely unambiguous (contain letters!)
     grammar.addSymbol("date-monthname", new Alt(
+      grammar.sym("js-date-tostring"),   // JS Date.toString(): "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
       grammar.sym("unix-date-tostring"), // Unix/Java Date.toString(): "Tue Apr 01 05:17:59 GMT 2025"
       grammar.sym("mmmddyyyy-space"),    // MMM dd yyyy (e.g., Jan 02 2025)
       grammar.sym("ddmmmyyyy-space"),    // DD MMM YYYY (e.g., 15 JAN 2025)
@@ -1169,6 +1183,41 @@ public class DateParser {
       grammar.sym("dayFlexible"), Literal.create(" "), grammar.sym("month3alpha"), Literal.create(" "), grammar.sym("year4")
     ));
 
+    // JavaScript Date.toString() format: "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
+    // Format: DDD MMM DD YYYY HH:MM:SS GMT±HHMM (Timezone Name)
+    grammar.addSymbol("js-date-tostring", new Seq(
+      grammar.sym("day3alpha"),           // Day name (ignored)
+      Literal.create(" "),
+      grammar.sym("month3alpha"),         // Month name
+      Literal.create(" "),
+      grammar.sym("dayFlexible"),         // Day of month
+      Literal.create(" "),
+      grammar.sym("year4"),               // Year (before time)
+      Literal.create(" "),
+      grammar.sym("hour2"),               // Hour
+      Literal.create(":"),
+      grammar.sym("minute2"),             // Minute
+      Literal.create(":"),
+      grammar.sym("second2"),             // Second
+      Literal.create(" "),
+      grammar.sym("jsTimezone"),          // GMT or GMT±HHMM
+      new Optional(new Seq(              // Optional (Timezone Name)
+        Literal.create(" "),
+        Literal.create("("),
+        new Repeat(new NotChars(")"), (Parser) null, 1),
+        Literal.create(")")
+      ))
+    ));
+
+    // JS timezone format: GMT optionally followed by ±HHMM offset
+    grammar.addSymbol("jsTimezone", new Seq(
+      new LiteralIC("GMT"),
+      new Optional(new Seq(
+        new Chars("+-"),
+        new Repeat(Range.create('0', '9'), null, 4, 4)
+      ))
+    ));
+
     // Unix/Java Date.toString() format: "Tue Apr 01 05:17:59 GMT 2025"
     // Format: DDD MMM DD HH:MM:SS TZ YYYY
     grammar.addSymbol("unix-date-tostring", new Seq(
@@ -1482,6 +1531,23 @@ public class DateParser {
         self.parseMonthName((String) v[2]),
         Integer.parseInt((String) v[0]),
         -1, -1, -1, -1, null);
+    });
+
+    // JS Date.toString() action: [DDD, ' ', MMM, ' ', DD, ' ', YYYY, ' ', HH, ':', MM, ':', SS, ' ', TZ, optional]
+    // Index mapping: 0=day_name, 1=' ', 2=month, 3=' ', 4=day, 5=' ', 6=year, 7=' ', 8=hour, 9=':', 10=min, 11=':', 12=sec, 13=' ', 14=tz, 15=optional
+    grammar.addAction("js-date-tostring", (val, x) -> {
+      Object[] v = (Object[]) val;
+      DateParseMode mode = (DateParseMode) x.get("dateParseMode");
+      String tz = self.normalizeJsTimezone(v[14]);
+      return self.buildDate(mode,
+        Integer.parseInt((String) v[6]),    // year
+        self.parseMonthName((String) v[2]), // month
+        Integer.parseInt((String) v[4]),    // day
+        Integer.parseInt((String) v[8]),    // hour
+        Integer.parseInt((String) v[10]),   // minute
+        Integer.parseInt((String) v[12]),   // second
+        -1,                                  // ms
+        tz);
     });
 
     // Unix/Java Date.toString() action: [DDD, ' ', MMM, ' ', DD, ' ', HH, ':', MM, ':', SS, ' ', TZ, ' ', YYYY]

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -561,6 +561,39 @@ foam.CLASS({
         -1, -1, -1, -1, null);
     },
 
+    // JavaScript Date.toString() format: DDD MMM DD YYYY HH:MM:SS GMT±HHMM (Timezone Name)
+    // e.g., "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
+    // v = [DDD, ' ', MMM, ' ', DD, ' ', YYYY, ' ', HH, ':', MM, ':', SS, ' ', TZ, optional]
+    function jsdatetostringAction(v) {
+      // v[0] = day name (ignored)
+      // v[2] = month name
+      // v[4] = day
+      // v[6] = year
+      // v[8] = hour
+      // v[10] = minute
+      // v[12] = second
+      // v[14] = jsTimezone [GMT_literal, optional_offset]
+      var tz = this.normalizeJsTimezone(v[14]);
+      return this.buildDate(this.dateParseMode,
+        parseInt(v[6]),
+        this.parseMonthName(v[2]),
+        parseInt(v[4]),
+        parseInt(v[8]),
+        parseInt(v[10]),
+        parseInt(v[12]),
+        -1,
+        tz);
+    },
+
+    // Normalize JS timezone: ['GMT', ['+', ['0','4','0','0']]] → '+0400'
+    // or ['GMT', null] → 'Z'
+    function normalizeJsTimezone(tz) {
+      if ( ! tz || ! Array.isArray(tz) ) return 'Z';
+      var offset = tz[1]; // optional offset part
+      if ( ! offset ) return 'Z'; // Just "GMT" with no offset
+      return this.flattenTimezone(offset);
+    },
+
     // Unix/Java Date.toString() format: DDD MMM DD HH:MM:SS TZ YYYY
     // e.g., "Tue Apr 01 05:17:59 GMT 2025"
     // v = [DDD, ' ', MMM, ' ', DD, ' ', HH, ':', MM, ':', SS, ' ', TZ, ' ', YYYY]

--- a/src/foam/parse/test/DateParserJavaTest.js
+++ b/src/foam/parse/test/DateParserJavaTest.js
@@ -85,6 +85,9 @@ foam.CLASS({
         // Unix/Java Date.toString() format tests
         DateParserTest_UnixDateToString();
 
+        // JavaScript Date.toString() format tests
+        DateParserTest_JSDateToString();
+
         // Julian Date Format Tests
         DateParserTest_JulianDate();
       `
@@ -1196,6 +1199,97 @@ foam.CLASS({
         Calendar calOffset4 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
         calOffset4.setTime(dateOffset4);
         test(calOffset4.get(Calendar.HOUR_OF_DAY) == 5, "Unix Date.toString() +05:00: hour 5 UTC (10 - 5)");
+      `
+    },
+
+    // ========== JavaScript Date.toString() Format Tests ==========
+
+    {
+      name: 'DateParserTest_JSDateToString',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // Test "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
+        // -04:00 → UTC is 4 hours later: 16+4 = 20
+        Date date1 = parser.parseDateTimeUTC("Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)");
+        Calendar cal1 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal1.setTime(date1);
+        test(cal1.get(Calendar.YEAR) == 2026, "JS Date.toString(): year 2026");
+        test(cal1.get(Calendar.MONTH) == 1, "JS Date.toString(): month 1 (Feb)");
+        test(cal1.get(Calendar.DAY_OF_MONTH) == 19, "JS Date.toString(): day 19");
+        test(cal1.get(Calendar.HOUR_OF_DAY) == 20, "JS Date.toString(): hour 20 UTC (16 + 4)");
+        test(cal1.get(Calendar.MINUTE) == 20, "JS Date.toString(): minute 20");
+        test(cal1.get(Calendar.SECOND) == 23, "JS Date.toString(): second 23");
+
+        // Test with +0530 (India Standard Time) - UTC = 10:17:59 - 5:30 = 04:47:59
+        Date date2 = parser.parseDateTimeUTC("Tue Apr 01 2025 10:17:59 GMT+0530 (India Standard Time)");
+        Calendar cal2 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal2.setTime(date2);
+        test(cal2.get(Calendar.YEAR) == 2025, "JS Date.toString() +0530: year 2025");
+        test(cal2.get(Calendar.MONTH) == 3, "JS Date.toString() +0530: month 3 (Apr)");
+        test(cal2.get(Calendar.DAY_OF_MONTH) == 1, "JS Date.toString() +0530: day 1");
+        test(cal2.get(Calendar.HOUR_OF_DAY) == 4, "JS Date.toString() +0530: hour 4 UTC (10 - 5.5 ≈ 4)");
+        test(cal2.get(Calendar.MINUTE) == 47, "JS Date.toString() +0530: minute 47 UTC (17 - 30 + 60)");
+
+        // Test with GMT bare (no offset, no parens)
+        Date date3 = parser.parseDateTimeUTC("Mon Jan 15 2025 12:30:45 GMT");
+        Calendar cal3 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal3.setTime(date3);
+        test(cal3.get(Calendar.YEAR) == 2025, "JS Date.toString() GMT bare: year 2025");
+        test(cal3.get(Calendar.MONTH) == 0, "JS Date.toString() GMT bare: month 0 (Jan)");
+        test(cal3.get(Calendar.DAY_OF_MONTH) == 15, "JS Date.toString() GMT bare: day 15");
+        test(cal3.get(Calendar.HOUR_OF_DAY) == 12, "JS Date.toString() GMT bare: hour 12");
+        test(cal3.get(Calendar.MINUTE) == 30, "JS Date.toString() GMT bare: minute 30");
+        test(cal3.get(Calendar.SECOND) == 45, "JS Date.toString() GMT bare: second 45");
+
+        // Test with GMT+0000 (explicit zero offset)
+        Date date4 = parser.parseDateTimeUTC("Tue Apr 01 2025 05:17:59 GMT+0000 (Coordinated Universal Time)");
+        Calendar cal4 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal4.setTime(date4);
+        test(cal4.get(Calendar.HOUR_OF_DAY) == 5, "JS Date.toString() +0000: hour 5 UTC");
+        test(cal4.get(Calendar.MINUTE) == 17, "JS Date.toString() +0000: minute 17");
+
+        // Test with negative offset -0500 (Eastern)
+        Date date5 = parser.parseDateTimeUTC("Wed Dec 31 2025 23:59:59 GMT-0500 (Eastern Standard Time)");
+        Calendar cal5 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal5.setTime(date5);
+        test(cal5.get(Calendar.YEAR) == 2026, "JS Date.toString() -0500: year rolls to 2026");
+        test(cal5.get(Calendar.MONTH) == 0, "JS Date.toString() -0500: month 0 (Jan)");
+        test(cal5.get(Calendar.DAY_OF_MONTH) == 1, "JS Date.toString() -0500: day 1 (rolled)");
+        test(cal5.get(Calendar.HOUR_OF_DAY) == 4, "JS Date.toString() -0500: hour 4 UTC (23 + 5)");
+        test(cal5.get(Calendar.MINUTE) == 59, "JS Date.toString() -0500: minute 59");
+
+        // Test case insensitive
+        Date date6 = parser.parseDateTimeUTC("thu feb 19 2026 16:20:23 gmt-0400 (Atlantic Standard Time)");
+        Calendar cal6 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal6.setTime(date6);
+        test(cal6.get(Calendar.YEAR) == 2026, "JS Date.toString() lowercase: year 2026");
+        test(cal6.get(Calendar.HOUR_OF_DAY) == 20, "JS Date.toString() lowercase: hour 20 UTC");
+
+        // Test single digit day
+        Date date7 = parser.parseDateTimeUTC("Tue Apr 1 2025 05:17:59 GMT+0000");
+        Calendar cal7 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal7.setTime(date7);
+        test(cal7.get(Calendar.DAY_OF_MONTH) == 1, "JS Date.toString() single digit day: day 1");
+        test(cal7.get(Calendar.HOUR_OF_DAY) == 5, "JS Date.toString() single digit day: hour 5");
+
+        // Test all day names are recognized
+        test(parser.parseDateTimeUTC("Mon Jan 06 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Mon recognized");
+        test(parser.parseDateTimeUTC("Tue Jan 07 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Tue recognized");
+        test(parser.parseDateTimeUTC("Wed Jan 08 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Wed recognized");
+        test(parser.parseDateTimeUTC("Thu Jan 09 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Thu recognized");
+        test(parser.parseDateTimeUTC("Fri Jan 10 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Fri recognized");
+        test(parser.parseDateTimeUTC("Sat Jan 11 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Sat recognized");
+        test(parser.parseDateTimeUTC("Sun Jan 12 2025 12:00:00 GMT+0000") != null, "JS Date.toString(): Sun recognized");
+
+        // Test all months
+        String[] months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+        for ( int i = 0 ; i < months.length ; i++ ) {
+          Date dateMonth = parser.parseDateTimeUTC("Mon " + months[i] + " 01 2025 12:00:00 GMT+0000");
+          Calendar calMonth = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+          calMonth.setTime(dateMonth);
+          test(calMonth.get(Calendar.MONTH) == i, "JS Date.toString(): " + months[i] + " recognized as month " + i);
+        }
       `
     },
 

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -23,6 +23,7 @@ foam.CLASS({
       this.testYYYYDDMMFormats(x);
       this.testDDMMMYYYYFormats(x);
       this.testUnixDateToStringFormat(x);
+      this.testJSDateToStringFormat(x);
       this.testDateTimeFormats(x);
       this.testFractionalSeconds(x);
       this.testParseDateString(x);
@@ -2313,6 +2314,139 @@ foam.CLASS({
         } catch (e) {
           x.test(false, `UnixDate-parseDateString Test${i + 1}: ${testCase.input} - ${e.message}`);
         }
+      });
+    },
+
+    /**
+     * Test JavaScript Date.toString() format: DDD MMM DD YYYY HH:MM:SS GMT±HHMM (Timezone Name)
+     * e.g., "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
+     */
+    function testJSDateToStringFormat(x) {
+      let parser = this.DateParser.create();
+
+      // Basic test cases with timezone offset and parenthesized timezone name
+      let basicCases = [
+        // -04:00 means 4 hours behind UTC, so UTC time is 4 hours later: 16+4 = 20
+        { input: 'Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)', year: 2026, month: 1, day: 19, hour: 20, minute: 20, second: 23 },
+        { input: 'Mon Jan 15 2025 12:30:45 GMT+0000 (Coordinated Universal Time)', year: 2025, month: 0, day: 15, hour: 12, minute: 30, second: 45 },
+        { input: 'Wed Dec 31 2025 23:59:59 GMT-0500 (Eastern Standard Time)', year: 2026, month: 0, day: 1, hour: 4, minute: 59, second: 59 },
+        // +05:30 means 5.5 hours ahead, UTC = 10:17:59 - 5:30 = 04:47:59
+        { input: 'Tue Apr 01 2025 10:17:59 GMT+0530 (India Standard Time)', year: 2025, month: 3, day: 1, hour: 4, minute: 47, second: 59 },
+        { input: 'Sat Jul 04 2025 09:15:00 GMT+0100 (British Summer Time)', year: 2025, month: 6, day: 4, hour: 8, minute: 15, second: 0 },
+        { input: 'Fri Nov 28 2025 18:00:00 GMT+0900 (Japan Standard Time)', year: 2025, month: 10, day: 28, hour: 9, minute: 0, second: 0 }
+      ];
+
+      basicCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `JSDate-Basic Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // GMT with no offset (bare)
+      let gmtBareCases = [
+        { input: 'Mon Jan 15 2025 12:30:45 GMT', year: 2025, month: 0, day: 15, hour: 12, minute: 30, second: 45 },
+        { input: 'Tue Apr 01 2025 05:17:59 GMT', year: 2025, month: 3, day: 1, hour: 5, minute: 17, second: 59 }
+      ];
+
+      gmtBareCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `JSDate-GMTBare Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // GMT with parenthesized name but no offset
+      let gmtWithNameCases = [
+        { input: 'Mon Jan 15 2025 12:30:45 GMT (Greenwich Mean Time)', year: 2025, month: 0, day: 15, hour: 12, minute: 30, second: 45 }
+      ];
+
+      gmtWithNameCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `JSDate-GMTWithName Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // Case insensitive
+      let caseInsensitiveCases = [
+        { input: 'thu feb 19 2026 16:20:23 gmt-0400 (Atlantic Standard Time)', year: 2026, month: 1, day: 19, hour: 20, minute: 20, second: 23 },
+        { input: 'THU FEB 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)', year: 2026, month: 1, day: 19, hour: 20, minute: 20, second: 23 }
+      ];
+
+      caseInsensitiveCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `JSDate-CaseInsensitive Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // Single digit day
+      let singleDigitDayCases = [
+        { input: 'Tue Apr 1 2025 05:17:59 GMT+0000', year: 2025, month: 3, day: 1, hour: 5, minute: 17, second: 59 },
+        { input: 'Wed Jan 5 2025 10:30:00 GMT-0500 (Eastern Standard Time)', year: 2025, month: 0, day: 5, hour: 15, minute: 30, second: 0 }
+      ];
+
+      singleDigitDayCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `JSDate-SingleDigitDay Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // All days of week
+      let dayOfWeekCases = [
+        { input: 'Mon Jan 06 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 6, hour: 12, minute: 0, second: 0 },
+        { input: 'Tue Jan 07 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 7, hour: 12, minute: 0, second: 0 },
+        { input: 'Wed Jan 08 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 8, hour: 12, minute: 0, second: 0 },
+        { input: 'Thu Jan 09 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 9, hour: 12, minute: 0, second: 0 },
+        { input: 'Fri Jan 10 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 10, hour: 12, minute: 0, second: 0 },
+        { input: 'Sat Jan 11 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 11, hour: 12, minute: 0, second: 0 },
+        { input: 'Sun Jan 12 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 12, hour: 12, minute: 0, second: 0 }
+      ];
+
+      dayOfWeekCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `JSDate-DayOfWeek Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // All months
+      let monthCases = [
+        { input: 'Wed Jan 01 2025 12:00:00 GMT+0000', year: 2025, month: 0, day: 1 },
+        { input: 'Sat Feb 01 2025 12:00:00 GMT+0000', year: 2025, month: 1, day: 1 },
+        { input: 'Sat Mar 01 2025 12:00:00 GMT+0000', year: 2025, month: 2, day: 1 },
+        { input: 'Tue Apr 01 2025 12:00:00 GMT+0000', year: 2025, month: 3, day: 1 },
+        { input: 'Thu May 01 2025 12:00:00 GMT+0000', year: 2025, month: 4, day: 1 },
+        { input: 'Sun Jun 01 2025 12:00:00 GMT+0000', year: 2025, month: 5, day: 1 },
+        { input: 'Tue Jul 01 2025 12:00:00 GMT+0000', year: 2025, month: 6, day: 1 },
+        { input: 'Fri Aug 01 2025 12:00:00 GMT+0000', year: 2025, month: 7, day: 1 },
+        { input: 'Mon Sep 01 2025 12:00:00 GMT+0000', year: 2025, month: 8, day: 1 },
+        { input: 'Wed Oct 01 2025 12:00:00 GMT+0000', year: 2025, month: 9, day: 1 },
+        { input: 'Sat Nov 01 2025 12:00:00 GMT+0000', year: 2025, month: 10, day: 1 },
+        { input: 'Mon Dec 01 2025 12:00:00 GMT+0000', year: 2025, month: 11, day: 1 }
+      ];
+
+      monthCases.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, 12, 0, 0);
+        let testName = `JSDate-Month Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
       });
     },
 


### PR DESCRIPTION

## Problem

DateParser could not parse dates produced by JavaScript's `Date.toString()`, which uses the format `DDD MMM DD YYYY HH:MM:SS GMT±HHMM (Timezone Name)` (e.g., `"Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"`). The parser only supported the Unix/Java `Date.toString()` format where the year comes after the timezone (`DDD MMM DD HH:MM:SS TZ YYYY`). The JS format differs in three ways: year appears before the time, GMT is fused with the offset (e.g., `GMT-0400` vs standalone `GMT`), and an optional parenthesized timezone name is appended. The partial-parse rejection in `parseDateTimeUTC()` meant the trailing `(Timezone Name)` caused the entire parse to fail with INVALID_DATE.

## Solution

Added a new `jsdatetostring` grammar rule (JS) / `js-date-tostring` symbol (Java) that matches the JS format with year before time, a `jsTimezone` component that handles `GMT` optionally fused with `±HHMM`, and an optional clause that consumes the parenthesized timezone name. The new rule is tried before the existing Unix format in the `datemonthname` alt since it's more specific (year position disambiguates). A `normalizeJsTimezone` helper extracts the offset from the `[GMT, optional_offset]` seq result and delegates to the existing `flattenTimezone`/`parseTimezone` pipeline.

## Changes

- **DateGrammar.js** — Added `notChars` to grammar function signature; added `jsdatetostring` and `jsTimezone` grammar rules; placed `jsdatetostring` first in `datemonthname` alt
- **DateParser.js** — Added `jsdatetostringAction` and `normalizeJsTimezone` methods
- **DateParser.java** — Added `js-date-tostring` grammar symbol, `jsTimezone` symbol, action handler, and `normalizeJsTimezone` method
- **DateParserTest.js** — Added `testJSDateToStringFormat` with tests for timezone offsets (negative, positive, half-hour, zero), bare GMT, GMT with timezone name, case insensitivity, single-digit days, all days of week, and all months
- **DateParserJavaTest.js** — Added `DateParserTest_JSDateToString` Java test block with equivalent coverage including date boundary roll-over (Dec 31 → Jan 1)
