### PR TITLE
Fix Reflow Button sidebar showing all Action properties

### DIFF
--- a/src/foam/core/reflow/ReflowConfigView.js
+++ b/src/foam/core/reflow/ReflowConfigView.js
@@ -71,7 +71,7 @@ foam.CLASS({
             showActions: true,
             showHeader: true
           });
-        }, self.data$configViewSpec$, self.selectedValue$, self.flowMode$, self.data$))
+        }))
       .end()
       .start(this.Tab, { label: 'Block Properties' })
         .add(this.dynamic(function(data, flowMode) {


### PR DESCRIPTION

## Problem
When selecting a Button block in the Reflow Console, the right sidebar (Flow Properties tab) displayed all ~26 properties from `foam.lang.Action` instead of just the 7 properties defined in the `config` section (`label`, `script`, `buttonStyle`, `size`, `icon`, `themeIcon`, `toolTip`). ButtonGroup blocks were not affected.

## Solution
The `dynamic()` call in `ReflowConfigView` was passing explicit slot arguments including `self.data$configViewSpec$`. FOAM does not create deep `$` chain property accessors (like `data$configViewSpec$`) as JavaScript properties on the prototype — only simple `prop$` slot accessors are created. This caused `self.data$configViewSpec$` to evaluate to `undefined`, which meant the `useSections` filter from `configViewSpec` was never applied.

When explicit slot arguments are provided to `dynamic()`, FOAM uses them directly instead of parsing the function's parameter names. Since the first slot was `undefined`, the `data$configViewSpec` parameter was always `undefined`, and `...(undefined || {})` spread an empty object — no `useSections` filtering.

The fix removes the explicit slot arguments, allowing FOAM to resolve slots from the parameter names via `obj.slot('data$configViewSpec')`, which correctly handles the `$` chain by splitting on `$` and calling `slot.dot('configViewSpec')`.

## Changes
- Removed explicit slot arguments from the Flow Properties tab `dynamic()` call in `ReflowConfigView.js`, restoring FOAM's parameter-name-based slot resolution for the deep `data$configViewSpec` chain


Seems 
https://github.com/kgrgreer/foam3/commit/91b2ef01ad
is one that broke it 
```
                                                                                                                       
  It changed the dynamic from:                                                                                          
  .add(this.dynamic(function(data$configViewSpec, selectedValue) {                                                      
      ...                                                                                                               
  }))                                                                                                                   
  to:                                                                                                                   
  .add(this.dynamic(function(data$configViewSpec, selectedValue, flowMode, data) {
      ...
  }, self.data$configViewSpec$, self.selectedValue$, self.flowMode$, self.data$))

```