### PR TITLE
Refactor lazy scroll manager

### DIFF
--- a/src/foam/u2/table/TableView.js
+++ b/src/foam/u2/table/TableView.js
@@ -44,6 +44,7 @@
     
     ^table-wrapper .foam-u2-view-LazyScrollManager-table-page {
       contain-intrinsic-width: auto var(--table-width, 100%);
+      min-width: var(--table-width, 100%);
     }
 
     @keyframes slide {

--- a/src/foam/u2/table/TableView.js
+++ b/src/foam/u2/table/TableView.js
@@ -42,7 +42,7 @@
       scroll-padding-top: 48px;
     }
     
-    ^table-wrapper ^table-page {
+    ^table-wrapper .foam-u2-view-LazyScrollManager-table-page {
       contain-intrinsic-width: auto var(--table-width, 100%);
     }
 

--- a/src/foam/u2/table/TableView.js
+++ b/src/foam/u2/table/TableView.js
@@ -38,7 +38,12 @@
       position: relative;
       overflow: auto;
       overscroll-behavior-y: contain;
-      // scroll-behavior: smooth;
+      scroll-behavior: smooth;
+      scroll-padding-top: 48px;
+    }
+    
+    ^table-wrapper ^table-page {
+      contain-intrinsic-width: auto var(--table-width, 100%);
     }
 
     @keyframes slide {

--- a/src/foam/u2/table/UnstyledTableView.js
+++ b/src/foam/u2/table/UnstyledTableView.js
@@ -535,6 +535,14 @@ foam.CLASS({
   ],
 
   listeners: [
+    {
+      name: 'updateTableWidthCSS',
+      isFramed: true,
+      on: ['this.propertyChange.tableWidth_'],
+      code: function() {
+        this.element_.style.setProperty('--table-width', this.tableWidth_);
+      }
+    },
     function resetColWidths() {
       this.selectedColumnsWidth = {};
       for ( var s of this.selectedColumnNames ) {

--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -561,7 +561,7 @@ foam.CLASS({
       }
 
       var page = this.currentTopPage_ + pageIndex;
-      if ( this.renderedPages_[page] || this.loadingPages_[page] ) {
+      if ( this.loadingPages_[page] ) {
         return this.processPageSequentially_(pageIndex + 1);
       }
 

--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -10,7 +10,21 @@ foam.CLASS({
   extends: 'foam.u2.View',
   mixins: [ 'foam.u2.memento.Memorable' ],
 
-  documentation: 'A configurable scroll manager that dynamically lazy loads dao data',
+  documentation: `
+    A scroll manager that uses a top/bottom spacer approach for virtual windowing.
+
+    Three pages of rows are rendered at a time. As the user scrolls, old pages
+    are removed and new ones loaded, with spacers maintaining correct scroll height
+    and position in both directions to prevent scroll jumping. 
+    
+    Page heights are measured after render and cached so that spacer estimates converge to exact values as the user scrolls.
+
+    TODO: There is potentially a small issue with grouping where if you jump pages in the table
+    and land the middle of a new group, the group header will be rendered in the middle of the group
+    where the view first saw it rather than the real start of it.
+    The fix for this would be to move the group header elements to different parent if the index on the group
+    header is greater than the current row being rendered that belongs to that group.
+  `,
 
   requires: [
     'foam.dao.FnSink',
@@ -24,21 +38,18 @@ foam.CLASS({
     'foam.mlang.Expressions'
   ],
 
-  imports: ['config'],
+  imports: ['config', 'requestAnimationFrame'],
 
   constants: [
     {
       type: 'Float',
       name: 'MIN_PAGE_PROGRESS',
-      documentation: `
-       If the top or bottom page is scrolled by this amount update the currentTopPage_ accordingly
-      `,
       value: 0.25
     },
     {
       type: 'Integer',
       name: 'NUM_PAGES_TO_RENDER',
-      value: 3
+      value: 5
     }
   ],
 
@@ -47,44 +58,62 @@ foam.CLASS({
   ],
 
   css: `
-    ^no-data{
-      display:flex;
+    ^no-data {
+      display: flex;
       height: 100%;
       justify-content: center;
       align-items: center;
     }
+    ^scroll-host {
+      overflow-anchor: none;
+    }
+    ^top-spacer, ^bottom-spacer {
+      width: 100%;
+      pointer-events: none;
+    }
 
     ^table-page {
       content-visibility: auto;
-      contain-intrinsic-size: auto 2400px; // Approx initial page height
+      contain-intrinsic-height: auto var(--avgPageHeight, 2400px);
+      min-width: 100%;
     }
   `,
+
   topics: ['pageLoading'],
 
   properties: [
+    // DAO Properties
     {
       class: 'foam.dao.DAOProperty',
       name: 'data'
     },
     {
+      type: 'Int',
+      name: 'pageSize',
+      max: 1000,
+      value: 50,
+      documentation: 'Desired number of items per page.'
+    },
+
+    // Internal DAO Properties
+
+    {
       class: 'Int',
-      name: 'daoCount'
+      name: 'daoCount',
+      postSet: function(o,n) {
+        if (o === n);
+        // If count is too big increase pageSize_ to reduce page load flicker
+        if ( n > 50000 ) this.pageSize_ = Math.min(100, this.pageSize_);
+        if ( n > 100000 ) this.pageSize_ = Math.min(200, this.pageSize_);
+      }
     },
     {
       type: 'Int',
       name: 'pageSize_',
-      // Used to prevent extra large datasets being requested as it caused chrome to crash
       max: 1000,
       factory: function() { return this.pageSize; },
-      documentation: 'The number of items in each "page". There are three pages.'
-    },
-    {
-      type: 'Int',
-      name: 'pageSize',
-      // Used to prevent extra large datasets being requested as it caused chrome to crash
-      max: 1000,
-      value: 50,
-      documentation: 'The number of items in each "page". There are three pages.'
+      postSet: function(o, n) { if ( o !== n ) this.refresh(); },
+      documentation: 'Effective page size, adjusted if displayedRowCount_ exceeds pageSize.'
     },
     {
       class: 'Int',
@@ -96,49 +125,71 @@ foam.CLASS({
     {
       class: 'Int',
       name: 'currentTopPage_',
-      factory: function() { return 0; },
+      factory: function() { return -1; },
       preSet: function(o, n) {
-        return foam.Number.clamp(0, n, this.numPages_ - this.NUM_PAGES_TO_RENDER );
+        let clamp = foam.Number.clamp(0, n, Math.max(0, this.numPages_ - this.NUM_PAGES_TO_RENDER));
+        if ( o !== clamp ) this.suspendObserver = true;
+        return clamp;
       }
     },
     {
       class: 'Map',
-      name: 'renderedPages_'
+      name: 'renderedPages_',
+      documentation: 'Map of page index -> FOAM element for currently rendered pages U2 Elements.'
     },
     {
       class: 'Map',
       name: 'loadingPages_',
-      documentation: 'Used to ensure pages that are currently being loaded are not reloaded/duplicated'
+      documentation: 'Set of page indices currently being fetched, to prevent duplicate loads.'
     },
+
+    // Spacer / Virtual Windowing
+
+    {
+      class: 'Map',
+      name: 'pageHeights_',
+      documentation: 'Measured px height for each page, keyed by page index.',
+      factory: function() { return {}; }
+    },
+    {
+      class: 'Int',
+      name: 'estimatedPageHeight',
+      expression: function(pageSize_) {
+        let val = pageSize_ * 48 // estimated regular row height
+        this.appendTo.element_.style.setProperty('--avgPageHeight', val + 'px');
+        return val;
+      },
+      postSet: function(o, n) {
+        if ( o !== n )
+          this.appendTo.element_.style.setProperty('--avgPageHeight', n + 'px');
+      },
+      documentation: 'Estimated height per page used for spacers until a page is measured.'
+    },
+    {
+      name: 'topSpacer_',
+      documentation: 'Element above rendered pages representing unrendered rows above.'
+    },
+    {
+      name: 'bottomSpacer_',
+      documentation: 'Element below rendered pages representing unrendered rows below.'
+    },
+
+    // Row Tracking
+
     {
       class: 'Int',
       name: 'topRow',
       memorable: true,
-      documentation: 'Stores the index top row that is currently displayed in the table',
-      postSet: function(o, n) {
-        // if ( this.scrollToIndex || o == n ) return;
-        // var n1 = (n-(this.currentTopPage_*this.pageSize_))/this.pageSize_;
-        // if ( n < o && n1 <= 1 && n1 < 1 - this.MIN_PAGE_PROGRESS ) {
-        //   this.currentTopPage_ --;
-        // }
-      }
+      documentation: '1-based index of the topmost visible row.'
     },
     {
       class: 'Int',
       name: 'bottomRow',
-      documentation: 'Stores the index of last row that is currently displayed in the table',
-      postSet: function(o, n) {
-        // if ( this.scrollToIndex || o == n ) return;
-        // var n1 = (n-(this.currentTopPage_*this.pageSize_))/this.pageSize_;
-        // if ( n > o && n1 >= this.NUM_PAGES_TO_RENDER - 2 && n1%1 >= this.MIN_PAGE_PROGRESS ) {
-        //   this.currentTopPage_++;
-        // }
-      }
+      documentation: '1-based index of the bottommost visible row.'
     },
     {
       class: 'Float',
       name: 'displayedRowCount_',
-      documentation: 'Stores the number of rows that are currently displayed in the div height',
       expression: function(topRow, bottomRow) {
         return topRow && bottomRow ? bottomRow - topRow : 0;
       }
@@ -146,14 +197,25 @@ foam.CLASS({
     {
       class: 'Int',
       name: 'scrollToIndex',
-      postSet: function () { 
-          this.safeScroll(); 
-      }
+      postSet: function() { this.safeScroll(); }
     },
-    'rowObserver',
+
+    // Observers
+
+    {
+      name: 'rowObserver',
+      documentation: 'IntersectionObserver for individual rows — tracks topRow/bottomRow.'
+    },
+    {
+      name: 'sentinelObserver_',
+      documentation: 'IntersectionObserver for topSpacer_/bottomSpacer_ — detects fast scrolls.'
+    },
+
+    // Configuration
+
     {
       name: 'rootElement',
-      documentation: 'FOAM element that is used as the observation bounds for intersectionManager'
+      documentation: 'FOAM element used as the scroll container and IntersectionObserver root.'
     },
     {
       class: 'foam.u2.ViewSpec',
@@ -165,51 +227,46 @@ foam.CLASS({
     },
     {
       class: 'FObjectProperty',
-      name: 'groupBy',
-      documentation: 'An expression which returns the group title. Can be a Property.'
+      name: 'groupBy'
     },
     {
       class: 'Boolean',
-      name: 'invertGroupingOrder',
-      documentation: 'GroupBy returns groups in ascending order, use this to flip that behaviour'
+      name: 'invertGroupingOrder'
     },
     {
       class: 'FObjectProperty',
-      name: 'order',
-      documentation: 'Optional order used to sort citations within a group'
+      name: 'order'
     },
     {
       name: 'ctx',
-      documentation: 'A context variable that is passed to the prepDAO function'
+      documentation: 'Context variable passed to prepDAO.'
     },
     {
       class: 'Function',
-      name:'prepDAO',
-      documentation: `Function that is run before each page is loaded on a limited DAO,
-      should always return a promise, can be used to create projections`,
+      name: 'prepDAO',
+      documentation: 'Called with a limited DAO before each page load. Must return a Promise.',
       factory: function() {
-        return function(dao) { return dao.select(); }
+        return function(dao) { return dao.select(); };
       }
     },
     {
       name: 'appendTo',
       factory: function() { return this.parentNode; },
-      documentation: 'FOAM element that the ScrollManager adds rows to. Defaults to parentNode to avoid layout shifts'
+      documentation: 'Parent element. The scroll host and spacers are added here.'
     },
     {
       class: 'Int',
       name: 'offsetTop',
-      value: 0,
-      documentation: 'Offset property that is passed to IntersectionObserver'
+      value: 0
     },
+
+    // Additional Internal Properties (defeedback and optimization)
+
     {
       class: 'FObjectProperty',
       of: 'foam.lang.Latch',
       name: 'dataLatch',
-      documentation: 'A latch used to wait for table data load.',
-      factory: function () {
-        return this.Latch.create();
-      }
+      factory: function() { return this.Latch.create(); }
     },
     {
       class: 'Boolean',
@@ -219,243 +276,284 @@ foam.CLASS({
     ['isInit', true],
     {
       class: 'Map',
-      name: 'collapsedGroups',
-      factory: function() { return {}; }
-    },
-    {
-      class: 'Map',
       name: 'groupFirstPage_',
-      documentation: 'Tracks the first page where each group appears to ensure headers show only once',
+      documentation: 'Tracks the first page where each group appears.',
       factory: function() { return {}; }
     },
-    ['suspendObserver', false],
-    {
-      name: 'seenPages',
-      class: 'Map'
-    },
-    { 
-      name: 'visibleRows', 
-      factory: function() { return new Set(); }
-    },
-    'lastScrollTop'
+    ['suspendObserver', false]
   ],
 
   methods: [
     function init() {
       this.onDetach(this.data$proxy.listen(this.FnSink.create({
-        fn: () => {
-          this.updateCount();
-        }
+        fn: () => { this.updateCount(); }
       })));
       this.updateCount();
-      this.dataLoading = false;
     },
-
     async function render() {
-      this.appendTo.id = 'id' + this.$UID;
-
       var self = this;
-      var resize = new ResizeObserver (this.checkPageSize_);
-      let root = await this.rootElement.el()
-      let options = {
+
+      // Build DOM structure
+      //
+      //   appendTo (rootElement)
+      //      top-spacer   (height = sum of pages above render window)
+      //      (rendered pages go here)
+      //      bottom-spacer  (height = sum of pages below render window)
+      //
+      // The rootElement is the IntersectionObserver root so all observations are
+      // relative to the visible scroll viewport.
+
+      // Empty / loading slot — appended inside the scroll host
+      var statusSlot = this.slot(function(daoCount, isInit, daoLoading) {
+        if ( daoLoading ) {
+          return self.E().addClass(self.myClass('no-data'))
+            .tag(self.LoadingSpinner, { size: 48 });
+        }
+        if ( isInit || daoCount ) return self.E(); // empty placeholder
+        return self.E().addClass(self.myClass('no-data'))
+          .add(self.NO_DATA({ modelName: self.config?.emptyLabel ?? 'Data' }));
+      });
+
+      this.appendTo
+        .addClass(this.myClass('scroll-host'))
+        .add(statusSlot)
+        .start('', {}, this.topSpacer_$).addClass(this.myClass('top-spacer')).style({ height: '0px' }).end()
+        .start('', {}, this.bottomSpacer_$).addClass(this.myClass('bottom-spacer')).style({ height: '0px' }).end();
+
+
+      // IntersectionObserver: row-level topRow/bottomRow tracking
+      let root = this.rootElement.element_;
+      let rowObserverOptions = {
         root: root ?? null,
         rootMargin: `-${this.offsetTop}px 0px 0px`,
-        threshold: [0.1, 0.99]
+        threshold: [0.1, 0.5, 0.9]
       };
+      this.rowObserver = new IntersectionObserver(
+        (entries) => self.onRowIntersect(entries, self),
+        rowObserverOptions
+      );
 
-      // defer till after atleast one page has been loaded in order
-      // to ensure correct value for displayedRowCount_
-      this.dataLatch.then(() => {
-        this.rootElement?.el().then(el => {
-          resize.observe(el);
-        })
-      })
-      // Render empty view if dao is empty
-      // Change to dynamic after U3
-      this.appendTo.add(this.slot(function(daoCount, isInit, daoLoading) {
-        if (daoLoading) {
-          return this.E().addClass(self.myClass('no-data'))
-          .tag(this.LoadingSpinner, { size: 48 });
-        }
-        if ( isInit || daoCount ) return;
-        return this.E().addClass(self.myClass('no-data'))
-          .add(self.NO_DATA({ modelName: self.config?.emptyLabel ?? 'Data' }));
-      }));
+      // IntersectionObserver: sentinel-level fast-scroll detection
+      //  Uses a generous rootMargin so it fires well before the spacer fully
+      //  enters the viewport, giving time to load the next page window.
+      this.sentinelObserver_ = new IntersectionObserver(
+        (entries) => self.onSentinelIntersect_(entries),
+        { root: root ?? null, rootMargin: `${this.estimatedPageHeight/2}px 0px` }
+      );
+      this.topSpacer_.el().then(el    => this.sentinelObserver_.observe(el));
+      this.bottomSpacer_.el().then(el => this.sentinelObserver_.observe(el));
 
-      this.rowObserver = new IntersectionObserver(handleIntersect, options);
-      // This needs to be here because intersectionObserver does not bind the correct this during callback
-      function handleIntersect(entries, observer) {
-        self.onRowIntersect(entries, self);
-      }
-      this.onDetach(() => {
-        // might already be disconnected
-        try { resize.disconnect(); } catch(x) {}
-      });
-      this.onDetach(() => {
-        // might already be disconnected
-        try { this.rowObserver.disconnect(); } catch(x) {}
-      });
-      this.onDetach(this.rootElement$.sub(this.updateRenderedPages_));
+      // ResizeObserver: adjust pageSize_ if container grows
+      var resize = new ResizeObserver(this.checkPageSize_);
+      this.dataLatch.then(() => { resize.observe(root); });
+
+      root.addEventListener('scroll', this.onScroll_);
+
+      // Detach things
+      this.onDetach(() => root.removeEventListener('scroll', this.onScroll_));
+      this.onDetach(() => { try { resize.disconnect();                   } catch(x) {} });
+      this.onDetach(() => { try { this.rowObserver.disconnect();         } catch(x) {} });
+      this.onDetach(() => { try { this.sentinelObserver_.disconnect();   } catch(x) {} });
+      this.onDetach(this.rootElement$.sub(this.updateRenderedPages));
       this.onDetach(this.order$.sub(this.refresh));
       this.onDetach(this.groupBy$.sub(this.refresh));
     },
 
-    function scrollView(scroll) {
-      if ( this.rootElement.el_() )
-        this.rootElement.el_().scrollTop = scroll - this.offsetTop;
-      this.scrollToIndex = undefined;
+    // Spacer Helpers
+    function getSpacerHeights_() {
+      // console.debug('getting spacer heights for', this.currentTopPage_);
+      var topPage    = this.currentTopPage_;
+      var bottomPage = topPage + this.NUM_PAGES_TO_RENDER;
+      var top = 0, bottom = 0;
+
+      for ( var i = 0; i < topPage; i++ ) {
+        top += this.pageHeights_[i] ?? this.estimatedPageHeight;
+      }
+      for ( var i = bottomPage; i < this.numPages_; i++ ) {
+        bottom += this.pageHeights_[i] ?? this.estimatedPageHeight;
+      }
+      // console.debug('returning heights: ', top, bottom);
+      return { top, bottom };
+    },
+    function correctSpacers_() {
+      var { top, bottom } = this.getSpacerHeights_();
+      this.topSpacer_.style({ height: top + 'px' });
+      this.bottomSpacer_.style({ height: bottom + 'px' });
+    },
+    {
+      name: 'estimatePageFromOffset_',
+      documentation: `Estimate which page a given scrollTop falls within, using measured
+      heights where available and estimatedPageHeight elsewhere.`,
+      code: function(scrollTop) {
+        var accumulated = 0;
+        for ( var i = 0; i < this.numPages_; i++ ) {
+          accumulated += this.pageHeights_[i] ?? this.estimatedPageHeight;
+          if ( accumulated >= scrollTop ) return i;
+        }
+        return Math.max(0, this.numPages_ - 1);
+      }
     },
 
+    // Scroll / Navigation
+    function scrollView(el) {
+      el.scrollIntoView();
+      this.scrollToIndex = undefined;
+    },
     function safeScroll() {
       if ( ! this.scrollToIndex ) return;
-      var page = Math.floor(this.scrollToIndex/this.pageSize_);
+      var page = Math.floor(this.scrollToIndex / this.pageSize_);
       if ( this.renderedPages_[page] ) {
-        var el = document.querySelector(`#${this.appendTo.id} [data-idx='${this.scrollToIndex}']`);
+        var el = this.renderedPages_[page].element_.querySelector(`[data-idx='${this.scrollToIndex}']`);
         if ( ! el ) return;
-        this.scrollView(el.offsetTop);
+        this.scrollView(el);
       } else {
-        if ( page == 0 && this.currentTopPage_ != 0 ) {
+        if ( page === 0 && this.currentTopPage_ !== 0 ) {
           this.currentTopPage_ = 0;
           return;
         }
-        if ( page == this.numPages_ - 1 && this.currentTopPage_ != this.numPages_ - this.NUM_PAGES_TO_RENDER ) {
+        if ( page === this.numPages_ - 1 &&
+             this.currentTopPage_ !== this.numPages_ - this.NUM_PAGES_TO_RENDER ) {
           this.currentTopPage_ = this.numPages_ - this.NUM_PAGES_TO_RENDER;
           return;
         }
-        if ( page != this.currentTopPage_ + 1 ) {
+        if ( page !== this.currentTopPage_ + 1 ) {
           this.currentTopPage_ = page - 1;
           return;
         }
       }
     },
 
-    function clearPage(page, opt_skipObserver) {
-      ! opt_skipObserver && this.renderedPages_[page].childNodes?.forEach((e) => {
-        if ( e.el_() )
-          this.rowObserver.unobserve(e.el_());
-      });
-      let el = this.seenPages[page] = this.renderedPages_[page];
-      let height = el.element_.offsetHeight;
-      this.seenPages[page].style({ height: height });
-      el.removeAllChildren();
-      delete this.renderedPages_[page];
-    },
+    // Page Lifecycle
+    {
+      name: 'clearPage',
+      documentation: `Remove a rendered page from the DOM. Spacers absorb the freed height so
+      layout does not jump.`,
+      code: function(page, opt_skipObserver) {
+        var pageEl = this.renderedPages_[page];
+        if ( ! pageEl ) return;
 
-    function renderPageWrapper(page) {
-      let self = this;
-      if ( self.renderedPages_[page] ) {
-        console.warn('Trying to overwrite a loaded page without clearing....Clearing page');
-        this.clearPage(page)
+        if ( ! opt_skipObserver ) {
+          pageEl.childNodes?.forEach(e => {
+            if ( e.el_() ) this.rowObserver.unobserve(e.el_());
+          });
+        }
+        pageEl.remove();
+        this.correctSpacers_();
+        delete this.renderedPages_[page];
       }
-      let oldPage = this.seenPages[page];
-      oldPage?.style({ height: 'auto' });
-      var e = oldPage ?? this.E().addClass(self.myClass('table-page')).attr('data-page', page);
-      e.el().then(el => {
-        self.rowObserver.observe(el);
-      })
-      let isSet = false;
-      if ( ! oldPage ) {
-        if ( Object.keys(self.renderedPages_).length ) {
-          for ( let j = page; j < Object.keys(self.renderedPages_) && ! isSet; j++) {
-            if ( self.renderedPages_[j+1] ) {
-              console.log("inserting at", j+1, page);
-              this.appendTo.insertBefore(e, self.renderedPages_[j+1]);
-              isSet = true;
+    },
+    {
+      name: 'renderPageWrapper',
+      documentation: `Create a page wrapper element and insert it into
+      scroll container in page-index order.`,
+      code: function(page) {
+        let self = this;
+
+        if ( self.renderedPages_[page] ) {
+          console.warn('Overwriting a loaded page — clearing first.');
+          this.clearPage(page);
+        }
+
+        let e = this.E()
+          .addClass(self.myClass('table-page'))
+          .attr('data-page', page).style({ height: this.estimatedPageHeight });
+
+        self.renderedPages_[page] = e;
+
+        this.requestAnimationFrame(() => {
+          // Insert in sorted order among sibling pages
+          var inserted = false;
+          var renderedPageNums = Object.keys(self.renderedPages_).map(Number).sort((a, b) => a - b);
+          for ( var j in renderedPageNums ) {
+            if ( renderedPageNums[j] > page && self.renderedPages_[renderedPageNums[j]].parentNode) {
+              self.appendTo.insertBefore(e, self.renderedPages_[renderedPageNums[j]]);
+              inserted = true;
+              break;
             }
           }
-        }
-        console.log("inserting at end", page);
-        if ( ! isSet ) { this.appendTo.add(e); isSet = true; }
+          if ( ! inserted ) self.appendTo.insertBefore(e, self.bottomSpacer_);
+          this.correctSpacers_();
+          e.load();
+          // console.debug('loaded wrapper', page);
+        });
+        return e;
       }
-      self.renderedPages_[page] = e;
-      return e;
     },
-
     function getPage(dao, page) {
-      console.log('getting page', page);
-      var self       = this;
+      let self = this;
       var proxy      = this.ProxyDAO.create({ delegate: dao });
       var sortParams = [];
 
       if ( this.groupBy )
-        sortParams.push(this.invertGroupingOrder ? this.DESC(this.groupBy) : this.groupBy)
-
-      if ( this.order ) sortParams.push(this.order)
-
+        sortParams.push(this.invertGroupingOrder ? this.DESC(this.groupBy) : this.groupBy);
+      if ( this.order ) sortParams.push(this.order);
       if ( sortParams.length ) proxy = proxy.orderBy(sortParams);
 
-      self.loadingPages_$set(page);
+      this.loadingPages_$set(page);
 
-      let promise = this.prepDAO(proxy, this.ctx);
-      let e = this.renderPageWrapper(page);
+      return this.prepDAO(proxy, this.ctx).then((values) => { 
+        if ( page < this.currentTopPage_ || page > this.currentTopPage_ + this.NUM_PAGES_TO_RENDER) {
+          // console.debug('Skipping load', page);
+          this.loadingPages_$remove(page);
+          return;
+        }
+        let e = self.renderedPages_[page];
+        var previousGroup = null;
 
-      return promise.then(values => {
         function populateRows(args) {
           if ( args.data === undefined ) return;
 
-          var index = (page*self.pageSize_) + i + 1;
-          var group = null;
-          var showHeader = false;
+          var index = (page * self.pageSize_) + i + 1;
 
           if ( self.groupBy ) {
-            group = self.groupBy.f(args.data);
+            var group    = self.groupBy.f(args.data);
             var groupKey = foam.json.stringify(group);
 
-            // Track if this is the first time we've seen this group
             if ( self.groupFirstPage_[groupKey] === undefined ) {
               self.groupFirstPage_[groupKey] = page;
             }
 
-            // Show header only if this is the first page where this group appears
-            // and it's different from the previous group in this page
-            if ( page === self.groupFirstPage_[groupKey] ) {
-              showHeader = ! foam.util.equals(group, previousGroup);
-            }
+            var showHeader = page === self.groupFirstPage_[groupKey] &&
+                             ! foam.util.equals(group, previousGroup);
 
             if ( showHeader ) {
-              e.start(self.groupHeaderView,
-                { ...args,
-                  groupLabel: group,
-                  groupBy: self.groupBy,
-                }
-              )
-                // Add index of the next row to the group as well for the intersection observer
+              e.start(self.groupHeaderView, {
+                ...args,
+                groupLabel: group,
+                groupBy:    self.groupBy
+              })
                 .attr('data-idx', index)
-                .call(function() {
-                  self.rowObserver.observe(this.element_)
-                })
+                .call(function() { self.rowObserver.observe(this.element_); })
               .end();
             }
 
             previousGroup = group;
           }
 
-          var isEven = (index + 1) % 2 !== 0 ;
-          var rowEl = e.start(self.rowView, args).attr('data-idx', index).attr('data-even', isEven);
-          rowEl.el().then(a => {
-            self.rowObserver.observe(a)
-          });
-        };
+          var isEven = (index + 1) % 2 !== 0;
+          var rowEl  = e.start(self.rowView, args)
+            .attr('data-idx',  index)
+            .attr('data-even', isEven);
 
-        var previousGroup = null;
+          rowEl.el().then(a => self.rowObserver.observe(a));
+        }
 
-        if ( foam.mlang.sink.Projection.isInstance( values ) ) {
-          for ( var i = 0 ; i < values.projection.length ; i++ ) {
-            let args = { data: values.array[i], projection: values.projection[i] };
-            populateRows(args);
+        if ( foam.mlang.sink.Projection.isInstance(values) ) {
+          for ( var i = 0; i < values.projection.length; i++ ) {
+            populateRows({ data: values.array[i], projection: values.projection[i] });
           }
-        } else if ( foam.dao.Sink.isInstance( values ) && values.array ) {
-          for ( var i = 0 ; i < values.array.length ; i++ ) {
-            let args = { data: values.array[i] };
-            populateRows(args);
+        } else if ( foam.dao.Sink.isInstance(values) && values.array ) {
+          for ( var i = 0; i < values.array.length; i++ ) {
+            populateRows({ data: values.array[i] });
           }
         }
 
         self.loadingPages_$remove(page);
+        e.style({ height: "unset" });
+        self.setEstimatedPageHeight(page);
         this.dataLatch.resolve();
       });
     },
-
     async function processPageSequentially_(pageIndex) {
       if ( pageIndex >= Math.min(this.numPages_, this.NUM_PAGES_TO_RENDER) ) {
         this.daoLoading = false;
@@ -464,16 +562,13 @@ foam.CLASS({
 
       var page = this.currentTopPage_ + pageIndex;
       if ( this.renderedPages_[page] || this.loadingPages_[page] ) {
-        // Skip this page and move to next
         return this.processPageSequentially_(pageIndex + 1);
       }
 
       var skip = page * this.pageSize_;
       var dao  = this.data.limit(this.pageSize_).skip(skip);
 
-      return await this.getPage(dao, page).then(() => {
-        console.log('Processed', pageIndex);
-        // Process next page after this one completes
+      return this.getPage(dao, page).then(() => {
         return this.processPageSequentially_(pageIndex + 1);
       });
     }
@@ -481,196 +576,238 @@ foam.CLASS({
 
   listeners: [
     {
-      name: 'checkPageSize_',
+      // This is framed to prevent layout thrashing 
+      name: 'setEstimatedPageHeight',
+      documentation: 'Updates estimated page height based on a median of all known heights',
       isFramed: true,
-      documentation: 'Ensure page size is always atleast as large as the displayedRowCount_',
-      code: function () {
-        let old = this.pageSize_;
-        if ( this.displayedRowCount_ && this.displayedRowCount_ != this.pageSize_ ) {
-          if (  this.pageSize < this.displayedRowCount_) {
-            this.pageSize_ = this.displayedRowCount_;
-          } else {
-            this.pageSize_ = this.pageSize;
-          }
-          if ( old != this.pageSize_ )
-            this.refresh();
+      code: function(page) {
+        let h = this.renderedPages_[page]?.getBoundingClientRect().height ?? 0;
+        if ( h && this.pageHeights_[page] !== h ) {
+          this.pageHeights_[page] = h;
+
+          values = Object.values(this.pageHeights_).sort((a, b) => a - b);
+  
+          const half = Math.floor(values.length / 2);
+  
+          this.estimatedPageHeight = (values.length % 2
+            ? values[half]
+            : (values[half - 1] + values[half]) / 2
+          );
         }
       }
     },
+    {
+      name: 'checkPageSize_',
+      isFramed: true,
+      documentation: 'Ensure pageSize_ is at least as large as displayedRowCount_.',
+      code: function() {
+        var old = this.pageSize_;
+        if ( this.displayedRowCount_ && this.displayedRowCount_ !== this.pageSize_ ) {
+          this.pageSize_ = this.pageSize < this.displayedRowCount_
+            ? this.displayedRowCount_
+            : this.pageSize;
+          if ( old !== this.pageSize_ ) this.refresh();
+        }
+      }
+    },
+
     {
       name: 'refresh',
       isFramed: true,
       code: function() {
         this.rowObserver?.disconnect();
-        // Don't clear loadingPages_ here since they are being
-        // loaded and will have latest data anyway
-        Object.keys(this.seenPages).forEach(i => {
-          if ( this.renderedPages_[i] ) this.clearPage(i, true); 
-          this.seenPages[i]?.remove();
-          delete this.seenPages[i];
-        });
-        // Clear group first page tracking
+        this.sentinelObserver_?.disconnect();
+
+        // Remove all rendered pages cleanly (spacers will be reset below)
+        Object.keys(this.renderedPages_).forEach(i => this.clearPage(i, true));
+
         this.groupFirstPage_ = {};
+        this.pageHeights_   = {};
+        this.loadingPages_   = {};
         if ( ! this.isInit ) {
           this.currentTopPage_ = 0;
-          this.topRow = 0;
-          this.bottomRow = 0;
-          this.pageHeights = {}
+          this.topRow          = 0;
+          this.bottomRow       = 0;
         }
         this.isInit = false;
-        this.updateRenderedPages_();
-        if ( this.topRow > 1) {
-          this.scrollToIndex = this.topRow;
-        }
+
+        // Reset spacers to zero — updateRenderedPages will recalculate
+        this.topSpacer_?.style({ height: '0px' });
+        this.bottomSpacer_?.style({ height: '0px' });
+
+        // Re-attach sentinel observer after disconnect
+        this.topSpacer_?.el().then(el    => this.sentinelObserver_?.observe(el));
+        this.bottomSpacer_?.el().then(el => this.sentinelObserver_?.observe(el));
+        this.updateRenderedPages();
+        if ( this.topRow > 1 ) this.scrollToIndex = this.topRow;
       }
     },
     {
       name: 'updateCount',
       isFramed: true,
       code: function() {
-        var limit = ( this.data && this.data.limit_ ) || undefined;
+        var limit = (this.data && this.data.limit_) || undefined;
         this.daoLoading = true;
         return this.data$proxy.select(this.Count.create()).then(s => {
-          this.daoCount = limit && limit < s.value ? limit : s.value;
+          this.daoCount   = limit && limit < s.value ? limit : s.value;
           this.daoLoading = false;
           this.refresh();
         });
       }
     },
     {
+      name: 'updateRenderedPages',
+      documentation: `Sync method responsible for loading page wrappers.
+      Calls internal method called updateRenderedPages_ that triggers dao calls.
+      This is required as  on slower connections we want to load the page wrappers
+      in order to preserve scroll position.`,
+      on: ['this.propertyChange.currentTopPage_'],
+      code: function() {
+        for ( let i = 0; i < Math.min(this.numPages_, this.NUM_PAGES_TO_RENDER); i++ ) {
+          var page = this.currentTopPage_ + i;
+          if ( this.renderedPages_[page] ) continue;
+          this.renderPageWrapper(page);
+        }
+        this.updateRenderedPages_();
+        // console.debug('PAGE render complete');
+      }
+    },
+    {
       name: 'updateRenderedPages_',
       isIdled: true,
       delay: 100,
-      on: [
-        'this.propertyChange.currentTopPage_'
-      ],
       code: function() {
-        let currentTopPage_ = this.currentTopPage_;
-        // If grouping is enabled, process pages sequentially to maintain group order
-        // Otherwise, process in parallel for better performance
-        this.suspendObserver = true;
-        this.pageLoading.pub('started');
-        let promise = Promise.resolve();
+        // console.debug('starting render', this.currentTopPage_);
+        var promise = Promise.resolve();
+
         if ( this.groupBy ) {
           promise = this.processPageSequentially_(0);
         } else {
-          let promiseArr = [];
-          // Add any pages that are not already rendered.
-          for ( var i = 0; i < Math.min(this.numPages_, this.NUM_PAGES_TO_RENDER) ; i++ ) {
+          var promiseArr = [];
+          for ( var i = 0; i < Math.min(this.numPages_, this.NUM_PAGES_TO_RENDER); i++ ) {
             var page = this.currentTopPage_ + i;
-            if ( this.renderedPages_[page] || this.loadingPages_[page] ) continue;
+            if ( this.loadingPages_[page] ) continue;
             var skip = page * this.pageSize_;
             var dao  = this.data.limit(this.pageSize_).skip(skip);
             promiseArr.push(this.getPage(dao, page));
           }
-          // If there is nothing to load, we should not set daoLoading to false
-          if ( promiseArr.length !== 0 ){
-            promise = Promise.all(promiseArr).then(()=>{
-              this.daoLoading = false;
-            });
+          if ( promiseArr.length ) {
+            promise = Promise.all(promiseArr).then(() => { this.daoLoading = false; });
           }
         }
+
         promise.finally(() => {
-          // If pages are still loading (can happen if current page changes multiple times) just return
-          if ( Object.keys(this.loadingPages_).length ) return;
+          // Evict pages outside the current window
           Object.keys(this.renderedPages_).forEach(i => {
-            if ( (i >= this.currentTopPage_ + this.NUM_PAGES_TO_RENDER) || i < this.currentTopPage_ ) {
-              this.clearPage(i);
+            var n = Number(i);
+            if ( n >= this.currentTopPage_ + this.NUM_PAGES_TO_RENDER ||
+                 n <  this.currentTopPage_ ) {
+              this.clearPage(n);
             }
           });
+          this.correctSpacers_();
+
           this.suspendObserver = false;
-          if ( this.scrollToIndex )
-            this.safeScroll();
+          if ( this.scrollToIndex ) this.safeScroll();
           if ( this.displayedRowCount_ < 0 ) this.bottomRow = this.daoCount;
-          this.pageLoading.pub('finished');
-        })
+          // console.debug('render complete');
+        });
+      }
+    },
+    {
+      name: 'onSentinelIntersect_',
+      documentation: `
+        Fires when topSpacer_ or bottomSpacer_ enters the viewport.
+        This indicates a fast scroll that jumped past the rendered window.
+        We estimate the target page from the current scrollTop and jump to it.
+      `,
+      code: function(entries) {
+        if ( this.suspendObserver ) return;
+        entries.forEach(entry => {
+          if ( ! entry.isIntersecting ) return;
+
+          var scrollTop  = this.rootElement.el_()?.scrollTop ?? 0;
+          var targetPage = this.estimatePageFromOffset_(scrollTop);
+          var isTop      = entry.target === this.topSpacer_.el_();
+          var newTopPage = isTop
+            ? Math.max(0, targetPage - 1)
+            : Math.min(Math.max(0, this.numPages_ - this.NUM_PAGES_TO_RENDER), targetPage);
+
+          // Only suspend and update if currentTopPage_ is actually changing.
+          // If it isn't, updateRenderedPages_ won't fire and suspendObserver
+          // would never reset to false, permanently blocking the sentinel.
+          if ( newTopPage === this.currentTopPage_ ) return;
+          // console.debug('Setting top page - observer', newTopPage);
+          this.currentTopPage_ = newTopPage;
+        });
       }
     },
     {
       name: 'onRowIntersect',
-      // isFramed: true,
-      code: function(entries, self){
-        let intersectingSet = false;
-        // const currentST = this.container.scrollTop;
-        // const isScrollingDown = currentST > this.lastScrollTop;
-        let pages = [];
-        let rows = [];
-        entries.reduce((acc,v) => {
-          var index = Number(v.target.dataset.idx);
-          if ( index ) {
-            acc.push(v);
-          } else {
-            pages.push(v);
-          }
-          return acc;
-        }, rows);
-        rows.forEach((entry) => {
-          if ( entry.intersectionRatio == 0 ) return;
+      code: function(entries, self) {
+        var intersectingSet = false;
+        entries.forEach(entry => {
+          if ( entry.intersectionRatio === 0 ) return;
           intersectingSet = true;
           if ( self.suspendObserver && self.scrollToIndex ) return;
-          let index = Number(entry.target.dataset.idx);
+
+          var index = Number(entry.target.dataset.idx);
           if ( entry.boundingClientRect.top <= entry.rootBounds.top ) {
-            // if ( entry.boundingClientRect.top + (entry.boundingClientRect.height/2) <= entry.rootBounds.top )
-            //   index += 1;
-
+            if ( entry.boundingClientRect.top + entry.boundingClientRect.height/2 <= entry.rootBounds.top ) index += 1; 
             self.topRow = index;
-          } else if( entry.boundingClientRect.bottom >= entry.rootBounds.bottom ) {
-            // if ( entry.boundingClientRect.top + (entry.boundingClientRect.height/2) >= entry.rootBounds.bottom )
-            //   index -= 1;
-
-            if ( index > 0 )
-              self.bottomRow = index;
+          } else if ( entry.boundingClientRect.bottom >= entry.rootBounds.bottom ) {
+            if ( entry.boundingClientRect.bottom + entry.boundingClientRect.height/2 >= entry.rootBounds.top ) index -= 1; 
+            if ( index > 0 ) self.bottomRow = index;
           }
         });
-        pages.forEach(v => {
-          if ( self.suspendObserver && self.scrollToIndex ) return;
-          if ( ! v.isIntersecting ) return;
-          // Re-get to ensure latest data
-          const { top, height } = entry.target.getBoundingClientRect();
-          const rootTop  = entry.rootBounds.top;
-          // let visibleTop = 
-          let progress = (Math.abs(top) / height) * 100;
-          let pageNo = Number(v.target.dataset.page);
-          let lowestAllowedCount = (Math.max(0, pageNo - 1) * self.pageSize_);
-          let maxAllowedCount = (Math.min(self.numPages_, pageNo + 1) * self.pageSize_);
-          let oldScroll = self.rootElement.el_().scrollTop;
-          if ( self.topRow > maxAllowedCount || self.bottomRow < lowestAllowedCount ) {
-            // Implies a scroll up so fast that the observer missed it
-            console.log("forcing page", pageNo, oldScroll);
-            self.pageLoading.sub('finished', foam.events.oneTime(() => {
-              if ( self.currentTopPage_ !== pageNo - 1 ) return;
-              console.log("scrolling to", oldScroll);
-              this.rootElement.el_().scrollTop = oldScroll;
-            }))
-            self.currentTopPage_ = pageNo - 1;
-          } 
-          // else if ( self.bottomRow < lowestAllowedCount ) {
-          //   // Implies a scroll down so fast that the observer missed it
-          //   self.currentTopPage_ = pageNo - 1;
-          //   self.pageLoading.sub('finished', foam.events.oneTime(() => {
-          //     self.scrollView(oldScroll);
-          //   }))
-          // }
-        })
-
         if ( ! intersectingSet ) return;
-
         if ( ! self.bottomRow && self.displayedRowCount_ <= 0 )
-          self.bottomRow = self.pageSize_ > rows.length ? rows.length : self.pageSize_;
+          self.bottomRow = self.pageSize_ > entries.length ? entries.length : self.pageSize_;
+      }
+    },
+    {
+      // Listener for extreme edge case where user scrolls faster than 
+      // we can listen to the observer or their device can process pages
+      // approximates desired page and loads that page will not be accurate
+      name: 'onScroll_',
+      documentation: `
+        Listener for extreme edge case where user scrolls faster than 
+        we can listen to the observer or their device can process pages
+        approximates desired page and loads that page will not be accurate
+      `,
+      isIdled: true,
+      delay: 48,
+      code: function() {
+        var scrollEl = this.rootElement.el_();
+        if ( ! scrollEl || this.scrollToIndex ) return;
+
+        var scrollTop  = scrollEl.scrollTop;
+        var targetPage = this.estimatePageFromOffset_(scrollTop);
+        if ( targetPage < 0 ) return;
+        var outsideWindow = targetPage < this.currentTopPage_ ||
+                            targetPage >= this.currentTopPage_ + this.NUM_PAGES_TO_RENDER;
+
+        if ( outsideWindow ) {
+          // console.debug('Setting top page - scroll listener', targetPage - 1);
+          this.currentTopPage_ = foam.Number.clamp(
+            0,
+            targetPage - 1,
+            Math.max(0, this.numPages_ - this.NUM_PAGES_TO_RENDER)
+          );
+        }
       }
     }
   ],
 
   actions: [
-    // All of these can be used by views that use this view for navigation
     {
       name: 'nextPage',
       toolTip: 'Next Page',
       isEnabled: function(bottomRow, daoCount, suspendObserver) {
-        return ! suspendObserver && bottomRow != daoCount;
+        return ! suspendObserver && bottomRow !== daoCount;
       },
       code: function() {
-        var n = foam.Number.clamp(1,this.topRow + this.displayedRowCount_ + 1,this.daoCount);
+        var n = foam.Number.clamp(1, this.topRow + this.displayedRowCount_ + 1, this.daoCount);
         this.scrollToIndex = n;
       }
     },
@@ -678,7 +815,7 @@ foam.CLASS({
       name: 'lastPage',
       toolTip: 'Last Page',
       isEnabled: function(bottomRow, daoCount, suspendObserver) {
-        return ! suspendObserver && bottomRow != daoCount;
+        return ! suspendObserver && bottomRow !== daoCount;
       },
       code: function() {
         this.scrollToIndex = this.daoCount;
@@ -691,7 +828,7 @@ foam.CLASS({
         return ! suspendObserver && topRow > 1;
       },
       code: function() {
-        var n = foam.Number.clamp(1,this.topRow - this.displayedRowCount_, this.daoCount);
+        var n = foam.Number.clamp(1, this.topRow - this.displayedRowCount_, this.daoCount);
         this.scrollToIndex = n;
       }
     },

--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -459,7 +459,7 @@ foam.CLASS({
           .attr('data-page', page).style({ height: this.estimatedPageHeight });
 
         self.renderedPages_[page] = e;
-
+        // All of this must happen in the same animation frame to avoid jitter
         this.requestAnimationFrame(() => {
           // Insert in sorted order among sibling pages
           var inserted = false;
@@ -766,9 +766,6 @@ foam.CLASS({
       }
     },
     {
-      // Listener for extreme edge case where user scrolls faster than 
-      // we can listen to the observer or their device can process pages
-      // approximates desired page and loads that page will not be accurate
       name: 'onScroll_',
       documentation: `
         Listener for extreme edge case where user scrolls faster than 

--- a/src/foam/u2/view/LazyScrollManager.js
+++ b/src/foam/u2/view/LazyScrollManager.js
@@ -53,7 +53,13 @@ foam.CLASS({
       justify-content: center;
       align-items: center;
     }
+
+    ^table-page {
+      content-visibility: auto;
+      contain-intrinsic-size: auto 2400px; // Approx initial page height
+    }
   `,
+  topics: ['pageLoading'],
 
   properties: [
     {
@@ -110,11 +116,11 @@ foam.CLASS({
       memorable: true,
       documentation: 'Stores the index top row that is currently displayed in the table',
       postSet: function(o, n) {
-        if ( this.scrollToIndex || o == n ) return;
-        var n1 = (n-(this.currentTopPage_*this.pageSize_))/this.pageSize_;
-        if ( n < o && n1 <= 1 && n1 < 1 - this.MIN_PAGE_PROGRESS ) {
-          this.currentTopPage_ --;
-        }
+        // if ( this.scrollToIndex || o == n ) return;
+        // var n1 = (n-(this.currentTopPage_*this.pageSize_))/this.pageSize_;
+        // if ( n < o && n1 <= 1 && n1 < 1 - this.MIN_PAGE_PROGRESS ) {
+        //   this.currentTopPage_ --;
+        // }
       }
     },
     {
@@ -122,11 +128,11 @@ foam.CLASS({
       name: 'bottomRow',
       documentation: 'Stores the index of last row that is currently displayed in the table',
       postSet: function(o, n) {
-        if ( this.scrollToIndex || o == n ) return;
-        var n1 = (n-(this.currentTopPage_*this.pageSize_))/this.pageSize_;
-        if ( n > o && n1 >= this.NUM_PAGES_TO_RENDER - 2 && n1%1 >= this.MIN_PAGE_PROGRESS ) {
-          this.currentTopPage_++;
-        }
+        // if ( this.scrollToIndex || o == n ) return;
+        // var n1 = (n-(this.currentTopPage_*this.pageSize_))/this.pageSize_;
+        // if ( n > o && n1 >= this.NUM_PAGES_TO_RENDER - 2 && n1%1 >= this.MIN_PAGE_PROGRESS ) {
+        //   this.currentTopPage_++;
+        // }
       }
     },
     {
@@ -222,7 +228,16 @@ foam.CLASS({
       documentation: 'Tracks the first page where each group appears to ensure headers show only once',
       factory: function() { return {}; }
     },
-    ['suspendObserver', false]
+    ['suspendObserver', false],
+    {
+      name: 'seenPages',
+      class: 'Map'
+    },
+    { 
+      name: 'visibleRows', 
+      factory: function() { return new Set(); }
+    },
+    'lastScrollTop'
   ],
 
   methods: [
@@ -245,7 +260,7 @@ foam.CLASS({
       let options = {
         root: root ?? null,
         rootMargin: `-${this.offsetTop}px 0px 0px`,
-        threshold: [0, 0.25, 0.5, 0.75]
+        threshold: [0.1, 0.99]
       };
 
       // defer till after atleast one page has been loaded in order
@@ -318,12 +333,46 @@ foam.CLASS({
       ! opt_skipObserver && this.renderedPages_[page].childNodes?.forEach((e) => {
         if ( e.el_() )
           this.rowObserver.unobserve(e.el_());
-      })
-      this.renderedPages_[page].remove();
+      });
+      let el = this.seenPages[page] = this.renderedPages_[page];
+      let height = el.element_.offsetHeight;
+      this.seenPages[page].style({ height: height });
+      el.removeAllChildren();
       delete this.renderedPages_[page];
     },
 
+    function renderPageWrapper(page) {
+      let self = this;
+      if ( self.renderedPages_[page] ) {
+        console.warn('Trying to overwrite a loaded page without clearing....Clearing page');
+        this.clearPage(page)
+      }
+      let oldPage = this.seenPages[page];
+      oldPage?.style({ height: 'auto' });
+      var e = oldPage ?? this.E().addClass(self.myClass('table-page')).attr('data-page', page);
+      e.el().then(el => {
+        self.rowObserver.observe(el);
+      })
+      let isSet = false;
+      if ( ! oldPage ) {
+        if ( Object.keys(self.renderedPages_).length ) {
+          for ( let j = page; j < Object.keys(self.renderedPages_) && ! isSet; j++) {
+            if ( self.renderedPages_[j+1] ) {
+              console.log("inserting at", j+1, page);
+              this.appendTo.insertBefore(e, self.renderedPages_[j+1]);
+              isSet = true;
+            }
+          }
+        }
+        console.log("inserting at end", page);
+        if ( ! isSet ) { this.appendTo.add(e); isSet = true; }
+      }
+      self.renderedPages_[page] = e;
+      return e;
+    },
+
     function getPage(dao, page) {
+      console.log('getting page', page);
       var self       = this;
       var proxy      = this.ProxyDAO.create({ delegate: dao });
       var sortParams = [];
@@ -338,7 +387,7 @@ foam.CLASS({
       self.loadingPages_$set(page);
 
       let promise = this.prepDAO(proxy, this.ctx);
-      var e       = this.E().attr('data-page', page);
+      let e = this.renderPageWrapper(page);
 
       return promise.then(values => {
         function populateRows(args) {
@@ -364,12 +413,18 @@ foam.CLASS({
             }
 
             if ( showHeader ) {
-              e.tag(self.groupHeaderView,
+              e.start(self.groupHeaderView,
                 { ...args,
                   groupLabel: group,
                   groupBy: self.groupBy,
                 }
-              );
+              )
+                // Add index of the next row to the group as well for the intersection observer
+                .attr('data-idx', index)
+                .call(function() {
+                  self.rowObserver.observe(this.element_)
+                })
+              .end();
             }
 
             previousGroup = group;
@@ -396,32 +451,8 @@ foam.CLASS({
           }
         }
 
-        var isSet = false;
-        if ( self.renderedPages_[page] ) {
-          console.warn('Trying to overwrite a loaded page without clearing....Clearing page');
-          this.clearPage(page)
-        }
-
-        Object.keys(self.renderedPages_).forEach(j => {
-          if ( j > page && self.renderedPages_[j] && ! isSet ) {
-            this.appendTo.insertBefore(e, self.renderedPages_[j]);
-            isSet = true;
-            // TODO: Figure out why scrolling to the top causes you to go to first page
-          }
-        });
-
-        if ( ! isSet ) { this.appendTo.add(e); isSet = true; }
-
-        self.renderedPages_[page] = e;
-        // self.loadingPages_[page]  = false;
         self.loadingPages_$remove(page);
-
-        // If there is a scroll in progress and all pages have been loaded, try to scroll again
-        if ( this.scrollToIndex && Object.keys(this.renderedPages_).length == Math.min(this.NUM_PAGES_TO_RENDER, this.numPages_) )
-          self.safeScroll();
-
         this.dataLatch.resolve();
-        if ( this.displayedRowCount_ < 0 ) this.bottomRow = this.daoCount
       });
     },
 
@@ -473,8 +504,10 @@ foam.CLASS({
         this.rowObserver?.disconnect();
         // Don't clear loadingPages_ here since they are being
         // loaded and will have latest data anyway
-        Object.keys(this.renderedPages_).forEach(i => {
-          this.clearPage(i, true);
+        Object.keys(this.seenPages).forEach(i => {
+          if ( this.renderedPages_[i] ) this.clearPage(i, true); 
+          this.seenPages[i]?.remove();
+          delete this.seenPages[i];
         });
         // Clear group first page tracking
         this.groupFirstPage_ = {};
@@ -482,6 +515,7 @@ foam.CLASS({
           this.currentTopPage_ = 0;
           this.topRow = 0;
           this.bottomRow = 0;
+          this.pageHeights = {}
         }
         this.isInit = false;
         this.updateRenderedPages_();
@@ -515,6 +549,7 @@ foam.CLASS({
         // If grouping is enabled, process pages sequentially to maintain group order
         // Otherwise, process in parallel for better performance
         this.suspendObserver = true;
+        this.pageLoading.pub('started');
         let promise = Promise.resolve();
         if ( this.groupBy ) {
           promise = this.processPageSequentially_(0);
@@ -536,66 +571,92 @@ foam.CLASS({
           }
         }
         promise.finally(() => {
+          // If pages are still loading (can happen if current page changes multiple times) just return
+          if ( Object.keys(this.loadingPages_).length ) return;
           Object.keys(this.renderedPages_).forEach(i => {
             if ( (i >= this.currentTopPage_ + this.NUM_PAGES_TO_RENDER) || i < this.currentTopPage_ ) {
               this.clearPage(i);
             }
           });
-          // Wait to delete pages to fix scroll jumping and causing issues
-          // this.rootElement.addEventListener('scroll', this.onScrollEnd);  
-          if ( ! this.scrollToIndex ) {
-            this.scrollToIndex = this.topRow;
-            this.suspendObserver = false;
-          } else {
-            this.suspendObserver = false;
+          this.suspendObserver = false;
+          if ( this.scrollToIndex )
             this.safeScroll();
-          }
+          if ( this.displayedRowCount_ < 0 ) this.bottomRow = this.daoCount;
+          this.pageLoading.pub('finished');
         })
       }
     },
-    // {
-    //   name: 'onScrollEnd',
-    //   isIdled: true,
-    //   delay: 200,
-    //   code: function() {
-    //     // Remove any pages that are no longer on screen to save on
-    //     // the amount of DOM we add to the page.
-        
-    //     this.removeEventListener('scroll', this.onScrollEnd);
-    //   }
-    // },
     {
       name: 'onRowIntersect',
-      isFramed: true,
+      // isFramed: true,
       code: function(entries, self){
         let intersectingSet = false;
-        entries.forEach((entry) => {
+        // const currentST = this.container.scrollTop;
+        // const isScrollingDown = currentST > this.lastScrollTop;
+        let pages = [];
+        let rows = [];
+        entries.reduce((acc,v) => {
+          var index = Number(v.target.dataset.idx);
+          if ( index ) {
+            acc.push(v);
+          } else {
+            pages.push(v);
+          }
+          return acc;
+        }, rows);
+        rows.forEach((entry) => {
           if ( entry.intersectionRatio == 0 ) return;
           intersectingSet = true;
           if ( self.suspendObserver && self.scrollToIndex ) return;
-          var index = Number(entry.target.dataset.idx);
+          let index = Number(entry.target.dataset.idx);
           if ( entry.boundingClientRect.top <= entry.rootBounds.top ) {
-            if ( entry.boundingClientRect.top + (entry.boundingClientRect.height/2) <= entry.rootBounds.top )
-              index += 1;
+            // if ( entry.boundingClientRect.top + (entry.boundingClientRect.height/2) <= entry.rootBounds.top )
+            //   index += 1;
 
             self.topRow = index;
           } else if( entry.boundingClientRect.bottom >= entry.rootBounds.bottom ) {
-            if ( entry.boundingClientRect.top + (entry.boundingClientRect.height/2) >= entry.rootBounds.bottom )
-              index -= 1;
+            // if ( entry.boundingClientRect.top + (entry.boundingClientRect.height/2) >= entry.rootBounds.bottom )
+            //   index -= 1;
 
             if ( index > 0 )
               self.bottomRow = index;
           }
         });
+        pages.forEach(v => {
+          if ( self.suspendObserver && self.scrollToIndex ) return;
+          if ( ! v.isIntersecting ) return;
+          // Re-get to ensure latest data
+          const { top, height } = entry.target.getBoundingClientRect();
+          const rootTop  = entry.rootBounds.top;
+          // let visibleTop = 
+          let progress = (Math.abs(top) / height) * 100;
+          let pageNo = Number(v.target.dataset.page);
+          let lowestAllowedCount = (Math.max(0, pageNo - 1) * self.pageSize_);
+          let maxAllowedCount = (Math.min(self.numPages_, pageNo + 1) * self.pageSize_);
+          let oldScroll = self.rootElement.el_().scrollTop;
+          if ( self.topRow > maxAllowedCount || self.bottomRow < lowestAllowedCount ) {
+            // Implies a scroll up so fast that the observer missed it
+            console.log("forcing page", pageNo, oldScroll);
+            self.pageLoading.sub('finished', foam.events.oneTime(() => {
+              if ( self.currentTopPage_ !== pageNo - 1 ) return;
+              console.log("scrolling to", oldScroll);
+              this.rootElement.el_().scrollTop = oldScroll;
+            }))
+            self.currentTopPage_ = pageNo - 1;
+          } 
+          // else if ( self.bottomRow < lowestAllowedCount ) {
+          //   // Implies a scroll down so fast that the observer missed it
+          //   self.currentTopPage_ = pageNo - 1;
+          //   self.pageLoading.sub('finished', foam.events.oneTime(() => {
+          //     self.scrollView(oldScroll);
+          //   }))
+          // }
+        })
 
-        if ( ! intersectingSet ) return
-        // Only applicable for grouped lists as group headers would be the ones intersecting and the "topRow" would eval to 0 in the code above
-        if ( ! self.topRow && entries.length ) {
-          self.topRow = entries[0].target.dataset.idx;
-        }
+        if ( ! intersectingSet ) return;
 
         if ( ! self.bottomRow && self.displayedRowCount_ <= 0 )
-          self.bottomRow = self.pageSize_ > entries.length ? entries.length : self.pageSize_;
+          self.bottomRow = self.pageSize_ > rows.length ? rows.length : self.pageSize_;
       }
     }
   ],


### PR DESCRIPTION
Rewrite LazyScrollManager to be a real virtual windowing view with a simpler pagination approach in order to prevent requiring a number of defeedback loops and deciding pages to load based on "position in the dao" rather than trying to accurately predict current row the user is on and their scroll direction.