### PR TITLE
Fix infinite loop in Until/Until0 parser when terminator is never found

### DIFF
--- a/src/foam/parse/parse.js
+++ b/src/foam/parse/parse.js
@@ -864,7 +864,7 @@ foam.CLASS({
       var ret = [];
       var p = this.p;
 
-      while ( true ) {
+      while ( ps.valid ) {
         var res;
 
         if ( res = ps.apply(p, obj) ) {
@@ -895,7 +895,7 @@ foam.CLASS({
     function parse(ps, obj) {
       var p = this.p;
 
-      while ( true ) {
+      while ( ps.valid ) {
         var res;
 
         if ( res = ps.apply(p, obj) ) {


### PR DESCRIPTION

## Problem

`Until.parse()` and `Until0.parse()` use `while ( true )` to consume characters until a terminator pattern matches. If the terminator is never found (e.g., `until(nl)` on input that doesn't end with a newline), the loop runs past the end of the string indefinitely. `ps.head` returns `undefined` and `ps.tail` keeps incrementing the position, causing unbounded memory growth and eventually an OOM crash.

This affects any grammar that uses `until(nl)` or similar patterns where the input may not contain the expected terminator before EOF.

## Solution

Replace `while ( true )` with `while ( ps.valid )` in both `Until.parse()` and `Until0.parse()`. When the PStream reaches EOF, `ps.valid` returns `false`, the loop exits, and the method returns `undefined` (a normal parse failure) instead of looping forever.

This is consistent with how other parsers in the framework handle EOF — they check `ps.valid` or `ps.head` before consuming.

## Changes

- `Until.parse()`: `while ( true )` → `while ( ps.valid )`
- `Until0.parse()`: `while ( true )` → `while ( ps.valid )`
