### PR TITLE
PT-FIXES:DOS-2613 Fix currency formatting for lesser-known currencies

### DIFF
--- a/src/foam/lang/Currency.js
+++ b/src/foam/lang/Currency.js
@@ -161,7 +161,7 @@ foam.CLASS({
          *
          */
         // Not using foam locale as foam locale can be reset to a different value mid-session based on translation available
-        // using browser default formatting when available 
+        // using browser default formatting when available
         if ( navigator.language ) {
           amount = Number(amount);
           let opts = {
@@ -173,14 +173,22 @@ foam.CLASS({
             opts.style = 'currency';
             opts.currency = this.id;
           }
-          let formatterId = navigator.language + '-' + this.id;
-          if ( this.FORMATTER_CACHE[formatterId] ) {
-            return this.FORMATTER_CACHE[formatterId].format(amount);
-          } else {
-            let formatter = new Intl.NumberFormat(navigator.language, opts);
+          let formatterId = navigator.language + '-' + this.id + (hideSymbol ? '-ns' : '');
+          var formatter = this.FORMATTER_CACHE[formatterId];
+          if ( ! formatter ) {
+            formatter = new Intl.NumberFormat(navigator.language, opts);
             this.FORMATTER_CACHE[formatterId] = formatter;
-            return formatter.format(amount);
           }
+          // Intl.NumberFormat may display the ISO code (e.g., "JOD") instead of
+          // the symbol for lesser-known currencies. Use formatToParts to replace
+          // with the actual symbol from the Currency model.
+          if ( ! hideSymbol && this.symbol ) {
+            var sym = this.symbol;
+            return formatter.formatToParts(amount).map(function(p) {
+              return p.type === 'currency' ? sym : p.value;
+            }).join('');
+          }
+          return formatter.format(amount);
         }
         // TODO: Maybe consider deleting the custom formatting logic below
         amount = Math.round(amount);

--- a/src/foam/lang/Currency.js
+++ b/src/foam/lang/Currency.js
@@ -180,12 +180,12 @@ foam.CLASS({
             this.FORMATTER_CACHE[formatterId] = formatter;
           }
           // Intl.NumberFormat may display the ISO code (e.g., "JOD") instead of
-          // the symbol for lesser-known currencies. Use formatToParts to replace
+          // the symbol for lesser-known currencies. When that happens, replace
           // with the actual symbol from the Currency model.
           if ( ! hideSymbol && this.symbol ) {
-            var sym = this.symbol;
+            var self = this;
             return formatter.formatToParts(amount).map(function(p) {
-              return p.type === 'currency' ? sym : p.value;
+              return p.type === 'currency' && p.value === self.id ? self.symbol : p.value;
             }).join('');
           }
           return formatter.format(amount);


### PR DESCRIPTION

## Problem
`Currency.format()` in JavaScript delegates to `Intl.NumberFormat` with `style: 'currency'`, which decides on its own whether to display a symbol (`$`) or the ISO code (`JOD`). For well-known currencies like USD, it shows `$586.02`. For lesser-known currencies like JOD (Jordanian Dinar), it shows `JOD 79,582.170` — ignoring the `Currency.symbol` property from the DAO entirely. The Java implementation already handles this correctly by checking if a symbol exists and using it.

Additionally, the formatter cache key did not account for the `hideSymbol` parameter, so a decimal-only formatter could be reused when currency formatting was needed (or vice versa).

## Solution
Use `Intl.NumberFormat.formatToParts()` to get structured output, then replace parts with `type === 'currency'` with the actual `Currency.symbol` from the model. This preserves all locale-aware number formatting (grouping separators, decimal characters, sign handling, accounting format) while ensuring the correct symbol is displayed. Falls back to the default `Intl` behavior when no custom symbol is defined.

## Changes
- Use `formatToParts()` to replace Intl's currency representation with `Currency.symbol` from the DAO
- Fix formatter cache key to include `hideSymbol` state, preventing cross-contamination between decimal and currency formatters
