### PR TITLE
Fix FObjectProperty.fromJSON assertion error and Desc.arg1 adapt crash

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -1049,7 +1049,7 @@ foam.CLASS({
     {
       name: 'fromJSON',
       value: function(json, ctx, prop) {
-        return foam.json.parse(json, foam.lookup(prop.type), ctx);
+        return foam.json.parse(json, prop.type ? foam.lookup(prop.type) : prop.of, ctx);
       }
     },
     {

--- a/src/foam/mlang/order/Desc.js
+++ b/src/foam/mlang/order/Desc.js
@@ -23,7 +23,7 @@ foam.CLASS({
       of: 'foam.mlang.order.Comparator',
       adapt: function(o, n, prop) {
         var ret  = foam.compare.toCompare(n);
-        var type = prop;
+        var type = prop.of;
         if ( type.isInstance(ret) ) {
           return ret;
         }


### PR DESCRIPTION

## Problem
`FObjectProperty.fromJSON` unconditionally called `foam.lookup(prop.type)`, but `prop.type` is often undefined (no factory/default unlike `FObjectArray`). This caused repeated `"Could not find any registered class for undefined"` assertion errors during JSON deserialization. Additionally, `Desc.arg1.adapt` called `isInstance` on the PropertyInfo object instead of the resolved class, which crashed once the fromJSON fix allowed execution to reach that code path.

## Solution
Fall back to `prop.of` (always set, defaults to `foam.lang.FObject`) when `prop.type` is undefined. Fixed `Desc.js` to use `prop.of` instead of `prop` to get the actual Comparator class.

## Changes
- **types.js**: `FObjectProperty.fromJSON` guards `prop.type` before calling `foam.lookup`, falls back to `prop.of`
- **Desc.js**: Fix `var type = prop` → `var type = prop.of` in `arg1.adapt`
