### PR TITLE
PT-FIXES:DOS-1219 Add duplicate name check before saving new Reflow flows

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1916,12 +1916,52 @@ foam.CLASS({
       this.generateScript();
     },
 
-    function save() {
+    async function save() {
       // This is a hackish solution to the bug that the memento is saved before
       // the last block's name is set. Ideally the block would be named before
       // being added to the flowChildren. Alternatively, the mementoStr could never
       // be created until just before you save, but updating it for every update
       // will make it easy to implement undo/redo in the future.
+      var flow = this.value;
+
+      // If this is a new flow (never saved/loaded), check for name collision
+      if ( ! flow.version && flow.name ) {
+        var existing = await flow.flowDAO.find(flow.name);
+        if ( existing ) {
+          return new Promise((resolve) => {
+            var self = this;
+            var modal = this.ConfirmationModal.create({
+              title: 'Name Already Exists',
+              modalStyle: 'WARN',
+              maxWidth: '35vw',
+              closeable: false,
+              primaryAction: foam.lang.Action.create({
+                name: 'overwrite',
+                label: 'Overwrite',
+                buttonStyle: 'PRIMARY',
+                code: function() {
+                  resolve(self.doSave_());
+                }
+              }),
+              secondaryAction: foam.lang.Action.create({
+                name: 'cancel',
+                label: 'Cancel',
+                code: function() {
+                  flow.version = 0;
+                  resolve();
+                }
+              })
+            });
+            modal.add('A Flow named "' + flow.name + '" already exists. Overwrite it?');
+            self.add(modal);
+          });
+        }
+      }
+
+      return this.doSave_();
+    },
+
+    function doSave_() {
       var flow = this.value;
 
       this.generateScript();

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1927,38 +1927,38 @@ foam.CLASS({
       // If this is a new flow (never saved/loaded), check for name collision
       if ( ! flow.version && flow.name ) {
         var existing = await flow.flowDAO.find(flow.name);
-        if ( existing ) {
-          return new Promise((resolve) => {
-            var self = this;
-            var modal = this.ConfirmationModal.create({
-              title: 'Name Already Exists',
-              modalStyle: 'WARN',
-              maxWidth: '35vw',
-              closeable: false,
-              primaryAction: foam.lang.Action.create({
-                name: 'overwrite',
-                label: 'Overwrite',
-                buttonStyle: 'PRIMARY',
-                code: function() {
-                  resolve(self.doSave_());
-                }
-              }),
-              secondaryAction: foam.lang.Action.create({
-                name: 'cancel',
-                label: 'Cancel',
-                code: function() {
-                  flow.version = 0;
-                  resolve();
-                }
-              })
-            });
-            modal.add('A Flow named "' + flow.name + '" already exists. Overwrite it?');
-            self.add(modal);
-          });
-        }
+        if ( existing ) return this.confirmOverwrite_(flow);
       }
 
       return this.doSave_();
+    },
+
+    function confirmOverwrite_(flow) {
+      var self = this;
+      return new Promise(function(resolve) {
+        var modal = self.ConfirmationModal.create({
+          title: 'Name Already Exists',
+          modalStyle: 'WARN',
+          maxWidth: '35vw',
+          closeable: false,
+          primaryAction: foam.lang.Action.create({
+            name: 'overwrite',
+            label: 'Overwrite',
+            buttonStyle: 'PRIMARY',
+            code: function() { resolve(self.doSave_()); }
+          }),
+          secondaryAction: foam.lang.Action.create({
+            name: 'cancel',
+            label: 'Cancel',
+            code: function() {
+              flow.version = 0;
+              resolve();
+            }
+          })
+        });
+        modal.add('A Flow named "' + flow.name + '" already exists. Overwrite it?');
+        self.add(modal);
+      });
     },
 
     function doSave_() {

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1937,7 +1937,7 @@ foam.CLASS({
       var self = this;
       return new Promise(function(resolve) {
         var modal = self.ConfirmationModal.create({
-          title: 'Name Already Exists',
+          title: 'Flow Name Already Exists',
           modalStyle: 'WARN',
           maxWidth: '35vw',
           closeable: false,

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -664,8 +664,8 @@ foam.CLASS({
       // Don't save the 'save' command
       this.currentBlock.del();
 
-      return this.save().then(() => {
-        this.notify('Flow saved');
+      return this.save().then(ret => {
+        if ( ret ) this.notify('Flow saved');
       }).catch(err => {
         this.notify('Error saving flow: ' + err.message);
       });


### PR DESCRIPTION

## Problem
When saving a new ReFLOW with a name that matches an existing Flow, the system silently overwrites the existing Flow without any warning. Since `Flow.ids = ['name']`, `flowDAO.put()` treats matching names as an update rather than a create, causing data loss. Users also saw a misleading "Flow saved" notification even when cancelling out of the wrong dialog.

## Solution
Added a duplicate name check in `Console.save()` that only triggers for **new flows** (`version === 0`). Before calling `flowDAO.put()`, it queries `flowDAO.find(name)` to check for an existing flow with the same name.

- If a collision is found, a `ConfirmationModal` warns: *"A Flow named X already exists. Overwrite it?"* with **Overwrite** / **Cancel** options
- If the flow was loaded from the DAO (`version >= 1`), the check is skipped — updating a loaded flow is expected behavior
- The Save command now only shows "Flow saved" when the save actually completes (not on cancel)

## Changes
- `Console.save()` — made async, added pre-save duplicate name check with ConfirmationModal warning for new flows
- `Console.doSave_()` — extracted original save logic (generateScript, version++, flowDAO.put) into separate method
- `Save.execute()` — only notify "Flow saved" when save returns a result (suppress on cancel)
