### PR TITLE
 Fix ValueView TypeError when prop is undefined

### DIFF
--- a/src/foam/u2/view/ValueView.js
+++ b/src/foam/u2/view/ValueView.js
@@ -50,7 +50,7 @@ foam.CLASS({
         );
       } else {
         this.add(this.data$.map(v => {
-          if ( prop && prop.name !== 'id' && foam.Number.isInstance(v) && foam.lang.Int.isSubClass(prop) && prop.formatValue ) {
+          if ( prop?.name !== 'id' && foam.Number.isInstance(v) && foam.lang.Int.isSubClass(prop) && prop.formatValue ) {
             return Number(v).toLocaleString(navigator.locale);
           }
           return v;

--- a/src/foam/u2/view/ValueView.js
+++ b/src/foam/u2/view/ValueView.js
@@ -50,7 +50,7 @@ foam.CLASS({
         );
       } else {
         this.add(this.data$.map(v => {
-          if ( prop.name !== 'id' && foam.Number.isInstance(v) && foam.lang.Int.isSubClass(prop) && prop.formatValue ) {
+          if ( prop && prop.name !== 'id' && foam.Number.isInstance(v) && foam.lang.Int.isSubClass(prop) && prop.formatValue ) {
             return Number(v).toLocaleString(navigator.locale);
           }
           return v;


### PR DESCRIPTION

## Problem
`ValueView.render()` throws `Uncaught TypeError: Cannot read properties of undefined (reading 'name')` when the view is created without being associated with a property (i.e., `fromProperty()` was never called). This happens when ValueView is rendered inside FObjectProperty sub-views (e.g., strategy reference pickers) where the view is instantiated without a property binding.

## Solution
Added a null guard (`prop &&`) before accessing `prop.name` in the `else` branch of `render()`. The `if` branch on line 40 already correctly guards with `prop && prop.unitPropValueToString`, but the `else` branch was missing this check.

## Changes
- Added `prop &&` guard in `ValueView.js:53` to prevent TypeError when `prop` is undefined
