### PR TITLE
Fix DST-flaky CronScheduleTest timezone test

### DIFF
--- a/src/foam/core/cron/test/CronScheduleTest.js
+++ b/src/foam/core/cron/test/CronScheduleTest.js
@@ -221,10 +221,12 @@ foam.CLASS({
       test ( diff == 12, "MonthsOfYear - next month "+diff+" "+lastTime+" "+nextTime );
 
       // TimeZone
+      // Use hour 10 instead of 2 to avoid DST spring-forward gap
+      // (2:00 AM doesn't exist on DST transition day in America/Toronto)
       sched = new CronSchedule();
-      sched.setHours("2");
+      sched.setHours("10");
       sched.setMinute(25);
-      sched.setTimeZone("America/Toronto"); // EST
+      sched.setTimeZone("America/Toronto"); // EST/EDT
       ZoneId zoneId = ZoneId.of("America/Toronto");
       last = sched.getNextScheduledTime(x, null);
       lastTime = LocalDateTime.ofInstant(last.toInstant(), zoneId);
@@ -236,7 +238,7 @@ foam.CLASS({
         cal.setTimeZone(TimeZone.getTimeZone(zoneId));
       }
       cal.setTime(next);
-      test ( cal.get(Calendar.HOUR_OF_DAY) == 2, "EST Hour 2" );
+      test ( cal.get(Calendar.HOUR_OF_DAY) == 10, "EST Hour 10" );
       test ( cal.get(Calendar.MINUTE) == 25, "EST Minute 25" );
       `
     }


### PR DESCRIPTION

## Problem

The `CronScheduleTest` timezone test was intermittently failing near DST transitions. The test scheduled a cron job at **2:00 AM America/Toronto**, but during the spring-forward DST transition, 2:00 AM doesn't exist (clocks jump from 1:59 AM to 3:00 AM). Java's `LocalDateTime.atZone()` adjusts the non-existent time forward, causing the `Calendar.HOUR_OF_DAY` assertion to fail (expects 2, gets 3).

## Solution

Changed the test hour from 2 to 10, which is unaffected by DST transitions (spring-forward and fall-back both occur at 2:00 AM). The test still validates the same timezone conversion logic — just with an hour that always exists.

## Changes

- **CronScheduleTest.js**: Changed timezone test hour from 2 to 10 to avoid DST spring-forward gap. Updated assertion from `HOUR_OF_DAY == 2` to `HOUR_OF_DAY == 10`. Added comment explaining the DST avoidance rationale.
