### PR TITLE
Fix dynamic model crashes from non-standard CSV headers

### DIFF
--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -233,7 +233,7 @@ foam.CLASS({
         for ( var i = 0 ; i < fileHeaders.length ; i++ ) {
           var original   = fileHeaders[i];
           var normalized = this.normalizeHeader(original);
-          normalized     = normalized || 'field_' + i;
+          normalized     = normalized || 'field' + i;
           normalized     = this.resolveConstantCollision(normalized, constantMap);
 
           headerMap[normalized] = original;

--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -233,6 +233,7 @@ foam.CLASS({
         for ( var i = 0 ; i < fileHeaders.length ; i++ ) {
           var original   = fileHeaders[i];
           var normalized = this.normalizeHeader(original);
+          normalized     = normalized || 'field_' + i;
           normalized     = this.resolveConstantCollision(normalized, constantMap);
 
           headerMap[normalized] = original;
@@ -360,29 +361,43 @@ foam.CLASS({
   methods: [
     function normalizeHeader(header) {
       /** Normalize a header string to a valid property name. */
-      return header.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^[0-9]+/, '');
+      var s = header.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^[^a-zA-Z]+/, '');
+      if ( ! s ) return '';
+      // FOAM property names must start with a lowercase letter to avoid
+      // collisions with the UPPER_CASE constant name that FOAM generates
+      // for each property (e.g., an all-caps name would clash with itself).
+      return s.charAt(0).toLowerCase() + s.substring(1);
     },
 
     function resolveConstantCollision(normalized, constantMap) {
       /**
-       * Resolve FOAM constant name collisions by appending a numeric suffix.
-       * Returns the resolved property name.
+       * Resolve FOAM constant and property name collisions by appending
+       * a numeric suffix. constantMap tracks both constant names (keys)
+       * and used property names (via a '__names__' Set).
+       * Returns a unique resolved property name.
        */
+      var names        = constantMap.__names__ || ( constantMap.__names__ = {} );
       var constantName = foam.String.constantize(normalized);
 
-      if ( ! constantMap[constantName] || constantMap[constantName] === normalized ) {
+      // No collision if both the constant and property name are unused
+      // or belong to this same normalized name
+      if ( ( ! constantMap[constantName] || constantMap[constantName] === normalized ) &&
+           ! names[normalized] ) {
         constantMap[constantName] = normalized;
+        names[normalized]         = true;
         return normalized;
       }
 
       // Collision detected - append suffix to make unique
       var suffix = 2;
       var newNormalized = normalized + '_' + suffix;
-      while ( constantMap[foam.String.constantize(newNormalized)] ) {
+      while ( constantMap[foam.String.constantize(newNormalized)] ||
+              names[newNormalized] ) {
         suffix++;
         newNormalized = normalized + '_' + suffix;
       }
       constantMap[foam.String.constantize(newNormalized)] = newNormalized;
+      names[newNormalized]                                = true;
       return newNormalized;
     },
 

--- a/src/foam/core/reflow/Mapping.js
+++ b/src/foam/core/reflow/Mapping.js
@@ -390,11 +390,11 @@ foam.CLASS({
 
       // Collision detected - append suffix to make unique
       var suffix = 2;
-      var newNormalized = normalized + '_' + suffix;
+      var newNormalized = normalized + suffix;
       while ( constantMap[foam.String.constantize(newNormalized)] ||
               names[newNormalized] ) {
         suffix++;
-        newNormalized = normalized + '_' + suffix;
+        newNormalized = normalized + suffix;
       }
       constantMap[foam.String.constantize(newNormalized)] = newNormalized;
       names[newNormalized]                                = true;


### PR DESCRIPTION
## Problem
When CSV files contain headers that are all-uppercase, all-numeric, or start with symbols/underscores, dynamically generated FOAM models crash during class installation. This happens because:

1. **Property-constant name collision**: FOAM generates an UPPER_CASE constant for every property. When the property name is already all-caps, `constantize()` returns the same string, causing the constant setter to write to `instance_` (which doesn't exist on the class object).
2. **Empty property names**: Headers starting with non-letter characters can normalize to empty strings after stripping, resulting in properties named `''`.
3. **Duplicate property names**: Multiple headers normalizing to the same property name bypass collision detection because the resolver only tracked constant names, not property names.

## Solution
Harden `Mapping.normalizeHeader()` and `resolveConstantCollision()` to produce valid, unique FOAM property names from any input:

- Strip all leading non-letter characters (not just digits) so names always start with a letter
- Lowercase the first character to ensure the property name differs from its generated UPPER_CASE constant
- Add empty-string fallback (`field_N`) in the `expressionParser_` caller
- Track both constant names and property names in collision resolution to prevent duplicate axioms

## Changes
- `normalizeHeader()`: use `/^[^a-zA-Z]+/` instead of `/^[0-9]+/` and lowercase first char
- `expressionParser_`: add `normalized || "field_" + i` fallback for empty headers
- `resolveConstantCollision()`: track used property names alongside constant names