### PR TITLE
[DOS-2358] Enhance oauth session security

### DIFF
--- a/src/foam/core/oauth/OAuthCredential.js
+++ b/src/foam/core/oauth/OAuthCredential.js
@@ -2,6 +2,12 @@ foam.CLASS({
   package: 'foam.core.oauth',
   name: 'OAuthCredential',
   ids: ["provider", "user"],
+
+  javaImports: [
+    'foam.util.SafetyUtil',
+    'java.time.Instant'
+  ],
+
   properties: [
     {
       class: 'Reference',
@@ -24,6 +30,11 @@ foam.CLASS({
     {
       class: 'StringArray',
       name: 'scopes'
+    },
+    {
+      class: 'DateTime',
+      name: 'expiresAt',
+      documentation: 'Expiration time of the access token, as returned by the OAuth provider'
     }
   ],
   methods: [
@@ -33,8 +44,23 @@ foam.CLASS({
       args: [ { name: 'x', type: 'Context' } ],
       javaCode: `
         var provider = findProvider(x);
-        String newAccessToken = provider.refreshAccessToken(x, getRefreshToken());
-        setAccessToken(newAccessToken);
+        provider.refreshAccessToken(x, this);
+      `
+    },
+    {
+      name: 'checkAndRefresh',
+      type: 'String',
+      documentation: 'Returns the access token, proactively refreshing if within 5 minutes of expiration',
+      args: 'Context x',
+      javaCode: `
+        if ( getExpiresAt() != null && ! SafetyUtil.isEmpty(getRefreshToken()) ) {
+          Instant expiresAt = getExpiresAt().toInstant();
+          Instant fiveMinutesFromNow = Instant.now().plusSeconds(300);
+          if ( expiresAt.isBefore(fiveMinutesFromNow) )
+            refreshAuth(x);
+        }
+
+        return getAccessToken();
       `
     }
   ]

--- a/src/foam/core/oauth/OAuthCredential.js
+++ b/src/foam/core/oauth/OAuthCredential.js
@@ -35,6 +35,11 @@ foam.CLASS({
       class: 'DateTime',
       name: 'expiresAt',
       documentation: 'Expiration time of the access token, as returned by the OAuth provider'
+    },
+    {
+      class: 'String',
+      name: 'sessionId',
+      documentation: 'Session ID associated with the OAuth token'
     }
   ],
   methods: [

--- a/src/foam/core/oauth/OAuthProvider.js
+++ b/src/foam/core/oauth/OAuthProvider.js
@@ -17,7 +17,9 @@ foam.CLASS({
     'java.security.PublicKey',
     'java.security.Signature',
     'java.security.spec.RSAPublicKeySpec',
+    'java.time.Instant',
     'java.util.Base64',
+    'java.util.Date',
     'java.util.Map',
     'java.util.concurrent.ConcurrentHashMap'
   ],
@@ -117,11 +119,8 @@ foam.CLASS({
     },
     {
       name: 'refreshAccessToken',
-      args: [
-        { name: 'x', type: "Context" },
-        { name: 'refreshToken', type: 'String' },
-      ],
-      type: 'String',
+      args: 'Context x, foam.core.oauth.OAuthCredential credential',
+      type: 'Void',
       throws: [ 'java.io.IOException' ],
       javaCode: `
 try {
@@ -130,6 +129,11 @@ java.net.HttpURLConnection connection = (java.net.HttpURLConnection) url.openCon
 connection.setRequestMethod("POST");
 connection.setDoOutput(true);
 connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+String refreshToken = credential.getRefreshToken();
+if ( refreshToken == null || refreshToken.isEmpty() ) {
+  throw new RuntimeException("No refresh token available");
+}
 
 // Prepare the request body
 String requestBody = String.join("&",
@@ -152,7 +156,18 @@ if (responseCode != 200) {
 java.io.InputStream is = connection.getInputStream();
 jakarta.json.JsonReader jsonReader = jakarta.json.Json.createReader(is);
 jakarta.json.JsonObject responseJson = jsonReader.readObject(); 
-return responseJson.getString("access_token");
+
+// Update oauth credential data
+credential.setAccessToken(responseJson.getString("access_token", null));
+if ( responseJson.containsKey("refresh_token") ) {
+  credential.setRefreshToken(responseJson.getString("refresh_token"));
+}
+
+if ( responseJson.containsKey("expires_in") ) {
+  int expiresIn = responseJson.getInt("expires_in");
+  Instant expiresAt = Instant.now().plusSeconds(expiresIn);
+  credential.setExpiresAt(Date.from(expiresAt));
+}
 } catch (Exception e) {
     throw new RuntimeException("Failed to refresh token", e);
 }

--- a/src/foam/core/oauth/OAuthWebAgent.java
+++ b/src/foam/core/oauth/OAuthWebAgent.java
@@ -1,6 +1,5 @@
 package foam.core.oauth;
 
-import foam.core.boot.Boot;
 import foam.core.auth.AuthenticationException;
 import foam.core.session.Session;
 import foam.lang.X;
@@ -14,6 +13,9 @@ import foam.core.logger.Logger;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+
+import java.time.Instant;
+import java.util.Date;
 
 // Generic OAuth Web Agent for handling oauth redirects
 // can be used for login and for storing oauth credentials for users
@@ -114,6 +116,13 @@ public class OAuthWebAgent implements WebAgent {
                 credential.setRefreshToken(refreshToken);
             }
             credential.setScopes(scopes);
+
+            // Handle expires_in if present
+            if ( tokenResponse.containsKey("expires_in") ) {
+                int expiresIn = tokenResponse.getInt("expires_in");
+                Instant expiresAt = Instant.now().plusSeconds(expiresIn);
+                credential.setExpiresAt(Date.from(expiresAt));
+            }
 
             oAuthCredentialsDAO.put(credential);
 

--- a/src/foam/core/oauth/OAuthWebAgent.java
+++ b/src/foam/core/oauth/OAuthWebAgent.java
@@ -109,6 +109,7 @@ public class OAuthWebAgent implements WebAgent {
             if (existingCredential != null) {
                 credential.copyFrom(existingCredential);
             }
+            credential.setSessionId(session.getId());
             credential.setUser(user.getId());
             credential.setProvider(provider.getId());
             credential.setAccessToken(accessToken);

--- a/src/foam/core/oauth/cronjobs.jrl
+++ b/src/foam/core/oauth/cronjobs.jrl
@@ -1,0 +1,59 @@
+p({
+  class: "foam.core.cron.Cron",
+  id: "OAuthTokenRefreshCron",
+  description: "Proactively refreshes OAuth access tokens before they expire. Iterates through oAuthCredentialDAO, finds matching sessions in sessionDAO, and triggers checkAndRefresh for tokens expiring within 5 minutes.",
+  enabled: false,
+  schedule: {
+    class: "foam.core.cron.IntervalSchedule",
+    duration: {
+      class: "foam.core.cron.TimeHMS",
+      minute: 5
+    }
+  },
+  code: """
+    import foam.dao.ArraySink;
+    import foam.dao.DAO;
+    import foam.core.oauth.OAuthCredential;
+    import foam.core.session.Session;
+    import foam.core.logger.Loggers;
+    import java.util.List;
+    
+    DAO oAuthCredentialDAO = (DAO) x.get("oAuthCredentialDAO");
+    DAO sessionDAO = (DAO) x.get("sessionDAO");
+    
+    List credentials = ((ArraySink) oAuthCredentialDAO.select(new ArraySink())).getArray();
+
+    int count = 0;
+    int refreshed = 0;
+    int errors = 0;
+    
+    for ( Object obj : credentials ) {
+      OAuthCredential cred = (OAuthCredential) obj;
+      count++;
+
+      try {
+        String sessionId = cred.getSessionId();
+        if (sessionId != null) {
+          Session session = (Session) sessionDAO.find(sessionId);
+          if ( session != null && (session.getUserId() == cred.getUser() || session.getAgentId() == cred.getUser()) ) {
+            cred = (OAuthCredential) cred.fclone();
+
+            String oldToken = cred.getAccessToken();
+            cred.checkAndRefresh(x);
+            if ( cred.getAccessToken() != null && ! cred.getAccessToken().equals(oldToken) ) {
+              oAuthCredentialDAO.put(cred);
+              refreshed++;
+            }
+          }
+        }
+      } catch ( Exception e ) {
+        errors++;
+        Loggers.logger(x).error(new Object[] {
+          "OAuthTokenRefreshCron: error refreshing OAuth credential for user " + cred.getUser(), e
+        });
+      }
+    }
+
+    print("OAuth Token Refresh: checked " + count + ", refreshed " + refreshed + ", errors " + errors);
+  """
+})

--- a/src/foam/core/session/cron/ExpireSessionsCron.java
+++ b/src/foam/core/session/cron/ExpireSessionsCron.java
@@ -8,6 +8,7 @@ import foam.core.logger.Logger;
 import java.util.List;
 import java.util.Date;
 import foam.core.session.Session;
+import foam.core.oauth.OAuthCredential;
 
 import static foam.mlang.MLang.*;
 
@@ -16,10 +17,15 @@ public class ExpireSessionsCron implements ContextAgent {
   private Logger logger;
   private DAO localSessionDAO;
 
+  // OAuth session TTL - 8 hours
+  protected int oauthSessionTtl = 28800000;
+
   @Override
   public void execute(X x) {
     logger = (Logger) x.get("logger");
     localSessionDAO = (DAO) x.get("localSessionDAO");
+
+    DAO oAuthCredentialDAO = (DAO) x.get("oAuthCredentialDAO");
     Date now = new Date();
 
     List<Session> expiredSessions = ((ArraySink) localSessionDAO.select(new ArraySink())).getArray();
@@ -40,6 +46,12 @@ public class ExpireSessionsCron implements ContextAgent {
       if ( session.getLastUsed().getTime() + session.getTtl() <= now.getTime() ) {
         logger.debug("Destroyed expired session : " + (String) session.getId());
         localSessionDAO.remove(session);
+      } else if ( session.getCreated().getTime() + oauthSessionTtl <= now.getTime() ) {
+        var oauthSession = oAuthCredentialDAO.find(EQ(OAuthCredential.SESSION_ID, session.getId()));
+        if ( oauthSession != null ) {
+          logger.debug("Destroyed long-running oauth session : " + (String) session.getId());
+          localSessionDAO.remove(session);
+        }
       }
     }
   }

--- a/src/foam/core/session/cron/ExpireSessionsCron.java
+++ b/src/foam/core/session/cron/ExpireSessionsCron.java
@@ -43,15 +43,14 @@ public class ExpireSessionsCron implements ContextAgent {
         session.setLastUsed(now);
       }
 
-      if ( session.getLastUsed().getTime() + session.getTtl() <= now.getTime() ) {
+      var oauthSession = (OAuthCredential) oAuthCredentialDAO.find(EQ(OAuthCredential.SESSION_ID, session.getId()));
+      if ( session.getLastUsed().getTime() + session.getTtl() <= now.getTime()
+          || ( oauthSession != null && oauthSession.getExpiresAt().getTime() <= now.getTime() ) ) {
         logger.debug("Destroyed expired session : " + (String) session.getId());
         localSessionDAO.remove(session);
-      } else if ( session.getCreated().getTime() + oauthSessionTtl <= now.getTime() ) {
-        var oauthSession = oAuthCredentialDAO.find(EQ(OAuthCredential.SESSION_ID, session.getId()));
-        if ( oauthSession != null ) {
-          logger.debug("Destroyed long-running oauth session : " + (String) session.getId());
-          localSessionDAO.remove(session);
-        }
+      } else if ( oauthSession != null && session.getCreated().getTime() + oauthSessionTtl <= now.getTime() ) {
+        logger.debug("Destroyed long-running oauth session : " + (String) session.getId());
+        localSessionDAO.remove(session);
       }
     }
   }


### PR DESCRIPTION
## Issues
OAuth sessions/tokens obtained from external Identity Provider (IdP) are short-lived in nature (usually 15 minutes); after user is authenticated and authorized we create a rolling session to allow for uninterrupted interactive access to the app beyonds the oauth session expiry. However the user might have been revoked access on the source IdP side.

## Changes
- Refresh OAuth access token proactively
- Remove session when OAuth session expired
- Remove OAuth sessions that have been active for more than 8 hours