### PR TITLE
Print individual client test results and report timeouts as failures

### DIFF
--- a/src/foam/core/test/TestBorder.js
+++ b/src/foam/core/test/TestBorder.js
@@ -160,9 +160,15 @@ foam.CLASS({
             if ( t.failed ) {
               self.failed += t.failed;
               if ( testRun ) {
-                // TODO: capture individual tests failures on the test,
-                // so they can be added here.
                 testRun.failures.push(t.id);
+                if ( t.output ) {
+                  var lines = t.output.split('\n');
+                  for ( var i = 0 ; i < lines.length ; i++ ) {
+                    if ( lines[i].startsWith('FAILURE') ) {
+                      testRun.failures.push(lines[i]);
+                    }
+                  }
+                }
               }
             }
           } catch (e) {

--- a/src/foam/core/test/TestRunnerScript.js
+++ b/src/foam/core/test/TestRunnerScript.js
@@ -213,6 +213,7 @@ This will also keep the foam application running for inspection from the GUI.
           exitCode = 1;
       }
       if ( clientTestRun != null ) {
+        reportClientTestDetails(x, clientTests);
         reportResults(x, clientTestRun, runTime);
         if (clientTestRun.getFailed() > 0 )
           exitCode = 1;
@@ -493,7 +494,31 @@ This will also keep the foam application running for inspection from the GUI.
       };
       agent.setHeadless( ! Boolean.getBoolean(SYSTEM_TEST_HEADED) );
       agent.execute(x);
-      return (TestRun) dao.find(testRun.getId());
+      TestRun result = (TestRun) dao.find(testRun.getId());
+      if ( ! result.getCompleted() ) {
+        result = (TestRun) result.fclone();
+        result.setCompleted(true);
+        result.setFailed(result.getFailed() + 1);
+        result.setTests(result.getTests() + 1);
+        List<String> failures = result.getFailures() != null ? new ArrayList<>((List<String>) result.getFailures()) : new ArrayList<>();
+        failures.add("FAILURE: Client tests timed out after " + agent.getTimeout() + " seconds. Tests may still be running in the browser.");
+        result.setFailures(failures);
+        result = (TestRun) dao.put(result);
+      }
+      return result;
+      `
+    },
+    {
+      name: 'reportClientTestDetails',
+      args: 'X x, List tests',
+      javaCode: `
+        DAO testDAO = (DAO) x.get("testDAO");
+        for ( Test test : (List<Test>) tests ) {
+          test = (Test) testDAO.find(test.getId());
+          if ( test == null ) continue;
+          printBold(test.getId());
+          printOutput(test);
+        }
       `
     },
     {


### PR DESCRIPTION
## Problem
Client-side tests only printed aggregate counts (PASSED: N, FAILED: N) without individual test names or assertion details. Server-side tests printed each test name with SUCCESS/FAILURE lines. When client tests timed out, the report showed TESTS: 0 with no indication of failure.

## Solution
Match client test output to server test behavior: print each test name and its SUCCESS/FAILURE lines after completion. Propagate actual failure messages from the browser to the server report. Detect browser timeouts and report them as explicit failures.

## Changes
- **TestBorder.js**: Push FAILURE output lines from each test into testRun.failures (previously only pushed test ID)
- **TestRunnerScript.js**: Add reportClientTestDetails() to print individual client test output matching server-side format
- **TestRunnerScript.js**: Detect incomplete TestRun after BrowserAgent timeout and record an explicit timeout failure