### PR TITLE
fix(UnitValue): convert minor units to float before formatting

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -907,7 +907,7 @@ foam.CLASS({
         if ( unitPropName ) {
           const unitProp = await x.currencyDAO.find(unitPropName);
           if ( unitProp )
-            return unitProp.format(val, excludeUnit, false);
+            return unitProp.format(unitProp.floatAmount(val), excludeUnit, false);
         }
         return val;
       }


### PR DESCRIPTION
## Problem
`UnitValue.unitPropValueToString` passes the raw Long value (minor units) directly to `Currency.format()`. The browser code path in `format()` uses `Intl.NumberFormat`, which treats the input as an actual decimal amount — not minor units. This causes `5040475` (MAD centimes) to display as `DH 5,040,475.00` instead of `DH 50,404.75`.

The non-browser fallback path in `Currency.format()` correctly splits the last `precision` digits as decimals, so the bug only manifests in browsers.

## Solution
Call `Currency.floatAmount(val)` before `format()` in `UnitValue.unitPropValueToString`. `floatAmount()` divides the Long by `10^precision`, converting minor units to the actual decimal value that `Intl.NumberFormat` expects.

`DoubleUnitValue` is unaffected — it stores actual decimal values and has its own `unitPropValueToString` that passes values directly to `format()` without conversion.

## Changes
- `src/foam/lang/types.js`: `UnitValue.unitPropValueToString` now calls `unitProp.floatAmount(val)` before `unitProp.format()`