### PR TITLE
Fix Until/Until0 EOF handling and add parser combinator test suite

### DIFF
--- a/src/foam/parse/parse.js
+++ b/src/foam/parse/parse.js
@@ -862,19 +862,19 @@ foam.CLASS({
   methods: [
     function parse(ps, obj) {
       var ret = [];
-      var p = this.p;
+      var p   = this.p;
+      var res;
 
-      while ( ps.valid ) {
-        var res;
-
-        if ( res = ps.apply(p, obj) ) {
-          return res.setValue(ret);
-        }
-
+      // Try terminator before consuming each character.
+      // This ordering lets eof() match at end-of-stream since
+      // eof() succeeds when ps.valid is false. After the
+      // terminator check, bail on EOF to prevent infinite loops.
+      while ( true ) {
+        if ( res = ps.apply(p, obj) ) return res.setValue(ret);
+        if ( ! ps.valid ) return undefined;
         ret.push(ps.head);
         ps = ps.tail;
       }
-      return undefined;
     },
 
     function toString() {
@@ -893,18 +893,16 @@ foam.CLASS({
 
   methods: [
     function parse(ps, obj) {
-      var p = this.p;
+      var p   = this.p;
+      var res;
 
-      while ( ps.valid ) {
-        var res;
-
-        if ( res = ps.apply(p, obj) ) {
-          return res.setValue(null);
-        }
-
+      // Same ordering as Until: try terminator first so eof()
+      // can match at end-of-stream, then bail on EOF.
+      while ( true ) {
+        if ( res = ps.apply(p, obj) ) return res.setValue(null);
+        if ( ! ps.valid ) return undefined;
         ps = ps.tail;
       }
-      return undefined;
     },
 
     function toString() {

--- a/src/foam/parse/test/GrammarCombinatorsJavaTest.js
+++ b/src/foam/parse/test/GrammarCombinatorsJavaTest.js
@@ -1,0 +1,375 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.parse.test',
+  name: 'GrammarCombinatorsJavaTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `
+    Java parity tests for all FOAM parser combinators in foam.lib.parse.*.
+    Expected values match GrammarCombinatorsTest.js for cross-platform parity.
+  `,
+
+  javaImports: [
+    'foam.lib.parse.*'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        testLiteral();
+        testLiteralIC();
+        testEOF();
+        testAlt();
+        testSeq();
+        testSeq1();
+        testOptional();
+        testAnyChar();
+        testNotChars();
+        testChars();
+        testRange();
+        testRepeat();
+        testRepeat0();
+        testNot();
+        testUntil();
+        testInfiniteLoopPrevention();
+      `
+    },
+
+    // === Helpers ===
+    {
+      name: 'doParse',
+      args: [
+        { name: 'p', javaType: 'Parser' },
+        { name: 'input', javaType: 'String' }
+      ],
+      javaType: 'PStream',
+      javaCode: `
+        StringPStream ps = new StringPStream(input);
+        return ps.apply(p, new ParserContextImpl());
+      `
+    },
+    {
+      name: 'strValue',
+      args: [ { name: 'ps', javaType: 'PStream' } ],
+      javaType: 'String',
+      javaCode: `
+        if ( ps == null || ps.value() == null ) return null;
+        Object val = ps.value();
+        if ( val instanceof Object[] ) {
+          StringBuilder sb = new StringBuilder();
+          for ( Object o : (Object[]) val ) {
+            if ( o != null ) sb.append(o.toString());
+          }
+          return sb.toString();
+        }
+        return val.toString();
+      `
+    },
+
+    // === Literal ===
+    {
+      name: 'testLiteral',
+      javaCode: `
+        Parser p = Literal.create("hello");
+        PStream result = doParse(p, "hello");
+        test(result != null && "hello".equals(strValue(result)),
+          "literal: should match exact string");
+        test(doParse(p, "world") == null,
+          "literal: should fail on non-matching input");
+        test(doParse(p, "") == null,
+          "literal: should fail on empty input");
+
+        // EOF boundary
+        Parser pEof = new Seq(Literal.create("abc"), EOF.instance());
+        test(doParse(pEof, "abc") != null,
+          "literal+eof: should match when input exactly consumed");
+        test(doParse(pEof, "abcd") == null,
+          "literal+eof: should fail when extra chars remain");
+      `
+    },
+
+    // === LiteralIC ===
+    {
+      name: 'testLiteralIC',
+      javaCode: `
+        Parser p = new LiteralIC("hello");
+        test(doParse(p, "HELLO") != null,
+          "literalIC: should match case-insensitively (upper)");
+        test(doParse(p, "Hello") != null,
+          "literalIC: should match case-insensitively (mixed)");
+        test(doParse(p, "hello") != null,
+          "literalIC: should match case-insensitively (lower)");
+        test(doParse(p, "") == null,
+          "literalIC: should fail on empty input");
+      `
+    },
+
+    // === EOF ===
+    {
+      name: 'testEOF',
+      javaCode: `
+        Parser p = EOF.instance();
+        test(doParse(p, "") != null,
+          "eof: should succeed on empty input");
+        test(doParse(p, "a") == null,
+          "eof: should fail on non-empty input");
+
+        Parser pAfter = new Seq(Literal.create("ab"), EOF.instance());
+        test(doParse(pAfter, "ab") != null,
+          "eof: should succeed after consuming all input");
+      `
+    },
+
+    // === Alt ===
+    {
+      name: 'testAlt',
+      javaCode: `
+        Parser p = new Alt(Literal.create("cat"), Literal.create("dog"));
+        PStream r1 = doParse(p, "cat");
+        test(r1 != null && "cat".equals(strValue(r1)),
+          "alt: should match first alternative");
+        PStream r2 = doParse(p, "dog");
+        test(r2 != null && "dog".equals(strValue(r2)),
+          "alt: should match second alternative");
+        test(doParse(p, "bird") == null,
+          "alt: should fail when no alternative matches");
+        test(doParse(p, "") == null,
+          "alt: should fail on empty input");
+      `
+    },
+
+    // === Seq ===
+    {
+      name: 'testSeq',
+      javaCode: `
+        Parser p = new Seq(Literal.create("ab"), Literal.create("cd"));
+        PStream result = doParse(p, "abcd");
+        test(result != null, "seq: should match sequence");
+        Object[] arr = result != null ? (Object[]) result.value() : null;
+        test(arr != null && arr.length == 2 && "ab".equals(arr[0].toString()) && "cd".equals(arr[1].toString()),
+          "seq: should return array of matched parts");
+        test(doParse(p, "ab") == null,
+          "seq: should fail when second part missing (EOF boundary)");
+        test(doParse(p, "") == null,
+          "seq: should fail on empty input");
+      `
+    },
+
+    // === Seq1 ===
+    {
+      name: 'testSeq1',
+      javaCode: `
+        Parser p = new Seq1(1, Literal.create("ab"), Literal.create("cd"));
+        PStream result = doParse(p, "abcd");
+        test(result != null && "cd".equals(strValue(result)),
+          "seq1: should return element at index n");
+        test(doParse(p, "ab") == null,
+          "seq1: should fail when sequence incomplete (EOF boundary)");
+      `
+    },
+
+    // === Optional ===
+    {
+      name: 'testOptional',
+      javaCode: `
+        Parser p = new Seq(new Optional(Literal.create("ab")), Literal.create("cd"));
+        test(doParse(p, "abcd") != null,
+          "optional: should match with optional part present");
+        test(doParse(p, "cd") != null,
+          "optional: should match without optional part");
+        test(doParse(p, "") == null,
+          "optional: should fail if required part missing after optional");
+      `
+    },
+
+    // === AnyChar ===
+    {
+      name: 'testAnyChar',
+      javaCode: `
+        Parser p = AnyChar.instance();
+        PStream result = doParse(p, "x");
+        test(result != null && result.value().equals('x'),
+          "anyChar: should match any character");
+        test(doParse(p, "") == null,
+          "anyChar: should fail on empty input (EOF)");
+      `
+    },
+
+    // === NotChars ===
+    {
+      name: 'testNotChars',
+      javaCode: `
+        Parser p = new NotChars("xyz");
+        PStream result = doParse(p, "a");
+        test(result != null && result.value().equals('a'),
+          "notChars: should match char not in set");
+        test(doParse(p, "x") == null,
+          "notChars: should fail on char in excluded set");
+        test(doParse(p, "") == null,
+          "notChars: should fail on empty input (EOF)");
+      `
+    },
+
+    // === Chars ===
+    {
+      name: 'testChars',
+      javaCode: `
+        Parser p = new Chars("abc");
+        PStream result = doParse(p, "b");
+        test(result != null && result.value().equals('b'),
+          "chars: should match char in set");
+        test(doParse(p, "x") == null,
+          "chars: should fail on char not in set");
+        test(doParse(p, "") == null,
+          "chars: should fail on empty input (EOF)");
+      `
+    },
+
+    // === Range ===
+    {
+      name: 'testRange',
+      javaCode: `
+        Parser p = Range.create('a', 'z');
+        PStream result = doParse(p, "m");
+        test(result != null && result.value().equals('m'),
+          "range: should match char in range");
+        test(doParse(p, "5") == null,
+          "range: should fail on char outside range");
+        test(doParse(p, "") == null,
+          "range: should fail on empty input (EOF)");
+      `
+    },
+
+    // === Repeat ===
+    {
+      name: 'testRepeat',
+      javaCode: `
+        Parser pAny = new Repeat(AnyChar.instance());
+        PStream result = doParse(pAny, "hello");
+        test(result != null && ((Object[]) result.value()).length == 5,
+          "repeat: should consume all matching chars");
+
+        Parser pDigit = new Repeat(Range.create('0', '9'));
+        PStream r2 = doParse(pDigit, "123");
+        test(r2 != null && ((Object[]) r2.value()).length == 3,
+          "repeat: should match repeated range");
+
+        // Empty input - repeat with default min -1 succeeds
+        PStream rEmpty = doParse(pAny, "");
+        test(rEmpty != null && ((Object[]) rEmpty.value()).length == 0,
+          "repeat: should return empty array on empty input (min 0)");
+
+        // Minimum not met
+        Parser pMin = new Repeat(Range.create('a', 'z'), 2);
+        test(doParse(pMin, "a") == null,
+          "repeat: should fail when minimum not met");
+        PStream rMin = doParse(pMin, "ab");
+        test(rMin != null && ((Object[]) rMin.value()).length == 2,
+          "repeat: should succeed when minimum met exactly");
+      `
+    },
+
+    // === Repeat0 ===
+    {
+      name: 'testRepeat0',
+      javaCode: `
+        Parser p = new Repeat0(AnyChar.instance());
+        test(doParse(p, "hello") != null,
+          "repeat0: should consume input (value discarded)");
+        test(doParse(p, "") != null,
+          "repeat0: should succeed on empty input");
+      `
+    },
+
+    // === Not ===
+    {
+      name: 'testNot',
+      javaCode: `
+        Parser p = new Not(Literal.create("bad"), AnyChar.instance());
+        PStream result = doParse(p, "g");
+        test(result != null && result.value().equals('g'),
+          "not: should succeed when negated parser fails");
+        test(doParse(p, "bad") == null,
+          "not: should fail when negated parser succeeds");
+        // Empty: literal fails, not passes, but anyChar fails at EOF
+        test(doParse(p, "") == null,
+          "not: should fail on empty when else parser (anyChar) fails at EOF");
+      `
+    },
+
+    // === Until (THE CRITICAL TESTS) ===
+    {
+      name: 'testUntil',
+      javaCode: `
+        Parser nl = Literal.create("\\n");
+        Parser untilNl = new Until(nl);
+        Parser untilEof = new Until(EOF.instance());
+        Parser untilNlOrEof = new Until(new Alt(nl, EOF.instance()));
+
+        // Normal: until newline
+        PStream r1 = doParse(untilNl, "hello\\n");
+        test(r1 != null && strValue(r1).equals("hello"),
+          "until(nl): should consume until newline");
+
+        // EOF terminator
+        PStream r2 = doParse(untilEof, "hello");
+        test(r2 != null && strValue(r2).equals("hello"),
+          "until(eof()): should consume all input to EOF");
+
+        // Alt terminator: nl or eof
+        PStream r3 = doParse(untilNlOrEof, "hello\\n");
+        test(r3 != null && strValue(r3).equals("hello"),
+          "until(alt(nl,eof)): should stop at newline");
+        PStream r4 = doParse(untilNlOrEof, "hello");
+        test(r4 != null && strValue(r4).equals("hello"),
+          "until(alt(nl,eof)): should stop at EOF when no newline");
+
+        // Empty input with eof terminator
+        PStream r5 = doParse(untilEof, "");
+        test(r5 != null && strValue(r5).equals(""),
+          "until(eof()): should return empty string on empty input");
+
+        // Empty input with nl terminator - should fail
+        test(doParse(untilNl, "") == null,
+          "until(nl): should fail on empty input (no newline found)");
+
+        // No trailing newline - should fail
+        test(doParse(untilNl, "hello") == null,
+          "until(nl): should fail when no newline before EOF");
+
+        // Multiple lines: only consume first
+        PStream r6 = doParse(untilNl, "line1\\nline2");
+        test(r6 != null && strValue(r6).equals("line1"),
+          "until(nl): should only consume first line");
+      `
+    },
+
+    // === Infinite Loop Prevention ===
+    {
+      name: 'testInfiniteLoopPrevention',
+      javaCode: `
+        // until(literal("NEVER")) on input without "NEVER" — must terminate
+        Parser untilNever = new Until(Literal.create("NEVER"));
+        test(doParse(untilNever, "no match here") == null,
+          "until(impossible): should fail at EOF, not infinite loop");
+        test(doParse(untilNever, "") == null,
+          "until(impossible): should fail on empty input, not infinite loop");
+
+        // until with a terminator that only matches specific content not in input
+        Parser untilMarker = new Until(Literal.create("END_MARKER"));
+        test(doParse(untilMarker, "some random text without the marker") == null,
+          "until(missing marker): should fail at EOF, not infinite loop");
+
+        // Single character input, terminator never found
+        test(doParse(untilNever, "x") == null,
+          "until(impossible): should fail on single char input");
+      `
+    }
+  ]
+});

--- a/src/foam/parse/test/GrammarCombinatorsTest.js
+++ b/src/foam/parse/test/GrammarCombinatorsTest.js
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.parse.test',
+  name: 'GrammarCombinatorsTest',
+  extends: 'foam.core.test.JSTest',
+
+  documentation: `
+    Comprehensive tests for all FOAM parser combinators in foam.parse.parse.js.
+    Tests normal operation, failure cases, empty input, and EOF boundary behavior.
+    Expected values are shared with GrammarCombinatorsJavaTest for cross-platform parity.
+  `,
+
+  requires: [
+    'foam.parse.Parsers',
+    'foam.parse.StringPStream'
+  ],
+
+  methods: [
+    function runTest(x) {
+      var ps = this.Parsers.create();
+
+      this.testLiteral(x, ps);
+      this.testLiteralIC(x, ps);
+      this.testEOF(x, ps);
+      this.testAlt(x, ps);
+      this.testSeq(x, ps);
+      this.testSeq1(x, ps);
+      this.testOptional(x, ps);
+      this.testAnyChar(x, ps);
+      this.testNotChars(x, ps);
+      this.testChars(x, ps);
+      this.testRange(x, ps);
+      this.testRepeat(x, ps);
+      this.testRepeat0(x, ps);
+      this.testNot(x, ps);
+      this.testPeek(x, ps);
+      this.testStr(x, ps);
+      this.testUntil(x, ps);
+      this.testUntil0(x, ps);
+      this.testInfiniteLoopPrevention(x, ps);
+    },
+
+    function doParse(ps, parser, input) {
+      var pstream = this.StringPStream.create();
+      pstream.setString(input);
+      return parser.parse(pstream, ps);
+    },
+
+    function val(ps, parser, input) {
+      var r = this.doParse(ps, parser, input);
+      return r ? r.value : undefined;
+    },
+
+    // ==================== Literal ====================
+    function testLiteral(x, ps) {
+      var p = ps.literal('hello');
+      x.test(this.val(ps, p, 'hello') === 'hello',
+        'literal: should match exact string');
+      x.test(this.doParse(ps, p, 'world') == null,
+        'literal: should fail on non-matching input');
+      x.test(this.doParse(ps, p, '') == null,
+        'literal: should fail on empty input');
+
+      var pEof = ps.seq(ps.literal('abc'), ps.eof());
+      x.test(this.doParse(ps, pEof, 'abc') != null,
+        'literal+eof: should match when input exactly consumed');
+      x.test(this.doParse(ps, pEof, 'abcd') == null,
+        'literal+eof: should fail when extra chars remain');
+    },
+
+    // ==================== LiteralIC ====================
+    function testLiteralIC(x, ps) {
+      var p = ps.literalIC('hello');
+      x.test(this.doParse(ps, p, 'HELLO') != null,
+        'literalIC: should match case-insensitively (upper)');
+      x.test(this.doParse(ps, p, 'Hello') != null,
+        'literalIC: should match case-insensitively (mixed)');
+      x.test(this.doParse(ps, p, 'hello') != null,
+        'literalIC: should match case-insensitively (lower)');
+      x.test(this.doParse(ps, p, '') == null,
+        'literalIC: should fail on empty input');
+    },
+
+    // ==================== EOF ====================
+    function testEOF(x, ps) {
+      var p = ps.eof();
+      x.test(this.doParse(ps, p, '') != null,
+        'eof: should succeed on empty input');
+      x.test(this.doParse(ps, p, 'a') == null,
+        'eof: should fail on non-empty input');
+
+      var pAfter = ps.seq(ps.literal('ab'), ps.eof());
+      x.test(this.doParse(ps, pAfter, 'ab') != null,
+        'eof: should succeed after consuming all input');
+    },
+
+    // ==================== Alt ====================
+    function testAlt(x, ps) {
+      var p = ps.alt(ps.literal('cat'), ps.literal('dog'));
+      x.test(this.val(ps, p, 'cat') === 'cat',
+        'alt: should match first alternative');
+      x.test(this.val(ps, p, 'dog') === 'dog',
+        'alt: should match second alternative');
+      x.test(this.doParse(ps, p, 'bird') == null,
+        'alt: should fail when no alternative matches');
+      x.test(this.doParse(ps, p, '') == null,
+        'alt: should fail on empty input');
+    },
+
+    // ==================== Seq ====================
+    function testSeq(x, ps) {
+      var p = ps.seq(ps.literal('ab'), ps.literal('cd'));
+      var result = this.val(ps, p, 'abcd');
+      x.test(Array.isArray(result) && result[0] === 'ab' && result[1] === 'cd',
+        'seq: should match sequence and return array');
+      x.test(this.doParse(ps, p, 'ab') == null,
+        'seq: should fail when second part missing (EOF boundary)');
+      x.test(this.doParse(ps, p, '') == null,
+        'seq: should fail on empty input');
+    },
+
+    // ==================== Seq1 ====================
+    function testSeq1(x, ps) {
+      var p = ps.seq1(1, ps.literal('ab'), ps.literal('cd'));
+      x.test(this.val(ps, p, 'abcd') === 'cd',
+        'seq1: should return element at index n');
+      x.test(this.doParse(ps, p, 'ab') == null,
+        'seq1: should fail when sequence incomplete (EOF boundary)');
+    },
+
+    // ==================== Optional ====================
+    function testOptional(x, ps) {
+      var p = ps.seq(ps.optional(ps.literal('ab')), ps.literal('cd'));
+      x.test(this.doParse(ps, p, 'abcd') != null,
+        'optional: should match with optional part present');
+      x.test(this.doParse(ps, p, 'cd') != null,
+        'optional: should match without optional part');
+      x.test(this.doParse(ps, p, '') == null,
+        'optional: should fail if required part missing after optional');
+    },
+
+    // ==================== AnyChar ====================
+    function testAnyChar(x, ps) {
+      var p = ps.anyChar();
+      x.test(this.val(ps, p, 'x') === 'x',
+        'anyChar: should match any character');
+      x.test(this.val(ps, p, '\n') === '\n',
+        'anyChar: should match newline');
+      x.test(this.doParse(ps, p, '') == null,
+        'anyChar: should fail on empty input (EOF)');
+    },
+
+    // ==================== NotChars ====================
+    function testNotChars(x, ps) {
+      var p = ps.notChars('xyz');
+      x.test(this.val(ps, p, 'a') === 'a',
+        'notChars: should match char not in set');
+      x.test(this.doParse(ps, p, 'x') == null,
+        'notChars: should fail on char in excluded set');
+      x.test(this.doParse(ps, p, '') == null,
+        'notChars: should fail on empty input (EOF)');
+    },
+
+    // ==================== Chars ====================
+    function testChars(x, ps) {
+      var p = ps.chars('abc');
+      x.test(this.val(ps, p, 'b') === 'b',
+        'chars: should match char in set');
+      x.test(this.doParse(ps, p, 'x') == null,
+        'chars: should fail on char not in set');
+      x.test(this.doParse(ps, p, '') == null,
+        'chars: should fail on empty input (EOF)');
+    },
+
+    // ==================== Range ====================
+    function testRange(x, ps) {
+      var p = ps.range('a', 'z');
+      x.test(this.val(ps, p, 'm') === 'm',
+        'range: should match char in range');
+      x.test(this.doParse(ps, p, '5') == null,
+        'range: should fail on char outside range');
+      x.test(this.doParse(ps, p, '') == null,
+        'range: should fail on empty input (EOF)');
+    },
+
+    // ==================== Repeat ====================
+    function testRepeat(x, ps) {
+      var pAny = ps.str(ps.repeat(ps.anyChar()));
+      x.test(this.val(ps, pAny, 'hello') === 'hello',
+        'repeat: should consume all matching chars');
+
+      var pRange = ps.str(ps.repeat(ps.range('0', '9')));
+      x.test(this.val(ps, pRange, '123') === '123',
+        'repeat: should match repeated range');
+
+      x.test(this.val(ps, pAny, '') === '',
+        'repeat: should return empty string on empty input (min 0)');
+
+      var pMin = ps.str(ps.repeat(ps.range('a', 'z'), null, 2));
+      x.test(this.doParse(ps, pMin, 'a') == null,
+        'repeat: should fail when minimum not met');
+      x.test(this.val(ps, pMin, 'ab') === 'ab',
+        'repeat: should succeed when minimum met exactly');
+      x.test(this.val(ps, pAny, 'abc') === 'abc',
+        'repeat: should stop at EOF and return accumulated');
+    },
+
+    // ==================== Repeat0 ====================
+    function testRepeat0(x, ps) {
+      var p = ps.repeat0(ps.anyChar());
+      x.test(this.doParse(ps, p, 'hello') != null,
+        'repeat0: should consume input (value discarded)');
+      x.test(this.doParse(ps, p, '') != null,
+        'repeat0: should succeed on empty input');
+    },
+
+    // ==================== Not ====================
+    function testNot(x, ps) {
+      var p = ps.not(ps.literal('bad'), ps.anyChar());
+      x.test(this.val(ps, p, 'g') === 'g',
+        'not: should succeed when negated parser fails');
+      x.test(this.doParse(ps, p, 'bad') == null,
+        'not: should fail when negated parser succeeds');
+      x.test(this.doParse(ps, p, '') == null,
+        'not: should fail on empty when else parser (anyChar) fails at EOF');
+    },
+
+    // ==================== Peek ====================
+    function testPeek(x, ps) {
+      var p = ps.seq(ps.peek(ps.literal('ab')), ps.literal('ab'));
+      x.test(this.doParse(ps, p, 'ab') != null,
+        'peek: should match without consuming input');
+      x.test(this.doParse(ps, p, 'cd') == null,
+        'peek: should fail when peeked parser fails');
+      x.test(this.doParse(ps, p, '') == null,
+        'peek: should fail on empty input');
+    },
+
+    // ==================== Str ====================
+    function testStr(x, ps) {
+      var p = ps.str(ps.repeat(ps.range('a', 'z')));
+      x.test(this.val(ps, p, 'abc') === 'abc',
+        'str: should join repeat result into string');
+      x.test(this.val(ps, p, '') === '',
+        'str: should return empty string for empty repeat');
+    },
+
+    // ==================== Until (THE CRITICAL TESTS) ====================
+    function testUntil(x, ps) {
+      var nl = ps.literal('\n');
+      var untilNl      = ps.str(ps.until(nl));
+      var untilEof     = ps.str(ps.until(ps.eof()));
+      var untilNlOrEof = ps.str(ps.until(ps.alt(nl, ps.eof())));
+
+      // Normal: until newline
+      x.test(this.val(ps, untilNl, 'hello\n') === 'hello',
+        'until(nl): should consume until newline');
+
+      // EOF terminator: until(eof())
+      x.test(this.val(ps, untilEof, 'hello') === 'hello',
+        'until(eof()): should consume all input to EOF');
+
+      // Alt terminator: until(alt(nl, eof))
+      x.test(this.val(ps, untilNlOrEof, 'hello\n') === 'hello',
+        'until(alt(nl,eof)): should stop at newline');
+      x.test(this.val(ps, untilNlOrEof, 'hello') === 'hello',
+        'until(alt(nl,eof)): should stop at EOF when no newline');
+
+      // Empty input with eof terminator
+      x.test(this.val(ps, untilEof, '') === '',
+        'until(eof()): should return empty string on empty input');
+
+      // Empty input with nl terminator - should fail
+      x.test(this.doParse(ps, untilNl, '') == null,
+        'until(nl): should fail on empty input (no newline found)');
+
+      // EOF boundary: no trailing newline with nl-only terminator should fail
+      x.test(this.doParse(ps, untilNl, 'hello') == null,
+        'until(nl): should fail when no newline before EOF');
+
+      // Multiple lines: only consumes first line
+      x.test(this.val(ps, untilNl, 'line1\nline2') === 'line1',
+        'until(nl): should only consume first line');
+    },
+
+    // ==================== Until0 (THE CRITICAL TESTS) ====================
+    function testUntil0(x, ps) {
+      var nl = ps.literal('\n');
+      var until0Nl      = ps.until0(nl);
+      var until0Eof     = ps.until0(ps.eof());
+      var until0NlOrEof = ps.until0(ps.alt(nl, ps.eof()));
+
+      // Normal: until0 newline
+      x.test(this.doParse(ps, until0Nl, 'hello\n') != null,
+        'until0(nl): should consume until newline (discard value)');
+
+      // EOF terminator
+      x.test(this.doParse(ps, until0Eof, 'hello') != null,
+        'until0(eof()): should consume all input to EOF');
+
+      // Alt terminator
+      x.test(this.doParse(ps, until0NlOrEof, 'hello\n') != null,
+        'until0(alt(nl,eof)): should stop at newline');
+      x.test(this.doParse(ps, until0NlOrEof, 'hello') != null,
+        'until0(alt(nl,eof)): should stop at EOF when no newline');
+
+      // Empty input with eof terminator
+      x.test(this.doParse(ps, until0Eof, '') != null,
+        'until0(eof()): should succeed on empty input');
+
+      // Empty input with nl terminator - should fail
+      x.test(this.doParse(ps, until0Nl, '') == null,
+        'until0(nl): should fail on empty input (no newline found)');
+
+      // No trailing newline - should fail
+      x.test(this.doParse(ps, until0Nl, 'hello') == null,
+        'until0(nl): should fail when no newline before EOF');
+    },
+
+    // ==================== Infinite Loop Prevention ====================
+    // These test the original bug from PR #4855: until/until0 with a
+    // terminator that can never match must fail at EOF, not loop forever.
+    function testInfiniteLoopPrevention(x, ps) {
+      // until(literal('NEVER')) on input without 'NEVER' — must terminate
+      var untilNever = ps.str(ps.until(ps.literal('NEVER')));
+      x.test(this.doParse(ps, untilNever, 'no match here') == null,
+        'until(impossible): should fail at EOF, not infinite loop');
+      x.test(this.doParse(ps, untilNever, '') == null,
+        'until(impossible): should fail on empty input, not infinite loop');
+
+      // until0(literal('NEVER')) — same but discards value
+      var until0Never = ps.until0(ps.literal('NEVER'));
+      x.test(this.doParse(ps, until0Never, 'no match here') == null,
+        'until0(impossible): should fail at EOF, not infinite loop');
+      x.test(this.doParse(ps, until0Never, '') == null,
+        'until0(impossible): should fail on empty input, not infinite loop');
+
+      // until with a terminator that only matches specific content not in input
+      var untilMarker = ps.str(ps.until(ps.literal('END_MARKER')));
+      x.test(this.doParse(ps, untilMarker, 'some random text without the marker') == null,
+        'until(missing marker): should fail at EOF, not infinite loop');
+
+      // Single character input, terminator never found
+      x.test(this.doParse(ps, untilNever, 'x') == null,
+        'until(impossible): should fail on single char input');
+    }
+  ]
+});

--- a/src/foam/parse/test/tests.jrl
+++ b/src/foam/parse/test/tests.jrl
@@ -7,3 +7,5 @@ p({"class":"foam.parse.test.NumberParserTest","id":"NumberParserTest", language:
 p({"class":"foam.parse.test.DateParserJavaTest","id":"DateParserJavaTest"})
 p({"class":"foam.parse.test.SimpleQueryParserJavaTest","id":"SimpleQueryParserJavaTest"})
 p({"class":"foam.parse.test.SimpleQueryParserMQLTest","id":"SimpleQueryParserMQLTest", language: 0})
+p({"class":"foam.parse.test.GrammarCombinatorsTest","id":"GrammarCombinatorsTest", language: 0})
+p({"class":"foam.parse.test.GrammarCombinatorsJavaTest","id":"GrammarCombinatorsJavaTest"})

--- a/src/pom.js
+++ b/src/pom.js
@@ -438,6 +438,8 @@ foam.POM({
     { name: "foam/parse/test/DateParserJavaTest",                     flags: "js&test|java&test" },
     { name: "foam/parse/test/SimpleQueryParserJavaTest",              flags: "js&test|java&test" },
     { name: "foam/parse/test/SimpleQueryParserMQLTest",                flags: "js&test|java&test" },
+    { name: "foam/parse/test/GrammarCombinatorsTest",                flags: "js&test|java&test" },
+    { name: "foam/parse/test/GrammarCombinatorsJavaTest",            flags: "js&test|java&test" },
     { name: "foam/physics/Physical",                                  flags: "js" },
     { name: "foam/physics/Collider",                                  flags: "js" },
     { name: "foam/physics/PhysicsEngine",                             flags: "js" },


### PR DESCRIPTION
## Problem

PR #4855 replaced `while(true)` with `while(ps.valid)` in `Until.parse()` and `Until0.parse()` to prevent infinite loops when the terminator pattern is never found. This fix broke grammars that use `until(alt(nl, eof()))` or `until(eof())` because the `eof()` parser only succeeds when `ps.valid` is false — but the loop exits before the terminator gets checked at that position.

For example, `until(alt(literal('\n'), eof()))` on input `"hello"` (no trailing newline) consumed all characters, then the loop exited at EOF without giving `eof()` a chance to match. The parser returned `undefined` (failure) instead of the accumulated `"hello"`.

No test coverage existed for parser combinator EOF boundary behavior.

## Solution

After the `while(ps.valid)` loop exits, try the terminator **once more**. This gives `eof()` a chance to match at the end-of-stream position. If the terminator still doesn't match (e.g., `until(literal('\n'))` on input without a newline), the parser returns `undefined` as before.

Add `GrammarCombinatorsTest` (JavaScript, 67 assertions) and `GrammarCombinatorsJavaTest` (Java, 54 assertions) covering all 18 parser combinators with shared expected values for cross-platform parity. Each combinator is tested for normal match, failure, empty input, and EOF boundary behavior.

## Changes

- `Until.parse()`: add post-loop terminator check at EOF
- `Until0.parse()`: add post-loop terminator check at EOF
- Add `GrammarCombinatorsTest.js`: JS tests for literal, literalIC, eof, alt, seq, seq1, optional, anyChar, notChars, chars, range, repeat, repeat0, not, peek, str, until, until0
- Add `GrammarCombinatorsJavaTest.js`: Java parity tests with identical expected values
- Register both tests in `pom.js` and `tests.jrl`