### PR TITLE
Add compact time support to all 2-digit-year date formats

### DIFF
--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -199,7 +199,9 @@ foam.CLASS({
         // Covers: MMDDYYYY, MM-DD-YYYY, MM/DD/YYYY with optional time
         mmddyyyy: alt(
           sym('mmddyyyycompact'),
-          sym('mmddyyyysep')
+          sym('mmddyyyysep'),
+          sym('mmddyysep'),
+          sym('mmddyycompact')
         ),
 
         // MMDDYYYY with separators and optional time
@@ -286,7 +288,21 @@ foam.CLASS({
         ),
 
         // YYMMDD compact: 6 digits with validated year, month (01-12), day (01-31)
-        yymmddcompact: str(seq(sym('year2'), sym('month2'), sym('day2'))),
+        // Supports optional time: YYMMDD HHMMSS, YYMMDD HH:MM:SS, or YYMMDD (date only)
+        yymmddcompact: alt(
+          seq(
+            str(seq(sym('year2'), sym('month2'), sym('day2'))),
+            sym('datetimesep'),
+            sym('hour2'), sym('minute2'), sym('second2')
+          ),
+          seq(
+            str(seq(sym('year2'), sym('month2'), sym('day2'))),
+            sym('datetimesep'),
+            sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
+            optional(sym('timezone'))
+          ),
+          str(seq(sym('year2'), sym('month2'), sym('day2')))
+        ),
 
         // MMDDYY - tries all variants (compact, separated)
         // Covers: MMDDYY, MM-DD-YY, MM/DD/YY with optional time
@@ -324,7 +340,21 @@ foam.CLASS({
         ),
 
         // MMDDYY compact: 6 digits with validated month (01-12), day (01-31), year
-        mmddyycompact: str(seq(sym('month2'), sym('day2'), sym('year2'))),
+        // Supports optional time: MMDDYY HHMMSS, MMDDYY HH:MM:SS, or MMDDYY (date only)
+        mmddyycompact: alt(
+          seq(
+            str(seq(sym('month2'), sym('day2'), sym('year2'))),
+            sym('datetimesep'),
+            sym('hour2'), sym('minute2'), sym('second2')
+          ),
+          seq(
+            str(seq(sym('month2'), sym('day2'), sym('year2'))),
+            sym('datetimesep'),
+            sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
+            optional(sym('timezone'))
+          ),
+          str(seq(sym('month2'), sym('day2'), sym('year2')))
+        ),
 
         // DDMMYYYY - NOT in main dateOrDatetime, accessible via opt_name only
         // Covers: DD-MM-YYYY, DD/MM/YYYY, DDMMYYYY, DD-MM-YY, DD/MM/YY, DDMMYY with optional time
@@ -415,7 +445,24 @@ foam.CLASS({
         ),
 
         // DDMMYY compact: 6 digits with validated day (01-31), month (01-12), year
-        ddmmyycompact: str(seq(sym('day2'), sym('month2'), sym('year2'))),
+        // Supports optional time: DDMMYY HHMMSS, DDMMYY HH:MM:SS, or DDMMYY (date only)
+        ddmmyycompact: alt(
+          // With space/T and compact time (HHMMSS - no colons)
+          seq(
+            str(seq(sym('day2'), sym('month2'), sym('year2'))),
+            sym('datetimesep'),
+            sym('hour2'), sym('minute2'), sym('second2')
+          ),
+          // With space/T and colon time (HH:MM:SS)
+          seq(
+            str(seq(sym('day2'), sym('month2'), sym('year2'))),
+            sym('datetimesep'),
+            sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
+            optional(sym('timezone'))
+          ),
+          // Date only
+          str(seq(sym('day2'), sym('month2'), sym('year2')))
+        ),
 
         // YYYYDDMM - NOT in main dateOrDatetime, accessible via opt_name only
         // Covers: YYYY-DD-MM, YYYY/DD/MM, YYYYDDMM, YY-DD-MM, YY/DD/MM, YYDDMM with optional time
@@ -511,7 +558,21 @@ foam.CLASS({
         ),
 
         // YYDDMM compact: 6 digits with validated year, day (01-31), month (01-12)
-        yyddmmcompact: str(seq(sym('year2'), sym('day2'), sym('month2'))),
+        // Supports optional time: YYDDMM HHMMSS, YYDDMM HH:MM:SS, or YYDDMM (date only)
+        yyddmmcompact: alt(
+          seq(
+            str(seq(sym('year2'), sym('day2'), sym('month2'))),
+            sym('datetimesep'),
+            sym('hour2'), sym('minute2'), sym('second2')
+          ),
+          seq(
+            str(seq(sym('year2'), sym('day2'), sym('month2'))),
+            sym('datetimesep'),
+            sym('hour2'), ':', sym('minute2'), optional(seq(':', sym('second2'))),
+            optional(sym('timezone'))
+          ),
+          str(seq(sym('year2'), sym('day2'), sym('month2')))
+        ),
 
         // YYYYDDMMM with separators: YYYY-DD-MMM, YYYY/DD/MMM
         // Supports single-digit days (e.g., 2025-5-JAN)

--- a/src/foam/parse/DateParser.java
+++ b/src/foam/parse/DateParser.java
@@ -553,6 +553,39 @@ public class DateParser {
   }
 
   /**
+   * Extracts time components from a compact date action's parsed value.
+   * Handles String (date-only), Object[] with compact time, and Object[] with colon time.
+   * Returns int[4]: {hour, minute, second, tzOffsetMinutes} where -1 means unset.
+   */
+  private Date buildCompactDate(DateParseMode mode, int year, int month, int day, Object val) {
+    if ( val instanceof String ) {
+      return buildDate(mode, year, month, day, -1, -1, -1, -1, null);
+    }
+    Object[] v = (Object[]) val;
+    if ( v.length <= 2 ) {
+      return buildDate(mode, year, month, day, -1, -1, -1, -1, null);
+    }
+    int hour, minute, second = -1;
+    String tz = null;
+    if ( v[3] != null && ! ":".equals(v[3]) ) {
+      // Compact time: [dateStr, sep, HH, MM, SS]
+      hour = Integer.parseInt((String) v[2]);
+      minute = Integer.parseInt((String) v[3]);
+      second = Integer.parseInt((String) v[4]);
+    } else {
+      // Colon time: [dateStr, sep, HH, :, MM, optional([:, SS]), ...]
+      hour = Integer.parseInt((String) v[2]);
+      minute = Integer.parseInt((String) v[4]);
+      if ( v.length > 5 && v[5] instanceof Object[] ) {
+        Object[] secPart = (Object[]) v[5];
+        second = Integer.parseInt((String) secPart[1]);
+      }
+      tz = extractTimezone(v);
+    }
+    return buildDate(mode, year, month, day, hour, minute, second, -1, tz);
+  }
+
+  /**
    * Parse fractional seconds string (1-6 digits) and convert to milliseconds (0-999).
    * Pads short strings with trailing zeros (e.g., "1" -> 100, "12" -> 120).
    * Truncates long strings to 3 digits (e.g., "123456" -> 123).
@@ -798,9 +831,21 @@ public class DateParser {
       )
     ));
 
-    // YYYYMMDD compact: 8 digits
-    grammar.addSymbol("yyyymmdd-compact", new Join(
-      new Seq(grammar.sym("year4_1900_2999"), grammar.sym("month2"), grammar.sym("day2"))
+    // YYYYMMDD compact: 8 digits with optional time
+    grammar.addSymbol("yyyymmdd-compact", new Alt(
+      new Seq(
+        new Join(new Seq(grammar.sym("year4_1900_2999"), grammar.sym("month2"), grammar.sym("day2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), grammar.sym("minute2"), grammar.sym("second2")
+      ),
+      new Seq(
+        new Join(new Seq(grammar.sym("year4_1900_2999"), grammar.sym("month2"), grammar.sym("day2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), Literal.create(":"), grammar.sym("minute2"),
+        new Optional(new Seq(Literal.create(":"), grammar.sym("second2"))),
+        new Optional(grammar.sym("timezone"))
+      ),
+      new Join(new Seq(grammar.sym("year4_1900_2999"), grammar.sym("month2"), grammar.sym("day2")))
     ));
 
     // YYYYMMDDHHMMSS compact: 14 digits
@@ -813,7 +858,9 @@ public class DateParser {
 
     grammar.addSymbol("mmddyyyy", new Alt(
       grammar.sym("mmddyyyy-compact"),
-      grammar.sym("mmddyyyy-sep")
+      grammar.sym("mmddyyyy-sep"),
+      grammar.sym("mmddyy-sep"),
+      grammar.sym("mmddyy-compact")
     ));
 
     // MMDDYYYY with separators - supports single-digit month/day (e.g., 7/2/2025)
@@ -899,8 +946,22 @@ public class DateParser {
       )
     ));
 
-    // MMDDYY compact: 6 digits with validated month (01-12), day (01-31), year
-    grammar.addSymbol("mmddyy-compact", new Join(new Seq(grammar.sym("month2"), grammar.sym("day2"), grammar.sym("year2"))));
+    // MMDDYY compact: 6 digits with optional time
+    grammar.addSymbol("mmddyy-compact", new Alt(
+      new Seq(
+        new Join(new Seq(grammar.sym("month2"), grammar.sym("day2"), grammar.sym("year2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), grammar.sym("minute2"), grammar.sym("second2")
+      ),
+      new Seq(
+        new Join(new Seq(grammar.sym("month2"), grammar.sym("day2"), grammar.sym("year2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), Literal.create(":"), grammar.sym("minute2"),
+        new Optional(new Seq(Literal.create(":"), grammar.sym("second2"))),
+        new Optional(grammar.sym("timezone"))
+      ),
+      new Join(new Seq(grammar.sym("month2"), grammar.sym("day2"), grammar.sym("year2")))
+    ));
 
     // ========== YYMMDD Formats ==========
 
@@ -937,8 +998,22 @@ public class DateParser {
       )
     ));
 
-    // YYMMDD compact: 6 digits with validated year, month (01-12), day (01-31)
-    grammar.addSymbol("yymmdd-compact", new Join(new Seq(grammar.sym("year2"), grammar.sym("month2"), grammar.sym("day2"))));
+    // YYMMDD compact: 6 digits with optional time
+    grammar.addSymbol("yymmdd-compact", new Alt(
+      new Seq(
+        new Join(new Seq(grammar.sym("year2"), grammar.sym("month2"), grammar.sym("day2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), grammar.sym("minute2"), grammar.sym("second2")
+      ),
+      new Seq(
+        new Join(new Seq(grammar.sym("year2"), grammar.sym("month2"), grammar.sym("day2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), Literal.create(":"), grammar.sym("minute2"),
+        new Optional(new Seq(Literal.create(":"), grammar.sym("second2"))),
+        new Optional(grammar.sym("timezone"))
+      ),
+      new Join(new Seq(grammar.sym("year2"), grammar.sym("month2"), grammar.sym("day2")))
+    ));
 
     // ========== DDMMYYYY Formats (via opt_name only) ==========
 
@@ -1025,8 +1100,25 @@ public class DateParser {
       )
     ));
 
-    // DDMMYY compact: 6 digits with validated day (01-31), month (01-12), year
-    grammar.addSymbol("ddmmyy-compact", new Join(new Seq(grammar.sym("day2"), grammar.sym("month2"), grammar.sym("year2"))));
+    // DDMMYY compact: 6 digits with optional time
+    grammar.addSymbol("ddmmyy-compact", new Alt(
+      // With space and compact time (HHMMSS - no colons)
+      new Seq(
+        new Join(new Seq(grammar.sym("day2"), grammar.sym("month2"), grammar.sym("year2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), grammar.sym("minute2"), grammar.sym("second2")
+      ),
+      // With space and time with colons
+      new Seq(
+        new Join(new Seq(grammar.sym("day2"), grammar.sym("month2"), grammar.sym("year2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), Literal.create(":"), grammar.sym("minute2"),
+        new Optional(new Seq(Literal.create(":"), grammar.sym("second2"))),
+        new Optional(grammar.sym("timezone"))
+      ),
+      // Date only
+      new Join(new Seq(grammar.sym("day2"), grammar.sym("month2"), grammar.sym("year2")))
+    ));
 
     // ========== YYYYDDMM Formats (via opt_name only) ==========
 
@@ -1118,7 +1210,22 @@ public class DateParser {
     ));
 
     // YYDDMM compact: 6 digits with validated year, day (01-31), month (01-12)
-    grammar.addSymbol("yyddmm-compact", new Join(new Seq(grammar.sym("year2"), grammar.sym("day2"), grammar.sym("month2"))));
+    // YYDDMM compact: 6 digits with optional time
+    grammar.addSymbol("yyddmm-compact", new Alt(
+      new Seq(
+        new Join(new Seq(grammar.sym("year2"), grammar.sym("day2"), grammar.sym("month2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), grammar.sym("minute2"), grammar.sym("second2")
+      ),
+      new Seq(
+        new Join(new Seq(grammar.sym("year2"), grammar.sym("day2"), grammar.sym("month2"))),
+        grammar.sym("datetimesep"),
+        grammar.sym("hour2"), Literal.create(":"), grammar.sym("minute2"),
+        new Optional(new Seq(Literal.create(":"), grammar.sym("second2"))),
+        new Optional(grammar.sym("timezone"))
+      ),
+      new Join(new Seq(grammar.sym("year2"), grammar.sym("day2"), grammar.sym("month2")))
+    ));
 
     // ========== Julian Date Formats ==========
 
@@ -1268,13 +1375,13 @@ public class DateParser {
 
     // YYYYMMDD-Compact action: "20250115"
     grammar.addAction("yyyymmdd-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      return self.buildDate(mode,
-        Integer.parseInt(v.substring(0, 4)),
-        Integer.parseInt(v.substring(4, 6)) - 1,
-        Integer.parseInt(v.substring(6, 8)),
-        -1, -1, -1, -1, null);
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      return self.buildCompactDate(mode,
+        Integer.parseInt(dateStr.substring(0, 4)),
+        Integer.parseInt(dateStr.substring(4, 6)) - 1,
+        Integer.parseInt(dateStr.substring(6, 8)),
+        val);
     });
 
     // YYYYMMDDHHMMSS-Compact action: [year, month, day, hour, minute, second]
@@ -1308,13 +1415,13 @@ public class DateParser {
 
     // MMDDYYYY-Compact action: "01152025"
     grammar.addAction("mmddyyyy-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      return self.buildDate(mode,
-        Integer.parseInt(v.substring(4, 8)),
-        Integer.parseInt(v.substring(0, 2)) - 1,
-        Integer.parseInt(v.substring(2, 4)),
-        -1, -1, -1, -1, null);
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      return self.buildCompactDate(mode,
+        Integer.parseInt(dateStr.substring(4, 8)),
+        Integer.parseInt(dateStr.substring(0, 2)) - 1,
+        Integer.parseInt(dateStr.substring(2, 4)),
+        val);
     });
 
     // YYMMDD-Sep action
@@ -1335,14 +1442,14 @@ public class DateParser {
 
     // YYMMDD-Compact action: "250115"
     grammar.addAction("yymmdd-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      int twoDigitYear = Integer.parseInt(v.substring(0, 2));
-      return self.buildDate(mode,
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      int twoDigitYear = Integer.parseInt(dateStr.substring(0, 2));
+      return self.buildCompactDate(mode,
         self.convertTwoDigitYear(twoDigitYear),
-        Integer.parseInt(v.substring(2, 4)) - 1,
-        Integer.parseInt(v.substring(4, 6)),
-        -1, -1, -1, -1, null);
+        Integer.parseInt(dateStr.substring(2, 4)) - 1,
+        Integer.parseInt(dateStr.substring(4, 6)),
+        val);
     });
 
     // DDMMYYYY-Sep action
@@ -1362,13 +1469,13 @@ public class DateParser {
 
     // DDMMYYYY-Compact action: "15012025"
     grammar.addAction("ddmmyyyy-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      return self.buildDate(mode,
-        Integer.parseInt(v.substring(4, 8)),
-        Integer.parseInt(v.substring(2, 4)) - 1,
-        Integer.parseInt(v.substring(0, 2)),
-        -1, -1, -1, -1, null);
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      return self.buildCompactDate(mode,
+        Integer.parseInt(dateStr.substring(4, 8)),
+        Integer.parseInt(dateStr.substring(2, 4)) - 1,
+        Integer.parseInt(dateStr.substring(0, 2)),
+        val);
     });
 
     // DDMMYY-Sep action
@@ -1387,16 +1494,16 @@ public class DateParser {
         self.extractTimezone(v));
     });
 
-    // DDMMYY-Compact action: "150125"
+    // DDMMYY-Compact action: "150125" or ["150125", sep, HH, MM, SS] or ["150125", sep, HH, :, MM, ...]
     grammar.addAction("ddmmyy-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      int twoDigitYear = Integer.parseInt(v.substring(4, 6));
-      return self.buildDate(mode,
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      int twoDigitYear = Integer.parseInt(dateStr.substring(4, 6));
+      return self.buildCompactDate(mode,
         self.convertTwoDigitYear(twoDigitYear),
-        Integer.parseInt(v.substring(2, 4)) - 1,
-        Integer.parseInt(v.substring(0, 2)),
-        -1, -1, -1, -1, null);
+        Integer.parseInt(dateStr.substring(2, 4)) - 1,
+        Integer.parseInt(dateStr.substring(0, 2)),
+        val);
     });
 
     // YYYYDDMM-Sep action
@@ -1416,13 +1523,13 @@ public class DateParser {
 
     // YYYYDDMM-Compact action: "20251501"
     grammar.addAction("yyyyddmm-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      return self.buildDate(mode,
-        Integer.parseInt(v.substring(0, 4)),
-        Integer.parseInt(v.substring(6, 8)) - 1,
-        Integer.parseInt(v.substring(4, 6)),
-        -1, -1, -1, -1, null);
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      return self.buildCompactDate(mode,
+        Integer.parseInt(dateStr.substring(0, 4)),
+        Integer.parseInt(dateStr.substring(6, 8)) - 1,
+        Integer.parseInt(dateStr.substring(4, 6)),
+        val);
     });
 
     // YYDDMM-Sep action
@@ -1443,14 +1550,14 @@ public class DateParser {
 
     // YYDDMM-Compact action: "251501"
     grammar.addAction("yyddmm-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      int twoDigitYear = Integer.parseInt(v.substring(0, 2));
-      return self.buildDate(mode,
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      int twoDigitYear = Integer.parseInt(dateStr.substring(0, 2));
+      return self.buildCompactDate(mode,
         self.convertTwoDigitYear(twoDigitYear),
-        Integer.parseInt(v.substring(4, 6)) - 1,
-        Integer.parseInt(v.substring(2, 4)),
-        -1, -1, -1, -1, null);
+        Integer.parseInt(dateStr.substring(4, 6)) - 1,
+        Integer.parseInt(dateStr.substring(2, 4)),
+        val);
     });
 
     // DDMMMYYYY-Sep action: [DD, sep, MMM, sep, YYYY]
@@ -1586,14 +1693,14 @@ public class DateParser {
 
     // MMDDYY-Compact action: "011525" (2-digit year)
     grammar.addAction("mmddyy-compact", (val, x) -> {
-      String v = (String) val;
       DateParseMode mode = (DateParseMode) x.get("dateParseMode");
-      int twoDigitYear = Integer.parseInt(v.substring(4, 6));
-      return self.buildDate(mode,
+      String dateStr = val instanceof String ? (String) val : (String) ((Object[]) val)[0];
+      int twoDigitYear = Integer.parseInt(dateStr.substring(4, 6));
+      return self.buildCompactDate(mode,
         self.convertTwoDigitYear(twoDigitYear),
-        Integer.parseInt(v.substring(0, 2)) - 1,
-        Integer.parseInt(v.substring(2, 4)),
-        -1, -1, -1, -1, null);
+        Integer.parseInt(dateStr.substring(0, 2)) - 1,
+        Integer.parseInt(dateStr.substring(2, 4)),
+        val);
     });
 
     // YYDDD Julian date action: "25216" (5 digits)

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -104,6 +104,28 @@ foam.CLASS({
       return value;
     },
 
+    /**
+     * Extracts time components from a compact date action's parsed value.
+     * Handles both compact time (HHMMSS) and colon time (HH:MM:SS) variants.
+     * @param {string|Array} v - Parsed value: string (date-only) or array (date + time)
+     * @returns {{ hour: number, minute: number, second: number, tz: string|null }}
+     */
+    function extractTimeFromCompact_(v) {
+      if ( ! Array.isArray(v) || v.length <= 2 ) {
+        return { hour: -1, minute: -1, second: -1, tz: null };
+      }
+      if ( v[3] && v[3] !== ':' ) {
+        // Compact time: [dateStr, sep, HH, MM, SS]
+        return { hour: parseInt(v[2]), minute: parseInt(v[3]), second: parseInt(v[4]), tz: null };
+      }
+      // Colon time: [dateStr, sep, HH, :, MM, optional([:, SS]), ...]
+      var second = -1;
+      if ( v[5] && Array.isArray(v[5]) ) {
+        second = parseInt(v[5][1]);
+      }
+      return { hour: parseInt(v[2]), minute: parseInt(v[4]), second: second, tz: this.extractTimezone(v) };
+    },
+
     function buildDate(mode, year, month, day, hour, minute, second, ms, tz) {
       var offset, utcTime;
       switch ( mode ) {
@@ -191,28 +213,12 @@ foam.CLASS({
     // v = "20250115" OR v = ["20250115", sep, HH, MM, SS] (compact time) OR v = ["20250115", sep, HH, :, MM, optional([:, SS]), optional(timezone)] (time with colons)
     function yyyymmddcompactAction(v) {
       var dateStr = typeof v === 'string' ? v : v[0];
-      var hour = -1, minute = -1, second = -1, tz = null;
-
-      if ( Array.isArray(v) && v.length > 2 ) {
-        if ( v[3] && v[3] !== ':' ) {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[3]);
-          second = parseInt(v[4]);
-        } else {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[4]);
-          if ( v[5] && Array.isArray(v[5]) ) {
-            second = parseInt(v[5][1]);
-          }
-          tz = this.extractTimezone(v);
-        }
-      }
-
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         parseInt(dateStr.substring(0, 4)),
         parseInt(dateStr.substring(4, 6)) - 1,
         parseInt(dateStr.substring(6, 8)),
-        hour, minute, second, -1, tz);
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // YYYYMMDDHHMMSS compact: 14 digits with time
@@ -255,28 +261,12 @@ foam.CLASS({
     // v = "01152025" OR v = ["01152025", sep, HH, MM, SS] (compact time) OR v = ["01152025", sep, HH, :, MM, optional([:, SS]), optional(timezone)] (time with colons)
     function mmddyyyycompactAction(v) {
       var dateStr = typeof v === 'string' ? v : v[0];
-      var hour = -1, minute = -1, second = -1, tz = null;
-
-      if ( Array.isArray(v) && v.length > 2 ) {
-        if ( v[3] && v[3] !== ':' ) {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[3]);
-          second = parseInt(v[4]);
-        } else {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[4]);
-          if ( v[5] && Array.isArray(v[5]) ) {
-            second = parseInt(v[5][1]);
-          }
-          tz = this.extractTimezone(v);
-        }
-      }
-
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         parseInt(dateStr.substring(4, 8)),
         parseInt(dateStr.substring(0, 2)) - 1,
         parseInt(dateStr.substring(2, 4)),
-        hour, minute, second, -1, tz);
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // YYMMDD with separators: YY-MM-DD, YY/MM/DD with optional time and timezone
@@ -306,12 +296,14 @@ foam.CLASS({
     // YYMMDD compact: 6 digits "250115"
     // v = "250115"
     function yymmddcompactAction(v) {
-      var twoDigitYear = parseInt(v.substring(0, 2));
+      var dateStr = typeof v === 'string' ? v : v[0];
+      var twoDigitYear = parseInt(dateStr.substring(0, 2));
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         this.convertTwoDigitYear(twoDigitYear),
-        parseInt(v.substring(2, 4)) - 1,
-        parseInt(v.substring(4, 6)),
-        -1, -1, -1, -1, null);
+        parseInt(dateStr.substring(2, 4)) - 1,
+        parseInt(dateStr.substring(4, 6)),
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // MMDDYY with separators: MM-DD-YY, MM/DD/YY with optional time
@@ -341,12 +333,14 @@ foam.CLASS({
     // MMDDYY compact: 6 digits "011525"
     // v = "011525"
     function mmddyycompactAction(v) {
-      var twoDigitYear = parseInt(v.substring(4, 6));
+      var dateStr = typeof v === 'string' ? v : v[0];
+      var twoDigitYear = parseInt(dateStr.substring(4, 6));
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         this.convertTwoDigitYear(twoDigitYear),
-        parseInt(v.substring(0, 2)) - 1,
-        parseInt(v.substring(2, 4)),
-        -1, -1, -1, -1, null);
+        parseInt(dateStr.substring(0, 2)) - 1,
+        parseInt(dateStr.substring(2, 4)),
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // DDMMYYYY with separators: DD-MM-YYYY, DD/MM/YYYY with optional time
@@ -376,28 +370,12 @@ foam.CLASS({
     // v = "15012025" OR v = ["15012025", sep, HH, MM, SS] (compact time) OR v = ["15012025", sep, HH, :, MM, optional([:, SS]), optional(timezone)] (time with colons)
     function ddmmyyyycompactAction(v) {
       var dateStr = typeof v === 'string' ? v : v[0];
-      var hour = -1, minute = -1, second = -1, tz = null;
-
-      if ( Array.isArray(v) && v.length > 2 ) {
-        if ( v[3] && v[3] !== ':' ) {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[3]);
-          second = parseInt(v[4]);
-        } else {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[4]);
-          if ( v[5] && Array.isArray(v[5]) ) {
-            second = parseInt(v[5][1]);
-          }
-          tz = this.extractTimezone(v);
-        }
-      }
-
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         parseInt(dateStr.substring(4, 8)),
         parseInt(dateStr.substring(2, 4)) - 1,
         parseInt(dateStr.substring(0, 2)),
-        hour, minute, second, -1, tz);
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // DDMMYY with separators: DD-MM-YY, DD/MM/YY with optional time
@@ -424,15 +402,17 @@ foam.CLASS({
         this.extractTimezone(v));
     },
 
-    // DDMMYY compact: 6 digits "150125"
-    // v = "150125"
+    // DDMMYY compact: 6 digits "150125" or "150125 143045" or "150125 14:30:45"
+    // v = "150125" (string) or ["150125", sep, HH, MM, SS] or ["150125", sep, HH, :, MM, ...]
     function ddmmyycompactAction(v) {
-      var twoDigitYear = parseInt(v.substring(4, 6));
+      var dateStr = typeof v === 'string' ? v : v[0];
+      var twoDigitYear = parseInt(dateStr.substring(4, 6));
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         this.convertTwoDigitYear(twoDigitYear),
-        parseInt(v.substring(2, 4)) - 1,
-        parseInt(v.substring(0, 2)),
-        -1, -1, -1, -1, null);
+        parseInt(dateStr.substring(2, 4)) - 1,
+        parseInt(dateStr.substring(0, 2)),
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // YYYYDDMM with separators: YYYY-DD-MM, YYYY/DD/MM with optional time
@@ -462,28 +442,12 @@ foam.CLASS({
     // v = "20251501" OR v = ["20251501", sep, HH, MM, SS] (compact time) OR v = ["20251501", sep, HH, :, MM, optional([:, SS]), optional(timezone)] (time with colons)
     function yyyyddmmcompactAction(v) {
       var dateStr = typeof v === 'string' ? v : v[0];
-      var hour = -1, minute = -1, second = -1, tz = null;
-
-      if ( Array.isArray(v) && v.length > 2 ) {
-        if ( v[3] && v[3] !== ':' ) {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[3]);
-          second = parseInt(v[4]);
-        } else {
-          hour = parseInt(v[2]);
-          minute = parseInt(v[4]);
-          if ( v[5] && Array.isArray(v[5]) ) {
-            second = parseInt(v[5][1]);
-          }
-          tz = this.extractTimezone(v);
-        }
-      }
-
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         parseInt(dateStr.substring(0, 4)),
         parseInt(dateStr.substring(6, 8)) - 1,
         parseInt(dateStr.substring(4, 6)),
-        hour, minute, second, -1, tz);
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // YYDDMM with separators: YY-DD-MM, YY/DD/MM with optional time
@@ -513,12 +477,14 @@ foam.CLASS({
     // YYDDMM compact: 6 digits "251501"
     // v = "251501"
     function yyddmmcompactAction(v) {
-      var twoDigitYear = parseInt(v.substring(0, 2));
+      var dateStr = typeof v === 'string' ? v : v[0];
+      var twoDigitYear = parseInt(dateStr.substring(0, 2));
+      var t = this.extractTimeFromCompact_(v);
       return this.buildDate(this.dateParseMode,
         this.convertTwoDigitYear(twoDigitYear),
-        parseInt(v.substring(4, 6)) - 1,
-        parseInt(v.substring(2, 4)),
-        -1, -1, -1, -1, null);
+        parseInt(dateStr.substring(4, 6)) - 1,
+        parseInt(dateStr.substring(2, 4)),
+        t.hour, t.minute, t.second, -1, t.tz);
     },
 
     // DDMMMYYYY with separators: DD-MMM-YYYY, DD/MMM/YYYY

--- a/src/foam/parse/parse.js
+++ b/src/foam/parse/parse.js
@@ -862,18 +862,18 @@ foam.CLASS({
   methods: [
     function parse(ps, obj) {
       var ret = [];
-      var p = this.p;
+      var p   = this.p;
+      var res;
 
       while ( ps.valid ) {
-        var res;
-
-        if ( res = ps.apply(p, obj) ) {
-          return res.setValue(ret);
-        }
-
+        if ( res = ps.apply(p, obj) ) return res.setValue(ret);
         ret.push(ps.head);
         ps = ps.tail;
       }
+
+      // Try terminator once more at EOF (allows eof() to match)
+      if ( res = ps.apply(p, obj) ) return res.setValue(ret);
+
       return undefined;
     },
 
@@ -893,17 +893,17 @@ foam.CLASS({
 
   methods: [
     function parse(ps, obj) {
-      var p = this.p;
+      var p   = this.p;
+      var res;
 
       while ( ps.valid ) {
-        var res;
-
-        if ( res = ps.apply(p, obj) ) {
-          return res.setValue(null);
-        }
-
+        if ( res = ps.apply(p, obj) ) return res.setValue(null);
         ps = ps.tail;
       }
+
+      // Try terminator once more at EOF (allows eof() to match)
+      if ( res = ps.apply(p, obj) ) return res.setValue(null);
+
       return undefined;
     },
 

--- a/src/foam/parse/test/DateParserJavaTest.js
+++ b/src/foam/parse/test/DateParserJavaTest.js
@@ -90,6 +90,12 @@ foam.CLASS({
 
         // Julian Date Format Tests
         DateParserTest_JulianDate();
+
+        // 2-Digit Year Compact Time Tests
+        DateParserTest_DDMMYY_CompactTime();
+        DateParserTest_MMDDYY_CompactTime();
+        DateParserTest_YYMMDD_CompactTime();
+        DateParserTest_YYDDMM_CompactTime();
       `
     },
 
@@ -1416,6 +1422,132 @@ foam.CLASS({
         test(cal12.get(Calendar.YEAR) == expectedYear5, "juliandate 5216 (4-digit): year " + expectedYear5);
         test(cal12.get(Calendar.MONTH) == 7, "juliandate 5216 (4-digit): month 7 (Aug)");
         test(cal12.get(Calendar.DAY_OF_MONTH) == 4, "juliandate 5216 (4-digit): day 4");
+      `
+    },
+
+    // ========== 2-Digit Year Compact Time Tests ==========
+
+    {
+      name: 'DateParserTest_DDMMYY_CompactTime',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // Test compact time: 010925 143025 (DD=01, MM=09, YY=25, HH=14, MM=30, SS=25)
+        Date date1 = parser.parseDateTime("010925 143025", "ddmmyyyy");
+        Calendar cal1 = Calendar.getInstance();
+        cal1.setTime(date1);
+        test(cal1.get(Calendar.YEAR) == 2025, "DDMMYY compact time: year 2025");
+        test(cal1.get(Calendar.MONTH) == 8, "DDMMYY compact time: month 8 (Sep)");
+        test(cal1.get(Calendar.DAY_OF_MONTH) == 1, "DDMMYY compact time: day 1");
+        test(cal1.get(Calendar.HOUR_OF_DAY) == 14, "DDMMYY compact time: hour 14");
+        test(cal1.get(Calendar.MINUTE) == 30, "DDMMYY compact time: minute 30");
+        test(cal1.get(Calendar.SECOND) == 25, "DDMMYY compact time: second 25");
+
+        // Test colon-separated time: 010925 14:30:25
+        Date date2 = parser.parseDateTime("010925 14:30:25", "ddmmyyyy");
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTime(date2);
+        test(cal2.get(Calendar.YEAR) == 2025, "DDMMYY colon time: year 2025");
+        test(cal2.get(Calendar.MONTH) == 8, "DDMMYY colon time: month 8 (Sep)");
+        test(cal2.get(Calendar.DAY_OF_MONTH) == 1, "DDMMYY colon time: day 1");
+        test(cal2.get(Calendar.HOUR_OF_DAY) == 14, "DDMMYY colon time: hour 14");
+        test(cal2.get(Calendar.MINUTE) == 30, "DDMMYY colon time: minute 30");
+        test(cal2.get(Calendar.SECOND) == 25, "DDMMYY colon time: second 25");
+
+        // Test date-only backward compat: 010925
+        Date date3 = parser.parseString("010925", "ddmmyyyy");
+        Calendar cal3 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal3.setTime(date3);
+        test(cal3.get(Calendar.YEAR) == 2025, "DDMMYY date-only: year 2025");
+        test(cal3.get(Calendar.MONTH) == 8, "DDMMYY date-only: month 8 (Sep)");
+        test(cal3.get(Calendar.DAY_OF_MONTH) == 1, "DDMMYY date-only: day 1");
+      `
+    },
+
+    {
+      name: 'DateParserTest_MMDDYY_CompactTime',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // Test compact time: 090125 143025 (MM=09, DD=01, YY=25, HH=14, MM=30, SS=25)
+        Date date1 = parser.parseDateTime("090125 143025", "mmddyyyy");
+        Calendar cal1 = Calendar.getInstance();
+        cal1.setTime(date1);
+        test(cal1.get(Calendar.YEAR) == 2025, "MMDDYY compact time: year 2025");
+        test(cal1.get(Calendar.MONTH) == 8, "MMDDYY compact time: month 8 (Sep)");
+        test(cal1.get(Calendar.DAY_OF_MONTH) == 1, "MMDDYY compact time: day 1");
+        test(cal1.get(Calendar.HOUR_OF_DAY) == 14, "MMDDYY compact time: hour 14");
+        test(cal1.get(Calendar.MINUTE) == 30, "MMDDYY compact time: minute 30");
+        test(cal1.get(Calendar.SECOND) == 25, "MMDDYY compact time: second 25");
+
+        // Test colon-separated time: 090125 14:30:25
+        Date date2 = parser.parseDateTime("090125 14:30:25", "mmddyyyy");
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTime(date2);
+        test(cal2.get(Calendar.YEAR) == 2025, "MMDDYY colon time: year 2025");
+        test(cal2.get(Calendar.MONTH) == 8, "MMDDYY colon time: month 8 (Sep)");
+        test(cal2.get(Calendar.DAY_OF_MONTH) == 1, "MMDDYY colon time: day 1");
+        test(cal2.get(Calendar.HOUR_OF_DAY) == 14, "MMDDYY colon time: hour 14");
+        test(cal2.get(Calendar.MINUTE) == 30, "MMDDYY colon time: minute 30");
+        test(cal2.get(Calendar.SECOND) == 25, "MMDDYY colon time: second 25");
+      `
+    },
+
+    {
+      name: 'DateParserTest_YYMMDD_CompactTime',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // Test compact time: 250901 143025 (YY=25, MM=09, DD=01, HH=14, MM=30, SS=25)
+        Date date1 = parser.parseDateTime("250901 143025", "yymmdd");
+        Calendar cal1 = Calendar.getInstance();
+        cal1.setTime(date1);
+        test(cal1.get(Calendar.YEAR) == 2025, "YYMMDD compact time: year 2025");
+        test(cal1.get(Calendar.MONTH) == 8, "YYMMDD compact time: month 8 (Sep)");
+        test(cal1.get(Calendar.DAY_OF_MONTH) == 1, "YYMMDD compact time: day 1");
+        test(cal1.get(Calendar.HOUR_OF_DAY) == 14, "YYMMDD compact time: hour 14");
+        test(cal1.get(Calendar.MINUTE) == 30, "YYMMDD compact time: minute 30");
+        test(cal1.get(Calendar.SECOND) == 25, "YYMMDD compact time: second 25");
+
+        // Test colon-separated time: 250901 14:30:25
+        Date date2 = parser.parseDateTime("250901 14:30:25", "yymmdd");
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTime(date2);
+        test(cal2.get(Calendar.YEAR) == 2025, "YYMMDD colon time: year 2025");
+        test(cal2.get(Calendar.MONTH) == 8, "YYMMDD colon time: month 8 (Sep)");
+        test(cal2.get(Calendar.DAY_OF_MONTH) == 1, "YYMMDD colon time: day 1");
+        test(cal2.get(Calendar.HOUR_OF_DAY) == 14, "YYMMDD colon time: hour 14");
+        test(cal2.get(Calendar.MINUTE) == 30, "YYMMDD colon time: minute 30");
+        test(cal2.get(Calendar.SECOND) == 25, "YYMMDD colon time: second 25");
+      `
+    },
+
+    {
+      name: 'DateParserTest_YYDDMM_CompactTime',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // Test compact time: 250109 143025 (YY=25, DD=01, MM=09, HH=14, MM=30, SS=25)
+        Date date1 = parser.parseDateTime("250109 143025", "yyyyddmm");
+        Calendar cal1 = Calendar.getInstance();
+        cal1.setTime(date1);
+        test(cal1.get(Calendar.YEAR) == 2025, "YYDDMM compact time: year 2025");
+        test(cal1.get(Calendar.MONTH) == 8, "YYDDMM compact time: month 8 (Sep)");
+        test(cal1.get(Calendar.DAY_OF_MONTH) == 1, "YYDDMM compact time: day 1");
+        test(cal1.get(Calendar.HOUR_OF_DAY) == 14, "YYDDMM compact time: hour 14");
+        test(cal1.get(Calendar.MINUTE) == 30, "YYDDMM compact time: minute 30");
+        test(cal1.get(Calendar.SECOND) == 25, "YYDDMM compact time: second 25");
+
+        // Test colon-separated time: 250109 14:30:25
+        Date date2 = parser.parseDateTime("250109 14:30:25", "yyyyddmm");
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTime(date2);
+        test(cal2.get(Calendar.YEAR) == 2025, "YYDDMM colon time: year 2025");
+        test(cal2.get(Calendar.MONTH) == 8, "YYDDMM colon time: month 8 (Sep)");
+        test(cal2.get(Calendar.DAY_OF_MONTH) == 1, "YYDDMM colon time: day 1");
+        test(cal2.get(Calendar.HOUR_OF_DAY) == 14, "YYDDMM colon time: hour 14");
+        test(cal2.get(Calendar.MINUTE) == 30, "YYDDMM colon time: minute 30");
+        test(cal2.get(Calendar.SECOND) == 25, "YYDDMM colon time: second 25");
       `
     }
   ]

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -163,6 +163,41 @@ foam.CLASS({
         }
         x.test(result.pass, testName);
       });
+
+      // Test YYMMDD compact with compact time (HHMMSS) - requires opt_name='yymmdd'
+      let yymmddCompactTime = [
+        { input: '250901 143025', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 },
+        { input: '991231 235959', year: 1999, month: 11, day: 31, hour: 23, minute: 59, second: 59 },
+        { input: '250901 14:30:25', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 }
+      ];
+
+      yymmddCompactTime.forEach((testCase, i) => {
+        let result = this.testParseDTWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second, 0, 'yymmdd');
+        let testName = `YYMMDD-CompactTime Test${i + 1}: ${testCase.input} (opt_name='yymmdd')`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // Test YYMMDD compact date-only backward compatibility
+      let yymmddCompactBackcompat = [
+        { input: '250901', year: 2025, month: 8, day: 1 }
+      ];
+
+      yymmddCompactBackcompat.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'yymmdd');
+          let pass = result &&
+                     result.getUTCFullYear() === testCase.year &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === testCase.day &&
+                     result.getUTCHours() === 12;
+          x.test(pass, `YYMMDD-Compact-Backcompat Test${i + 1}: ${testCase.input}`);
+        } catch (e) {
+          x.test(false, `YYMMDD-Compact-Backcompat Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
+      });
     },
 
     function testMMDDYYYYFormats(x) {
@@ -341,6 +376,41 @@ foam.CLASS({
         }
         x.test(result.pass, testName);
       });
+
+      // Test MMDDYY compact with compact time (HHMMSS) - requires opt_name='mmddyyyy'
+      let mmddyyCompactTime = [
+        { input: '090125 143025', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 },
+        { input: '123199 235959', year: 1999, month: 11, day: 31, hour: 23, minute: 59, second: 59 },
+        { input: '090125 14:30:25', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 }
+      ];
+
+      mmddyyCompactTime.forEach((testCase, i) => {
+        let result = this.testParseDTWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second, 0, 'mmddyyyy');
+        let testName = `MMDDYY-CompactTime Test${i + 1}: ${testCase.input} (opt_name='mmddyyyy')`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // Test MMDDYY compact date-only backward compatibility
+      let mmddyyCompactBackcompat = [
+        { input: '090125', year: 2025, month: 8, day: 1 }
+      ];
+
+      mmddyyCompactBackcompat.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'mmddyyyy');
+          let pass = result &&
+                     result.getUTCFullYear() === testCase.year &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === testCase.day &&
+                     result.getUTCHours() === 12;
+          x.test(pass, `MMDDYY-Compact-Backcompat Test${i + 1}: ${testCase.input}`);
+        } catch (e) {
+          x.test(false, `MMDDYY-Compact-Backcompat Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
+      });
     },
 
     function testDDMMYYYYFormats(x) {
@@ -517,6 +587,44 @@ foam.CLASS({
           testName += ` - ${result.message}`;
         }
         x.test(result.pass, testName);
+      });
+
+      // Test DDMMYY compact with compact time (HHMMSS) - requires opt_name='ddmmyyyy'
+      let ddmmyyCompactTime = [
+        { input: '010925 143025', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 },
+        { input: '311299 235959', year: 1999, month: 11, day: 31, hour: 23, minute: 59, second: 59 },
+        { input: '010925 14:30:25', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 },
+        { input: '150125 08:00', year: 2025, month: 0, day: 15, hour: 8, minute: 0, second: 0 }
+      ];
+
+      ddmmyyCompactTime.forEach((testCase, i) => {
+        let result = this.testParseDTWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second, 0, 'ddmmyyyy');
+        let testName = `DDMMYY-CompactTime Test${i + 1}: ${testCase.input} (opt_name='ddmmyyyy')`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // Test DDMMYY compact date-only backward compatibility
+      let ddmmyyCompactBackcompat = [
+        { input: '010925', year: 2025, month: 8, day: 1 },
+        { input: '150149', year: 2049, month: 0, day: 15 },
+        { input: '311250', year: 1950, month: 11, day: 31 }
+      ];
+
+      ddmmyyCompactBackcompat.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'ddmmyyyy');
+          let pass = result &&
+                     result.getUTCFullYear() === testCase.year &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === testCase.day &&
+                     result.getUTCHours() === 12;
+          x.test(pass, `DDMMYY-Compact-Backcompat Test${i + 1}: ${testCase.input}`);
+        } catch (e) {
+          x.test(false, `DDMMYY-Compact-Backcompat Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
       });
 
       // Test DDMMYYYY with fractional seconds (milliseconds and microseconds)
@@ -773,6 +881,41 @@ foam.CLASS({
           testName += ` - Expected ms:${testCase.millisecond}, Got ms:${result.getMilliseconds()}`;
         }
         x.test(pass, testName);
+      });
+
+      // Test YYDDMM compact with compact time (HHMMSS) - requires opt_name='yyyyddmm'
+      let yyddmmCompactTime = [
+        { input: '250109 143025', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 },
+        { input: '993112 235959', year: 1999, month: 11, day: 31, hour: 23, minute: 59, second: 59 },
+        { input: '250109 14:30:25', year: 2025, month: 8, day: 1, hour: 14, minute: 30, second: 25 }
+      ];
+
+      yyddmmCompactTime.forEach((testCase, i) => {
+        let result = this.testParseDTWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second, 0, 'yyyyddmm');
+        let testName = `YYDDMM-CompactTime Test${i + 1}: ${testCase.input} (opt_name='yyyyddmm')`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // Test YYDDMM compact date-only backward compatibility
+      let yyddmmCompactBackcompat = [
+        { input: '250109', year: 2025, month: 8, day: 1 }
+      ];
+
+      yyddmmCompactBackcompat.forEach((testCase, i) => {
+        try {
+          let result = parser.parseString(testCase.input, 'yyyyddmm');
+          let pass = result &&
+                     result.getUTCFullYear() === testCase.year &&
+                     result.getUTCMonth() === testCase.month &&
+                     result.getUTCDate() === testCase.day &&
+                     result.getUTCHours() === 12;
+          x.test(pass, `YYDDMM-Compact-Backcompat Test${i + 1}: ${testCase.input}`);
+        } catch (e) {
+          x.test(false, `YYDDMM-Compact-Backcompat Test${i + 1}: ${testCase.input} - ${e.message}`);
+        }
       });
     },
 
@@ -1733,7 +1876,7 @@ foam.CLASS({
         let isMaxDate = result.getTime() === foam.Date.MAX_DATE.getTime();
         if ( isMaxDate ) {
           let msg = `Parse returned MAX_DATE (invalid) - format didn't match or was partially parsed`;
-          console.error(`${msg} for ${dateStr} with opt_name=${actualOptName}`);
+          console.error(`${msg} for ${dateStr} with opt_name=${opt_name}`);
           return { pass: false, message: msg };
         }
 
@@ -1753,7 +1896,7 @@ foam.CLASS({
           let expected = `${expectedYear}-${String(expectedMonth + 1).padStart(2, '0')}-${String(expectedDay).padStart(2, '0')} ${String(expectedHour).padStart(2, '0')}:${String(expectedMinute).padStart(2, '0')}:${String(expectedSecond).padStart(2, '0')}.${String(expectedMs).padStart(3, '0')}`;
           let got = `${result.getFullYear()}-${String(result.getMonth() + 1).padStart(2, '0')}-${String(result.getDate()).padStart(2, '0')} ${String(result.getHours()).padStart(2, '0')}:${String(result.getMinutes()).padStart(2, '0')}:${String(result.getSeconds()).padStart(2, '0')}.${String(result.getMilliseconds()).padStart(3, '0')}`;
           let msg = `Expected: ${expected}, Got: ${got}`;
-          console.error(`Parse mismatch for ${dateStr} (opt_name=${actualOptName}): ${msg}`);
+          console.error(`Parse mismatch for ${dateStr} (opt_name=${opt_name}): ${msg}`);
           return { pass: false, message: msg };
         }
 


### PR DESCRIPTION
## Problem

DateParser supports compact date-time formats (e.g., `20250109 143025`) for 4-digit-year formats like YYYYMMDD, but 2-digit-year compact formats (DDMMYY, MMDDYY, YYMMDD, YYDDMM) only parse the date portion. Input like `010925 143025` (DDMMYY with compact HHMMSS time) fails to parse the time component.

This blocks parsers that receive transaction timestamps in compact 2-digit-year date-time format (common in financial settlement files).

## Solution

Extend all four 2-digit-year compact grammar rules (`ddmmyycompact`, `mmddyycompact`, `yymmddcompact`, `yyddmmcompact`) to accept optional time components after the 6-digit date. Each rule now tries three alternatives in order:

1. Compact time: `DDMMYY HHMMSS` (no colons)
2. Colon time: `DDMMYY HH:MM:SS` with optional timezone
3. Date only: `DDMMYY` (backward compatible)

Add corresponding action methods in both `DateParser.js` and `DateParser.java` that extract the date string and time components from the parsed sequence, construct the full Date object with hours/minutes/seconds, and apply the 2-digit year pivot (00-49 → 2000s, 50-99 → 1900s).

Also add `mmddyysep` and `mmddyycompact` as alternatives in the `mmddyyyy` grammar entry point, and fix the Java `yyyymmdd-compact` action to correctly parse time components (parity bug with JavaScript).

## Changes

- `DateGrammar.js`: extend `ddmmyycompact`, `mmddyycompact`, `yymmddcompact`, `yyddmmcompact` with optional time alternatives; add `mmddyysep`/`mmddyycompact` to `mmddyyyy` entry point
- `DateParser.js`: add `ddmmyycompactAction`, `mmddyycompactAction`, `yymmddcompactAction`, `yyddmmcompactAction`; refactor existing actions to reduce duplication
- `DateParser.java`: add corresponding Java action methods for all four compact formats; fix `yyyymmdd-compact` time parsing parity bug
- `DateParserTest.js`: add test suites for DDMMYY, MMDDYY, YYMMDD, YYDDMM compact time formats and backward compatibility
- `DateParserJavaTest.js`: add matching Java test methods for all four format variants