### PR TITLE
fix: DST timezone bugs in DateTo*Expr classes and add disableLegendCl…

### DIFF
--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -952,7 +952,6 @@ foam.CLASS({
       class: 'Boolean',
       name: 'disableLegendClick',
       label: 'Disable Legend Click',
-      value: false,
       help: 'Prevent clicking legend items from toggling slice visibility'
     },
   ],

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -880,7 +880,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 3,
       collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage', 'disableLegendClick']
+      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage']
     },
     {
       name: 'colors',

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -873,14 +873,14 @@ foam.CLASS({
       title: 'Pie Chart Settings',
       order: 2,
       collapsable: true,
-      properties: ['showPercentages', 'cutoutPercentage', 'clockwise', 'rotation']
+      properties: ['showPercentages', 'cutoutPercentage', 'clockwise', 'rotation', 'disableLegendClick']
     },
     {
       name: 'display',
       title: 'Display Options',
       order: 3,
       collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage']
+      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage', 'disableLegendClick']
     },
     {
       name: 'colors',
@@ -948,6 +948,13 @@ foam.CLASS({
       help: 'Message to display when there is no data',
       value: 'No data available'
     },
+    {
+      class: 'Boolean',
+      name: 'disableLegendClick',
+      label: 'Disable Legend Click',
+      value: false,
+      help: 'Prevent clicking legend items from toggling slice visibility'
+    },
   ],
 
   methods: [
@@ -981,7 +988,8 @@ foam.CLASS({
         animate: this.animate,
         animationDuration: this.animationDuration,
         alignment: this.alignment,
-        emptyValueMessage: this.emptyValueMessage
+        emptyValueMessage: this.emptyValueMessage,
+        disableLegendClick: this.disableLegendClick
       });
 
       return sink;
@@ -993,8 +1001,8 @@ foam.CLASS({
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(cutoutPercentage, rotation, colors, showPercentages, clockwise,
-                                  maintainAspectRatio, height, showLegend, legendPosition, 
-                                  showTooltips, showTooltipSum, animate, animationDuration, alignment) { 
+                                  maintainAspectRatio, height, showLegend, legendPosition,
+                                  showTooltips, showTooltipSum, animate, animationDuration, alignment, disableLegendClick) {
         s.cutoutPercentage = cutoutPercentage;
         s.rotation = rotation;
         s.colors = colors;
@@ -1009,6 +1017,7 @@ foam.CLASS({
         s.animate = animate;
         s.animationDuration = animationDuration;
         s.alignment = alignment;
+        s.disableLegendClick = disableLegendClick;
         
         // Force chart to update/redraw
         if ( s.updateChart ) s.updateChart();
@@ -1039,6 +1048,7 @@ foam.CLASS({
       clone.showTooltipSum$ = this.showTooltipSum$;
       clone.animate$ = this.animate$;
       clone.animationDuration$ = this.animationDuration$;
+      clone.disableLegendClick$ = this.disableLegendClick$;
       return clone;
     }
   ]

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -486,7 +486,7 @@ foam.CLASS({
     { class: 'Int', name: 'cutoutPercentage', value: 0 },
     { class: 'Boolean', name: 'clockwise', value: true },
     { class: 'Int', name: 'rotation', value: -90 },
-    { class: 'Boolean', name: 'disableLegendClick', value: false, help: 'Disable legend click to toggle slice visibility' },
+    { class: 'Boolean', name: 'disableLegendClick', help: 'Disable legend click to toggle slice visibility' },
     // Display properties
     { class: 'Boolean', name: 'responsive', value: true },
     { class: 'Boolean', name: 'maintainAspectRatio', value: false },

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -486,6 +486,7 @@ foam.CLASS({
     { class: 'Int', name: 'cutoutPercentage', value: 0 },
     { class: 'Boolean', name: 'clockwise', value: true },
     { class: 'Int', name: 'rotation', value: -90 },
+    { class: 'Boolean', name: 'disableLegendClick', value: false, help: 'Disable legend click to toggle slice visibility' },
     // Display properties
     { class: 'Boolean', name: 'responsive', value: true },
     { class: 'Boolean', name: 'maintainAspectRatio', value: false },
@@ -505,7 +506,7 @@ foam.CLASS({
       transient: true,
       expression: function(groups,groupKeys, colors, showPercentages, cutoutPercentage, clockwise, rotation,
                           responsive, maintainAspectRatio, showLegend,
-                          legendPosition, showTooltips, showTooltipSum, animate, animationDuration, width, emptyValueMessage) {
+                          legendPosition, showTooltips, showTooltipSum, animate, animationDuration, width, emptyValueMessage, disableLegendClick) {
         // Don't create chart until we have a valid width
         if ( ! width || width <= 0 ) {
           return null;
@@ -557,13 +558,13 @@ foam.CLASS({
             legend: {
               display: showLegend,
               position: legendPosition ? legendPosition.toString().toLowerCase() : 'top',
-
+              onClick: disableLegendClick ? function() { /* no-op: prevent slice toggle */ } : undefined,
             },
             tooltip: {
               enabled: showTooltips,
               callbacks: (function() {
                 var callbacks = {};
-                
+
                 // Add percentage display to individual tooltip labels
                 if ( showPercentages ) {
                   callbacks.label = function(context) {

--- a/src/foam/mlang/expr/DateToDayOfYearExpr.js
+++ b/src/foam/mlang/expr/DateToDayOfYearExpr.js
@@ -42,7 +42,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToDayOfYearExpr.js
+++ b/src/foam/mlang/expr/DateToDayOfYearExpr.js
@@ -30,12 +30,13 @@ foam.CLASS({
         var date = this.delegate.f(obj);
         if ( ! date ) return '';
 
-        var start = new Date(date.getFullYear(), 0, 0);
-        var diff = date - start;
+        // Use UTC methods to avoid DST/timezone shifts
+        var start = new Date(Date.UTC(date.getUTCFullYear(), 0, 0));
+        var diff = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) - start.getTime();
         var oneDay = 1000 * 60 * 60 * 24;
         var dayOfYear = Math.floor(diff / oneDay);
 
-        return date.getFullYear() + '-' + String(dayOfYear).padStart(3, '0');
+        return date.getUTCFullYear() + '-' + String(dayOfYear).padStart(3, '0');
       },
       javaCode: `
         java.util.Date date = (java.util.Date) getDelegate().f(obj);

--- a/src/foam/mlang/expr/DateToQuarterExpr.js
+++ b/src/foam/mlang/expr/DateToQuarterExpr.js
@@ -40,7 +40,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToQuarterExpr.js
+++ b/src/foam/mlang/expr/DateToQuarterExpr.js
@@ -30,8 +30,9 @@ foam.CLASS({
         var date = this.delegate.f(obj);
         if ( ! date ) return '';
 
-        var year = date.getFullYear();
-        var quarter = Math.floor(date.getMonth() / 3) + 1;
+        // Use UTC methods to avoid DST/timezone shifts causing wrong quarter
+        var year = date.getUTCFullYear();
+        var quarter = Math.floor(date.getUTCMonth() / 3) + 1;
 
         return year + '-Q' + quarter;
       },

--- a/src/foam/mlang/expr/DateToWeekExpr.js
+++ b/src/foam/mlang/expr/DateToWeekExpr.js
@@ -45,7 +45,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
         cal.setFirstDayOfWeek(java.util.Calendar.MONDAY);
         cal.setMinimalDaysInFirstWeek(4);

--- a/src/foam/mlang/expr/DateToWeekExpr.js
+++ b/src/foam/mlang/expr/DateToWeekExpr.js
@@ -32,13 +32,14 @@ foam.CLASS({
 
         // Get ISO week number (1-53)
         // ISO week starts on Monday, week 1 contains first Thursday of year
-        var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        // Use UTC methods to avoid DST/timezone shifts
+        var d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
         var dayNum = d.getUTCDay() || 7;
         d.setUTCDate(d.getUTCDate() + 4 - dayNum);
         var yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
         var weekNum = Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
 
-        return date.getFullYear() + '-W' + String(weekNum).padStart(2, '0');
+        return date.getUTCFullYear() + '-W' + String(weekNum).padStart(2, '0');
       },
       javaCode: `
         java.util.Date date = (java.util.Date) getDelegate().f(obj);

--- a/src/foam/mlang/expr/DateToYYYYExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYExpr.js
@@ -39,7 +39,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year  = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToYYYYExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYExpr.js
@@ -30,7 +30,8 @@ foam.CLASS({
         var date = this.delegate.f(obj);
         if ( ! date ) return '';
 
-        var year  = date.getFullYear();
+        // Use UTC to avoid DST/timezone shifts causing wrong year at boundaries
+        var year  = date.getUTCFullYear();
 
         return year;
       },

--- a/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
@@ -36,7 +36,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year  = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
@@ -25,9 +25,10 @@ foam.CLASS({
         var date = this.delegate.f(obj);
         if ( ! date ) return '';
 
-        var year  = date.getFullYear();
-        var month = (date.getMonth() + 1).toString().padStart(2, '0');
-        var day   = date.getDate().toString().padStart(2, '0');
+        // Use UTC methods to avoid DST/timezone shifts causing wrong date
+        var year  = date.getUTCFullYear();
+        var month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+        var day   = date.getUTCDate().toString().padStart(2, '0');
 
         return year + '/' + month + '/' + day;
       },

--- a/src/foam/mlang/expr/DateToYYYYMMExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMExpr.js
@@ -40,12 +40,11 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year  = cal.get(java.util.Calendar.YEAR);
         int month = cal.get(java.util.Calendar.MONTH) + 1;
-        int day   = cal.get(java.util.Calendar.DAY_OF_MONTH);
 
         return String.format("%04d/%02d", year, month);
       `

--- a/src/foam/mlang/expr/DateToYYYYMMExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMExpr.js
@@ -30,8 +30,9 @@ foam.CLASS({
         var date = this.delegate.f(obj);
         if ( ! date ) return '';
 
-        var year  = date.getFullYear();
-        var month = (date.getMonth() + 1).toString().padStart(2, '0');
+        // Use UTC methods to avoid DST/timezone shifts causing wrong month
+        var year  = date.getUTCFullYear();
+        var month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
 
         return year + '/' + month;
       },


### PR DESCRIPTION
…ick to dashboard pie charts

DOS-2042: Replace local timezone methods (getFullYear, getMonth, getDate, getDay) with UTC equivalents (getUTCFullYear, getUTCMonth, getUTCDate, getUTCDay) in all DateTo*Expr classes to prevent date boundary shifts when UTC dates cross midnight.

DOS-2282: Add disableLegendClick property to DashboardPieSink and DashboardPieChartDAOAgent to allow flow configs to disable pie chart legend click interactions, preventing users from hiding chart segments.

Affected files:
- DateToYYYYMMExpr, DateToYYYYMMDDExpr, DateToYYYYExpr, DateToQuarterExpr, DateToWeekExpr, DateToDayOfYearExpr
- DashboardSinks.js, DashboardDAOAgents.js