### PR TITLE
fix: UTC timezone for Java DateTo*Expr + cleanup duplicate section

### DIFF
--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -880,7 +880,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 3,
       collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage', 'disableLegendClick']
+      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage']
     },
     {
       name: 'colors',

--- a/src/foam/mlang/expr/DateToDayOfYearExpr.js
+++ b/src/foam/mlang/expr/DateToDayOfYearExpr.js
@@ -42,7 +42,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToQuarterExpr.js
+++ b/src/foam/mlang/expr/DateToQuarterExpr.js
@@ -40,7 +40,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToWeekExpr.js
+++ b/src/foam/mlang/expr/DateToWeekExpr.js
@@ -45,7 +45,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
         cal.setFirstDayOfWeek(java.util.Calendar.MONDAY);
         cal.setMinimalDaysInFirstWeek(4);

--- a/src/foam/mlang/expr/DateToYYYYExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYExpr.js
@@ -39,7 +39,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year  = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
@@ -36,7 +36,7 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year  = cal.get(java.util.Calendar.YEAR);

--- a/src/foam/mlang/expr/DateToYYYYMMExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMExpr.js
@@ -40,12 +40,11 @@ foam.CLASS({
         java.util.Date date = (java.util.Date) getDelegate().f(obj);
         if ( date == null ) return "";
 
-        java.util.Calendar cal = java.util.Calendar.getInstance();
+        java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
         cal.setTime(date);
 
         int year  = cal.get(java.util.Calendar.YEAR);
         int month = cal.get(java.util.Calendar.MONTH) + 1;
-        int day   = cal.get(java.util.Calendar.DAY_OF_MONTH);
 
         return String.format("%04d/%02d", year, month);
       `


### PR DESCRIPTION
## Summary

Review fixes for #4936:

- **Java UTC Calendar**: All 6 `DateTo*Expr` classes had `Calendar.getInstance()` (local timezone) in their `javaCode` blocks while the JS side was fixed to use UTC methods. This causes server-side date grouping to disagree with client-side grouping when dates cross midnight boundaries in the server's local timezone. Fixed by using `Calendar.getInstance(TimeZone.getTimeZone("UTC"))`.
- **Unused variable**: Removed `DAY_OF_MONTH` fetch in `DateToYYYYMMExpr` Java code — it was never used in the output.
- **Duplicate section**: `disableLegendClick` was listed in both "Pie Chart Settings" and "Display Options" sections in `DashboardPieChartDAOAgent`. Removed from "Display Options" since it's pie-specific.

## Affected files
- `DateToYYYYMMExpr.js` — UTC Calendar + remove unused `day` variable
- `DateToYYYYMMDDExpr.js` — UTC Calendar
- `DateToYYYYExpr.js` — UTC Calendar
- `DateToQuarterExpr.js` — UTC Calendar
- `DateToWeekExpr.js` — UTC Calendar
- `DateToDayOfYearExpr.js` — UTC Calendar
- `DashboardDAOAgents.js` — Remove duplicate section entry

## Test plan
- [ ] Build with `-XcleanAll` to recompile Java Calendar changes
- [ ] Verify server-side date grouping matches client-side for dates near midnight UTC
- [ ] Verify disableLegendClick still appears in Pie Chart Settings section only