### PR TITLE
TitledArrayView: use toSummary as row title, fix scrollToIndex crash

### DIFF
--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -209,7 +209,7 @@ foam.CLASS({
           },
           code: function() {
             this.data = this.data.toSpliced(this.index, 1);
-            this.scrollToIndex(this.index == 0 ? 0 : this.index -1);
+            this.scrollToIndex?.(this.index == 0 ? 0 : this.index -1);
           }
         }
       ]

--- a/src/foam/u2/view/TitledArrayView.js
+++ b/src/foam/u2/view/TitledArrayView.js
@@ -77,8 +77,8 @@ foam.CLASS({
       methods: [
         function render() {
           let arrView = this.arrayView
-          var summaryType = arrView.title || this.value.toSummary ? this.value$.map(v => v.toSummary()) : 'default';
-          var label = this.value$.dot('label').map(label => label || ('New ' + arrView.of.model_.label))
+          var summaryType = arrView.title || this.value.toSummary ? this.value$.map(v => v.toSummary()) : ('New ' + arrView.of.model_.label);
+          // var label = this.value$.dot('label').map(label => label || ('New ' + arrView.of.model_.label))
           var summaryTypeClass = this.value.toCSSClassName ? this.value$.map(v => v.toCSSClassName().code()) : 'default';
 
           this
@@ -93,16 +93,16 @@ foam.CLASS({
                   .enableClass('opened', this.collapsed$.map(c => !c))
                   .start().style({alignContent: 'center'}).addClass(this.myClass('item-row'))
                     .start('span').addClass(this.myClass('item-index')).add(this.index$.map(i => i + 1)).end()
-                    .start('span').addClass(this.myClass('item-name')).add(
-                      label
+                    .start('span').addClass(this.myClass('item-name'), 'h600').add(
+                      summaryType
                     ).end()
                   .end()
                   .start().addClass(this.myClass('actions-holder'))
-                    .start('span')
-                      .addClass('type-label')
-                      .addClass(summaryTypeClass)
-                      .add(summaryType)
-                    .end()
+                    // .start('span')
+                    //   .addClass('type-label')
+                    //   .addClass(summaryTypeClass)
+                    //   .add(summaryType)
+                    // .end()
                     .tag(this.REMOVE_ROW, {
                       buttonStyle: 'TERTIARY',
                       themeIcon: 'trash',

--- a/src/foam/u2/view/TitledArrayView.js
+++ b/src/foam/u2/view/TitledArrayView.js
@@ -78,7 +78,6 @@ foam.CLASS({
         function render() {
           let arrView = this.arrayView
           var summaryType = arrView.title || this.value.toSummary ? this.value$.map(v => v.toSummary()) : ('New ' + arrView.of.model_.label);
-          // var label = this.value$.dot('label').map(label => label || ('New ' + arrView.of.model_.label))
           var summaryTypeClass = this.value.toCSSClassName ? this.value$.map(v => v.toCSSClassName().code()) : 'default';
 
           this
@@ -98,11 +97,6 @@ foam.CLASS({
                     ).end()
                   .end()
                   .start().addClass(this.myClass('actions-holder'))
-                    // .start('span')
-                    //   .addClass('type-label')
-                    //   .addClass(summaryTypeClass)
-                    //   .add(summaryType)
-                    // .end()
                     .tag(this.REMOVE_ROW, {
                       buttonStyle: 'TERTIARY',
                       themeIcon: 'trash',


### PR DESCRIPTION
## Problem

TitledArrayView shows a redundant layout: the left side displays a generic "New [ClassName]" label while the right side shows the `toSummary()` result. The summary (the useful information) is pushed to the right and competes with the action buttons. Additionally, `ArrayView.Row.removeRow` calls `this.scrollToIndex()` which crashes when the method is unavailable in the context (e.g., in TitledArrayView's CollapsableRow subclass).

## Solution

Move `toSummary()` to the left-side row title (item-name) so the most descriptive text appears as the primary label. Remove the separate right-side type-label span. Add optional chaining (`?.`) on the `scrollToIndex` call in `removeRow` to prevent crashes when the method is not in scope.

## Changes

- Move `summaryType` (toSummary result) to the item-name span as the primary row title with `h600` bold styling
- Fix `summaryType` fallback from `'default'` to `'New ' + model_.label` when toSummary is not available
- Add optional chaining on `scrollToIndex` call in `ArrayView.Row.removeRow` to prevent TypeError in subclasses