### PR TITLE
fix(CurrencyCode): show full currency name in table cells

### DIFF
--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -550,8 +550,15 @@ foam.CLASS({
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
       value: function(value, obj, axiom) {
-        // Since currency codes resolve their values async, their tcfs are slotted 
-        this.add(axiom.toSlot(obj));
+        // Reactive slot — re-fires when currency property changes.
+        // Uses FOAM's $find to resolve Currency object, then shows toSummary().
+        // Falls back to raw code for GroupBy/generated objects that lack currencyDAO.
+        this.add(axiom.toSlot(obj).map(function(code) {
+          if ( ! code || ! obj.__context__[axiom.targetDAOKey] ) return code || '';
+          return obj[axiom.name + '$find'].then(function(c) {
+            return c?.toSummary?.() ?? code;
+          });
+        }));
       }
     },
     ['projectionSafe', false]


### PR DESCRIPTION
## Problem
CurrencyCode properties in table views display only the raw currency code (e.g., "HKD") instead of the full currency name (e.g., "HKD - Hong Kong Dollar"). The existing tableCellFormatter uses `axiom.toSlot(obj)` which resolves to the code string, not the Currency object's summary.

## Solution
Map the reactive slot through a `currencyDAO.find()` lookup that calls `toSummary()` on the resolved Currency object. The slot-based reactivity is preserved — when the currency property changes, the map re-fires the DAO lookup and updates the cell. Falls back to the raw code if the DAO is unavailable or the lookup fails.

## Changes
- `CurrencyCodeTableCellFormatterRefinement`: replace `axiom.toSlot(obj)` with `axiom.toSlot(obj).map()` that resolves through `currencyDAO` to display `Currency.toSummary()`