### PR TITLE
Add help text to Rule and RuleGroup priority properties

### DIFF
--- a/src/foam/core/ruler/Rule.js
+++ b/src/foam/core/ruler/Rule.js
@@ -101,7 +101,8 @@ foam.CLASS({
     {
       name: 'priority',
       tableWidth: 66,
-      section: 'basicInfo'
+      section: 'basicInfo',
+      help: 'Controls execution order within the same rule group, operation, and timing phase. Higher values run first. Use multiples of 10 (e.g. 10, 20, 30) to leave room for inserting rules later.'
     },
     {
       class: 'String',

--- a/src/foam/core/ruler/RuleGroup.js
+++ b/src/foam/core/ruler/RuleGroup.js
@@ -61,6 +61,7 @@
         Priority is a multiple of 10 in the range of (lowest) 0 -> inf (highest).
         Priority is defaulted to 10 so rule groups can ensure they go last by setting priority to 0
       `,
+      help: 'Controls the order in which rule groups are evaluated. Higher values run first. Default is 10. Set to 0 to ensure a group runs last.',
       writePermissionRequired: true
     }
   ],

--- a/src/foam/core/ruler/Ruled.js
+++ b/src/foam/core/ruler/Ruled.js
@@ -39,6 +39,7 @@ foam.CLASS({
         Rules with a higher priority are to be applied first.
         The convention for values is ints that are multiple of 10.
       `,
+      help: 'Controls execution order. Higher values run first. Use multiples of 10 (e.g. 10, 20, 30) to leave room for inserting rules later.',
       readPermissionRequired: true,
       writePermissionRequired: true
     },


### PR DESCRIPTION
## Problem
The `priority` property on Rule, Ruled, and RuleGroup has no user-facing help text. Users editing rules in the UI see the priority field but get no guidance on what values mean, which direction runs first, or the recommended convention.

## Solution
Add `help` text to the `priority` property on all three rule-related models. The help text explains execution order (higher runs first), scoping (within same group/operation/phase), and the multiples-of-10 convention.

## Changes
- `Ruled.js` — add `help` to the base priority property
- `Rule.js` — add `help` with additional context about group/operation/phase scoping
- `RuleGroup.js` — add `help` explaining group-level ordering and the default value of 10