### PR TITLE
fix(test): distinguish JS variables from string literals in CSSAuditTest

### DIFF
--- a/src/foam/core/theme/test/CSSAuditTest.js
+++ b/src/foam/core/theme/test/CSSAuditTest.js
@@ -94,7 +94,12 @@ a = foam.u2.view.ColorEditView.create(); ctrl.stack.set(a);
       name: 'runTest',
       javaCode: `
     Logger logger = new PrefixLogger(new Object[] { "CSSAuditTest"}, (Logger) x.get("logger"));
-    Pattern pattern = Pattern.compile(".*?([;']?)(color|font|border|font-weight):\\s*([a-zA-Z0-9#\\s.(]*)");
+    // Group 1: CSS property name.
+    // Group 2: optional opening quote (' or ") — empty means the value is unquoted.
+    // Group 3: value content (stops at the closing quote / comma / semicolon / etc.).
+    // The previously-captured "embedded" group ([;']?) was removed: a quoted
+    // property key like 'color': should NOT cause the line to be skipped.
+    Pattern pattern = Pattern.compile(".*?(color|font|border|font-weight):\\s*(['\\\"]?)([a-zA-Z0-9#\\s.($_-]*)");
     String projectHome = System.getProperty("project.home");
     if ( SafetyUtil.isEmpty(projectHome) ) {
       test ( false, "project.home found "+projectHome );
@@ -157,50 +162,44 @@ a = foam.u2.view.ColorEditView.create(); ctrl.stack.set(a);
     try (BufferedReader br = new BufferedReader(new FileReader(path.toFile()))) {
       String line;
       int lineNum = 0;
-      // Tracks paren depth of an open .style( call across lines so that
-      // multi-line .style({ ... }) bodies are skipped (the values inside
-      // are JS variables/expressions, not hardcoded CSS literals).
-      int styleParenDepth = 0;
       while ( (line = br.readLine()) != null ) {
         lineNum += 1;
-        boolean lineStartsInStyleCall = styleParenDepth > 0;
-        // Update styleParenDepth by scanning this line for ".style(" and
-        // any matching parentheses while inside an open style call.
-        int searchFrom = 0;
-        while ( searchFrom < line.length() ) {
-          if ( styleParenDepth == 0 ) {
-            int idx = line.indexOf(".style(", searchFrom);
-            if ( idx < 0 ) break;
-            styleParenDepth = 1;
-            searchFrom = idx + 7; // length of ".style("
-          } else {
-            char c = line.charAt(searchFrom);
-            if ( c == '(' ) styleParenDepth++;
-            else if ( c == ')' ) styleParenDepth--;
-            searchFrom++;
-          }
-        }
         Matcher matcher = pattern.matcher(line);
         if ( matcher.find() ) {
-          if ( lineStartsInStyleCall || line.contains("style") ) {
-            logger.info("ignoring", line);
-            continue;
-          }
           if ( line.contains("foam.CSS") ) {
             logger.info("ignoring", line);
             continue;
           }
-          String embedded = matcher.group(1);
-          if ( ! SafetyUtil.isEmpty(embedded) ) {
-            // style lines, console.log with color, ... 
-            logger.info("ignoring", line);
+          String property  = matcher.group(1);
+          String openQuote = matcher.group(2);
+          String value     = matcher.group(3);
+          boolean isStringLiteral = ! SafetyUtil.isEmpty(openQuote);
+
+          // For unquoted values, distinguish a CSS rule from a JS object entry.
+          // A CSS rule terminates with ';' (audit it). A JS object entry
+          // terminates with ',', '}' or ')' and the value is therefore a JS
+          // variable / expression (skip — not a hardcoded literal).
+          if ( ! isStringLiteral ) {
+            int valueEnd = matcher.end(3);
+            boolean isCssRule = false;
+            for ( int i = valueEnd ; i < line.length() ; i++ ) {
+              char c = line.charAt(i);
+              if ( c == ';' ) { isCssRule = true; break; }
+              if ( c == ',' || c == '}' || c == ')' ) break;
+            }
+            if ( ! isCssRule ) {
+              logger.info("ignoring JS variable", line);
+              continue;
+            }
+          }
+
+          if ( SafetyUtil.isEmpty(value) ) {
+            // no value content captured (e.g. empty string or interpolation) - skip
             continue;
           }
-          String property = matcher.group(2);
-          String value = matcher.group(3);
-          if ( SafetyUtil.isEmpty(value) ) {
-            // no match - line is correct
-            // logger.info("ignoring", line);
+          // FOAM theme tokens (e.g. '$primary', '$blue500') are valid - skip.
+          if ( value.startsWith("$") ) {
+            logger.info("ignoring theme token", property, value);
             continue;
           }
           if ( "color".equals(property) ) {

--- a/src/foam/core/theme/test/CSSAuditTest.js
+++ b/src/foam/core/theme/test/CSSAuditTest.js
@@ -157,11 +157,32 @@ a = foam.u2.view.ColorEditView.create(); ctrl.stack.set(a);
     try (BufferedReader br = new BufferedReader(new FileReader(path.toFile()))) {
       String line;
       int lineNum = 0;
+      // Tracks paren depth of an open .style( call across lines so that
+      // multi-line .style({ ... }) bodies are skipped (the values inside
+      // are JS variables/expressions, not hardcoded CSS literals).
+      int styleParenDepth = 0;
       while ( (line = br.readLine()) != null ) {
         lineNum += 1;
+        boolean lineStartsInStyleCall = styleParenDepth > 0;
+        // Update styleParenDepth by scanning this line for ".style(" and
+        // any matching parentheses while inside an open style call.
+        int searchFrom = 0;
+        while ( searchFrom < line.length() ) {
+          if ( styleParenDepth == 0 ) {
+            int idx = line.indexOf(".style(", searchFrom);
+            if ( idx < 0 ) break;
+            styleParenDepth = 1;
+            searchFrom = idx + 7; // length of ".style("
+          } else {
+            char c = line.charAt(searchFrom);
+            if ( c == '(' ) styleParenDepth++;
+            else if ( c == ')' ) styleParenDepth--;
+            searchFrom++;
+          }
+        }
         Matcher matcher = pattern.matcher(line);
         if ( matcher.find() ) {
-          if ( line.contains("style") ) {
+          if ( lineStartsInStyleCall || line.contains("style") ) {
             logger.info("ignoring", line);
             continue;
           }


### PR DESCRIPTION
## Problem
`CSSAuditTest` was producing both false positives and false negatives:

- **False positive:** `color: color` inside a multi-line `.style({...})` got flagged. The single-line `line.contains("style")` short-circuit only matched the opening line; inner property lines slipped past it even though their values are JS variable references, not hardcoded CSS literals.
- **False positive:** quoting the property key (`'color': value`) silently bypassed the audit because the regex's leading `[;']?` "embedded" group matched the `'` and short-circuited. Quoting the key shouldn't change whether the value is audited.
- **False negative:** quoted string-literal values inside `.style({...})` were never audited at all. The value charset `[a-zA-Z0-9#\s.(]` excludes `'` and `"`, so `color: '#FFFFFF'` and `color: 'red'` produced an empty value group and were skipped — exactly the cases that should be flagged.

Concrete examples that all failed to behave correctly before:
```js
.style({
  'background-color': background,    // skipped (correctly) — quoted key + variable
  color: color,                      // FLAGGED (wrong) — JS variable, not a literal
  'border-color': borderColor        // skipped (wrong reason) — embedded quote bypass
})
.style({ color: '#4444' })           // skipped (wrong) — should be flagged, hardcoded hex
.style({ color: 'red' })             // skipped (wrong) — should be flagged, hardcoded color
```

## Solution
Rewrite the matcher to model the rule explicitly: **string literals are audited, JS expressions are skipped, CSS rules are audited.**

- Drop the `[;']?` "embedded" capture so a quoted key no longer auto-skips.
- Drop the `line.contains("style")` early-out; it was both too coarse (skipped legitimate audits) and not coarse enough (missed multi-line bodies).
- Capture the optional opening quote (`'` or `"`) as group 2 so the value's syntactic category is known.
- For unquoted values, scan forward for the terminator: `;` means a CSS rule (audit), while `,` `}` `)` mean a JS object entry whose value is a variable/expression (skip).
- For quoted values, always run the existing whitelist checks against the captured string content.
- Extend the value charset to include `$ _ -` so FOAM theme tokens (e.g. `'$blue500'`) are captured intact, and add a `value.startsWith("$")` whitelist entry so token references pass.

Net effect on the audit:
- `color: color` (unquoted, terminated by `,`) → JS variable → skipped
- `color: '#4444'` / `color: 'red'` (quoted) → string literal → audited (and flagged, as intended)
- `color: '$blue500'` (quoted FOAM token) → string literal → whitelisted by `$` prefix
- `color: red;` in a `css:` template (unquoted, terminated by `;`) → CSS rule → audited (unchanged)

## Changes
- `src/foam/core/theme/test/CSSAuditTest.js`:
  - Replace regex: drop the leading `[;']?` group; capture optional opening quote as group 2; extend value charset to include `$ _ -`.
  - Replace match-handling: detect string-literal vs unquoted values, scan for `;` vs `,`/`}`/`)` to decide CSS rule vs JS expression, and whitelist FOAM `$` theme tokens.
