### PR TITLE
Add outputType to DateToYYYYMMDDExpr

### DIFF
--- a/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
+++ b/src/foam/mlang/expr/DateToYYYYMMDDExpr.js
@@ -15,6 +15,11 @@ foam.CLASS({
     {
       class: 'foam.mlang.ExprProperty',
       name: 'delegate'
+    },
+    {
+      name: 'outputType',
+      value: 'String',
+      documentation: 'Output type is String (YYYY/MM/DD format)'
     }
   ],
 


### PR DESCRIPTION
## Summary

`DateToYYYYMMDDExpr` was missing the `outputType: 'String'` property that its sibling `DateToYYYYMMExpr` (`foam3/src/foam/mlang/expr/DateToYYYYMMExpr.js:20-23`) already declares. One-line parity fix.

## Why it matters

When `DateToYYYYMMDDExpr` is used as the `prop` on a `GroupByDAOAgent`, `GroupBy.genModel` (`foam3/src/foam/mlang/sink/GroupBy.js:258-268`) runs its fallback logic: it walks the expression's `delegate` chain until it finds a `foam.lang.Property`, then uses that Property's class for the auto-generated group-by column.

Since the delegate is a `Date` property, the column is typed as `Date`. But the expression's `f()` returns a **String** (`"YYYY/MM/DD"`). FOAM's Date property `adapt` rejects the string — the column reads back empty.

Effect: any downstream transform/view that reads the grouped date (e.g., `this.date` on the flattened row) gets nothing, and any `TJoin` that keys on the grouped date fails to match records on the other side.

## Fix

Add `outputType: 'String'` to `DateToYYYYMMDDExpr`, mirroring `DateToYYYYMMExpr`. `GroupBy.genModel` short-circuits to that value (line 255-257) and types the column as String, matching what `f()` actually returns.

## Test plan

- [ ] Build & run server
- [ ] In a Reflow flow, use `DateToYYYYMMDDExpr` as the `prop` on a `GroupByDAOAgent`; verify the grouped date column renders non-empty `YYYY/MM/DD` values
- [ ] Verify downstream transforms reading the grouped date field see the string value
- [ ] Confirm `DateToYYYYMMExpr` behaviour is unchanged (same property, already present)