### PR TITLE
PT-FIXES:DOS-3191 Treat c entries as p during journal replay

### DIFF
--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -106,10 +106,9 @@ foam.CLASS({
                     return;
                   }
                   switch ( operation ) {
-                    case OP_CREATE:
-                      dao.put(obj);
-                      break;
-
+                    case OP_CREATE: // Workaround: treat c as p so that duplicate IDs
+                                    // across journals are merged instead of silently dropped.
+                                    // Real fix: make honorCreate configurable at EasyDAO level.
                     case OP_PUT:
                       foam.lang.FObject old = dao.find(obj.getProperty("id"));
                       dao.put(old != null ? mergeFObject(old.fclone(), obj) : obj);

--- a/src/foam/dao/test/F3FileJournalTest.js
+++ b/src/foam/dao/test/F3FileJournalTest.js
@@ -204,7 +204,7 @@ foam.CLASS({
         c = (Count) languageDAO.select(COUNT());
         test ( c.getValue() == 2, "Language replay count 2 "+c);
 
-        // Remove 
+        // Remove
         languageDAO.remove(language);
         languageDAO = new foam.dao.java.JDAO();
         languageDAO.setX(x);
@@ -212,6 +212,35 @@ foam.CLASS({
         languageDAO.setDelegate(new foam.dao.MDAO(foam.core.auth.Language.getOwnClassInfo()));
         c = (Count) languageDAO.select(COUNT());
         test ( c.getValue() == 1, "Language replay count 1 after remove "+c);
+
+        // OP_CREATE treated as OP_PUT (c-as-p)
+        // Two c entries for the same ID: second is sparse (only firstName).
+        // After replay, lastName from the first c entry must survive via merge.
+        // Use FileSystemStorage context (same as JDAO does) so reader finds files on disk
+        X fsX = testX.put(foam.core.fs.Storage.class, testX.get(foam.core.fs.FileSystemStorage.class));
+
+        String cAsPFile = "cAsPutJournal";
+        foam.core.fs.Storage cAsPStorage = (foam.core.fs.Storage) fsX.get(foam.core.fs.Storage.class);
+        try ( BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(cAsPStorage.getOutputStream(cAsPFile))) ) {
+          bw.write("c({\\"class\\":\\"foam.core.auth.User\\",\\"id\\":999,\\"firstName\\":\\"First\\",\\"lastName\\":\\"Last\\"})");
+          bw.newLine();
+          bw.write("c({\\"class\\":\\"foam.core.auth.User\\",\\"id\\":999,\\"firstName\\":\\"Updated\\"})");
+          bw.newLine();
+        }
+
+        foam.dao.MDAO cAsPMdao = new foam.dao.MDAO(User.getOwnClassInfo());
+        foam.dao.F3FileJournal cAsPJournal = new foam.dao.F3FileJournal.Builder(fsX)
+          .setFilename(cAsPFile)
+          .build();
+        cAsPJournal.replay(fsX, cAsPMdao);
+
+        c = (Count) cAsPMdao.select(COUNT());
+        test ( c.getValue() == 1, "c-as-p: one record after two c entries for same ID " + c);
+
+        User cAsPUser = (User) cAsPMdao.find(999L);
+        test ( cAsPUser != null, "c-as-p: record found" );
+        test ( "Updated".equals(cAsPUser.getFirstName()), "c-as-p: firstName updated by second c entry " + (cAsPUser != null ? cAsPUser.getFirstName() : "null") );
+        test ( "Last".equals(cAsPUser.getLastName()), "c-as-p: lastName preserved from first c entry via merge " + (cAsPUser != null ? cAsPUser.getLastName() : "null") );
 
       `
     },


### PR DESCRIPTION
## Problem

During journal replay, `c` (create) entries bypassed the find+merge path and performed a blind `dao.put(obj)`. When multiple journals contained `c` entries for the same ID — for example, a deployment `.0` journal and a runtime journal both defining the same record — the second journal's `c` entry replaced the first entirely instead of merging. This caused deployment journal data to be silently overwritten by stale runtime copies on ID collisions.

The root cause: `FileJournal` and `RoutingJournal` ignore `c` entries entirely (no `case 'c':` in their switch), and `F3FileJournal` handled `c` with a blind put that skipped the merge logic used by `p` entries.

## Solution

Fall `case OP_CREATE:` through to `case OP_PUT:` in `F3FileJournal.replay()` so that `c` entries go through the same find+merge+put path as `p` entries. When the same ID already exists in the DAO, properties from both entries are merged instead of the first being discarded.

This is a **workaround**. The real fix is making honorCreate configurable at the EasyDAO level so that the create-vs-put distinction can be preserved where needed while still allowing deployment journals to override runtime state.

## Changes

- `F3FileJournal.js`: `case OP_CREATE` falls through to `case OP_PUT` — `c` entries now use find+merge instead of blind put
- `F3FileJournalTest.js`: Add test that replays two `c` entries for the same ID (second is sparse) and verifies merge preserves fields from the first entry