### PR TITLE
PT-FIXES:DOS-3126 Journal replay for ClassInfo without Java class

### DIFF
--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -96,7 +96,13 @@ foam.CLASS({
                 FObject obj;
 
                 public void executeJob() {
-                  obj = getParser(x).parseString(strEntry, dao.getOf().getObjClass());
+                  // For ClassInfos without a backing Java class (getObjClass() == null),
+                  // thread the ClassInfo through X so the parser can still instantiate
+                  // the target via ci.newInstance() when the journal entry omits "class:".
+                  foam.lang.X parseX = dao.getOf().getObjClass() == null
+                    ? x.put("defaultClassInfo", dao.getOf())
+                    : x;
+                  obj = getParser(parseX).parseString(strEntry, dao.getOf().getObjClass());
                 }
 
                 public void endJob(boolean isLast) {

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -62,6 +62,18 @@ foam.CLASS({
 
         getLogger().info("Replay starting");
 
+        // Pre-compute the parser X context once per replay. When the target
+        // ClassInfo has no backing Java class (getObjClass() is null), thread
+        // the ClassInfo itself through X so the parser can instantiate via
+        // ci.newInstance() for entries that omit the class: prefix.
+        final foam.lang.X parseX;
+        if ( dao.getOf().getObjClass() == null ) {
+          getLogger().warning("Class not found for of, falling back to defaultClassInfo", dao.getOf().getId());
+          parseX = x.put("defaultClassInfo", dao.getOf());
+        } else {
+          parseX = x;
+        }
+
         // NOTE: explicitly calling PM constructor as create only creates
         // a percentage of PMs, but we want all replay statistics
         PM pm = new PM(dao.getOf(), "replay." + getFilename());
@@ -96,12 +108,6 @@ foam.CLASS({
                 FObject obj;
 
                 public void executeJob() {
-                  // For ClassInfos without a backing Java class (getObjClass() == null),
-                  // thread the ClassInfo through X so the parser can still instantiate
-                  // the target via ci.newInstance() when the journal entry omits "class:".
-                  foam.lang.X parseX = dao.getOf().getObjClass() == null
-                    ? x.put("defaultClassInfo", dao.getOf())
-                    : x;
                   obj = getParser(parseX).parseString(strEntry, dao.getOf().getObjClass());
                 }
 

--- a/src/foam/lib/json/FObjectParser.java
+++ b/src/foam/lib/json/FObjectParser.java
@@ -95,6 +95,13 @@ public class FObjectParser
               }
             } else {
               c = defaultClass;
+              // No "class:" prefix and no Java Class supplied; fall back to
+              // a caller-supplied default ClassInfo (threaded via X context).
+              // Used for types whose getObjClass() returns null.
+              if ( c == null ) {
+                ClassInfo fallbackCi = (ClassInfo) ctx.get("defaultClassInfo");
+                if ( fallbackCi != null ) ci = fallbackCi;
+              }
             }
 
             ParserContext subx = x.sub();


### PR DESCRIPTION
## Problem
Journal replay fails for any DAO whose `of` is a `ClassInfo` with no backing Java class (`getObjClass()` returns `null`).

Since the writer was set to omit the `class:` prefix when an object's type matches the DAO's `of`, journal entries look like `c({id:1,...})`. On replay, `F3FileJournal` passes `dao.getOf().getObjClass()` to the parser — which is `null` for ClassInfos without a backing Java class. With no `class:` hint in the entry and no default Class, `FObjectParser` has nothing to instantiate from and returns `null`, so every entry reports a parse error and the DAO comes up empty after restart.

## Solution
Thread the full `ClassInfo` (not just its Java Class) to the parser through the existing X context. In the class-absent fallback path, `FObjectParser` checks the context for a default `ClassInfo` and uses `ci.newInstance()` to construct the target object — the same primitive it already uses when a `class:` prefix is present.

No API change. DAOs whose `getObjClass()` returns a real Class keep their existing path untouched.

## Changes
- `src/foam/dao/F3FileJournal.js` — when `dao.getOf().getObjClass()` is null, put `dao.getOf()` into X under `"defaultClassInfo"` before calling the parser
- `src/foam/lib/json/FObjectParser.java` — in the `class:`-absent branch, if no default Class was supplied, read `"defaultClassInfo"` from the parser context and use it as the target ClassInfo