### PR TITLE
LSP: add Claude Code editor integration via MCP

### DIFF
--- a/tools/lsp/editors/claude-code/README.md
+++ b/tools/lsp/editors/claude-code/README.md
@@ -1,0 +1,71 @@
+# FOAM LSP — Claude Code MCP Integration
+
+Exposes the FOAM Language Server to Claude Code as an MCP (Model Context
+Protocol) server, so Claude can query hover, definitions, references,
+symbols, and diagnostics against the live FOAM registry — instead of
+falling back to text search.
+
+## Install
+
+```bash
+./install.sh
+```
+
+The installer writes (or merges into) `.mcp.json` at the FOAM project
+root with a `foam-lsp` MCP server entry. Restart Claude Code (or run
+`/mcp` to reload). On first prompt, approve the project-scoped `.mcp.json`.
+
+The LSP takes ~10-15 seconds to index all FOAM models on first startup.
+Because the MCP server keeps the LSP alive for the session, only the
+first tool call in a given Claude Code session pays that cost.
+
+## Tools
+
+| Tool | Arguments | Returns |
+|---|---|---|
+| `foam_hover` | `uri`, `line`, `character` (0-based) | Class docs, property types, method signatures, short-name resolution |
+| `foam_definition` | `uri`, `line`, `character` | Source location for classes in `extends:`, `requires:`, `of:`, property types |
+| `foam_references` | `uri`, `line`, `character` | Subclasses of a class, implementors of an interface |
+| `foam_document_symbols` | `uri` | Outline of a file (classes, properties, methods, actions) |
+| `foam_workspace_symbols` | `query` | All FOAM classes matching a name substring |
+| `foam_diagnostics` | `uri` (optional) | Unknown classes, bad `foam.nanos.*` imports, CSS-token violations, invalid getters/setters in javaCode |
+
+URIs accept: absolute paths, project-relative paths, or `file://` URIs.
+
+## Architecture
+
+```
+Claude Code ──NDJSON──► server.js ──Content-Length JSON-RPC──► lsp-start.js
+  (MCP stdio)           (this dir)                             (foam3/tools)
+```
+
+- `server.js` — pure Node, zero dependencies. Speaks MCP on its own
+  stdin/stdout, spawns the FOAM LSP as a child, translates MCP tool
+  calls into LSP JSON-RPC requests.
+- `install.sh` — detects the project root (first ancestor with `pom.js`
+  and a `foam3/` dir), writes or merges `.mcp.json`.
+
+## Troubleshooting
+
+**LSP boot never completes.** Check stderr output in Claude Code's
+`/mcp` view. The server logs are prefixed `[foam-mcp]` and the LSP's
+output is forwarded with `[foam-lsp]`. A syntax error in a model file
+is non-fatal — the LSP continues — but a broken `pom.js` will prevent
+model indexing.
+
+**Tool returns empty results.** For `foam_workspace_symbols`, the query
+matches substrings against full class ids. For position-based tools,
+verify the URI + line/character land on a FOAM class reference (not
+inside a string literal or Java block that the LSP doesn't yet parse).
+
+**Changing `foam.flags`.** The LSP respects `{ js, java, web, test,
+node, swift, debug }` flag state. Toggling flags requires restarting
+the LSP — kill the MCP server (via `/mcp` or restart Claude Code) and
+it'll respawn the LSP on the next tool call.
+
+**Uninstall.** Remove the `foam-lsp` entry from `.mcp.json` at the
+project root.
+
+## License
+
+Apache 2.0 (FOAM Authors, 2026). Same as the rest of `foam3/`.

--- a/tools/lsp/editors/claude-code/install.sh
+++ b/tools/lsp/editors/claude-code/install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Register the FOAM LSP MCP server with Claude Code by writing/merging
+# `.mcp.json` at the FOAM project root.
+#
+# Usage:
+#   ./install.sh        # detect project root and install
+#   ./install.sh --dry  # print the entry that would be written, no write
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVER_JS="$SCRIPT_DIR/server.js"
+
+# --- sanity checks --------------------------------------------------------
+
+if ! command -v node &>/dev/null; then
+  echo "ERROR: node is not installed. Install Node.js first." >&2
+  exit 1
+fi
+
+if ! command -v claude &>/dev/null; then
+  echo "WARNING: 'claude' CLI not found in PATH." >&2
+  echo "         Install Claude Code: https://docs.claude.com/en/docs/claude-code/setup" >&2
+  echo "         Continuing — .mcp.json will still be written." >&2
+fi
+
+if [ ! -f "$SERVER_JS" ]; then
+  echo "ERROR: MCP server not found at $SERVER_JS" >&2
+  exit 1
+fi
+
+# --- locate project root -------------------------------------------------
+#
+# This script lives at <root>/foam3/tools/lsp/editors/claude-code/, so the
+# project root is exactly 5 levels up. (Walking upward by "pom.js + foam3/"
+# is unreliable because foam3/ self-symlinks foam3 -> .)
+
+if [ -n "${FOAM_PROJECT_ROOT:-}" ]; then
+  PROJECT_ROOT="$FOAM_PROJECT_ROOT"
+else
+  PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+fi
+
+if [ ! -f "$PROJECT_ROOT/pom.js" ]; then
+  echo "ERROR: $PROJECT_ROOT/pom.js not found — not a FOAM project root." >&2
+  echo "       Set FOAM_PROJECT_ROOT explicitly and retry." >&2
+  exit 1
+fi
+
+MCP_JSON="$PROJECT_ROOT/.mcp.json"
+
+echo "==> FOAM LSP MCP — installing for Claude Code"
+echo "    Project root : $PROJECT_ROOT"
+echo "    Server       : $SERVER_JS"
+echo "    Config       : $MCP_JSON"
+echo ""
+
+# --- build the merged config via Node (reliable JSON handling) ----------
+
+NEW_JSON="$(
+  node -e '
+    const fs = require("fs");
+    const p  = process.argv[1];
+    const server = process.argv[2];
+    const root   = process.argv[3];
+    let cfg = {};
+    if ( fs.existsSync(p) ) {
+      try { cfg = JSON.parse(fs.readFileSync(p, "utf8")); } catch (e) { cfg = {}; }
+    }
+    if ( ! cfg.mcpServers ) cfg.mcpServers = {};
+    cfg.mcpServers["foam-lsp"] = {
+      command: "node",
+      args:    [server],
+      env:     { FOAM_PROJECT_ROOT: root }
+    };
+    process.stdout.write(JSON.stringify(cfg, null, 2) + "\n");
+  ' "$MCP_JSON" "$SERVER_JS" "$PROJECT_ROOT"
+)"
+
+if [ "${1:-}" = "--dry" ]; then
+  echo "--- Dry run — would write to $MCP_JSON ---"
+  echo "$NEW_JSON"
+  exit 0
+fi
+
+printf '%s' "$NEW_JSON" > "$MCP_JSON"
+
+echo "OK — wrote $MCP_JSON"
+echo ""
+echo "============================================================"
+echo "  FOAM LSP MCP server registered."
+echo ""
+echo "  Next steps:"
+echo "    1. Restart Claude Code (or run /mcp to reload)."
+echo "    2. Approve the project-scoped .mcp.json if prompted."
+echo "    3. First tool call pays ~10-15s LSP boot; then fast."
+echo ""
+echo "  Available tools:"
+echo "    foam_hover              hover info at a cursor position"
+echo "    foam_definition         jump to definition"
+echo "    foam_references         find subclasses / implementors"
+echo "    foam_document_symbols   outline of a file"
+echo "    foam_workspace_symbols  search classes by name"
+echo "    foam_diagnostics        FOAM-aware diagnostics"
+echo ""
+echo "  To uninstall: remove the \"foam-lsp\" entry from .mcp.json"
+echo "============================================================"

--- a/tools/lsp/editors/claude-code/server.js
+++ b/tools/lsp/editors/claude-code/server.js
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// FOAM LSP MCP Server — exposes the FOAM Language Server as MCP tools
+// for Claude Code. Speaks MCP (NDJSON) on its own stdio, spawns the FOAM
+// LSP (`foam3/tools/lsp-start.js`) as a child, and speaks LSP (Content-
+// Length-framed JSON-RPC) to it.
+//
+// Environment:
+//   FOAM_PROJECT_ROOT  — absolute path to the FOAM project root (the dir
+//                        containing pom.js and the foam3/ submodule).
+//                        Falls back to process.cwd() if unset.
+
+'use strict';
+
+const { spawn }   = require('child_process');
+const fs          = require('fs');
+const path        = require('path');
+const readline    = require('readline');
+
+// --- stderr logger (stdout is reserved for MCP protocol) -----------------
+
+function log() {
+  const args = Array.prototype.slice.call(arguments);
+  process.stderr.write('[foam-mcp] ' + args.join(' ') + '\n');
+}
+
+function sleep(ms) { return new Promise(function(r) { setTimeout(r, ms); }); }
+
+// --- URI helpers ---------------------------------------------------------
+
+function normalizeUri(raw, projectRoot) {
+  if ( ! raw ) return raw;
+  if ( raw.startsWith('file://') ) return raw;
+  if ( path.isAbsolute(raw) ) return 'file://' + raw;
+  return 'file://' + path.resolve(projectRoot, raw);
+}
+
+function uriToPath(uri) {
+  if ( uri.startsWith('file://') ) return decodeURIComponent(uri.slice(7));
+  return uri;
+}
+
+// --- FOAM LSP client ------------------------------------------------------
+
+class FoamLSPClient {
+  constructor(projectRoot) {
+    this.projectRoot       = projectRoot;
+    this.nextId            = 1;
+    this.pending           = new Map();       // id -> { resolve, reject }
+    this.openedUris        = new Set();
+    this.diagnosticsByUri  = new Map();       // uri -> diagnostics[]
+    this.buffer            = Buffer.alloc(0);
+    this.isReady           = false;
+    this._whenReady        = new Promise(function(resolve, reject) {
+      this._resolveReady = resolve;
+      this._rejectReady  = reject;
+    }.bind(this));
+  }
+
+  whenReady() { return this._whenReady; }
+
+  start() {
+    const entry = path.join(this.projectRoot, 'foam3/tools/lsp-start.js');
+    if ( ! fs.existsSync(entry) ) {
+      this._rejectReady(new Error('FOAM LSP entry not found at ' + entry));
+      return;
+    }
+    log('spawning LSP:', 'node', entry, '(cwd=' + this.projectRoot + ')');
+
+    this.child = spawn('node', [entry], {
+      cwd:   this.projectRoot,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    this.child.stdout.on('data', this._onStdout.bind(this));
+    this.child.stderr.on('data', function(chunk) {
+      // Forward LSP stderr to our stderr with a prefix; never touch stdout.
+      const text = chunk.toString('utf8');
+      text.split('\n').forEach(function(ln) {
+        if ( ln ) process.stderr.write('[foam-lsp] ' + ln + '\n');
+      });
+    });
+    this.child.on('exit', function(code, signal) {
+      log('LSP exited code=' + code + ' signal=' + signal);
+      if ( ! this.isReady ) {
+        this._rejectReady(new Error('LSP exited during init (code=' + code + ')'));
+      }
+    }.bind(this));
+
+    // Kick off initialize.
+    this._rawRequest('initialize', {
+      processId:    process.pid,
+      rootUri:      'file://' + this.projectRoot,
+      capabilities: {
+        textDocument: {
+          publishDiagnostics: { relatedInformation: false },
+          hover:              { contentFormat: ['markdown', 'plaintext'] }
+        }
+      },
+      workspaceFolders: [{
+        uri:  'file://' + this.projectRoot,
+        name: path.basename(this.projectRoot)
+      }]
+    }).then(function(initResult) {
+      log('LSP initialized');
+      this._notify('initialized', {});
+      this.isReady = true;
+      this._resolveReady(initResult);
+    }.bind(this)).catch(function(e) {
+      log('LSP initialize failed:', e.message);
+      this._rejectReady(e);
+    }.bind(this));
+  }
+
+  // Stream parser — LSP uses Content-Length framing.
+  _onStdout(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while ( true ) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if ( headerEnd < 0 ) return;
+      const header = this.buffer.slice(0, headerEnd).toString('utf8');
+      const match  = header.match(/Content-Length:\s*(\d+)/i);
+      if ( ! match ) {
+        // Malformed header — skip past it.
+        this.buffer = this.buffer.slice(headerEnd + 4);
+        continue;
+      }
+      const len   = parseInt(match[1], 10);
+      const total = headerEnd + 4 + len;
+      if ( this.buffer.length < total ) return;
+      const body  = this.buffer.slice(headerEnd + 4, total).toString('utf8');
+      this.buffer = this.buffer.slice(total);
+      let msg;
+      try { msg = JSON.parse(body); }
+      catch (e) { log('LSP body parse error:', e.message); continue; }
+      this._onMessage(msg);
+    }
+  }
+
+  _onMessage(msg) {
+    if ( msg.id !== undefined && this.pending.has(msg.id) ) {
+      const p = this.pending.get(msg.id);
+      this.pending.delete(msg.id);
+      if ( msg.error ) p.reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+      else             p.resolve(msg.result);
+      return;
+    }
+    if ( msg.method === 'textDocument/publishDiagnostics' ) {
+      const params = msg.params || {};
+      if ( params.uri ) this.diagnosticsByUri.set(params.uri, params.diagnostics || []);
+      return;
+    }
+    // Ignore server-initiated window/* and other notifications.
+  }
+
+  _sendRaw(message) {
+    const body   = JSON.stringify(message);
+    const buf    = Buffer.from(body, 'utf8');
+    const header = 'Content-Length: ' + buf.length + '\r\n\r\n';
+    this.child.stdin.write(header);
+    this.child.stdin.write(buf);
+  }
+
+  _rawRequest(method, params) {
+    const id   = this.nextId++;
+    const self = this;
+    return new Promise(function(resolve, reject) {
+      self.pending.set(id, { resolve: resolve, reject: reject });
+      self._sendRaw({ jsonrpc: '2.0', id: id, method: method, params: params });
+    });
+  }
+
+  _notify(method, params) {
+    this._sendRaw({ jsonrpc: '2.0', method: method, params: params });
+  }
+
+  async request(method, params) {
+    await this.whenReady();
+    return this._rawRequest(method, params);
+  }
+
+  async ensureOpen(uri) {
+    await this.whenReady();
+    if ( this.openedUris.has(uri) ) return;
+    const fsPath = uriToPath(uri);
+    const text   = fs.readFileSync(fsPath, 'utf8');
+    this._notify('textDocument/didOpen', {
+      textDocument: {
+        uri:        uri,
+        languageId: 'javascript',
+        version:    1,
+        text:       text
+      }
+    });
+    this.openedUris.add(uri);
+  }
+
+  async getDiagnostics(uri) {
+    await this.whenReady();
+    if ( ! uri ) {
+      const out = {};
+      for ( const entry of this.diagnosticsByUri ) out[entry[0]] = entry[1];
+      return out;
+    }
+    await this.ensureOpen(uri);
+    // Diagnostics are pushed asynchronously after didOpen; give the server
+    // a moment to publish for this URI.
+    for ( let i = 0 ; i < 10 && ! this.diagnosticsByUri.has(uri) ; i++ ) {
+      await sleep(100);
+    }
+    return this.diagnosticsByUri.get(uri) || [];
+  }
+}
+
+// --- MCP tool schemas -----------------------------------------------------
+
+function toolSchemas() {
+  const pos = {
+    uri: {
+      type:        'string',
+      description: 'Absolute path, project-relative path, or file:// URI'
+    },
+    line:      { type: 'integer', description: '0-based line number' },
+    character: { type: 'integer', description: '0-based column' }
+  };
+  return [
+    {
+      name:        'foam_hover',
+      description: 'FOAM-aware hover at a cursor position. Returns class docs, property types, method signatures, and short-name resolution from the live FOAM registry.',
+      inputSchema: {
+        type: 'object', required: ['uri','line','character'], properties: pos
+      }
+    },
+    {
+      name:        'foam_definition',
+      description: 'Go-to-definition for FOAM classes, property types, or require references at a cursor position.',
+      inputSchema: {
+        type: 'object', required: ['uri','line','character'], properties: pos
+      }
+    },
+    {
+      name:        'foam_references',
+      description: 'Find FOAM references: subclasses of a class or implementors of an interface at a cursor position.',
+      inputSchema: {
+        type: 'object', required: ['uri','line','character'], properties: pos
+      }
+    },
+    {
+      name:        'foam_document_symbols',
+      description: 'Outline of a FOAM file: classes, properties, methods, actions. Good for quickly understanding a model.',
+      inputSchema: {
+        type: 'object', required: ['uri'], properties: { uri: pos.uri }
+      }
+    },
+    {
+      name:        'foam_workspace_symbols',
+      description: 'Search all FOAM classes across the workspace by name (substring match against the full class id).',
+      inputSchema: {
+        type:     'object',
+        required: ['query'],
+        properties: {
+          query: { type: 'string', description: 'Class name or substring, e.g. "MCIFee" or "Fee"' }
+        }
+      }
+    },
+    {
+      name:        'foam_diagnostics',
+      description: 'FOAM-aware diagnostics for a file or the whole workspace: unknown class references, wrong foam.nanos.* imports, CSS-token violations, invalid getters/setters in javaCode blocks.',
+      inputSchema: {
+        type: 'object', properties: { uri: pos.uri }
+      }
+    }
+  ];
+}
+
+// --- Tool dispatch --------------------------------------------------------
+
+async function callTool(lsp, projectRoot, name, args) {
+  args = args || {};
+  switch ( name ) {
+    case 'foam_hover': {
+      const uri = normalizeUri(args.uri, projectRoot);
+      await lsp.ensureOpen(uri);
+      const res = await lsp.request('textDocument/hover', {
+        textDocument: { uri: uri },
+        position:     { line: args.line | 0, character: args.character | 0 }
+      });
+      return res || { contents: null };
+    }
+    case 'foam_definition': {
+      const uri = normalizeUri(args.uri, projectRoot);
+      await lsp.ensureOpen(uri);
+      const res = await lsp.request('textDocument/definition', {
+        textDocument: { uri: uri },
+        position:     { line: args.line | 0, character: args.character | 0 }
+      });
+      return res || [];
+    }
+    case 'foam_references': {
+      const uri = normalizeUri(args.uri, projectRoot);
+      await lsp.ensureOpen(uri);
+      const res = await lsp.request('textDocument/references', {
+        textDocument: { uri: uri },
+        position:     { line: args.line | 0, character: args.character | 0 },
+        context:      { includeDeclaration: false }
+      });
+      return res || [];
+    }
+    case 'foam_document_symbols': {
+      const uri = normalizeUri(args.uri, projectRoot);
+      await lsp.ensureOpen(uri);
+      const res = await lsp.request('textDocument/documentSymbol', {
+        textDocument: { uri: uri }
+      });
+      return res || [];
+    }
+    case 'foam_workspace_symbols': {
+      const res = await lsp.request('workspace/symbol', {
+        query: String(args.query || '')
+      });
+      return res || [];
+    }
+    case 'foam_diagnostics': {
+      const uri = args.uri ? normalizeUri(args.uri, projectRoot) : null;
+      return await lsp.getDiagnostics(uri);
+    }
+    default:
+      throw new Error('Unknown tool: ' + name);
+  }
+}
+
+// --- MCP server over stdio (NDJSON) --------------------------------------
+
+function sendMCP(message) {
+  process.stdout.write(JSON.stringify(message) + '\n');
+}
+
+function mcpResult(id, result) { sendMCP({ jsonrpc: '2.0', id: id, result: result }); }
+function mcpError(id, code, message) {
+  sendMCP({ jsonrpc: '2.0', id: id, error: { code: code, message: message } });
+}
+function toolContent(obj) {
+  return { content: [{ type: 'text', text: JSON.stringify(obj, null, 2) }] };
+}
+
+(async function main() {
+  const projectRoot = process.env.FOAM_PROJECT_ROOT || process.cwd();
+  log('project root:', projectRoot);
+
+  const lsp = new FoamLSPClient(projectRoot);
+  lsp.start();                              // fire-and-forget; tool calls await whenReady()
+  lsp.whenReady().catch(function() {});     // prevent unhandled rejection
+
+  const tools = toolSchemas();
+
+  const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+  rl.on('line', async function(line) {
+    if ( ! line.trim() ) return;
+    let msg;
+    try { msg = JSON.parse(line); }
+    catch (e) { log('MCP parse error:', e.message); return; }
+
+    const id     = msg.id;
+    const method = msg.method;
+
+    if ( id === undefined ) {
+      // MCP notification (e.g. notifications/initialized) — no response.
+      return;
+    }
+
+    try {
+      if ( method === 'initialize' ) {
+        mcpResult(id, {
+          protocolVersion: '2024-11-05',
+          capabilities:    { tools: {} },
+          serverInfo:      { name: 'foam-lsp', version: '0.1.0' }
+        });
+        return;
+      }
+      if ( method === 'tools/list' ) {
+        mcpResult(id, { tools: tools });
+        return;
+      }
+      if ( method === 'tools/call' ) {
+        const name = msg.params && msg.params.name;
+        const args = msg.params && msg.params.arguments;
+        try {
+          const out = await callTool(lsp, projectRoot, name, args);
+          mcpResult(id, toolContent(out));
+        } catch (e) {
+          log('tool error (' + name + '):', e.message);
+          mcpResult(id, {
+            content: [{ type: 'text', text: 'Error: ' + e.message }],
+            isError: true
+          });
+        }
+        return;
+      }
+      mcpError(id, -32601, 'Method not found: ' + method);
+    } catch (e) {
+      mcpError(id, -32603, 'Internal error: ' + e.message);
+    }
+  });
+
+  rl.on('close', function() {
+    log('stdin closed, shutting down');
+    if ( lsp.child && ! lsp.child.killed ) lsp.child.kill();
+    process.exit(0);
+  });
+})();

--- a/tools/lsp/install.sh
+++ b/tools/lsp/install.sh
@@ -41,6 +41,7 @@ show_help() {
   echo "  vscode              VS Code (builds .vsix and installs)"
   echo "  emacs               Emacs (eglot + lsp-mode)"
   echo "  zed                 Zed IDE (dev extension)"
+  echo "  claude-code         Claude Code (MCP server)"
   echo ""
   echo "Build system:"
   echo "  ./build.sh lsp-install              Same as $0"
@@ -52,6 +53,7 @@ detect_editors() {
   if command -v code &>/dev/null; then found+=("vscode"); fi
   if command -v emacs &>/dev/null; then found+=("emacs"); fi
   if command -v zed &>/dev/null; then found+=("zed"); fi
+  if command -v claude &>/dev/null; then found+=("claude-code"); fi
   echo "${found[@]}"
 }
 
@@ -82,14 +84,24 @@ install_zed() {
   (cd "$EDITORS_DIR/zed-foam3" && ./install.sh)
 }
 
+install_claude_code() {
+  echo -e "${CYAN}==> Claude Code${RESET}"
+  if [ ! -d "$EDITORS_DIR/claude-code" ]; then
+    echo "ERROR: Claude Code integration not found at $EDITORS_DIR/claude-code"
+    return 1
+  fi
+  (cd "$EDITORS_DIR/claude-code" && ./install.sh)
+}
+
 install_editor() {
   case "$1" in
-    vscode|vs-code|code)  install_vscode ;;
-    emacs)                install_emacs ;;
-    zed)                  install_zed ;;
+    vscode|vs-code|code)               install_vscode ;;
+    emacs)                             install_emacs ;;
+    zed)                               install_zed ;;
+    claude|claude-code|claude_code)    install_claude_code ;;
     *)
       echo "Unknown editor: $1"
-      echo "Available: vscode, emacs, zed"
+      echo "Available: vscode, emacs, zed, claude-code"
       return 1
       ;;
   esac
@@ -107,7 +119,7 @@ case "${1:-}" in
     detected=$(detect_editors)
     if [ -z "$detected" ]; then
       echo "No supported editors detected in PATH."
-      echo "Supported: code (VS Code), emacs, zed"
+      echo "Supported: code (VS Code), emacs, zed, claude (Claude Code)"
       exit 1
     fi
     for editor in $detected; do
@@ -123,7 +135,7 @@ case "${1:-}" in
     detected=$(detect_editors)
     if [ -z "$detected" ]; then
       echo "No supported editors detected in PATH."
-      echo "Supported: code (VS Code), emacs, zed"
+      echo "Supported: code (VS Code), emacs, zed, claude (Claude Code)"
       echo ""
       echo "Run with a specific editor: $0 vscode"
       exit 1


### PR DESCRIPTION
## Problem

The FOAM LSP ships editor integrations for VS Code, Emacs, and Zed, but no integration for Claude Code — an LLM-driven CLI coding assistant. Claude Code speaks the Model Context Protocol (MCP), not LSP directly, so it cannot consume the LSP's hover, go-to-definition, find-references, symbol search, or diagnostics. Without a bridge, it falls back to text search when answering FOAM-specific questions, ignoring the class registry and CSS-token checks the LSP already provides.

## Solution

Add a new editor integration at `tools/lsp/editors/claude-code/` that hosts a zero-dependency Node.js MCP server. The server spawns `foam3/tools/lsp-start.js` as a child, speaks LSP (Content-Length-framed JSON-RPC) to it, and exposes six MCP tools backed by standard LSP methods: `foam_hover`, `foam_definition`, `foam_references`, `foam_document_symbols`, `foam_workspace_symbols`, and `foam_diagnostics`. Requests normalize URIs (accepting absolute paths, project-relative paths, or `file://` URIs) and issue `textDocument/didOpen` lazily per file before position-based queries. Diagnostics are captured from `publishDiagnostics` notifications and returned on request.

The integration installs the same way as the Zed and Emacs ones: a standalone `install.sh` under the new directory, plus dispatch wiring in the parent `tools/lsp/install.sh` (auto-detection, named case, help text). The installer writes or merges an `.mcp.json` entry at the FOAM project root pointing the Claude Code CLI at the MCP server with `FOAM_PROJECT_ROOT` set, so the LSP boots against the correct workspace.

## Changes

- `tools/lsp/editors/claude-code/server.js` — dependency-free Node MCP server. LSP client class (Content-Length framing, request/notify helpers, `publishDiagnostics` capture, lazy `ensureOpen`). MCP server over stdio (NDJSON) handling `initialize`, `tools/list`, and `tools/call`. Six tool schemas with 0-based `line`/`character` inputs matching LSP convention.

- `tools/lsp/editors/claude-code/install.sh` — project-root detection (5 levels up from the script dir; deterministic rather than walking because `foam3/foam3` self-symlinks), Node CLI check, and a Node-driven JSON merge that preserves any existing `mcpServers` entries in `.mcp.json`. Supports `--dry` for preview.

- `tools/lsp/editors/claude-code/README.md` — install command, tool reference, architecture diagram, and troubleshooting notes (boot time, flag toggles, uninstall).

- `tools/lsp/install.sh` — register `claude-code` alongside `vscode`, `emacs`, `zed`: `detect_editors` checks for `claude` in PATH; `install_editor` routes `claude|claude-code|claude_code`; new `install_claude_code` delegates to the subdirectory installer; help text and usage hints updated.