### PR TITLE
fix(dashboard): align stacked pie legends to fixed width

### DIFF
--- a/src/foam/core/reflow/dashboard/CanvasTextUtil.js
+++ b/src/foam/core/reflow/dashboard/CanvasTextUtil.js
@@ -70,17 +70,23 @@ foam.LIB({
 
     {
       name: 'legendLabelChromePx',
-      documentation: `Horizontal overhead Chart.js reserves per legend
-        item for the swatch + inner/outer padding, before any text is
-        drawn. Used to derive the per-line text area from the overall
-        legend.maxWidth.`,
+      documentation: `Horizontal overhead Chart.js v4 reserves around the
+        widest legend item in a right/left (single-column) legend,
+        before any text is drawn. Derived directly from chart.js 4.x
+        _fitCols + calculateItemWidth:
+          legendWidth = padding + (boxWidth + fontSize/2 + textWidth) + 10
+        so chrome (non-text) = padding + boxWidth + fontSize/2 + 10.
+        Defaults match Chart.js v4: boxWidth falls back to fontSize
+        (v4 changed this from v2/v3's 40 — see chart.js getBoxSize),
+        padding to 10. With labelFont.size=12 and no overrides chrome
+        ≈ 10 + 12 + 6 + 10 = 38.`,
       code: function(chart) {
         var labelOpts = chart.options.plugins.legend.labels || {};
-        var boxWidth  = labelOpts.boxWidth !== undefined ? labelOpts.boxWidth : 40;
+        var f         = labelOpts.font || chart.options.font || {};
+        var fontSize  = f.size || 12;
+        var boxWidth  = labelOpts.boxWidth !== undefined ? labelOpts.boxWidth : fontSize;
         var padding   = labelOpts.padding  !== undefined ? labelOpts.padding  : 10;
-        // Chart.js v4 item layout (right/left position):
-        //   boxWidth + (boxWidth / 2) + textWidth + outer padding × 2.
-        return boxWidth + (boxWidth / 2) + (padding * 2);
+        return padding + boxWidth + (fontSize / 2) + 10;
       }
     },
 
@@ -121,12 +127,33 @@ foam.LIB({
         var target = items[bestItemIdx];
         var line = Array.isArray(target.text) ? target.text[bestLineIdx] : target.text;
         var padded = line;
-        // Binary-growth then fine tune: start with a single NBSP run,
-        // double until it overshoots, then trim back one at a time.
+        // HAIR space (U+200A) closes the last NBSP-width gap down to ~1px. Like
+        // NBSP, it's non-collapsing so Chart.js preserves it at draw time.
+        var HAIR = '\u200A';
+        // Four phases, each closing a narrower gap than the last:
+        //   1. geometric NBSP doubling — coarse approach (cheap for large gaps)
+        //   2. linear NBSP fill — closes the up-to-one-run undershoot that the
+        //      geometric loop leaves behind (without this, shorter-label charts
+        //      undershoot by different amounts than longer-label ones and
+        //      stacked pies still drift)
+        //   3. linear HAIR fill — closes the final NBSP-width gap (~3.5px) to
+        //      hair-space granularity (~1px). Guarded against fonts that render
+        //      HAIR as zero-width; in that case phase 2's accuracy stands.
+        //   4. defensive trim — shouldn't run after phase 3, cheap insurance.
         var run = NBSP;
         while ( ctx.measureText(padded + run).width < minPx ) {
           padded += run;
           if ( run.length < 64 ) run += run; // geometric growth caps overshoot
+        }
+        while ( ctx.measureText(padded + NBSP).width <= minPx ) {
+          padded += NBSP;
+        }
+        // Guard against fonts that render HAIR as 0-width (infinite loop) —
+        // we still get NBSP-level accuracy from the phase above.
+        if ( ctx.measureText(HAIR).width > 0 ) {
+          while ( ctx.measureText(padded + HAIR).width <= minPx ) {
+            padded += HAIR;
+          }
         }
         while ( padded.length > line.length && ctx.measureText(padded).width > minPx ) {
           padded = padded.slice(0, -1);


### PR DESCRIPTION
## Problem
Setting `legendMinWidthPercent = legendMaxWidthPercent` on a `DashboardPieChartDAOAgent` is supposed to give every pie in a stacked column an identical legend width so the arcs line up. In practice the legends still came out different widths, and shorter-label charts ended up with shorter legends — so the pie centers drifted by 10-12px between charts. Two independent bugs in `CanvasTextUtil`.

## Solution
**1. `legendLabelChromePx` used the Chart.js v2 default `boxWidth = 40` and added outer padding twice.** Chart.js 4's `_fitCols` + `calculateItemWidth` reserves `padding + (boxWidth + fontSize/2 + textWidth) + 10`, and `boxWidth` defaults to `fontSize`, not 40. The helper over-reserved by ~40px so the pad target sat well below the real legend width. Rewrite to match the v4 formula: `chrome = padding + boxWidth + fontSize/2 + 10`, with `boxWidth` defaulting to `fontSize`.

**2. `padWidestToMin`'s geometric NBSP loop exits one run short of the target.** The loop doubles the NBSP run length and stops when the *next* doubled run would push `padded` past `minPx`. That leaves `padded` up to 64 NBSPs under the target — and since the trim loop only runs on overshoot, the undershoot is kept. Shorter-label charts undershoot by different amounts than longer-label ones, so stacked pies still drift. Add a linear single-NBSP fill after the geometric phase, then a hair-space (U+200A) fill to close the final NBSP-width gap to ~1px. The hair-space phase is guarded against fonts that render U+200A as zero-width (would infinite-loop) — in that case NBSP-level accuracy still holds.

## Changes
- `legendLabelChromePx`: correct the chrome formula for Chart.js v4 (`padding + boxWidth + fontSize/2 + 10`, `boxWidth` defaults to `fontSize`).
- `padWidestToMin`: add a linear NBSP fill phase after the geometric doubling, and a guarded hair-space (U+200A) fill phase after that, so padded width converges to within ~1px of `minPx`.
- Update documentation on both helpers to cite the Chart.js 4 source formula and explain why the extra fill phases matter.