### PR TITLE
feat(dashboard): truncate long pie legend labels with ellipsis

### DIFF
--- a/src/foam/core/reflow/dashboard/CanvasTextUtil.js
+++ b/src/foam/core/reflow/dashboard/CanvasTextUtil.js
@@ -54,6 +54,44 @@ foam.LIB({
     },
 
     {
+      name: 'truncate',
+      documentation: `Single-line truncation that ends with a Unicode
+        ellipsis (U+2026) when the input would exceed maxPx. Uses the
+        caller's font via ctx for accurate measurement. Returns the
+        original string when it already fits or when maxPx is non-positive.
+        For legend labels paired with a hover tooltip that shows the full
+        text — the ellipsis signals truncation without the extra legend
+        row that wrap() would add.`,
+      code: function(ctx, text, fontStr, maxPx) {
+        if ( ! text || maxPx <= 0 ) return text;
+        var s = String(text);
+        ctx.save();
+        if ( fontStr ) ctx.font = fontStr;
+        if ( ctx.measureText(s).width <= maxPx ) {
+          ctx.restore();
+          return s;
+        }
+        var ELLIPSIS  = '…';
+        var ellipsisW = ctx.measureText(ELLIPSIS).width;
+        // Binary-search the longest prefix whose measured width + the
+        // ellipsis still fits within maxPx.
+        var lo = 0, hi = s.length;
+        while ( lo < hi ) {
+          var mid = (lo + hi + 1) >> 1;
+          if ( ctx.measureText(s.slice(0, mid)).width + ellipsisW <= maxPx ) {
+            lo = mid;
+          } else {
+            hi = mid - 1;
+          }
+        }
+        // Strip trailing whitespace so the ellipsis sits tight against text.
+        var prefix = s.slice(0, lo).replace(/\s+$/, '');
+        ctx.restore();
+        return prefix + ELLIPSIS;
+      }
+    },
+
+    {
       name: 'legendLabelFont',
       documentation: `Builds the CSS font string Chart.js would use for a
         legend item, falling back to chart.options.font then Chart.js

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -489,8 +489,8 @@ foam.CLASS({
     { class: 'Boolean', name: 'clockwise', value: true },
     { class: 'Int', name: 'rotation', value: -90 },
     { class: 'Boolean', name: 'disableLegendClick', help: 'Disable legend click to toggle slice visibility' },
-    { class: 'Int', name: 'legendMinWidthPercent', help: 'Forces the legend to be at least this percentage (0-100) of container width by padding the widest label with trailing non-breaking spaces. Short legends grow to match; unboundedly long labels are also wrapped at this width (so a single long label can\'t push the legend wider than intended). 0 = no floor.' },
-    { class: 'Int', name: 'legendMaxWidthPercent', help: 'Caps the legend at this percentage (0-100) of container width and word-wraps long labels at the cap. 0 = no cap. Setting min = max gives an exact fixed-width legend — arcs line up perfectly across stacked pies.' },
+    { class: 'Int', name: 'legendMinWidthPercent', help: 'Forces the legend to be at least this percentage (0-100) of container width by padding the widest label with trailing non-breaking spaces. Short legends grow to match; longer labels are truncated with an ellipsis at this width (full text available in the hover tooltip) so a single long label can\'t push the legend wider than intended. 0 = no floor.' },
+    { class: 'Int', name: 'legendMaxWidthPercent', help: 'Caps the legend at this percentage (0-100) of container width; labels wider than the cap are truncated with an ellipsis (full text available in the hover tooltip). 0 = no cap. Setting min = max gives an exact fixed-width legend — arcs line up perfectly across stacked pies.' },
     // Display properties
     { class: 'Boolean', name: 'responsive', value: true },
     { class: 'Boolean', name: 'maintainAspectRatio', value: false },
@@ -706,14 +706,14 @@ foam.CLASS({
         //   1. percentage prefixing (showPercentages) — with '~' prefix
         //      when the displayed value is rounded (e.g. 0.04 → ~0.0%),
         //      so users know small slices survived rounding
-        //   2. word-wrap at the cap (legendCapPx — from max, or min when max
-        //      is unset, so a runaway label can't push the legend wider)
+        //   2. single-line ellipsis truncation at the cap (legendCapPx —
+        //      from max, or min when max is unset, so a runaway label
+        //      can't push the legend wider). The hover tooltip still
+        //      surfaces the full label.
         //   3. trailing-NBSP pad of the widest label up to legendMinPx so
         //      short legends grow out to the reserved width (Chart.js has
         //      no legend.minWidth; padding one item widens the whole legend
         //      column since its width tracks the widest item)
-        // Wrap returns either a string or an array of lines; Chart.js v4's
-        // renderText helper draws array-text as stacked lines.
         var CanvasTextUtil = foam.core.reflow.dashboard.CanvasTextUtil;
         if ( showPercentages || legendCapPx > 0 || legendMinPx > 0 ) {
           options.plugins.legend.labels = {
@@ -750,7 +750,7 @@ foam.CLASS({
                   var isApprox = parseFloat(pct) !== rawPct;
                   text = (isApprox ? '~' : '') + pct + '% ' + text;
                 }
-                if ( textMaxPx > 0 ) text = CanvasTextUtil.wrap(chart.ctx, text, fontStr, textMaxPx);
+                if ( textMaxPx > 0 ) text = CanvasTextUtil.truncate(chart.ctx, text, fontStr, textMaxPx);
 
                 var style = meta && meta.controller
                   ? meta.controller.getStyle(i)


### PR DESCRIPTION
## Truncate long pie legend labels with ellipsis

  Before this change, `DashboardPieSink` called `CanvasTextUtil.wrap` on labels wider than `legendMaxWidthPercent`, pushing long labels onto a second line. On stacked pies that made legend
   rows uneven and wasted vertical space. The full label is already surfaced by the hover tooltip, so a single-line prefix + `…` is enough to signal truncation.

  ## Changes
  - **`CanvasTextUtil.truncate(ctx, text, fontStr, maxPx)`** — new helper. Binary-searches the longest prefix whose width + ellipsis (U+2026) fits under `maxPx`, saves/restores `ctx.font`
  like the other helpers, and strips trailing whitespace so the ellipsis sits tight.
  - **`DashboardPieSink.generateLabels`** — swaps `CanvasTextUtil.wrap(...)` for `CanvasTextUtil.truncate(...)`. `padWidestToMin` is unchanged; it handles the single-string output the same
   way it handled arrayed text.
  - **Help text + nearby comment** updated to describe the new behavior.
  - `wrap()` is kept for any caller that still wants multi-line output.

## Before
<img width="555" height="238" alt="image" src="https://github.com/user-attachments/assets/6a151dc0-7a6a-48f8-8547-fb31ddeff461" />

## After
<img width="559" height="233" alt="image" src="https://github.com/user-attachments/assets/f3fec93d-6062-49d8-ad58-6fffb16f8e2b" />
