### PR TITLE
Add GlobalConfig: journal-backed key/value store for global configura…

### DIFF
--- a/src/foam/core/config/GlobalConfig.js
+++ b/src/foam/core/config/GlobalConfig.js
@@ -24,11 +24,17 @@ foam.CLASS({
     'foam.core.config.GlobalConfigType'
   ],
 
+  tableColumns: [ 'name', 'type', 'value', 'description' ],
+
   properties: [
     {
       class: 'String',
       name: 'name',
       required: true
+    },
+    {
+      class: 'String',
+      name: 'description'
     },
     {
       class: 'Enum',
@@ -58,8 +64,14 @@ foam.CLASS({
     {
       name: 'value',
       transient: true,
-      storageTransient: true,
+      projectionSafe: false,
       view: { class: 'foam.core.config.GlobalConfigValueView' },
+      tableWidth: 200,
+      tableCellFormatter: function(value) {
+        if ( value == null ) return;
+        if ( value instanceof Date ) { this.add(value.toISOString()); return; }
+        this.add(String(value));
+      },
       expression: function(type, stringValue, booleanValue, intValue, longValue, floatValue, doubleValue, dateValue, dateTimeValue) {
         if ( ! type ) return undefined;
         return this[type.valueField];

--- a/src/foam/core/config/GlobalConfig.js
+++ b/src/foam/core/config/GlobalConfig.js
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.config',
+  name: 'GlobalConfig',
+
+  documentation: `A journal-backed key/value store for global configuration.
+    Each entry stores its value in a type-specific backing property
+    (stringValue, booleanValue, intValue, ...). setValue/getValue route to the
+    correct backing based on the current type; the read-only 'value' property
+    exposes the same routing reactively for UI and programmatic reads.`,
+
+  ids: [ 'name' ],
+
+  requires: [
+    'foam.core.config.GlobalConfigType'
+  ],
+
+  javaImports: [
+    'foam.core.config.GlobalConfigType'
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'name',
+      required: true
+    },
+    {
+      class: 'Enum',
+      of: 'foam.core.config.GlobalConfigType',
+      name: 'type',
+      value: 'STRING',
+      postSet: function(old, nu) {
+        var values = this.GlobalConfigType.VALUES;
+        for ( var i = 0 ; i < values.length ; i++ ) {
+          if ( values[i] !== nu ) this.clearProperty(values[i].valueField);
+        }
+      },
+      javaPostSet: `
+        for ( GlobalConfigType t : GlobalConfigType.values() ) {
+          if ( t != val ) clearProperty(t.getValueField());
+        }
+      `
+    },
+    { class: 'String',   name: 'stringValue',   hidden: true },
+    { class: 'Boolean',  name: 'booleanValue',  hidden: true },
+    { class: 'Int',      name: 'intValue',      hidden: true },
+    { class: 'Long',     name: 'longValue',     hidden: true },
+    { class: 'Float',    name: 'floatValue',    hidden: true },
+    { class: 'Double',   name: 'doubleValue',   hidden: true },
+    { class: 'Date',     name: 'dateValue',     hidden: true },
+    { class: 'DateTime', name: 'dateTimeValue', hidden: true },
+    {
+      name: 'value',
+      transient: true,
+      storageTransient: true,
+      view: { class: 'foam.core.config.GlobalConfigValueView' },
+      expression: function(type, stringValue, booleanValue, intValue, longValue, floatValue, doubleValue, dateValue, dateTimeValue) {
+        if ( ! type ) return undefined;
+        return this[type.valueField];
+      }
+    }
+  ],
+
+  methods: [
+    {
+      name: 'setValue',
+      args: 'Object val',
+      code: function(val) {
+        if ( ! this.type ) return;
+        this[this.type.valueField] = val;
+      },
+      javaCode: `
+        if ( getType() == null ) return;
+        String field = getType().getValueField();
+        if ( field == null ) return;
+        switch ( field ) {
+          case "stringValue":
+            setStringValue(val == null ? "" : val.toString());
+            break;
+          case "booleanValue":
+            setBooleanValue(val instanceof Boolean
+              ? ((Boolean) val).booleanValue()
+              : Boolean.parseBoolean(String.valueOf(val)));
+            break;
+          case "intValue":
+            setIntValue(val instanceof Number
+              ? ((Number) val).intValue()
+              : Integer.parseInt(String.valueOf(val)));
+            break;
+          case "longValue":
+            setLongValue(val instanceof Number
+              ? ((Number) val).longValue()
+              : Long.parseLong(String.valueOf(val)));
+            break;
+          case "floatValue":
+            setFloatValue(val instanceof Number
+              ? ((Number) val).floatValue()
+              : Float.parseFloat(String.valueOf(val)));
+            break;
+          case "doubleValue":
+            setDoubleValue(val instanceof Number
+              ? ((Number) val).doubleValue()
+              : Double.parseDouble(String.valueOf(val)));
+            break;
+          case "dateValue":
+            setDateValue((java.util.Date) val);
+            break;
+          case "dateTimeValue":
+            setDateTimeValue((java.util.Date) val);
+            break;
+        }
+      `
+    },
+    {
+      name: 'getValue',
+      type: 'Object',
+      code: function() {
+        if ( ! this.type ) return undefined;
+        return this[this.type.valueField];
+      },
+      javaCode: `
+        if ( getType() == null ) return null;
+        String field = getType().getValueField();
+        if ( field == null ) return null;
+        switch ( field ) {
+          case "stringValue":   return getStringValue();
+          case "booleanValue":  return getBooleanValue();
+          case "intValue":      return getIntValue();
+          case "longValue":     return getLongValue();
+          case "floatValue":    return getFloatValue();
+          case "doubleValue":   return getDoubleValue();
+          case "dateValue":     return getDateValue();
+          case "dateTimeValue": return getDateTimeValue();
+        }
+        return null;
+      `
+    }
+  ]
+});

--- a/src/foam/core/config/GlobalConfigType.js
+++ b/src/foam/core/config/GlobalConfigType.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.core.config',
+  name: 'GlobalConfigType',
+
+  documentation: `Supported types for GlobalConfig values. Each value knows the
+    name of the backing *Value property on GlobalConfig that stores its data.`,
+
+  properties: [
+    {
+      class: 'String',
+      name: 'valueField'
+    }
+  ],
+
+  values: [
+    { name: 'STRING',    label: 'String',    valueField: 'stringValue' },
+    { name: 'BOOLEAN',   label: 'Boolean',   valueField: 'booleanValue' },
+    { name: 'INT',       label: 'Int',       valueField: 'intValue' },
+    { name: 'LONG',      label: 'Long',      valueField: 'longValue' },
+    { name: 'FLOAT',     label: 'Float',     valueField: 'floatValue' },
+    { name: 'DOUBLE',    label: 'Double',    valueField: 'doubleValue' },
+    { name: 'DATE',      label: 'Date',      valueField: 'dateValue' },
+    { name: 'DATE_TIME', label: 'DateTime',  valueField: 'dateTimeValue' }
+  ]
+});

--- a/src/foam/core/config/GlobalConfigValueView.js
+++ b/src/foam/core/config/GlobalConfigValueView.js
@@ -18,13 +18,14 @@ foam.CLASS({
   methods: [
     function render() {
       this.SUPER();
+      var self = this;
       var config = this.objData;
       if ( ! config ) return;
       this.add(config.dynamic(function(type) {
         if ( ! type ) return;
         var axiom = config.cls_.getAxiomByName(type.valueField);
         if ( ! axiom ) return;
-        this.startContext({ data: config }).tag(axiom).endContext();
+        this.add(axiom.toE({ data$: config.slot(type.valueField) }, self.__subContext__));
       }));
     }
   ]

--- a/src/foam/core/config/GlobalConfigValueView.js
+++ b/src/foam/core/config/GlobalConfigValueView.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.config',
+  name: 'GlobalConfigValueView',
+  extends: 'foam.u2.View',
+
+  documentation: `Dynamic editor for GlobalConfig.value. Renders the input for
+    whichever *Value backing property matches the parent's current type, so the
+    editor swaps automatically when the type selector changes.`,
+
+  imports: [ 'objData?' ],
+
+  methods: [
+    function render() {
+      this.SUPER();
+      var config = this.objData;
+      if ( ! config ) return;
+      this.add(config.dynamic(function(type) {
+        if ( ! type ) return;
+        var axiom = config.cls_.getAxiomByName(type.valueField);
+        if ( ! axiom ) return;
+        this.startContext({ data: config }).tag(axiom).endContext();
+      }));
+    }
+  ]
+});

--- a/src/foam/core/config/GlobalConfigs.java
+++ b/src/foam/core/config/GlobalConfigs.java
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core.config;
+
+import foam.dao.DAO;
+import foam.lang.X;
+import java.util.Date;
+
+/**
+ * Lookup helpers for GlobalConfig. Each typed getter takes an X context,
+ * an entry name, and a default value returned when the entry is missing,
+ * the DAO is not registered, or the entry's type does not match.
+ */
+public final class GlobalConfigs {
+  private GlobalConfigs() {}
+
+  public static Object get(X x, String name) {
+    GlobalConfig cfg = find_(x, name);
+    return cfg == null ? null : cfg.getValue();
+  }
+
+  public static String getString(X x, String name, String defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.STRING) ? cfg.getStringValue() : defaultValue;
+  }
+
+  public static boolean getBoolean(X x, String name, boolean defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.BOOLEAN) ? cfg.getBooleanValue() : defaultValue;
+  }
+
+  public static int getInt(X x, String name, int defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.INT) ? cfg.getIntValue() : defaultValue;
+  }
+
+  public static long getLong(X x, String name, long defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.LONG) ? cfg.getLongValue() : defaultValue;
+  }
+
+  public static float getFloat(X x, String name, float defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.FLOAT) ? cfg.getFloatValue() : defaultValue;
+  }
+
+  public static double getDouble(X x, String name, double defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.DOUBLE) ? cfg.getDoubleValue() : defaultValue;
+  }
+
+  public static Date getDate(X x, String name, Date defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.DATE) ? cfg.getDateValue() : defaultValue;
+  }
+
+  public static Date getDateTime(X x, String name, Date defaultValue) {
+    GlobalConfig cfg = find_(x, name);
+    return matches_(cfg, GlobalConfigType.DATE_TIME) ? cfg.getDateTimeValue() : defaultValue;
+  }
+
+  private static GlobalConfig find_(X x, String name) {
+    if ( x == null || name == null ) return null;
+    DAO dao = (DAO) x.get("globalConfigDAO");
+    if ( dao == null ) return null;
+    return (GlobalConfig) dao.find(name);
+  }
+
+  private static boolean matches_(GlobalConfig cfg, GlobalConfigType type) {
+    return cfg != null && cfg.getType() == type;
+  }
+}

--- a/src/foam/core/config/GlobalConfigs.js
+++ b/src/foam/core/config/GlobalConfigs.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.LIB({
+  name: 'foam.core.config.GlobalConfigs',
+
+  documentation: `Lookup helpers for GlobalConfig. Each typed getter takes an
+    X context, an entry name, and a default value returned when the entry is
+    missing, the DAO is not registered, or the entry's type does not match.`,
+
+  methods: [
+    async function get(x, name) {
+      var dao = x && x.globalConfigDAO;
+      if ( ! dao || ! name ) return undefined;
+      var cfg = await dao.find(name);
+      return cfg ? cfg.getValue() : undefined;
+    },
+
+    async function getTyped_(x, name, type, defaultValue) {
+      var dao = x && x.globalConfigDAO;
+      if ( ! dao || ! name ) return defaultValue;
+      var cfg = await dao.find(name);
+      if ( ! cfg || cfg.type !== type ) return defaultValue;
+      return cfg.getValue();
+    },
+
+    async function getString(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.STRING, defaultValue);
+    },
+    async function getBoolean(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.BOOLEAN, defaultValue);
+    },
+    async function getInt(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.INT, defaultValue);
+    },
+    async function getLong(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.LONG, defaultValue);
+    },
+    async function getFloat(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.FLOAT, defaultValue);
+    },
+    async function getDouble(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.DOUBLE, defaultValue);
+    },
+    async function getDate(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.DATE, defaultValue);
+    },
+    async function getDateTime(x, name, defaultValue) {
+      return this.getTyped_(x, name, foam.core.config.GlobalConfigType.DATE_TIME, defaultValue);
+    }
+  ]
+});

--- a/src/foam/core/config/pom.js
+++ b/src/foam/core/config/pom.js
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+foam.POM({
+  name: "config",
+  files: [
+    { name: "GlobalConfigType",      flags: "js|java" },
+    { name: "GlobalConfig",          flags: "js|java" },
+    { name: "GlobalConfigValueView", flags: "js"      }
+  ]
+});

--- a/src/foam/core/config/pom.js
+++ b/src/foam/core/config/pom.js
@@ -8,6 +8,10 @@ foam.POM({
   files: [
     { name: "GlobalConfigType",      flags: "js|java" },
     { name: "GlobalConfig",          flags: "js|java" },
-    { name: "GlobalConfigValueView", flags: "js"      }
+    { name: "GlobalConfigValueView", flags: "js"      },
+    { name: "GlobalConfigs",         flags: "js"      }
+  ],
+  javaFiles: [
+    { name: "GlobalConfigs" }
   ]
 });

--- a/src/foam/core/config/services.jrl
+++ b/src/foam/core/config/services.jrl
@@ -1,0 +1,18 @@
+p({
+  "class": "foam.core.boot.CSpec",
+  "name": "globalConfigDAO",
+  "serve": true,
+  "serviceScript": """
+    return new foam.dao.EasyDAO.Builder(x)
+      .setOf(foam.core.config.GlobalConfig.getOwnClassInfo())
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName("globalConfigs")
+      .setAuthorize(false)
+      .build();
+  """,
+  "client": """
+    {
+      "of": "foam.core.config.GlobalConfig"
+    }
+  """
+})

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -21,6 +21,7 @@ foam.POM({
     { name: "app/pom" },
     { name: "auth/pom" },
     { name: "browser/pom" },
+    { name: "config/pom" },
     { name: "reflow/pom" },
     { name: "er/pom" },
     { name: "jetty/pom" },


### PR DESCRIPTION
## Summary
Adds `foam.core.config`; a journal-backed key/value store for system-wide configuration, so global settings can be managed easily.

## Changes
- `GlobalConfigType` enum: supported value types (String, Boolean, Int, Long, Float, Double, Date, DateTime), each pointing at its backing property name.
- `GlobalConfig`: stores values in type-specific backing props; `setValue`/`getValue` and the reactive `value` expression route by current type. Changing type clears unused backings.
- `GlobalConfigValueView`: renders the editor for the current type's backing axiom; swaps automatically on type change.
- `globalConfigDAO` backed by the `globalConfigs` journal.