### PR TITLE
CronScheduler now shutdown gracefully to avoid corrupt journal entries.

### DIFF
--- a/src/foam/core/cron/CronScheduler.js
+++ b/src/foam/core/cron/CronScheduler.js
@@ -78,6 +78,11 @@ foam.CLASS({
       name: 'enabled',
       class: 'Boolean',
       value: true
+    },
+    {
+      name: 'timer',
+      class: 'Object',
+      visibility: 'HIDDEN'
     }
   ],
 
@@ -88,6 +93,7 @@ foam.CLASS({
       javaCode: `
       Loggers.logger(getX(), this).info("start");
       Timer timer = new Timer(this.getClass().getSimpleName());
+      setTimer(timer);
       timer.schedule(
         new AgencyTimerTask(getX(), this),
         getInitialTimerDelay());
@@ -98,6 +104,9 @@ foam.CLASS({
       javaCode: `
       synchronized ( lock_ ) {
         running_.set(false);
+        Timer timer = (Timer) getTimer();
+        if ( timer != null )
+          timer.cancel();
       }
       `
     },

--- a/src/foam/core/cron/CronScheduler.js
+++ b/src/foam/core/cron/CronScheduler.js
@@ -41,8 +41,14 @@ foam.CLASS({
     'foam.mlang.sink.Sequence',
     'java.util.Date',
     'java.util.List',
-    'java.util.Timer'
+    'java.util.Timer',
+    'java.util.concurrent.atomic.AtomicBoolean'
   ],
+
+  javaCode: `
+  AtomicBoolean running_ = new AtomicBoolean();
+  Object lock_           = new Object();
+  `,
 
   properties: [
     {
@@ -88,9 +94,25 @@ foam.CLASS({
       `
     },
     {
+      name: 'stop',
+      javaCode: `
+      synchronized ( lock_ ) {
+        running_.set(false);
+      }
+      `
+    },
+    {
       name: 'execute',
       javaCode: `
     final Logger logger = Loggers.logger(x, this);
+    synchronized ( lock_ ) {
+      if ( running_.get() ) {
+        logger.warning("already running");
+        return;
+      }
+      running_.set(true);
+    }
+
     try {
       logger.info("initialize", "cronjobs", "start");
       DAO cronJobDAO = (DAO) x.get(getCronJobDAO());
@@ -132,7 +154,7 @@ foam.CLASS({
 
       logger.info("initialize", "cronjobs", "complete");
 
-      while ( true ) {
+      while ( running_.get() ) {
         long delay = getCronDelay();
         if ( getEnabled() ) {
           Date now = new Date();


### PR DESCRIPTION
CronScheduler was not updated with a 'stop' operation when shutdown features were added to foam.
Note, that it is still the responsibility of any long running agent/service started with cron to handle shutdown itself.
These changes only affect the rescheduling of cron jobs.