### PR TITLE
Support JS only test models that don't support java.

### DIFF
--- a/src/foam/core/test/JSTest.js
+++ b/src/foam/core/test/JSTest.js
@@ -10,16 +10,13 @@ foam.CLASS({
   extends: 'foam.core.test.Test',
   abstract: false,
   documentation: `Abstract base class for modelled JS tests that implement runTest directly.
-Also for JS only modelled tests:
+Also for JS only modelled tests that do not support java:
 - use pom flags: 'js'
 - in tests.jrl use:
     class: foam.core.test.JSTest
     source: to the modelled class id
 Test.runScript will test for this combination and create an instance of
 'source' and call 'runTest' on it.
-This resolves the issue of having to build JS only tests with flags 'java'
-to satisfy journal loading when the tests.jrl class is set to the
-modelled class id.
 `,
   properties: [
     {

--- a/src/foam/core/test/JSTest.js
+++ b/src/foam/core/test/JSTest.js
@@ -8,17 +8,35 @@ foam.CLASS({
   package: 'foam.core.test',
   name: 'JSTest',
   extends: 'foam.core.test.Test',
-  abstract: true,
-
-  documentation: 'Abstract base class for modelled JS tests that implement runTest directly.',
-
+  abstract: false,
+  documentation: `Abstract base class for modelled JS tests that implement runTest directly.
+Also for JS only modelled tests:
+- use pom flags: 'js'
+- in tests.jrl use:
+    class: foam.core.test.JSTest
+    source: to the modelled class id
+Test.runScript will test for this combination and create an instance of
+'source' and call 'runTest' on it.
+This resolves the issue of having to build JS only tests with flags 'java'
+to satisfy journal loading when the tests.jrl class is set to the
+modelled class id.
+`,
   properties: [
     {
       name: 'language',
       factory: function() { return foam.core.script.Language.JS; },
       javaFactory: 'return foam.core.script.Language.JS;',
       visibility: foam.u2.DisplayMode.RO
-    }
+    },
+    {
+      class: 'String',
+      name: 'source',
+      tableWidth: 300,
+      transient: false,
+      visibility: 'RO',
+      factory: function() { return this.cls_.id },
+      documentation: 'See Test.runScript(). JSTests '
+    },
   ]
 
   /*

--- a/src/foam/core/test/Test.js
+++ b/src/foam/core/test/Test.js
@@ -63,6 +63,7 @@ foam.CLASS({
       class: 'String',
       name: 'source',
       tableWidth: 300,
+      transient: true,
       visibility: 'RO',
       factory: function() { return this.cls_.id === 'foam.core.test.Test' ? this.language : this.cls_.id; },
       javaFactory: 'return getClass().toString();'

--- a/src/foam/core/test/Test.js
+++ b/src/foam/core/test/Test.js
@@ -344,8 +344,9 @@ foam.CLASS({
             };
             with ( { log: log, print: log, x: this.__context__, expect: expect, test: test } ) {
               var script = '';
-              if ( this.cls_.id === 'foam.core.test.JSTest' &&
-                   this.source &&
+              if ( ! this.code && // see RunTest above.
+                   this.cls_.id === 'foam.core.test.JSTest' &&
+                   this.source && // eval source.runTest
                    this.source !== 'foam.core.test.JSTest' ) {
                 script = '(async () => { ';
                 script += 'let t = ' + this.source + '.create(); ';

--- a/src/foam/core/test/Test.js
+++ b/src/foam/core/test/Test.js
@@ -63,7 +63,6 @@ foam.CLASS({
       class: 'String',
       name: 'source',
       tableWidth: 300,
-      transient: true,
       visibility: 'RO',
       factory: function() { return this.cls_.id === 'foam.core.test.Test' ? this.language : this.cls_.id; },
       javaFactory: 'return getClass().toString();'
@@ -342,11 +341,20 @@ foam.CLASS({
                 output: this.output
               }));
             };
-
             with ( { log: log, print: log, x: this.__context__, expect: expect, test: test } ) {
+              var script = '';
+              if ( this.cls_.id === 'foam.core.test.JSTest' &&
+                   this.source &&
+                   this.source !== 'foam.core.test.JSTest' ) {
+                script = '(async () => { ';
+                script += 'let t = ' + this.source + '.create(); ';
+                script += 'await t.runTest(this.__context__.createSubContext({ log: log, print: print, expect: expect, test: test })); ';
+                script += 'updateStats()';
+                script += '})()';
+              }
               Promise.resolve(
-                this.code ?
-                  eval('(async () => {' + this.code + '})()') :
+                script ?
+                  eval(script) :
                   this.runTest(this.__context__.createSubContext({
                     log: log, print: log, expect: expect, test: test
                   }))

--- a/src/foam/dashboard/view/UserGreetingView.js
+++ b/src/foam/dashboard/view/UserGreetingView.js
@@ -11,7 +11,6 @@ foam.CLASS({
 
   imports: [
     'auth',
-    'ctrl',
     'subject'
   ],
 
@@ -46,7 +45,9 @@ foam.CLASS({
 
   methods: [
     async function render() {
-      this.subject = await ctrl.__subContext__.auth.getCurrentSubject(null);
+      this.auth.getCurrentSubject(null).then(v => {
+        this.subject = v;
+      });
       this.addClass(this.myClass(), 'h200')
         .start()
           .add(this.slot(function(subject$realUser, title) {

--- a/src/foam/demos/u2/working-with-u2/flows.jrl
+++ b/src/foam/demos/u2/working-with-u2/flows.jrl
@@ -221,3 +221,314 @@ p({
 ]""",
 "lastModified":"2026-04-29T19:31:32.345Z"
 })
+
+p({
+"class":"foam.core.reflow.Flow",
+"name":"SectionedDetailView",
+"category": "demos",
+"version":36,
+"script":"""[
+	{
+
+		"flowName": "script1",
+		"cmd": "script",
+		"value": {
+			"class": "foam.core.reflow.Script",
+			"code": "foam.CLASS({\\u000a  package: 'foam.u2.demos',\\u000a  name: 'DemoAddress',\\u000a  label: 'Address',\\u000a\\u000a  properties: [\\u000a    {\\u000a      class: 'String',\\u000a      name: 'type',\\u000a      label: 'Type',\\u000a      gridColumns: 4,\\u000a      view: {\\u000a        class: 'foam.u2.view.ChoiceView',\\u000a        choices: [['HOME', 'Home'], ['WORK', 'Work'], ['OTHER', 'Other']]\\u000a      }\\u000a    },\\u000a    { class: 'String', name: 'street' },\\u000a    { class: 'String', name: 'city', onKey: true},\\u000a    { class: 'String', name: 'country' }\\u000a  ]\\u000a});\\u000a\\u000afoam.CLASS({\\u000a  package: 'foam.u2.demos',\\u000a  name: 'DemoContact',\\u000a\\u000a  tableColumns: ['name', 'email', 'contactType'],\\u000a\\u000a  sections: [\\u000a    { name: 'identity',    title: 'Identity',     order: 1 },\\u000a    { name: 'contactInfo', title: 'Contact Info', order: 2 },\\u000a    { name: 'preferences', title: 'Preferences',  order: 3 }\\u000a  ],\\u000a\\u000a  properties: [\\u000a    { class: 'Long', name: 'id', hidden: true },\\u000a\\u000a    {\\u000a      class: 'String',\\u000a      name: 'name',\\u000a      label: 'Full Name',\\u000a      placeholder: 'Enter full name',\\u000a      section: 'identity',\\u000a      gridColumns: 6,\\u000a      required: true,\\u000a      minLength: 3\\u000a    },\\u000a    {\\u000a      class: 'String',\\u000a      name: 'contactType',\\u000a      label: 'Type',\\u000a      section: 'identity',\\u000a      gridColumns: 6,\\u000a      view: {\\u000a        class: 'foam.u2.view.ChoiceView',\\u000a        choices: [['PERSONAL', 'Personal'], ['BUSINESS', 'Business']]\\u000a      }\\u000a    },\\u000a    {\\u000a      class: 'String',\\u000a      name: 'organization',\\u000a      section: 'identity',\\u000a      gridColumns: 8,\\u000a      labelFormatter: function(data) {\\u000a        this.add(data.contactType$.map(function(contactType) {\\u000a          return contactType === 'BUSINESS' ? 'Organization Name' : 'Employer';\\u000a        }));\\u000a      },\\u000a      visibility: function(contactType) {\\u000a        return contactType\\u000a          ? foam.u2.DisplayMode.RW\\u000a          : foam.u2.DisplayMode.HIDDEN;\\u000a      }\\u000a    },\\u000a\\u000a    {\\u000a      class: 'String',\\u000a      name: 'email',\\u000a      label: 'Email',\\u000a      section: 'contactInfo',\\u000a      gridColumns: 6,\\u000a      supportingLabel: 'Used for login and notifications'\\u000a    },\\u000a    {\\u000a      class: 'String',\\u000a      name: 'phone',\\u000a      label: 'Phone',\\u000a      section: 'contactInfo',\\u000a      gridColumns: 6\\u000a    },\\u000a    {\\u000a      class: 'FObjectArray',\\u000a      of: 'foam.u2.demos.DemoAddress',\\u000a      name: 'addresses',\\u000a      label: 'Addresses',\\u000a      section: 'contactInfo',\\u000a      gridColumns: 12,\\u000a      view: function(_, X) {\\u000a        return {\\u000a          class: 'foam.u2.view.TitledArrayView',\\u000a          valueView: {\\u000a            class: 'foam.u2.detail.VerticalDetailView',\\u000a            of: 'foam.u2.demos.DemoAddress',\\u000a            propertyWhitelist: {\\u000a              'type':    { gridColumns: 4 },\\u000a              'street':  { gridColumns: 8 },\\u000a              'city':    { gridColumns: 6 },\\u000a              'country': { gridColumns: 6 }\\u000a            }\\u000a          }\\u000a        };\\u000a      }\\u000a    },\\u000a\\u000a    {\\u000a      class: 'Int',\\u000a      name: 'age',\\u000a      label: 'Age',\\u000a      units: 'years',\\u000a      section: 'preferences',\\u000a      gridColumns: 4\\u000a    },\\u000a    {\\u000a      class: 'String',\\u000a      name: 'notes',\\u000a      label: 'Notes',\\u000a      section: 'preferences',\\u000a      gridColumns: 12,\\u000a      view: { class: 'foam.u2.tag.TextArea', rows: 3 }\\u000a    },\\u000a    {\\u000a      class: 'Boolean',\\u000a      name: 'active',\\u000a      label: 'Active',\\u000a      section: 'preferences',\\u000a      gridColumns: 4,\\u000a      value: true\\u000a    }\\u000a  ]\\u000a});\\u000a\\u000a",
+			"autoRun": true
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"shown": false,
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "intro",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "## AbstractSectionedDetailView\\u000a`foam.u2.detail.<Some>DetailView` organises a model's properties into named, ordered **sections**, rendering each as a bordered card. It is FOAM's standard form view — used in DAO browsers, wizards, and detail panels.\\u000a\\u000aThe views work in two steps:\\u000a-  `foam.u2.detail.<Some>DetailView` act as the layout/ordering controllers for FObjects\\u000a-  These views then use `foam.u2.detail.SectionView` or some subclass of that in order to render the individual sections and the axioms contained in them.\\u000a\\u000a### Class Hierarchy\\u000a\\u000a```\\u000aIndividual section views:\\u000afoam.u2.detail.SectionView                  (renders a single section's properties)\\u000a  └── foam.u2.detail.TabularSectionView     (renders a section with each property in a row, uses tableCellFormatter for properties)\\u000a\\u000aModel level section views:\\u000afoam.u2.detail.AbstractSectionedDetailView  (abstract base; holds common logic)\\u000a  ├── foam.u2.detail.SectionedDetailView    (one card per section in a grid/list)\\u000a  └── foam.u2.detail.VerticalDetailView     (sections stacked vertically, no cards)\\u000a  └── foam.u2.detail.TabbedDetailView       (sections rendered as Tabs)\\u000a```\\u000a\\u000a`AbstractSectionedDetailView` auto-discovers sections from the model, sorts them by `order`, filters hidden sections, and wires reactivity. The two concrete subclasses differ only in layout.\\u000a\\u000a### Shared Key Properties\\u000a\\u000a| Property | Type | Description |\\u000a|----------|------|-------------|\\u000a| `data` | FObject | Model instance being rendered. |\\u000a| `of` | Class | Model class; inferred from `data` if omitted. |\\u000a| `useSections` | StringArray | Whitelist of section names to render (in that order). |\\u000a| `showTitle` | Boolean | Show/hide section title headers (default `true`). |\\u000a| `hideActions` | Boolean | Show/hide model actions |\\u000a| `propertyWhitelist` | Map/Array | Limit which properties appear and override their attributes. |\\u000a| `sections` | Array | List of sections defined on the model. Can be overridden if default sections are not desirable |\\u000a\\u000a#### Why use these:\\u000a\\u000aYou might say why not make a layout custom to the models we need to display, especially given how easy it is to do with the PropertyBorders. There are a few reasons for this. \\u000a\\u000a- This approach of a generic view for every FObject allows for rapid prototyping for devs and allows building features without overhead while UX can be streamlined in complete isolation.\\u000a- The `<Some>DetailViews` add responsive behaviour that make the default views suitable for all screen sizes. Usually this functionality would need a lot of CSS code for every custom view and is something that is often forgotten. You can see this in action my resizing your window through this demo.\\u000a- As you will see in the following document, there are so many ways to customize these default views that it is often more work to make custom views for anything but the most important models in your app.\\u000a\\u000a##### NOTE:\\u000aThroughout this demo you will see\\u000a\\u000a```javascript\\u000a.startContext({ data: <someValue> }).....endContext()\\u000a```\\u000aThis is required when you use these views without any data already in the context.\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "sectionAxiomDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Defining Sections on a Model\\u000a\\u000aSections are declared in the model's `sections` array. Each entry is a **SectionAxiom** with these key properties:\\u000a\\u000a| Property | Type | Description |\\u000a|----------|------|-------------|\\u000a| `name` | String | Unique identifier for the model. |\\u000a| `title` | String/Function | Section heading (auto-labelize'd from `name` if omitted). Set to '' to exclude. |\\u000a| `subTitle` | String/Function | Optional subtitle rendered below the title. |\\u000a| `order` | Int | Sort order (lower = first). Defaults to `Number.MAX_SAFE_INTEGER`. |\\u000a| `isAvailable` | Function | Visibility gate: `function(prop1) { return bool }`. Dynamically responds to changes when the proeprties specified in the argument list change. |\\u000a| `collapsable` | Boolean | Show collapse/expand toggle in the title bar (default `false`). |\\u000a| `gridColumns` | Value | Section card width in the outer Grid (default full-width). |\\u000a| `view` | ViewSpec | The view this section uses. |\\u000a\\u000aProperties are assigned to a section via the `section` attribute:\\u000a\\u000a```javascript\\u000afoam.CLASS({\\u000a  name: 'MyModel',\\u000a  sections: [\\u000a    { name: 'basics',  title: 'Basic Info', order: 1 },\\u000a    { \\u000a       name: 'details',\\u000a       title: 'Details',\\u000a       order: 2,\\u000a       view: { class: 'foam.u2.detail.TabularSectionView' }\\u000a    }\\u000a  ],\\u000a  properties: [\\u000a    { class: 'String', name: 'name',  section: 'basics'  },\\u000a    { class: 'String', name: 'notes', section: 'details' }\\u000a  ]\\u000a});\\u000a```\\u000a\\u000aProperties without a `section` attribute are grouped into an anonymous default section rendered first.\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "sectionAxiomExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "// DemoContact has 3 sections: identity, contactInfo, preferences\\u000a// Properties are assigned to sections via section: 'sectionName'\\u000a// SectionedDetailView auto-discovers and renders them as cards\\u000avar DC = foam.u2.demos.DemoContact;\\u000avar contact = DC.create({\\u000a  name: 'Jane Doe',\\u000a  email: 'jane@example.com',\\u000a  contactType: 'BUSINESS',\\u000a  organization: 'Acme Corp',\\u000a  age: 32,\\u000a  active: true\\u000a});\\u000astart().startContext({ data: contact })\\u000a  .tag({ class: 'foam.u2.detail.SectionedDetailView', data: contact })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "sectionedDetailViewDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### SectionedDetailView\\u000a\\u000a`SectionedDetailView` renders each section as a **card** inside a responsive grid. Each card gets a title and a `CardBorder` wrapper by default.\\u000a\\u000a#### Additional Properties\\u000a\\u000a| Property | Type | Description |\\u000a|----------|------|-------------|\\u000a| `borders` | Map | Per-section border spec: `{ sectionName: { class: 'foam.u2.borders.CardBorder' } }`. |\\u000a| `showTitle` | Boolean | Show section title heading (default `true`). |\\u000a\\u000a#### Customising Section Borders\\u000a\\u000aOverride the border for any individual section:\\u000a\\u000a```javascript\\u000atag({\\u000a  class: 'foam.u2.detail.SectionedDetailView',\\u000a  data: myInstance,\\u000a  borders: {\\u000a    identity: { class: 'foam.u2.borders.NullBorder' }  // borderless for this section\\u000a  }\\u000a})\\u000a```\\u000a\\u000aPass `{}` or omit the key for the default `CardBorder`. Most borders can be found in `foam.u2.borders.*`\\u000a\\u000a#### Title Visibility\\u000a\\u000aPass `showTitle: false` to hide all section headings. Useful when the surrounding UI already provides context. Try setting this parameter in the example below.\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "sectionedDetailViewExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "var DC = foam.u2.demos.DemoContact;\\u000avar contact = DC.create({\\u000a  name: 'Jane Doe',\\u000a  email: 'jane@example.com',\\u000a  contactType: 'BUSINESS',\\u000a  organization: 'Acme Corp',\\u000a  age: 32,\\u000a  active: true\\u000a});\\u000a// Full SectionedDetailView — 3 section cards in a grid\\u000astart().startContext({ data: contact })\\u000a  .tag({\\u000a      class: 'foam.u2.detail.SectionedDetailView',\\u000a      data: contact,\\u000a      borders: {\\u000a          identity: {\\u000a              class: 'foam.u2.borders.BackgroundCard',\\u000a              padding: '2rem',\\u000a              backgroundColor: '#ccc'\\u000a          }\\u000a      }\\u000a  })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "verticalDetailViewDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### VerticalDetailView\\u000a\\u000a`VerticalDetailView` stacks sections **vertically** without card wrapping. It is lighter-weight than `SectionedDetailView` and is used inside `TitledArrayView` rows, wizard steps, and anywhere a flat layout is preferred.\\u000a\\u000a#### Additional Properties\\u000a\\u000a| Property | Type | Description |\\u000a|----------|------|-------------|\\u000a| `config` | Map | Property attribute overrides applied to every property. Same as `PropertyBorder.config` — clones without mutating the model. |\\u000a| `centered` | Boolean | Centre section content (default `false`). |\\u000a\\u000a#### Per-render Property Overrides\\u000a\\u000a```javascript\\u000atag({\\u000a  class: 'foam.u2.detail.VerticalDetailView',\\u000a  data: myInstance,\\u000a  config: { name: { gridColumns: 12 } } // Scroll up and note that the name property was only half the width (in desktop). The total grid columns available on desktop are 12. \\u000a})\\u000a```\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "verticalDetailViewExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "var DC = foam.u2.demos.DemoContact;\\u000avar contact = DC.create({\\u000a  name: 'Jane Doe',\\u000a  email: 'jane@example.com',\\u000a  contactType: 'BUSINESS',\\u000a  organization: 'Acme Corp',\\u000a  age: 32,\\u000a  active: true\\u000a});\\u000a\\u000a// Compare: SectionedDetailView (cards) vs VerticalDetailView (stacked)\\u000a\\u000astart('div').style({ display: 'flex', gap: '2rem' })\\u000a  .start('div').style({ flex: 1 })\\u000a    .start('p').addClass('p-semiBold').add('SectionedDetailView').end()\\u000a    .startContext({ data: contact })\\u000a      .tag({ class: 'foam.u2.detail.SectionedDetailView', data: contact })\\u000a    .endContext()\\u000a  .end()\\u000a  .start('div').style({ flex: 1 })\\u000a    .start('p').addClass('p-semiBold').add('VerticalDetailView').end()\\u000a    .startContext({ data: contact })\\u000a      .tag({ \\u000a          class: 'foam.u2.detail.VerticalDetailView',\\u000a          data: contact,\\u000a          config: {\\u000a              email: { gridColumns: 12 },\\u000a              phone: { supportingLabel: 'Enter your personal phone #' }\\u000a          }\\u000a      })\\u000a    .endContext()\\u000a  .end()\\u000a.end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "sectionVisibilityDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Section Visibility\\u000a\\u000aThe `isAvailable` function on a SectionAxiom controls whether the **entire section** is rendered. The function's parameter names tell FOAM which properties to watch; the section re-evaluates automatically when those properties change.\\u000a\\u000a```javascript\\u000asections: [\\u000a  {\\u000a    name: 'billingAddress',\\u000a    title: 'Billing Address',\\u000a    isAvailable: function(contactType) {\\u000a      return contactType === 'BUSINESS';\\u000a    }\\u000a  }\\u000a]\\u000a```\\u000a\\u000aWhen `isAvailable` returns `false`, the section card is **completely removed** from the DOM — no whitespace is left behind.\\u000a\\u000a#### Section Permissioning\\u000a\\u000aSet `permissionRequired: true` on a section to hide it when the user lacks the corresponding auth permission. This check is evaluated in addition to `isAvailable`. The permission string is formatted as \\u000a\\u000a```\\u000a<class.id.toLowerCase()>.section.<sectionName>\\u000a```\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "sectionVisibilityExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "// DemoVisibility has 2 sections:\\u000a// 'Always Visible' is always shown\\u000a// 'Business Only' appears only when contactType === 'BUSINESS'\\u000afoam.CLASS({\\u000a  package: 'foam.u2.demos',\\u000a  name: 'DemoVisibility',\\u000a\\u000a  sections: [\\u000a    { name: 'always',      title: 'Always Visible', order: 1 },\\u000a    {\\u000a      name: 'conditional',\\u000a      title: 'Business Only',\\u000a      order: 2,\\u000a      isAvailable: function(contactType) { return contactType === 'BUSINESS'; }\\u000a    }\\u000a  ],\\u000a\\u000a  properties: [\\u000a    {\\u000a      class: 'String',\\u000a      name: 'contactType',\\u000a      label: 'Type',\\u000a      section: 'always',\\u000a      view: {\\u000a        class: 'foam.u2.view.ChoiceView',\\u000a        choices: [['PERSONAL', 'Personal'], ['BUSINESS', 'Business']]\\u000a      }\\u000a    },\\u000a    { class: 'String', name: 'orgName', label: 'Organization', section: 'conditional' }\\u000a  ]\\u000a});\\u000a\\u000a// Switch the dropdown from Personal -> Business to reveal the hidden section\\u000avar instance = foam.u2.demos.DemoVisibility.create({ contactType: 'PERSONAL' });\\u000astart().startContext({ data: instance })\\u000a  .tag({ class: 'foam.u2.detail.SectionedDetailView', data: instance })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "filteringDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Customizing <Some>DetailViews\\u000a\\u000a#### useSections\\u000a\\u000aRender only a specific subset of sections, in a given order:\\u000a\\u000a```javascript\\u000atag({\\u000a  class: 'foam.u2.detail.SectionedDetailView',\\u000a  data: myContact,\\u000a  useSections: ['identity', 'preferences']  // skips contactInfo\\u000a})\\u000a```\\u000a\\u000a#### propertyWhitelist\\u000a\\u000aA map of `{ propertyName: { ...overrides } }`. When provided:\\u000a- Only whitelisted properties are shown across all sections\\u000a- Each entry can override any property attribute (`gridColumns`, `label`, etc.)\\u000a- Sections with no visible properties after filtering are hidden automatically\\u000a\\u000a```javascript\\u000atag({\\u000a  class: 'foam.u2.detail.VerticalDetailView',\\u000a  data: myInstance,\\u000a  propertyWhitelist: {\\u000a    'name':  { gridColumns: 12 },\\u000a    'email': { label: 'Work Email' }\\u000a  }\\u000a})\\u000a```\\u000a\\u000aBoth options can be combined: `useSections` picks which sections appear; `propertyWhitelist` further filters properties within those sections.\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "filteringExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "var DC = foam.u2.demos.DemoContact;\\u000avar contact = DC.create({\\u000a  name: 'Jane Doe',\\u000a  email: 'jane@example.com',\\u000a  contactType: 'BUSINESS',\\u000a  organization: 'Acme Corp',\\u000a  age: 32,\\u000a  active: true\\u000a});\\u000astart('div').style({ display: 'flex', gap: '2rem' })\\u000a  .start('div').style({ flex: 1 })\\u000a    .start('p').addClass('p-label').add('useSections: identity + preferences only').end()\\u000a    .startContext({ data: contact })\\u000a      .tag({\\u000a        class: 'foam.u2.detail.SectionedDetailView',\\u000a        data: contact,\\u000a        useSections: ['identity', 'preferences']\\u000a      })\\u000a    .endContext()\\u000a  .end()\\u000a  .start('div').style({ flex: 1 })\\u000a    .start('p').addClass('p-label').add('propertyWhitelist: name and email only').end()\\u000a    .startContext({ data: contact })\\u000a      .tag({\\u000a        class: 'foam.u2.detail.VerticalDetailView',\\u000a        data: contact,\\u000a        propertyWhitelist: {\\u000a          'name':  { gridColumns: 12 },\\u000a          'email': { gridColumns: 12, label: 'Work Email' },\\u000a          'phone': {} // no overrides\\u000a        }\\u000a      })\\u000a    .endContext()\\u000a  .end()\\u000a.end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "reactiveTitleDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Reactive Section Titles and Subtitles\\u000a\\u000aSection `title` and `subTitle` can be strings or **functions** that receive the model instance's property values as arguments. FOAM infers which properties to watch from the **parameter names**. The title re-renders automatically when those properties change.\\u000a\\u000a```javascript\\u000asections: [\\u000a  {\\u000a    name: 'identity',\\u000a    title: function(name) {\\u000a      return name ? 'Profile — ' + name : 'Profile';\\u000a    },\\u000a    subTitle: 'Edit contact details'\\u000a  }\\u000a]\\u000a```\\u000a\\u000a#### subTitle\\u000a\\u000a`subTitle` works the same way and appears in a lighter style below the title.\\u000a\\u000aBoth `title` and `subTitle` also support **template literal** strings with `${propName}` — FOAM evaluates these against the live data automatically.\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "reactiveTitleExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "// DemoReactiveTitle has a section whose title maps over the 'name' property.\\u000afoam.CLASS({\\u000a  package: 'foam.u2.demos',\\u000a  name: 'DemoReactiveTitle',\\u000a\\u000a  sections: [\\u000a    {\\u000a      name: 'main',\\u000a      order: 1,\\u000a      title: function(name) { return name ? 'Profile — ' + name : 'Profile'; },\\u000a      subTitle: 'Edit your contact details'\\u000a    }\\u000a  ],\\u000a\\u000a  properties: [\\u000a    { class: 'String', name: 'name',  label: 'Full Name', section: 'main', gridColumns: 6, onKey: true },\\u000a    { class: 'String', name: 'email', label: 'Email',     section: 'main', gridColumns: 6 }\\u000a  ]\\u000a});\\u000a\\u000a// Edit the Full Name field and watch the section title update live.\\u000avar instance = foam.u2.demos.DemoReactiveTitle.create({ name: 'Jane Doe', email: 'jane@example.com' });\\u000astart().startContext({ data: instance })\\u000a  .tag({ class: 'foam.u2.detail.SectionedDetailView', data: instance })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "collapsibleDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Collapsible Sections\\u000a\\u000aSet `collapsable: true` on a SectionAxiom to add a collapse/expand toggle to the section title bar. The section starts **expanded**; users can collapse it to hide the properties.\\u000a\\u000a```javascript\\u000asections: [\\u000a  { name: 'advanced', title: 'Advanced', collapsable: true, order: 3 }\\u000a]\\u000a```\\u000a\\u000a#### help\\u000a\\u000aAdd a `help` string to display an expandable hint area below the section title. Useful for explaining what the section contains or when to use it.\\u000a\\u000a```javascript\\u000asections: [\\u000a  {\\u000a    name: 'advanced',\\u000a    title: 'Advanced',\\u000a    collapsable: true,\\u000a    help: 'These settings are optional — expand this section to configure them.'\\u000a  }\\u000a]\\u000a```\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "collapsibleExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "// DemoCollapsible has two sections:\\u000a// 'Basic Info' is always visible\\u000a// 'Advanced' is collapsable and has help text — click the chevron to collapse it\\u000a\\u000afoam.CLASS({\\u000a  package: 'foam.u2.demos',\\u000a  name: 'DemoCollapsible',\\u000a\\u000a  sections: [\\u000a    { name: 'basic',    title: 'Basic Info', order: 1 },\\u000a    {\\u000a      name: 'advanced',\\u000a      title: 'Advanced',\\u000a      order: 2,\\u000a      collapsable: true,\\u000a      help: 'These settings are optional'\\u000a    }\\u000a  ],\\u000a\\u000a  properties: [\\u000a    { class: 'String', name: 'name',  label: 'Name',  section: 'basic',    gridColumns: 6 },\\u000a    { class: 'String', name: 'email', label: 'Email', section: 'basic',    gridColumns: 6 },\\u000a    { class: 'String', name: 'notes', label: 'Notes', section: 'advanced', gridColumns: 12 },\\u000a    { class: 'Int',    name: 'age',   label: 'Age',   section: 'advanced', gridColumns: 4 }\\u000a  ]\\u000a});\\u000a\\u000avar instance = foam.u2.demos.DemoCollapsible.create({\\u000a  name: 'Jane Doe',\\u000a  email: 'jane@example.com',\\u000a  age: 32,\\u000a  notes: 'Prefers email contact.'\\u000a});\\u000astart().startContext({ data: instance })\\u000a  .tag({ class: 'foam.u2.detail.VerticalDetailView', data: instance })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "sectionViewDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### SectionView\\u000a\\u000a`foam.u2.detail.SectionView` renders **one section's properties** directly. Use it when you want full control over wrapping in a custom layout.\\u000a\\u000a```javascript\\u000a.tag({\\u000a  class: 'foam.u2.detail.SectionView',\\u000a  data: myInstance,\\u000a  of: MyModel,\\u000a  sectionName: 'identity',\\u000a  showTitle: false\\u000a})\\u000a```\\u000a\\u000a#### Key Properties\\u000a\\u000a| Property | Type | Description |\\u000a|----------|------|-------------|\\u000a| `sectionName` | String | Name of the section to render. |\\u000a| `section` | Section | Direct Section object (alternative to `sectionName`). |\\u000a| `showTitle` | Boolean | Show section title and subtitle (default `true`). |\\u000a| `config` | Map | Per-property attribute overrides for this render. |\\u000a| `hideActions` | Boolean | Suppress action buttons. |\\u000a\\u000a`SectionView` is what `<Some>DetailView` uses internally for each card.\\u000a\\u000a#### TabularSectionView\\u000a`SectionView` has an alternative view called `TabularSectionView`. Try replacing the class in the view to see what it looks like.\\u000aThe TabularSectionView also uses TableCellFormatters to render the property values in order to use views that would typically be more compatible with the single row style it uses.\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "sectionViewExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "var DC = foam.u2.demos.DemoContact;\\u000avar contact = DC.create({\\u000a  name: 'Jane Doe',\\u000a  contactType: 'BUSINESS',\\u000a  organization: 'Acme Corp'\\u000a});\\u000a// Render only the 'identity' section directly via SectionView\\u000astart().startContext({ data: contact, controllerMode: 'VIEW' })\\u000a  .tag({\\u000a    class: 'foam.u2.detail.TabularSectionView',\\u000a    data: contact,\\u000a    of: DC,\\u000a    sectionName: 'identity',\\u000a    showTitle: true\\u000a  })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "0 16px"
+	},
+	{
+
+		"flowName": "AdvancedSectionsDoc",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Advanced Section Customization\\u000a\\u000aIn case the above doesnt satisfy your requirements there are still more ways to customize the sections.\\u000a\\u000a#### Overloading properties and sections in the model\\u000a\\u000aUntil now we have been adding sections to the model and then specifying the section on the property definition. However sometimes we may need to group properties into a section based on the context. FOAM allows for this by specifying the properties on the section definition itself.\\u000a\\u000aWhen specifying the properties on the section you can override the property properties and they will only apply to that section.\\u000a\\u000aAdditionally you may specify nested properties on FObjectProperties on the model and they will be rendered as if they were native to the current model."
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "AdvancedSectionsExample",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "/* \\u000aNote that the section for contact details specifies its own properties.\\u000aThese properties can belong to another section without conflicting.\\u000aIt is the responsibility of the user configuring the view to make sure \\u000athe properties are visible only once\\u000a*/\\u000afoam.CLASS({\\u000a  package: 'foam.u2.demos',\\u000a  name: 'DemoOverloading',\\u000a\\u000a  sections: [\\u000a    { name: 'basic',    title: 'Basic Info' },\\u000a    {\\u000a      name: 'contactDetails',\\u000a      properties: [\\u000a        // You can use propName if you dont need overrides\\u000a        'email', \\u000a        // Or use a map if you need overrides\\u000a        { name: 'phone', label: '####', supportingLabel: 'This label is different from the one in the other section' },\\u000a        // Or use a nested property on an FObjectProperty\\u000a        { name: 'address.city' }\\u000a      ]\\u000a    }\\u000a  ],\\u000a\\u000a  properties: [\\u000a    { class: 'String', name: 'name',  section: 'basic',    gridColumns: 6 },\\u000a    { class: 'String', name: 'email', section: 'basic',    gridColumns: 6 },\\u000a    { class: 'PhoneNumber', name: 'phone', section: 'basic',    gridColumns: 6 },\\u000a    { class: 'Int',    name: 'age',   section: 'basic', gridColumns: 4 },\\u000a    {\\u000a      class: 'FObjectProperty',\\u000a      of: 'foam.u2.demos.DemoAddress',\\u000a      name: 'address',\\u000a      section: 'basic',\\u000a      gridColumns: 12,\\u000a      factory: function() { return foam.u2.demos.DemoAddress.create({ city: 'Toronto' }) }\\u000a    }\\u000a  ]\\u000a});\\u000a\\u000avar instance = foam.u2.demos.DemoOverloading.create({\\u000a  name: 'Jane Doe',\\u000a  email: 'jane@example.com',\\u000a  age: 32,\\u000a  phone: '123456'\\u000a});\\u000astart().startContext({ data: instance })\\u000a  .tag({ class: 'foam.u2.detail.SectionedDetailView', data: instance })\\u000a.endContext().end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "markdown1",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### What if I cant edit the model \\u000a\\u000aNo worries! Sometimes you may not want to add a section to a model (one-off section for a particular menu, wizard screen etc).\\u000aFOAM allows you to define sections on the fly while describing your `<Some>DetailView`. This is a function of the `AbstractDetailView` so this can be done with any DetailView that extends it.\\u000a\\u000a"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "example1",
+		"cmd": "example",
+		"value": {
+			"class": "foam.core.reflow.example.Example",
+			"code": "/* \\u000afoam.u2.demos.DemoContact has the following properties that already belong to \\u000adifferent sections: \\u000a- name: identity section\\u000a- email: contactInfo section\\u000a- active: preferences section\\u000a\\u000aIt is reasonable to expect a management screen to maybe show these three properties in a section so that a user can manage contacts at a glance.\\u000a*/\\u000avar instance = foam.u2.demos.DemoContact.create({\\u000a  name: 'John Doe',\\u000a  email: 'john@example.com',\\u000a  age: 32,\\u000a  phone: '123456'\\u000a});\\u000astart()\\u000a  .tag({\\u000a      class: 'foam.u2.detail.SectionedDetailView',\\u000a      // When defining your own sections, `of` must be provided\\u000a      of: 'foam.u2.demos.DemoContact',\\u000a      data: instance,\\u000a      sections: [\\u000a         /* \\u000a         Define your own set of sections that are only used for this view\\u000a         This is the same sectionAxiom that we define on models so all the same\\u000a         features are available here\\u000a        */\\u000a        {\\u000a          name: 'myCustomManagementSection_',\\u000a          properties: ['name', 'email', 'active'],\\u000a          title: function(name) { return `Manage Contact - ${name}` }\\u000a        }    \\u000a      ]\\u000a  }).end();"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	},
+	{
+
+		"flowName": "markdown2",
+		"cmd": "markdown",
+		"value": {
+			"class": "foam.core.reflow.Markdown",
+			"markdown": "### Final Notes\\u000a\\u000a#### Actions and Sections \\u000a\\u000aEverything we have discussed with sections and properties also applies to the actions. \\u000a\\u000a```javascript\\u000asections: [\\u000a  {\\u000a    name: 'someSection',\\u000a    actions: ['myModelAction']\\u000a  }\\u000a]\\u000a```\\u000a\\u000a```javascript\\u000aactions: [\\u000a  {\\u000a     name: 'myAction',\\u000a     section: 'someSection'\\u000a     code: () => {......}\\u000a   }\\u000a]\\u000a```\\u000a\\u000a#### References\\u000a\\u000aIf you have made it this far, and you have not found your answer you are probably trying to do something pretty complex. Its time to read some code: \\u000a\\u000a- [AbstractSectionedDetailView](https://github.com/kgrgreer/foam3/blob/development/src/foam/u2/detail/AbstractSectionedDetailView.js) - Handles all logic for turning model SectionAxioms into to Section objects that can be consumed by child views\\u000a- [<Some>DetailView](https://github.com/kgrgreer/foam3/tree/development/src/foam/u2/detail) - The layout views that use the AbstractSectionedDetailView to render all sections\\u000a- [SectionView](https://github.com/kgrgreer/foam3/blob/development/src/foam/u2/detail/SectionView.js) - View for one section. Alternate is [TabularSectionView](https://github.com/kgrgreer/foam3/blob/development/src/foam/u2/detail/TabularSectionView.js)"
+		},
+		"border": {
+			"oldTitleStyle_": "h300"
+		},
+		"padding_st": "16px"
+	}
+]""",
+"lastModified":"2026-04-30T14:35:54.274Z"
+})

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -174,6 +174,7 @@ foam.CLASS({
       factory: function() { return this.property.sheetsOutput; },
       documentation: 'The sheetsOutput specifies if property shoud be written to Google Sheet on import. eg on Transaction import in case there is Status column transaction\'s status will be written there'
     },
+    { name: 'propOrder',           factory: function() { return this.property.order; } },
     {
       name: 'methods',
       factory: function() {
@@ -574,6 +575,12 @@ foam.CLASS({
             body: this.formatJSON + ';'
           });
         }
+        m.push({
+          name: 'getOrder',
+          visibility: 'public',
+          type: 'int',
+          body: 'return ' + ( this.propOrder || '0') + ';'
+        });
 
         return m;
       }

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -174,6 +174,7 @@ foam.CLASS({
       factory: function() { return this.property.sheetsOutput; },
       documentation: 'The sheetsOutput specifies if property shoud be written to Google Sheet on import. eg on Transaction import in case there is Status column transaction\'s status will be written there'
     },
+    { name: 'propOrder',           factory: function() { return this.property.order; } },
     {
       name: 'methods',
       factory: function() {
@@ -634,6 +635,12 @@ foam.CLASS({
             body: this.formatJSON + ';'
           });
         }
+        m.push({
+          name: 'getOrder',
+          visibility: 'public',
+          type: 'int',
+          body: 'return ' + ( this.propOrder || '0') + ';'
+        });
 
         return m;
       }

--- a/src/foam/lang/Property.js
+++ b/src/foam/lang/Property.js
@@ -322,7 +322,12 @@ foam.CLASS({
       value: []
     },
     'initObject',
-    'copyValueFrom'
+    'copyValueFrom',
+    {
+      // class: 'Integer',
+      name: 'order',
+      documentation: 'Default display order in detail views.'
+    }
   ],
 
   methods: [

--- a/src/foam/lang/PropertyInfo.js
+++ b/src/foam/lang/PropertyInfo.js
@@ -147,6 +147,7 @@ foam.INTERFACE({
     }`,
     'void fromCSVLabelMapping(java.util.Map<String,foam.lib.csv.FromCSVSetter> map)',
     'boolean getSheetsOutput() { return false; }',
-    'Object castObject(Object value) { return value; }'
+    'Object castObject(Object value) { return value; }',
+    'int getOrder() { return 0; }',
   ]
 });

--- a/src/foam/lang/PropertyInfo.js
+++ b/src/foam/lang/PropertyInfo.js
@@ -148,6 +148,7 @@ foam.INTERFACE({
     'void fromCSVLabelMapping(java.util.Map<String,foam.lib.csv.FromCSVSetter> map)',
     'boolean getSheetsOutput() { return false; }',
     'Object castObject(Object value) { return value; }',
+    'int getOrder() { return 0; }',
 
     // REVIEW: FixedWidth PropertyInfo properties/methods. Unsuccessful attempting to add these via refine or extends of foam.lang.PropertyInfo - Joel
     'int fixedWidthOffset() { return 0; }',

--- a/src/foam/u2/view/MarkdownView.js
+++ b/src/foam/u2/view/MarkdownView.js
@@ -446,7 +446,7 @@ foam.CLASS({
 
         function link(v) {
           let title = v[1], url = v[3];
-          return function() { this.start('a').attrs({href: url}).add(title); };
+          return function() { this.start('a').attrs({href: url, target: '_blank'}).add(title); };
         },
 
         function strikethrough(v) {

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -301,6 +301,15 @@ foam.CLASS({
     ^section:not(:last-child) {
       border-bottom: 1px solid #f4f4f9;
     }
+
+    ^container .highlighted {
+      border-color: $borderDefault;
+      background-color: $backgroundHover;
+    }
+
+    ^container .highlighted.disabled {
+      background-color: initial;
+    }
   `,
 
   properties: [
@@ -347,6 +356,10 @@ foam.CLASS({
           this.sections.forEach((section) => {
             section.clearProperty('filteredDAO');
           });
+        }
+        // Reset highlighted index when dropdown opens/closes
+        if ( nv ) {
+          this.highlightedIndex_ = -1;
         }
       }
     },
@@ -479,7 +492,12 @@ foam.CLASS({
       class: 'String',
       value: 'id'
     },
-    'inputField',
+    {
+      name: 'inputField',
+      postSet: function(_, n) {
+        this.autoFocus();
+      }
+    },
     {
       class: 'FObjectProperty',
       of: 'foam.u2.Element',
@@ -493,7 +511,18 @@ foam.CLASS({
         });
       }
     },
-    'selectionEl_'
+    'selectionEl_',
+    {
+      class: 'Int',
+      name: 'highlightedIndex_',
+      documentation: 'Tracks the currently highlighted item index for keyboard navigation.',
+      value: -1
+    },
+    {
+      name: 'selectableItems_',
+      documentation: 'Array of selectable items in the dropdown.',
+      factory: function() { return []; }
+    }
   ],
 
   methods: [
@@ -529,6 +558,7 @@ foam.CLASS({
         if ( ! hasBeenOpenedYet_ ) return this.E();
         return this.E()
           .addClass(self.myClass('container'))
+          // .attrs({ tabindex: 0 })
           .add(self.search$.map(searchEnabled => {
             if ( ! searchEnabled ) return null;
             return this.E()
@@ -552,6 +582,7 @@ foam.CLASS({
             });
             return Promise.all(promiseArray).then(resp => {
               var index = 0;
+              self.selectableItems_ = [];
               return this.E().forEach(sections, function(section) {
                 if ( section.hideIfEmpty && resp[index].value <= 0 ) {
                   index++;
@@ -567,10 +598,16 @@ foam.CLASS({
                   .start()
                     .select( section.choicesLimit ? section.filteredDAO$proxy.limit(section.choicesLimit) : section.filteredDAO$proxy, function(obj) {
                       let addRow = function() {
+                        let itemIndex = self.selectableItems_.length;
+                        if ( ! section.disabled ) {
+                          self.selectableItems_.push(obj);
+                        }
                         this.start(self.rowView, { data: obj })
+                          .addClass(self.myClass('selectable-item'))
                           .attr('disabled', section.disabled)
                           .attr('role', 'option')
                           .enableClass('disabled', section.disabled)
+                          .enableClass('highlighted', self.highlightedIndex_$.map(v => v === itemIndex))
                           .callIf(! section.disabled, function() {
                             this.on('click', () => {
                               self.onSelect(obj);
@@ -593,6 +630,9 @@ foam.CLASS({
               });
             });
           }))
+          .on('keydown', function(evt) {
+            self.onKeyDown(evt);
+          })
           .add(this.slot(self.addAction));
       }));
 
@@ -606,6 +646,19 @@ foam.CLASS({
             }
             return self.E()
               .attrs({ tabindex: 0 })
+              .on('keydown', function(evt) {
+                // Press space to open the dropdown when the RichChoiceView has focused
+                if ( evt.key == ' ' ) {
+                  evt.preventDefault();
+                  if ( ! self.isOpen_ ) {
+                    let x = self.selectionEl_.el_().getBoundingClientRect().x;
+                    let y = self.selectionEl_.el_().getBoundingClientRect().y;
+                    self.dropdown_.parentEl = self.selectionEl_.el_();
+                    self.dropdown_.open(x, y);
+                    self.autoFocus();
+                  }
+                }
+              })
               .addClass(this.myClass())
               .start('', {}, this.selectionEl_$)
                 .addClass(this.myClass('selection-view'))
@@ -616,7 +669,7 @@ foam.CLASS({
                   if ( self.mode === foam.u2.DisplayMode.RW ) {
                     self.dropdown_.parentEl = self.selectionEl_.el_();
                     self.dropdown_.open(x, y);
-                    if ( self.inputField ) self.inputField.focused = true;
+                    self.autoFocus();
                   }
                   e.preventDefault();
                   e.stopPropagation();
@@ -660,6 +713,62 @@ foam.CLASS({
       this.fullObject_ = obj;
       this.data = obj[this.idProperty];
       this.isOpen_ = false;
+    },
+
+    function onKeyDown(evt) {
+      if ( ! this.isOpen_ ) return;
+
+      var items = this.selectableItems_;
+      if ( items.length === 0 ) return;
+
+      var idx = this.highlightedIndex_;
+
+      switch ( evt.key ) {
+        // Moving down in the dropdown item list
+        case 'ArrowDown':
+          evt.preventDefault();
+          idx = ( idx + 1 ) % items.length;
+          this.highlightedIndex_ = idx;
+          this.scrollToHighlighted_();
+          break;
+
+        // Moving up in the dropdown item list
+        case 'ArrowUp':
+          evt.preventDefault();
+          idx = idx <= 0 ? items.length - 1 : idx - 1;
+          this.highlightedIndex_ = idx;
+          this.scrollToHighlighted_();
+          break;
+
+        // Select the current highlighted item
+        case 'Enter':
+        case 'Tab':
+          if ( idx >= 0 && idx < items.length ) {
+            evt.preventDefault();
+            this.onSelect(items[idx]);
+            this.dropdown_.close();
+          }
+          break;
+
+        // Close the dropdown
+        case 'Escape':
+          evt.preventDefault();
+          this.dropdown_.close();
+          break;
+
+      }
+    },
+
+    function scrollToHighlighted_() {
+      var container = this.dropdown_.el_();
+      if ( ! container ) return;
+      var items = container.querySelectorAll('.' + this.myClass('selectable-item'));
+      if ( this.highlightedIndex_ >= 0 && this.highlightedIndex_ < items.length ) {
+        var el = items[this.highlightedIndex_];
+        if ( el ) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
     },
 
     function addAction(action, actionData) {
@@ -744,6 +853,13 @@ foam.CLASS({
       // the put. Instead, we need to explicitly set the value to the default
       // value.
       this.data = this.prop ? this.prop.value : undefined;
+    },
+    {
+      name: 'autoFocus',
+      isFramed: true,
+      code: function() {
+        if ( this.inputField ) this.inputField.focused = true;
+      }
     }
   ],
 

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -575,10 +575,11 @@ foam.CLASS({
                   } }), {}, self.inputField$)
                 .endContext();
           }))
-          .add(self.slot(function(sections) {
+          .add(self.slot(function(sections, filter_) {
+            // Check filteredDAO count for each section to respect hideIfEmpty when searching
             var promiseArray = [];
             sections.forEach(function(section) {
-              promiseArray.push(section.dao.select(self.COUNT()));
+              promiseArray.push(section.filteredDAO.select(self.COUNT()));
             });
             return Promise.all(promiseArray).then(resp => {
               var index = 0;

--- a/tools/deploy/bin/run-docker.sh
+++ b/tools/deploy/bin/run-docker.sh
@@ -98,9 +98,11 @@ RES_JAR=$(ls ${APP_HOME}/lib/${APP_NAME}-resources-*.jar 2>/dev/null | head -1)
 if [ -n "${RES_JAR}" ]; then
     echo "Using resources JAR: ${RES_JAR}"
     JAVA_OPTS="${JAVA_OPTS} -DRES_JAR_HOME=${RES_JAR}"
+    export RES_JAR_HOME="${RES_JAR}"
 else
     echo "No resources JAR found (optional)"
     JAVA_OPTS="${JAVA_OPTS} -DRES_JAR_HOME="
+    export RES_JAR_HOME=""
 fi
 
 export JAVA_TOOL_OPTIONS="${JAVA_OPTS}"
@@ -121,6 +123,6 @@ echo "Main class: ${MAIN_CLASS}"
 
 # Launch using classpath with all JARs in lib directory
 # In Docker, both binary and resources JARs are in lib/
-java -server -cp "${APP_HOME}/lib/*" ${MAIN_CLASS}
+java -server ${JAVA_OPTS} -cp "${APP_HOME}/lib/*" ${MAIN_CLASS}
 
 exit $?

--- a/tools/lsp/AxiomCatalog.js
+++ b/tools/lsp/AxiomCatalog.js
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.parse.lsp',
+  name: 'AxiomCatalog',
+
+  documentation: `
+    Single source of truth for FOAM axiom metadata used by the LSP.
+
+    Each entry describes one axiom slot — what it does, where it lives
+    (top-level vs property vs POM), and whether its value is treated
+    as a class id. Both FoamClassGrammar (for completion hints) and
+    HoverHandler (for hover text) read from this catalog so the
+    descriptions exist in exactly one place.
+
+    Adding a new axiom slot requires touching only this file: the
+    grammar's hint and the editor's hover both update automatically.
+  `,
+
+  constants: {
+    // Top-level class-body axioms. Each entry: { name, scope, hint }.
+    // scope is one of 'topKey' / 'propKey' / 'pomKey' so the grammar
+    // can route via the correct suggestion factory.
+    AXIOMS: [
+      // === Top-level class-body slots ===
+      { name: 'package',       scope: 'topKey', hint: 'Java/JS package id (e.g., foam.lang)' },
+      { name: 'name',          scope: 'topKey', hint: 'Class name (CamelCase)' },
+      { name: 'extends',       scope: 'topKey', hint: 'Parent class id' },
+      { name: 'implements',    scope: 'topKey', hint: 'Interface ids implemented by this class' },
+      { name: 'refines',       scope: 'topKey', hint: 'Target class id this refinement modifies' },
+      { name: 'requires',      scope: 'topKey', hint: 'Class ids required by this class (for create())' },
+      { name: 'imports',       scope: 'topKey', hint: 'Context names this class consumes' },
+      { name: 'exports',       scope: 'topKey', hint: 'Context names this class exports' },
+      { name: 'properties',    scope: 'topKey', hint: 'Property axioms (FObject fields)' },
+      { name: 'methods',       scope: 'topKey', hint: 'Method axioms' },
+      { name: 'actions',       scope: 'topKey', hint: 'Action axioms (UI buttons)' },
+      { name: 'listeners',     scope: 'topKey', hint: 'Listener axioms' },
+      { name: 'axioms',        scope: 'topKey', hint: 'Raw axiom objects' },
+      { name: 'topics',        scope: 'topKey', hint: 'Topic axioms (pub/sub channels)' },
+      { name: 'constants',     scope: 'topKey', hint: 'Constant axioms' },
+      { name: 'messages',      scope: 'topKey', hint: 'Localizable message axioms' },
+      { name: 'sections',      scope: 'topKey', hint: 'Section grouping for properties' },
+      { name: 'values',        scope: 'topKey', hint: 'Enum value declarations (foam.ENUM)' },
+      { name: 'documentation', scope: 'topKey', hint: 'Class-level documentation string' },
+      { name: 'abstract',      scope: 'topKey', hint: 'Boolean — true if class is abstract' },
+      { name: 'flags',         scope: 'topKey', hint: 'Build flags ("js", "java", "web", "test", ...)' },
+      { name: 'javaImports',   scope: 'topKey', hint: 'Java import statements' },
+      { name: 'javaCode',      scope: 'topKey', hint: 'Class-level Java code' },
+      { name: 'css',           scope: 'topKey', hint: 'Class-scoped CSS' },
+      { name: 'cssTokens',     scope: 'topKey', hint: 'CSS design-token declarations' },
+      { name: 'mixins',        scope: 'topKey', hint: 'Mixin class ids' },
+      { name: 'tableColumns',  scope: 'topKey', hint: 'Column property names for table views' },
+      { name: 'searchColumns', scope: 'topKey', hint: 'Property names for filterable columns' },
+      { name: 'sourceModel',   scope: 'topKey', hint: 'RELATIONSHIP — class id at the source side' },
+      { name: 'targetModel',   scope: 'topKey', hint: 'RELATIONSHIP — class id at the target side' },
+      { name: 'forwardName',   scope: 'topKey', hint: 'RELATIONSHIP — name of the forward navigation' },
+      { name: 'inverseName',   scope: 'topKey', hint: 'RELATIONSHIP — name of the inverse navigation' },
+      { name: 'cardinality',   scope: 'topKey', hint: 'RELATIONSHIP — "1:*" / "*:*" / "1:1"' },
+      { name: 'sourceProperty',scope: 'topKey', hint: 'RELATIONSHIP — overrides for the source side' },
+      { name: 'targetProperty',scope: 'topKey', hint: 'RELATIONSHIP — overrides for the target side' },
+      { name: 'label',         scope: 'topKey', hint: 'Display label' },
+      { name: 'plural',        scope: 'topKey', hint: 'Plural form for UI' },
+      { name: 'order',         scope: 'topKey', hint: 'Sort order in containing list' },
+      { name: 'ids',           scope: 'topKey', hint: 'Property names that form the primary key' },
+      { name: 'static',        scope: 'topKey', hint: 'Static (LIB-style) members' },
+      { name: 'of',            scope: 'topKey', hint: 'Class id of contained type' },
+
+      // === Per-property axiom slots ===
+      { name: 'class',          scope: 'propKey', hint: 'Property type — short name (String, Long, ...) or full class id' },
+      { name: 'name',           scope: 'propKey', hint: 'Property name (camelCase)' },
+      { name: 'of',             scope: 'propKey', hint: 'Class id of the contained type (FObjectProperty/Reference/FObjectArray)' },
+      { name: 'documentation',  scope: 'propKey', hint: 'Property docstring' },
+      { name: 'hidden',         scope: 'propKey', hint: 'Boolean — hide from auto-rendered views' },
+      { name: 'transient',      scope: 'propKey', hint: 'Boolean — exclude from serialization' },
+      { name: 'value',          scope: 'propKey', hint: 'Default value (literal)' },
+      { name: 'factory',        scope: 'propKey', hint: 'function() — computed default' },
+      { name: 'expression',     scope: 'propKey', hint: 'function(deps...) — reactive derived value' },
+      { name: 'javaCode',       scope: 'propKey', hint: 'Java statement(s) for class-level body' },
+      { name: 'javaGetter',     scope: 'propKey', hint: 'Java getter body' },
+      { name: 'javaSetter',     scope: 'propKey', hint: 'Java setter body' },
+      { name: 'javaFactory',    scope: 'propKey', hint: 'Java factory body' },
+      { name: 'javaPreSet',     scope: 'propKey', hint: 'Java code run before set' },
+      { name: 'javaPostSet',    scope: 'propKey', hint: 'Java code run after set' },
+      { name: 'javaInfoType',   scope: 'propKey', hint: 'Java PropertyInfo class (rare)' },
+      { name: 'aliases',        scope: 'propKey', hint: 'Alternate names for serialization' },
+      { name: 'label',          scope: 'propKey', hint: 'Display label for UI' },
+      { name: 'section',        scope: 'propKey', hint: 'Section name for grouped views' },
+      { name: 'visibility',     scope: 'propKey', hint: 'Visibility enum (RW, RO, HIDDEN, ...)' },
+      { name: 'view',           scope: 'propKey', hint: 'View class id or { class: "..." }' },
+      { name: 'adapt',          scope: 'propKey', hint: 'function(old, nu, prop) — JS adapter' },
+      { name: 'preSet',         scope: 'propKey', hint: 'function(old, nu) — JS pre-set hook' },
+      { name: 'postSet',        scope: 'propKey', hint: 'function(old, nu) — JS post-set hook' },
+      { name: 'required',       scope: 'propKey', hint: 'Boolean — fail validation if empty' },
+      { name: 'width',          scope: 'propKey', hint: 'Display width for inputs' },
+      { name: 'placeholder',    scope: 'propKey', hint: 'Input placeholder text' },
+      { name: 'help',           scope: 'propKey', hint: 'Help text shown next to the input' },
+      { name: 'gridColumns',    scope: 'propKey', hint: 'Grid columns occupied by this field' },
+      { name: 'tableCellFormatter',     scope: 'propKey', hint: 'function(value, obj, prop) — table cell formatter' },
+      { name: 'labelFormatter',         scope: 'propKey', hint: 'function(data, prop) — render-time label' },
+      { name: 'shortName',              scope: 'propKey', hint: 'Short name used in CLI/JRL' },
+      { name: 'readPermissionRequired', scope: 'propKey', hint: 'Boolean — gate reads on permission' },
+      { name: 'writePermissionRequired',scope: 'propKey', hint: 'Boolean — gate writes on permission' },
+      { name: 'permissionRequired',     scope: 'propKey', hint: 'Boolean — gate read AND write' },
+      { name: 'validateObj',            scope: 'propKey', hint: 'function(...) — validation method' },
+      { name: 'tableWidth',             scope: 'propKey', hint: 'Table column width' },
+      { name: 'storageTransient',       scope: 'propKey', hint: 'Boolean — exclude from persistence' },
+      { name: 'networkTransient',       scope: 'propKey', hint: 'Boolean — exclude from RPC' },
+      { name: 'cloneProperty',          scope: 'propKey', hint: 'function(value) — clone hook' },
+      { name: 'readOnly',               scope: 'propKey', hint: 'Boolean — disable editing in default view' },
+
+      // === Per-method-object slots (inside `methods: [...]`) ===
+      { name: 'name',          scope: 'methodKey', hint: 'Method name (camelCase)' },
+      { name: 'code',          scope: 'methodKey', hint: 'function(...) — JS implementation' },
+      { name: 'args',          scope: 'methodKey', hint: 'String "T name, …" or array of { name, type, javaType }' },
+      { name: 'type',          scope: 'methodKey', hint: 'Return type (FOAM class id)' },
+      { name: 'javaType',      scope: 'methodKey', hint: 'Java return type (e.g., "void", "List<String>")' },
+      { name: 'javaCode',      scope: 'methodKey', hint: 'Java implementation body' },
+      { name: 'javaThrows',    scope: 'methodKey', hint: 'Array of checked-exception class ids' },
+      { name: 'documentation', scope: 'methodKey', hint: 'Method docstring' },
+      { name: 'async',         scope: 'methodKey', hint: 'Boolean — async function form' },
+
+      // === Per-action-object slots (inside `actions: [...]`) ===
+      { name: 'name',           scope: 'actionKey', hint: 'Action name' },
+      { name: 'label',          scope: 'actionKey', hint: 'Display label for the action button' },
+      { name: 'icon',           scope: 'actionKey', hint: 'Icon URL or token' },
+      { name: 'iconFontName',   scope: 'actionKey', hint: 'Icon-font glyph name' },
+      { name: 'iconFontFamily', scope: 'actionKey', hint: 'Icon font family' },
+      { name: 'iconFontClass',  scope: 'actionKey', hint: 'CSS class for the icon font' },
+      { name: 'isAvailable',    scope: 'actionKey', hint: 'function() — returns true if action is selectable' },
+      { name: 'isEnabled',      scope: 'actionKey', hint: 'function() — returns true if action is clickable' },
+      { name: 'confirmationRequired', scope: 'actionKey', hint: 'Boolean — show confirm dialog before invoking' },
+      { name: 'code',           scope: 'actionKey', hint: 'function() — action handler' },
+      { name: 'documentation',  scope: 'actionKey', hint: 'Action docstring' },
+
+      // === Per-section-object slots (inside `sections: [...]`) ===
+      { name: 'name',          scope: 'sectionKey', hint: 'Section identifier' },
+      { name: 'title',         scope: 'sectionKey', hint: 'Section heading text' },
+      { name: 'help',          scope: 'sectionKey', hint: 'Helper text under the section heading' },
+      { name: 'isAvailable',   scope: 'sectionKey', hint: 'function() — show/hide the section' },
+      { name: 'view',          scope: 'sectionKey', hint: 'View class id or { class: "..." }' },
+      { name: 'order',         scope: 'sectionKey', hint: 'Sort order among siblings' },
+
+      // === Per-message-object slots (inside `messages: [...]`) ===
+      { name: 'name',          scope: 'messageKey', hint: 'Message identifier (UPPER_SNAKE_CASE convention)' },
+      { name: 'message',       scope: 'messageKey', hint: 'Localizable message text' },
+      { name: 'documentation', scope: 'messageKey', hint: 'Message docstring' },
+
+      // === Per-enum-value slots (inside `values: [...]` of foam.ENUM) ===
+      { name: 'name',          scope: 'valueKey', hint: 'Enum value identifier (UPPER_SNAKE_CASE)' },
+      { name: 'label',         scope: 'valueKey', hint: 'Display label for this enum value' },
+      { name: 'ordinal',       scope: 'valueKey', hint: 'Numeric ordinal (rare; auto-assigned by default)' },
+      { name: 'documentation', scope: 'valueKey', hint: 'Enum value docstring' },
+
+      // === Per-listener slots (inside `listeners: [...]`) ===
+      { name: 'name',          scope: 'listenerKey', hint: 'Listener name' },
+      { name: 'code',          scope: 'listenerKey', hint: 'function(...) — listener body' },
+      { name: 'isFramed',      scope: 'listenerKey', hint: 'Boolean — coalesce calls to one per animation frame' },
+      { name: 'isMerged',      scope: 'listenerKey', hint: 'Boolean — merge bursts of calls' },
+      { name: 'mergeDelay',    scope: 'listenerKey', hint: 'Merge delay in ms (when isMerged is true)' },
+      { name: 'documentation', scope: 'listenerKey', hint: 'Listener docstring' },
+
+      // === POM-body slots ===
+      { name: 'name',             scope: 'pomKey', hint: 'POM project name' },
+      { name: 'version',          scope: 'pomKey', hint: 'POM project version' },
+      { name: 'journalFiles',     scope: 'pomKey', hint: 'Extra .jrl files to load (rare; usually auto-loaded from same dir)' },
+      { name: 'files',            scope: 'pomKey', hint: 'FOAM .js model files in this project (flags decide js/java/test)' },
+      { name: 'javaFiles',        scope: 'pomKey', hint: 'Hand-written .java files (no FOAM .js sibling)' },
+      { name: 'projects',         scope: 'pomKey', hint: 'Sub-project pom.js paths to include' },
+      { name: 'javaDependencies', scope: 'pomKey', hint: 'Maven coordinates ("group:artifact:version")' }
+    ]
+  },
+
+  methods: [
+
+    function getHint(scope, name) {
+      /**
+       * Look up an axiom's hint description by scope ('topKey', 'propKey',
+       * 'pomKey') and slot name. Returns '' if no match.
+       */
+      var axioms = this.AXIOMS;
+      for ( var i = 0 ; i < axioms.length ; i++ ) {
+        if ( axioms[i].scope === scope && axioms[i].name === name ) {
+          return axioms[i].hint;
+        }
+      }
+      return '';
+    },
+
+    function findHint(name) {
+      /**
+       * Find the FIRST hint matching `name` regardless of scope. Used by
+       * HoverHandler for cursor-on-axiom-key hover where the scope can be
+       * inferred from context but a single description is fine. Top-level
+       * scope is checked first because it's what users hit most often.
+       */
+      var order = [ 'topKey', 'propKey', 'pomKey' ];
+      for ( var s = 0 ; s < order.length ; s++ ) {
+        var hint = this.getHint(order[s], name);
+        if ( hint ) return hint;
+      }
+      return '';
+    },
+
+    function byScope(scope) {
+      /**
+       * Return all axiom entries for a given scope, in declaration order.
+       * Used by FoamClassGrammar to build the topLevelKey/propKey alts.
+       */
+      var axioms = this.AXIOMS;
+      var out = [];
+      for ( var i = 0 ; i < axioms.length ; i++ ) {
+        if ( axioms[i].scope === scope ) out.push(axioms[i]);
+      }
+      return out;
+    }
+  ]
+});

--- a/tools/lsp/CursorAnalyzer.js
+++ b/tools/lsp/CursorAnalyzer.js
@@ -11,15 +11,17 @@ foam.CLASS({
   documentation: 'Shared text analysis utilities for LSP handlers.',
 
   constants: {
-    // Matches the opening of any FOAM model call. Shared by all handlers for
-    // file-type detection and by FileModelCache for bracket-matching fallback.
-    FOAM_CALL_REGEX: /foam\.(CLASS|ENUM|INTERFACE|RELATIONSHIP)\s*\(/,
-    FOAM_CALL_REGEX_POM: /foam\.(CLASS|ENUM|INTERFACE|RELATIONSHIP|POM)\s*\(/
+    // Matches the opening of any FOAM model call: foam.<UPPER_IDENT>( ... ).
+    // Generic on purpose — any extension (FSM, future model types) is picked up
+    // without changes here. POM is excluded from the default form because
+    // diagnostics aren't meaningful on POM bodies; the _POM variant includes it.
+    FOAM_CALL_REGEX: /foam\.(?!POM\b)[A-Z][A-Z0-9_]*\s*\(/,
+    FOAM_CALL_REGEX_POM: /foam\.[A-Z][A-Z0-9_]*\s*\(/
   },
 
   methods: [
     function isFoamFile(text, opt_includePom) {
-      /** True if the text contains a foam.CLASS/ENUM/INTERFACE/RELATIONSHIP (or POM) call. */
+      /** True if the text contains any foam.<UPPER>(...) model-defining call. */
       var re = opt_includePom ? this.FOAM_CALL_REGEX_POM : this.FOAM_CALL_REGEX;
       return re.test(text);
     },
@@ -234,15 +236,27 @@ foam.CLASS({
       return method.name + '()';
     },
 
-    function resolveJavaVariableType(text, position, varName, model, index) {
+    function resolveJavaVariableType(text, position, varName, model, index, opt_seen) {
       /**
        * Resolve a Java variable's type from cast, declaration, or method return type.
        * Resolution order:
        *   1. Cast on current/nearby line: ((TypeName) varName).
        *   2. Explicit type declaration: TypeName varName = ...
-       *   3. Method return type: var varName = expr.method(...) → method.type
-       *   4. Getter return type: var varName = getProperty() → property type
+       *   3. var x = new T(...)  →  T
+       *   4. var x = (T) expr    →  T
+       *   5. var x = expr.method(...) — resolve receiver then method return type.
+       *   6. var x = getProperty() → property's java type.
+       *
+       * `opt_seen` is the recursion-guard set; it tracks variable names
+       * already on the resolution stack so cycles (`var a = b.x();
+       * var b = a.y();`) and self-references (`var x = x.f();`) terminate
+       * instead of recursing forever.
        */
+      var seen = opt_seen || {};
+      if ( seen[varName] ) return null;
+      seen = Object.assign({}, seen);
+      seen[varName] = true;
+
       var lines = text.split('\n');
 
       // 1. Check for cast on current or nearby lines
@@ -270,6 +284,16 @@ foam.CLASS({
         }
 
         // 3. 'var' declaration — infer from the right-hand side
+        // var x = new T(...)  → T
+        // var x = (T) expr     → T (with optional generics stripped)
+        // var x = T.class      → T (the class type itself)
+        var newM = scanLine.match(new RegExp(varName + '\\s*=\\s*new\\s+([A-Z][\\w.$]*)'));
+        if ( newM ) return this.resolveJavaTypeName(newM[1], model, index);
+
+        var simpleCastM = scanLine.match(
+          new RegExp(varName + '\\s*=\\s*\\(\\s*([A-Z][\\w.$]*)\\s*(?:<[^()]*>)?\\s*\\)'));
+        if ( simpleCastM ) return this.resolveJavaTypeName(simpleCastM[1], model, index);
+
         // var x = ((Cast) y).method() → resolve cast chain
         var rhsCastInfo = this.resolveJavaCastType(scanLine, model, index);
         if ( rhsCastInfo && rhsCastInfo.classId && rhsCastInfo.methodName ) {
@@ -290,8 +314,8 @@ foam.CLASS({
             if ( returnType ) return returnType;
           }
 
-          // Try receiver as a variable
-          var receiverType = this.resolveJavaVariableType(text, { line: i, character: 0 }, receiverName, model, index);
+          // Try receiver as a variable — pass `seen` so cycles terminate
+          var receiverType = this.resolveJavaVariableType(text, { line: i, character: 0 }, receiverName, model, index, seen);
           if ( receiverType ) {
             var returnType = this.resolveMethodReturnType(receiverType, methodName, index);
             if ( returnType ) return returnType;
@@ -310,6 +334,75 @@ foam.CLASS({
         }
 
         return null;
+      }
+
+      // 7. FOAM method parameter — declared in the enclosing method's
+      //    `args:` axiom, NOT in the javaCode body. Common pattern:
+      //      methods: [{
+      //        name: 'foo',
+      //        args: 'X x, MyType someParam',
+      //        javaCode: `someParam.bar();`
+      //      }]
+      //    The javaCode reference resolves through the args string of the
+      //    nearest preceding method-axiom block. Both string form
+      //    ('X x, MyType p') and array-of-objects form
+      //    ([{name:'p', javaType:'MyType'}]) are recognized.
+      var argType = this.resolveMethodParamType_(text, position, varName, model, index);
+      if ( argType ) return argType;
+      return null;
+    },
+
+    function resolveMethodParamType_(text, position, varName, model, index) {
+      /**
+       * Find the type of a FOAM method parameter declared in the enclosing
+       * method's `args:` axiom. Scans back from the cursor for the nearest
+       * `args:` declaration above the current javaCode block.
+       *
+       * Two `args:` shapes are supported:
+       *   - String form:   args: 'X x, MyType someParam'
+       *   - Array form:    args: [{ name: 'someParam', javaType: 'MyType' }]
+       *
+       * Returns a class id resolved via resolveJavaTypeName, or null.
+       */
+      var lines = text.split('\n');
+      var maxScan = Math.min(position.line, 200);
+
+      // String form
+      for ( var i = position.line ; i >= position.line - maxScan ; i-- ) {
+        if ( i < 0 ) break;
+        var line = lines[i] || '';
+        var stringArgs = line.match(/args\s*:\s*['"]([^'"]*)['"]/);
+        if ( stringArgs ) {
+          var pairs = stringArgs[1].split(',');
+          for ( var p = 0 ; p < pairs.length ; p++ ) {
+            var parts = pairs[p].trim().split(/\s+/);
+            if ( parts.length < 2 ) continue;
+            // Tail is the param name; everything before is the type. This
+            // handles generics-as-tokens (e.g., `List<String> items`).
+            var nm = parts[parts.length - 1];
+            var ty = parts.slice(0, parts.length - 1).join(' ');
+            if ( nm === varName && ty ) {
+              return this.resolveJavaTypeName(ty.replace(/<.*$/, ''), model, index);
+            }
+          }
+          break;
+        }
+        // Array form (single-line subset). Multi-line array form would
+        // require a richer parser — fall through to break the scan since
+        // the simple match didn't fire.
+        var arrayArgs = line.match(/args\s*:\s*\[\s*\{([\s\S]*?)\}\s*\]/);
+        if ( arrayArgs ) {
+          var entries = arrayArgs[1].split(/\}\s*,\s*\{/);
+          for ( var e = 0 ; e < entries.length ; e++ ) {
+            var entry = entries[e];
+            var nameM = entry.match(/name\s*:\s*['"]([^'"]+)['"]/);
+            if ( nameM && nameM[1] === varName ) {
+              var typeM = entry.match(/(?:javaType|type)\s*:\s*['"]([^'"]+)['"]/);
+              if ( typeM ) return this.resolveJavaTypeName(typeM[1].replace(/<.*$/, ''), model, index);
+            }
+          }
+          break;
+        }
       }
       return null;
     },
@@ -411,7 +504,36 @@ foam.CLASS({
       var blockKey = keyMatch[1];
 
       // Only return for known block keys
-      var knownKeys = { css: true, javaCode: true, javaPreSet: true, javaPostSet: true, javaFactory: true, javaGetter: true };
+      // Every key that holds a Java code/CSS template-literal block. The
+      // SemanticTokenHandler scans the same superset; keep them in sync so
+      // hover/go-to-def fire inside any Java slot (not just `javaCode:`).
+      var knownKeys = {
+        css:                            true,
+        javaCode:                       true,
+        javaPreSet:                     true,
+        javaPostSet:                    true,
+        javaFactory:                    true,
+        javaGetter:                     true,
+        javaSetter:                     true,
+        javaAdapt:                      true,
+        javaCompare:                    true,
+        javaComparePropertyToObject:    true,
+        javaComparePropertyToValue:     true,
+        javaCloneProperty:              true,
+        javaDiffProperty:               true,
+        javaFormatJSON:                 true,
+        javaJSONParser:                 true,
+        javaCSVParser:                  true,
+        javaQueryParser:                true,
+        javaToCSV:                      true,
+        javaToCSVLabel:                 true,
+        javaFromCSVLabelMapping:        true,
+        javaAssertValue:                true,
+        javaValidateObj:                true,
+        javaCondition:                  true,
+        javaValue:                      true,
+        javaInit:                       true
+      };
       if ( ! knownKeys[blockKey] ) return null;
 
       // Extract block content (between opening backtick and next backtick or end)

--- a/tools/lsp/FileModelCache.js
+++ b/tools/lsp/FileModelCache.js
@@ -118,58 +118,91 @@ foam.CLASS({
 
     function parseFileModels(text) {
       /**
-       * Execute file text with overridden foam.CLASS/ENUM/INTERFACE to capture
+       * Execute file text with overridden foam.<X>(...) calls to capture
        * model objects. Same pattern as ModelFileDAO.js:47-108.
+       *
+       * Generic on purpose: any uppercase foam call (foam.CLASS, foam.ENUM,
+       * foam.FSM, future extensions) is captured. Specials with non-class
+       * bodies (POM, SCRIPT) are no-ops; LIB and RELATIONSHIP have custom
+       * shape handling. Everything else routes through `captureGeneric`.
        *
        * Returns array of raw model JS objects with all fields:
        * { package, name, extends, implements, requires, imports, exports,
-       *   properties, methods, javaImports, javaCode, refines, ... }
+       *   properties, methods, javaImports, javaCode, refines, type_, ... }
        */
       var models = [];
       var modelCount = 0;
-      var context = { foam: Object.create(foam) };
 
-      context.foam.CLASS = function(m) {
+      var captureClass = function(m) {
         m.sourceLine_ = findCallLine(text, modelCount);
         m.type_ = m.type_ || 'CLASS';
         models.push(m);
         modelCount++;
       };
-      context.foam.ENUM = function(m) {
-        m.class = m.class || 'foam.lang.EnumModel';
-        m.type_ = 'ENUM';
-        context.foam.CLASS(m);
+
+      // Generic capturer for any foam.<TYPE>(model). Sets type_ from the call
+      // name (FSM → 'FSM') and a best-effort default `class` axiom so the
+      // FOAM JSON serializer can still round-trip the captured model.
+      var captureGeneric = function(typeName) {
+        return function(m) {
+          if ( ! m ) return;
+          m.type_ = typeName;
+          if ( ! m.class ) {
+            m.class = 'foam.lang.' + typeName.charAt(0)
+              + typeName.slice(1).toLowerCase() + 'Model';
+          }
+          captureClass(m);
+        };
       };
-      context.foam.INTERFACE = function(m) {
-        m.class = m.class || 'foam.lang.InterfaceModel';
-        m.type_ = 'INTERFACE';
-        context.foam.CLASS(m);
-      };
-      context.foam.RELATIONSHIP = function(r) {
-        r.class = r.class || 'foam.dao.Relationship';
-        r.type_ = 'RELATIONSHIP';
-        if ( ! r.name && r.sourceModel ) {
-          var s = r.sourceModel;
-          var t = r.targetModel || '';
-          r.package = r.package || s.substring(0, s.lastIndexOf('.'));
-          r.name = s.split('.').pop() + t.split('.').pop() + 'Relationship';
+
+      var overrides = {
+        CLASS: captureClass,
+        ENUM: captureGeneric('ENUM'),
+        INTERFACE: captureGeneric('INTERFACE'),
+        RELATIONSHIP: function(r) {
+          if ( ! r ) return;
+          r.class = r.class || 'foam.dao.Relationship';
+          r.type_ = 'RELATIONSHIP';
+          if ( ! r.name && r.sourceModel ) {
+            var s = r.sourceModel;
+            var t = r.targetModel || '';
+            r.package = r.package || s.substring(0, s.lastIndexOf('.'));
+            r.name = s.split('.').pop() + t.split('.').pop() + 'Relationship';
+          }
+          captureClass(r);
+        },
+        SCRIPT: function() {},
+        POM:    function() {},
+        LIB:    function(m) {
+          if ( ! m || ! m.name ) return;
+          m.type_ = 'LIB';
+          m.sourceLine_ = findLibCallLine(text, models);
+          models.push(m);
         }
-        context.foam.CLASS(r);
       };
-      context.foam.SCRIPT = function() {};
-      context.foam.POM = function() {};
-      context.foam.LIB = function(m) {
-        if ( ! m || ! m.name ) return;
-        m.type_ = 'LIB';
-        m.sourceLine_ = findLibCallLine(text, models);
-        models.push(m);
-      };
+
+      // Proxy intercepts every foam.<X> read inside the eval'd text so unknown
+      // uppercase types (foam.FSM and any future extension) get a generic
+      // capturer instead of falling through to the real foam[<X>] (which
+      // would actually register the class for real — bad side-effect).
+      var foamProxy = new Proxy(Object.create(foam), {
+        get: function(target, prop) {
+          if ( typeof prop === 'string' && Object.prototype.hasOwnProperty.call(overrides, prop) ) {
+            return overrides[prop];
+          }
+          if ( typeof prop === 'string' && /^[A-Z][A-Z0-9_]*$/.test(prop) ) {
+            return captureGeneric(prop);
+          }
+          return target[prop];
+        }
+      });
+      var context = { foam: foamProxy };
 
       try {
         with ( context ) { eval(text); }
       } catch (e) {
         // SyntaxError prevents ALL execution — JS parses before running.
-        // Fall back to extracting individual foam.CLASS blocks and eval each.
+        // Fall back to extracting individual foam.<X>(...) blocks and eval each.
         if ( e instanceof SyntaxError && models.length === 0 ) {
           modelCount = 0;
           this.evalIndividualBlocks_(text, context, models);
@@ -182,10 +215,11 @@ foam.CLASS({
 
     function evalIndividualBlocks_(text, context, models) {
       /**
-       * Fallback for SyntaxError: extract individual foam.CLASS/ENUM/INTERFACE
-       * blocks using bracket matching and eval each separately.
+       * Fallback for SyntaxError: extract individual foam.<X>(...) blocks
+       * using bracket matching and eval each separately. Generic on the call
+       * name so foam.FSM/foam.RELATIONSHIP/etc. all participate.
        */
-      var regex = /foam\.(CLASS|ENUM|INTERFACE|RELATIONSHIP|LIB)\s*\(/g;
+      var regex = /foam\.[A-Z][A-Z0-9_]*\s*\(/g;
       var match;
       while ( ( match = regex.exec(text) ) !== null ) {
         var start = match.index;
@@ -221,7 +255,7 @@ foam.CLASS({
 
 function findCallLine(text, index) {
   /**
-   * Find the line number of the Nth foam.CLASS/ENUM/INTERFACE call in text.
+   * Find the line number of the Nth foam.<X>(...) call in text.
    *
    * WHY: Multi-class files (e.g., Element2.js) contain multiple foam.CLASS
    * calls. When the user's cursor is on line 50, getModelAt() needs to know
@@ -229,10 +263,17 @@ function findCallLine(text, index) {
    * this lookup. Also needed by SymbolHandler for accurate outline positions
    * and DiagnosticsHandler for correct error squiggle placement.
    *
+   * Generic on the call name (CLASS/ENUM/INTERFACE/RELATIONSHIP/FSM/...) so
+   * model-position tracking works for any foam.<X> extension. POM/SCRIPT are
+   * matched too but never appear in `models` (their overrides are no-ops).
+   *
    * For single-class files (99% of cases), sourceLine_ is always 0 and
    * getModelAt() returns the only model regardless. The cost is negligible.
+   *
+   * Skips POM/SCRIPT/LIB — those don't enter the regular `models` array via
+   * captureClass(), so counting them would misalign the index.
    */
-  var regex = /foam\.(CLASS|ENUM|INTERFACE|RELATIONSHIP)\s*\(/g;
+  var regex = /foam\.(?!POM\b|SCRIPT\b|LIB\b)[A-Z][A-Z0-9_]*\s*\(/g;
   var match;
   var count = 0;
   while ( ( match = regex.exec(text) ) !== null ) {

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -12,6 +12,7 @@ foam.CLASS({
   documentation: 'Grammar that parses foam.CLASS/ENUM/INTERFACE definitions with dynamic suggestions.',
 
   requires: [
+    'foam.parse.lsp.AxiomCatalog',
     'foam.parse.lsp.FoamIndex'
   ],
 
@@ -23,12 +24,24 @@ foam.CLASS({
       factory: function() { return this.FoamIndex.create(); }
     },
     {
+      class: 'FObjectProperty',
+      of: 'foam.parse.lsp.AxiomCatalog',
+      name: 'catalog',
+      factory: function() { return this.AxiomCatalog.create(); }
+    },
+    {
       name: 'classRefParser_',
       documentation: 'Cached alt() parser of all class ID suggestions.'
     },
     {
       name: 'propTypeParser_',
       documentation: 'Cached alt() parser of all property type suggestions.'
+    },
+    {
+      name: 'classTypedKeyParser_',
+      documentation: `Cached alt() parser matching any axiom slot name whose
+        value is a class id (Class/Reference/FObjectProperty/FObjectArray on
+        any registered model). Drives the generic classTypedSlotEntry rule.`
     },
     {
       name: 'symbols',
@@ -218,7 +231,14 @@ foam.CLASS({
       // package must be inserted as its full class id so the generated code
       // resolves unambiguously (fixes issue where `class: 'foam.u2.ViewSpec'`
       // completed to bare `'ViewSpec'`).
-      var propTypes = this.index.getPropertyTypes();
+      // Property type alts MUST be sorted longest-first. P.alt returns
+      // the FIRST match — without the sort, `Double` would prefix-match
+      // and short-circuit `DoubleUnitValue`/`UnitValue`, leaving the
+      // `UnitValue` suffix to choke the outer rule. Same bug as the
+      // classRefParser_ ordering below.
+      var propTypes = this.index.getPropertyTypes().slice().sort(function(a, b) {
+        return b.name.length - a.name.length;
+      });
       var propTypeParsers = propTypes.map(function(t) {
         var isLang = t.id && t.id.indexOf('foam.lang.') === 0;
         var insertText = isLang ? t.name : t.id;
@@ -251,67 +271,169 @@ foam.CLASS({
       });
       this.classRefParser_ = classRefParsers.length > 0 ?
         P.alt.apply(P, classRefParsers) : P.literal('foam.lang.FObject');
+
+      // Class-typed axiom slot names — any axiom whose value is a class id.
+      // Used by classTypedSlotEntry so a custom property like FSM `next`
+      // (Class-typed) parses its `'foo.X'` value as a class reference
+      // without the LSP knowing about FSM. Sorted longest-first to keep
+      // alt() deterministic for prefix-overlapping names.
+      var slotNames = this.index.getClassTypedPropertyNames().slice().sort(function(a, b) {
+        return b.length - a.length;
+      });
+      // Skip names already handled by their own first-class entry to avoid
+      // duplicate matching (extends/implements/refines/sourceModel/
+      // targetModel/of/class/view).
+      var handled = {
+        'extends':     true, 'implements':  true, 'refines':     true,
+        'sourceModel': true, 'targetModel': true,
+        'of':          true, 'class':       true, 'view':        true
+      };
+      var classTypedKeyParsers = [];
+      for ( var s = 0 ; s < slotNames.length ; s++ ) {
+        if ( handled[slotNames[s]] ) continue;
+        classTypedKeyParsers.push(P.literal(slotNames[s]));
+      }
+      this.classTypedKeyParser_ = classTypedKeyParsers.length > 0 ?
+        P.alt.apply(P, classTypedKeyParsers) :
+        // Fallback: if registry walk yielded nothing (unlikely), match a
+        // sentinel that never appears so this rule simply never fires.
+        P.literal('');
     },
 
     function buildGrammar_(P) {
       var self = this;
 
       // === PRIMITIVES ===
-      var ws = P.repeat0(P.alt(P.literal(' '), P.literal('\t'), P.literal('\n'), P.literal('\r')));
+      // Reusable character classes — these are the primitive building
+      // blocks. Defining them once and reusing them keeps the grammar
+      // DRY and ensures every identifier-shaped position uses the same
+      // tolerance (e.g., letters / digits / underscore / `$`).
+      var lower = P.range('a', 'z');
+      var upper = P.range('A', 'Z');
+      var digit = P.range('0', '9');
+      var alpha = P.alt(lower, upper);
+      var alphaNum = P.alt(lower, upper, digit);
 
-      // Comments
+      // Whitespace primitives. `ws` is whitespace-only; `wsc` is the
+      // whitespace + comments form used between grammar tokens.
       var lineComment = P.seq(P.literal('//'), P.str(P.repeat(P.notChars('\n\r'), null, 0)),
         P.alt(P.literal('\r\n'), P.literal('\n'), P.literal('\r')));
       var blockComment = P.seq(P.literal('/*'), P.str(P.until(P.literal('*/'))));
+      var wsChar = P.chars(' \t\n\r');
+      var ws  = P.repeat0(wsChar);
+      var wsc = P.repeat0(P.alt(wsChar, lineComment, blockComment));
 
-      // Whitespace including comments
-      var wsc = P.repeat0(P.alt(P.literal(' '), P.literal('\t'), P.literal('\n'), P.literal('\r'),
-        lineComment, blockComment));
+      // String literals — three quote flavors share the same shape.
+      function quotedString(qChar) {
+        return P.seq1(1, P.literal(qChar),
+          P.str(P.repeat(P.alt(P.literal('\\' + qChar), P.notChars(qChar)), null, 0)),
+          P.literal(qChar));
+      }
+      var sqString       = quotedString("'");
+      var dqString       = quotedString('"');
+      var backtickString = quotedString('`');
+      var stringLiteral  = P.alt(sqString, dqString, backtickString);
 
-      // String literals
-      var sqString = P.seq1(1, P.literal("'"),
-        P.str(P.repeat(P.alt(P.literal("\\'"), P.notChars("'")), null, 0)), P.literal("'"));
-      var dqString = P.seq1(1, P.literal('"'),
-        P.str(P.repeat(P.alt(P.literal('\\"'), P.notChars('"')), null, 0)), P.literal('"'));
-      var backtickString = P.seq1(1, P.literal('`'),
-        P.str(P.repeat(P.alt(P.literal('\\`'), P.notChars('`')), null, 0)), P.literal('`'));
-      var stringLiteral = P.alt(sqString, dqString, backtickString);
-
-      var digit = P.range('0', '9');
       var number = P.str(P.repeat(P.alt(digit, P.literal('.'), P.literal('-')), null, 1));
       var booleanLiteral = P.alt(P.literal('true'), P.literal('false'),
         P.literal('null'), P.literal('undefined'));
-      var identifier = P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-        P.range('0', '9'), P.chars('_$')), null, 1));
-      var dottedId = P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-        P.range('0', '9'), P.chars('_.$')), null, 1));
 
-      function key(name) {
-        return P.sug(P.literal(name), foam.parse.Suggestion.create({
-          text: name + ': ', category: 'key'
-        }));
+      // Identifier shapes. Plain ident = `[A-Za-z0-9_$]+`; dotted form
+      // also accepts `.`. Centralized so future tweaks (e.g., adding
+      // `-` for property names that allow it) hit one place.
+      var identChars       = P.alt(alphaNum, P.chars('_$'));
+      var dottedIdentChars = P.alt(alphaNum, P.chars('_.$'));
+      var identifier = P.str(P.repeat(identChars, null, 1));
+      var dottedId   = P.str(P.repeat(dottedIdentChars, null, 1));
+
+      // Identifier-as-msg helper. The grammar has many `name: ` slots
+      // that must emit a position-tagged msg for downstream handlers
+      // (axiom-position lookups, references, definition jumps). All of
+      // them use the same identifier shape, so route through one helper.
+      function identMsg(kind) {
+        return P.msg(P.str(P.repeat(identChars, null, 1)), { kind: kind });
       }
 
-      // Category-tagged key helpers so callers can distinguish cursor context
-      // from collected suggestions (top-level class body vs property object
-      // vs POM body). LSP handler maps all of these to Keyword kind (14).
-      function topKey(name) {
-        return P.sug(P.literal(name), foam.parse.Suggestion.create({
-          text: name + ': ', category: 'topKey'
-        }));
+      // Suggestion-shaped key helpers. All four (key/topKey/propKey/
+      // pomKey) emit a sug() with a label, category, and optional hint
+      // — only the category differs. Generate the four flavors from one
+      // factory so the suggestion shape stays in sync. LSP handler
+      // maps all four categories to Keyword kind (14). The hint is
+      // shown as the suggestion description in IDEs that render it
+      // (e.g., VS Code shows it under the label).
+      function makeKeyHelper(category) {
+        return function(name, hint) {
+          return P.sug(P.literal(name), foam.parse.Suggestion.create({
+            text: name + ': ', category: category, hint: hint || ''
+          }));
+        };
       }
-      function propKey(name) {
-        return P.sug(P.literal(name), foam.parse.Suggestion.create({
-          text: name + ': ', category: 'propKey'
-        }));
+      var key           = makeKeyHelper('key');
+      var topKey        = makeKeyHelper('topKey');
+      var propKey       = makeKeyHelper('propKey');
+      var pomKeyHelper  = makeKeyHelper('pomKey');
+
+      // Build an alt() of all key suggestions for a given scope, sourced
+      // from AxiomCatalog. Single source of truth: adding a new axiom
+      // slot in AxiomCatalog automatically grows the grammar's hint
+      // and the editor's hover.
+      var catalog = this.catalog;
+      function catalogAlt(scope) {
+        var helper = makeKeyHelper(scope);
+        var entries = catalog.byScope(scope);
+        var alts = entries.map(function(e) { return helper(e.name, e.hint); });
+        return alts.length > 0 ? P.alt.apply(P, alts) : P.literal('');
       }
-      function pomKeyHelper(name) {
-        return P.sug(P.literal(name), foam.parse.Suggestion.create({
-          text: name + ': ', category: 'pomKey'
-        }));
+
+      // Convenience: pull a hint by scope+name. Used in explicit entry
+      // declarations (extendsEntry, refinesEntry, etc.) so their key()
+      // suggestion uses the same hint text as catalogAlt's auto-generated
+      // sug() arms.
+      function topHint(name)  { return catalog.getHint('topKey',  name); }
+      function propHint(name) { return catalog.getHint('propKey', name); }
+      function pomHint(name)  { return catalog.getHint('pomKey',  name); }
+
+      // Accept either 'value' or "value" — defensive against mismatched/
+      // mixed quote styles in hand-edited files. The closing quote is
+      // optional so cursor-mid-edit input still parses far enough for
+      // suggestions and diagnostics to fire.
+      function quotedAny(inner) {
+        return P.alt(
+          P.seq(P.literal("'"), inner, P.optional(P.literal("'"))),
+          P.seq(P.literal('"'), inner, P.optional(P.literal('"')))
+        );
+      }
+
+      // Like quotedAny but tags the double-quote arm with a style hint
+      // (FOAM convention is single quotes for class refs). The
+      // DiagnosticsHandler converts the msg to a hint-level diagnostic
+      // and the server.js CodeAction provides a one-click fix.
+      function quoted(inner) {
+        return P.alt(
+          P.seq(P.literal("'"), inner, P.optional(P.literal("'"))),
+          P.msg(
+            P.seq(P.literal('"'), inner, P.optional(P.literal('"'))),
+            { type: 'doubleQuotedClassRef' }
+          )
+        );
       }
 
       var comma = P.seq0(wsc, P.literal(','), wsc);
+
+      // Trailing-comma-tolerant list: `entry (, entry)* ,?`. JavaScript
+      // allows trailing commas in arrays / object literals, and so does
+      // the FOAM JSON serializer; without this helper the parser would
+      // bail at the first list with one (silently swallowing every
+      // downstream property/method emission). All array-of-entries
+      // sites in the grammar route through this so the bug only has
+      // one place to fix.
+      function repeatList(entry) {
+        return P.optional(P.seq(
+          entry,
+          P.repeat(P.seq(comma, entry)),
+          P.optional(comma)
+        ));
+      }
 
       var anyValue = P.alt(
         stringLiteral, number, booleanLiteral,
@@ -323,21 +445,33 @@ foam.CLASS({
         // === FILE-LEVEL ===
         START: P.repeat(P.alt(P.sym('foamCall'), P.sym('ignoredContent')), null, 0),
 
-        foamCall: P.alt(P.sym('foamClass'), P.sym('foamEnum'), P.sym('foamInterface'),
-          P.sym('foamPOM')),
-
-        foamClass: P.seq(P.literal('foam.CLASS'), wsc, P.literal('('), wsc,
-          P.sym('classBody'), wsc, P.optional(P.literal(')'))),
-        foamEnum: P.seq(P.literal('foam.ENUM'), wsc, P.literal('('), wsc,
-          P.sym('classBody'), wsc, P.optional(P.literal(')'))),
-        foamInterface: P.seq(P.literal('foam.INTERFACE'), wsc, P.literal('('), wsc,
-          P.sym('classBody'), wsc, P.optional(P.literal(')'))),
+        // POM keeps a distinct rule because its body grammar (pomBody) is
+        // different from a class body. Everything else (CLASS, ENUM,
+        // INTERFACE, RELATIONSHIP, FSM, and any future foam.<X> extension)
+        // routes through `foamGenericCall` so adding a new model type
+        // requires no grammar changes.
+        foamCall: P.alt(P.sym('foamPOM'), P.sym('foamGenericCall')),
 
         foamPOM: P.seq(P.literal('foam.POM'), wsc, P.literal('('), wsc,
           P.sym('pomBody'), wsc, P.optional(P.literal(')'))),
 
+        // Captures `foam.<UPPER>(<classBody>)` for any uppercase identifier
+        // other than POM. The captured name is preserved by `foamCallName`
+        // so handlers can branch (e.g., FSM-specific completions) if needed.
+        foamGenericCall: P.seq(
+          P.literal('foam.'),
+          P.sym('foamCallName'),
+          wsc, P.literal('('), wsc,
+          P.sym('classBody'),
+          wsc, P.optional(P.literal(')'))
+        ),
+
+        foamCallName: P.str(P.repeat(P.alt(
+          P.range('A', 'Z'), P.range('0', '9'), P.literal('_')
+        ), null, 1)),
+
         pomBody: P.seq(P.literal('{'), wsc,
-          P.optional(P.repeat(P.sym('pomEntry'), comma)),
+          repeatList(P.sym('pomEntry')),
           wsc, P.optional(P.literal('}'))),
 
         pomEntry: P.alt(
@@ -354,37 +488,37 @@ foam.CLASS({
         // Scalar string entries — each emits its key sug and parses through
         // the rest of the `key: 'value'` assignment so the outer repeat can
         // move on to the next comma-separated entry without blocking.
-        pomNameEntry: P.seq(pomKeyHelper('name'), wsc, P.literal(':'), wsc, stringLiteral),
-        pomVersionEntry: P.seq(pomKeyHelper('version'), wsc, P.literal(':'), wsc, stringLiteral),
+        pomNameEntry: P.seq(pomKeyHelper('name', pomHint('name')), wsc, P.literal(':'), wsc, stringLiteral),
+        pomVersionEntry: P.seq(pomKeyHelper('version', pomHint('version')), wsc, P.literal(':'), wsc, stringLiteral),
 
-        pomJournalFilesEntry: P.seq(pomKeyHelper('journalFiles'), wsc, P.literal(':'), wsc,
+        pomJournalFilesEntry: P.seq(pomKeyHelper('journalFiles', pomHint('journalFiles')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, stringLiteral, wsc), comma)),
+          repeatList(P.seq(wsc, stringLiteral, wsc)),
           wsc, P.optional(P.literal(']'))),
 
         // Specific POM entry rules. Each emits a context marker (via sug with
         // \u0002 that never matches) so the LSP handler can detect cursor
         // position by inspecting collected sug categories.
 
-        pomFilesEntry: P.seq(pomKeyHelper('files'), wsc, P.literal(':'), wsc,
+        pomFilesEntry: P.seq(pomKeyHelper('files', pomHint('files')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('pomFileObj'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('pomFileObj'), wsc)),
           wsc, P.optional(P.literal(']'))),
 
-        pomJavaFilesEntry: P.seq(pomKeyHelper('javaFiles'), wsc, P.literal(':'), wsc,
+        pomJavaFilesEntry: P.seq(pomKeyHelper('javaFiles', pomHint('javaFiles')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('pomJavaFileObj'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('pomJavaFileObj'), wsc)),
           wsc, P.optional(P.literal(']'))),
 
-        pomProjectsEntry: P.seq(pomKeyHelper('projects'), wsc, P.literal(':'), wsc,
+        pomProjectsEntry: P.seq(pomKeyHelper('projects', pomHint('projects')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('pomProjectObj'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('pomProjectObj'), wsc)),
           wsc, P.optional(P.literal(']'))),
 
-        pomJavaDepsEntry: P.seq(pomKeyHelper('javaDependencies'), wsc, P.literal(':'), wsc,
+        pomJavaDepsEntry: P.seq(pomKeyHelper('javaDependencies', pomHint('javaDependencies')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.literal("'"), P.sym('pomJavaDep'),
-            P.optional(P.literal("'")), wsc), comma)),
+          repeatList(P.seq(wsc, P.literal("'"), P.sym('pomJavaDep'),
+            P.optional(P.literal("'")), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         // File/project object headers fire a snippet sug when `{` is expected
@@ -397,7 +531,7 @@ foam.CLASS({
             hint: 'new file entry'
           })),
           wsc,
-          P.optional(P.repeat(P.sym('pomFileObjEntry'), comma)),
+          repeatList(P.sym('pomFileObjEntry')),
           wsc, P.optional(P.literal('}'))),
 
         pomJavaFileObj: P.seq(
@@ -406,7 +540,7 @@ foam.CLASS({
             hint: 'new Java file entry'
           })),
           wsc,
-          P.optional(P.repeat(P.sym('pomJavaFileObjEntry'), comma)),
+          repeatList(P.sym('pomJavaFileObjEntry')),
           wsc, P.optional(P.literal('}'))),
 
         pomProjectObj: P.seq(
@@ -415,7 +549,7 @@ foam.CLASS({
             hint: 'new project entry'
           })),
           wsc,
-          P.optional(P.repeat(P.sym('pomProjectObjEntry'), comma)),
+          repeatList(P.sym('pomProjectObjEntry')),
           wsc, P.optional(P.literal('}'))),
 
         pomFileObjEntry: P.alt(
@@ -483,13 +617,14 @@ foam.CLASS({
         classBody: P.seq(P.literal('{'), wsc,
           P.optional(P.sym('classEntries')), wsc, P.optional(P.literal('}'))),
 
-        classEntries: P.repeat(P.sym('classEntry'), P.seq0(wsc, P.literal(','), wsc)),
+        classEntries: repeatList(P.sym('classEntry')),
 
         classEntry: P.alt(
           P.sym('packageEntry'),
           P.sym('nameEntry'),
           P.sym('extendsEntry'),
           P.sym('implementsEntry'),
+          P.sym('refinesEntry'),
           P.sym('requiresEntry'),
           P.sym('propertiesEntry'),
           P.sym('methodsEntry'),
@@ -505,31 +640,101 @@ foam.CLASS({
           P.sym('flagsEntry'),
           P.sym('actionsEntry'),
           P.sym('listenersEntry'),
+          P.sym('sectionsEntry'),
           P.sym('cssEntry'),
+          P.sym('sourceModelEntry'),
+          P.sym('targetModelEntry'),
+          P.sym('classTypedSlotEntry'),
           P.sym('topLevelKey'),
           P.sym('genericEntry')
         ),
 
         // === SPECIFIC ENTRIES ===
-        packageEntry: P.seq(key('package'), wsc, P.literal(':'), wsc, stringLiteral),
-        nameEntry: P.seq(key('name'), wsc, P.literal(':'), wsc, stringLiteral),
-        extendsEntry: P.seq(key('extends'), wsc, P.literal(':'), wsc,
-          P.literal("'"), P.sym('classRef'), P.optional(P.literal("'"))),
-        documentationEntry: P.seq(key('documentation'), wsc, P.literal(':'), wsc, stringLiteral),
-        abstractEntry: P.seq(key('abstract'), wsc, P.literal(':'), wsc, booleanLiteral),
-        flagsEntry: P.seq(key('flags'), wsc, P.literal(':'), wsc, P.sym('array')),
-        actionsEntry: P.seq(key('actions'), wsc, P.literal(':'), wsc, P.sym('array')),
-        listenersEntry: P.seq(key('listeners'), wsc, P.literal(':'), wsc, P.sym('array')),
-        cssEntry: P.seq(key('css'), wsc, P.literal(':'), wsc, backtickString),
+        // Hints are sourced from AxiomCatalog via topHint() — keeps the
+        // descriptions in one place and reachable from HoverHandler too.
+        packageEntry: P.seq(key('package',  topHint('package')),  wsc, P.literal(':'), wsc, stringLiteral),
+        nameEntry:    P.seq(key('name',     topHint('name')),     wsc, P.literal(':'), wsc, stringLiteral),
+        extendsEntry: P.seq(key('extends',  topHint('extends')),  wsc, P.literal(':'), wsc,
+          quoted(P.sym('classRef'))),
 
-        implementsEntry: P.seq(key('implements'), wsc, P.literal(':'), wsc, P.literal('['), wsc,
-          P.optional(P.repeat(
-            P.seq(wsc, P.literal("'"), P.sym('classRef'), P.optional(P.literal("'")), wsc), comma)),
+        // refines: 'foam.x.Y' — classRef-typed top-level slot. Promoted from
+        // suggestion-only topLevelKey to first-class entry so go-to-def,
+        // hover, and unknown-class diagnostics work the same as `extends:`.
+        refinesEntry: P.seq(key('refines', topHint('refines')), wsc, P.literal(':'), wsc,
+          quoted(P.sym('classRef'))),
+
+        // sourceModel/targetModel: classRef-typed slots used by
+        // foam.RELATIONSHIP({...}). Same treatment as extends/refines.
+        sourceModelEntry: P.seq(key('sourceModel', topHint('sourceModel')), wsc, P.literal(':'), wsc,
+          quoted(P.sym('classRef'))),
+        targetModelEntry: P.seq(key('targetModel', topHint('targetModel')), wsc, P.literal(':'), wsc,
+          quoted(P.sym('classRef'))),
+
+        // Generic axiom-class-typed slot: `<key>: 'foo.X'` where <key> is
+        // the name of any property defined as Class/Reference/FObjectProperty/
+        // FObjectArray on a model in the FOAM registry. Driven by
+        // FoamIndex.getClassTypedPropertyNames() — adding a new class-typed
+        // axiom (e.g., FSM `next: 'foo.X.STATE'`) requires no grammar change.
+        classTypedSlotEntry: P.seq(
+          self.classTypedKeyParser_,
+          wsc, P.literal(':'), wsc,
+          quoted(P.sym('classRef'))
+        ),
+        documentationEntry: P.seq(key('documentation', topHint('documentation')), wsc, P.literal(':'), wsc, stringLiteral),
+        abstractEntry: P.seq(key('abstract', topHint('abstract')), wsc, P.literal(':'), wsc, booleanLiteral),
+        flagsEntry: P.seq(key('flags', topHint('flags')), wsc, P.literal(':'), wsc, P.sym('array')),
+        // actions/listeners/sections — array-of-object axioms. Each gets a
+        // dedicated inner-object rule so completion suggests the right keys
+        // for THAT scope (actionKey/listenerKey/sectionKey from
+        // AxiomCatalog). Falls back to `array` of unstructured values
+        // when the inner-object form isn't used.
+        actionsEntry: P.seq(key('actions', topHint('actions')), wsc, P.literal(':'), wsc,
+          P.alt(P.sym('actionsArray'), P.sym('array'))),
+        listenersEntry: P.seq(key('listeners', topHint('listeners')), wsc, P.literal(':'), wsc,
+          P.alt(P.sym('listenersArray'), P.sym('array'))),
+        sectionsEntry: P.seq(key('sections', topHint('sections')), wsc, P.literal(':'), wsc,
+          P.alt(P.sym('sectionsArray'), P.sym('array'))),
+
+        actionsArray: P.seq(P.literal('['), wsc,
+          repeatList(P.seq(wsc, P.sym('actionObject'), wsc)),
+          wsc, P.optional(P.literal(']'))),
+        actionObject: P.seq(P.literal('{'), wsc,
+          repeatList(P.sym('actionObjEntry')),
+          wsc, P.optional(P.literal('}'))),
+        actionObjEntry: P.alt(
+          P.seq(catalogAlt('actionKey'), wsc, P.literal(':'), wsc, anyValue),
+          P.sym('genericEntry')
+        ),
+
+        listenersArray: P.seq(P.literal('['), wsc,
+          repeatList(P.seq(wsc, P.sym('listenerObject'), wsc)),
+          wsc, P.optional(P.literal(']'))),
+        listenerObject: P.seq(P.literal('{'), wsc,
+          repeatList(P.sym('listenerObjEntry')),
+          wsc, P.optional(P.literal('}'))),
+        listenerObjEntry: P.alt(
+          P.seq(catalogAlt('listenerKey'), wsc, P.literal(':'), wsc, anyValue),
+          P.sym('genericEntry')
+        ),
+
+        sectionsArray: P.seq(P.literal('['), wsc,
+          repeatList(P.seq(wsc, P.sym('sectionObject'), wsc)),
+          wsc, P.optional(P.literal(']'))),
+        sectionObject: P.seq(P.literal('{'), wsc,
+          repeatList(P.sym('sectionObjEntry')),
+          wsc, P.optional(P.literal('}'))),
+        sectionObjEntry: P.alt(
+          P.seq(catalogAlt('sectionKey'), wsc, P.literal(':'), wsc, anyValue),
+          P.sym('genericEntry')
+        ),
+        cssEntry: P.seq(key('css', topHint('css')), wsc, P.literal(':'), wsc, backtickString),
+
+        implementsEntry: P.seq(key('implements', topHint('implements')), wsc, P.literal(':'), wsc, P.literal('['), wsc,
+          repeatList(P.seq(wsc, quoted(P.sym('classRef')), wsc)),
           wsc, P.optional(P.literal(']'))),
 
-        requiresEntry: P.seq(key('requires'), wsc, P.literal(':'), wsc, P.literal('['), wsc,
-          P.optional(P.repeat(
-            P.seq(wsc, P.literal("'"), P.sym('classRef'), P.optional(P.literal("'")), wsc), comma)),
+        requiresEntry: P.seq(key('requires', topHint('requires')), wsc, P.literal(':'), wsc, P.literal('['), wsc,
+          repeatList(P.seq(wsc, quoted(P.sym('classRef')), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         // messages: [ { name: 'LABEL_X', message: '…' } ]
@@ -538,73 +743,64 @@ foam.CLASS({
         // per-axiom regex scanners we used to need.
         messagesEntry: P.seq(topKey('messages'), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('messageObject'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('messageObject'), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         messageObject: P.seq(P.literal('{'), wsc,
-          P.optional(P.repeat(P.sym('messageObjEntry'), comma)),
+          repeatList(P.sym('messageObjEntry')),
           wsc, P.optional(P.literal('}'))),
 
+        // First arm emits the 'message' axiom position; catalogAlt covers
+        // every other message-object slot (name/message/documentation).
         messageObjEntry: P.alt(
-          P.seq(propKey('name'), wsc, P.literal(':'), wsc,
-            P.literal("'"), P.sym('messageNameValue'), P.optional(P.literal("'"))),
-          P.seq(propKey('name'), wsc, P.literal(':'), wsc,
-            P.literal('"'), P.sym('messageNameValue'), P.optional(P.literal('"'))),
-          P.seq(propKey('message'), wsc, P.literal(':'), wsc, stringLiteral),
+          P.seq(propKey('name', catalog.getHint('messageKey', 'name')),
+            wsc, P.literal(':'), wsc,
+            quotedAny(P.sym('messageNameValue'))),
+          P.seq(catalogAlt('messageKey'), wsc, P.literal(':'), wsc, anyValue),
           P.sym('genericEntry')
         ),
 
-        messageNameValue: P.msg(
-          P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-            P.range('0', '9'), P.chars('_$')), null, 1)),
-          { kind: 'message' }
-        ),
+        messageNameValue: identMsg('message'),
 
         // values: [ { name: 'X', ... } ] — foam.ENUM value declarations.
         valuesEntry: P.seq(topKey('values'), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('valueObject'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('valueObject'), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         valueObject: P.seq(P.literal('{'), wsc,
-          P.optional(P.repeat(P.sym('valueObjEntry'), comma)),
+          repeatList(P.sym('valueObjEntry')),
           wsc, P.optional(P.literal('}'))),
 
+        // First arm emits the 'value' axiom position for enum values;
+        // catalogAlt covers everything else (label/ordinal/documentation).
         valueObjEntry: P.alt(
-          P.seq(propKey('name'), wsc, P.literal(':'), wsc,
-            P.literal("'"), P.sym('enumValueName'), P.optional(P.literal("'"))),
-          P.seq(propKey('name'), wsc, P.literal(':'), wsc,
-            P.literal('"'), P.sym('enumValueName'), P.optional(P.literal('"'))),
+          P.seq(propKey('name', catalog.getHint('valueKey', 'name')),
+            wsc, P.literal(':'), wsc,
+            quotedAny(P.sym('enumValueName'))),
+          P.seq(catalogAlt('valueKey'), wsc, P.literal(':'), wsc, anyValue),
           P.sym('genericEntry')
         ),
 
-        enumValueName: P.msg(
-          P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-            P.range('0', '9'), P.chars('_$')), null, 1)),
-          { kind: 'value' }
-        ),
+        enumValueName: identMsg('value'),
 
         // Property `name: 'foo'` — emit a 'property' axiom position so
         // DefinitionHandler.buildLocationAtProperty can jump straight to
         // the declaration without text-scan regex.
-        propertyNameValue: P.msg(
-          P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-            P.range('0', '9'), P.chars('_$')), null, 1)),
-          { kind: 'property' }
-        ),
+        propertyNameValue: identMsg('property'),
 
         // tableColumns/searchColumns: emit a 'columnName' category at each value
         // position so the LSP handler can detect context without regex scanning.
         // Real suggestions come from the model (this class's properties).
         tableColumnsEntry: P.seq(topKey('tableColumns'), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.literal("'"), P.sym('columnName'),
-            P.optional(P.literal("'")), wsc), comma)),
+          repeatList(P.seq(wsc, P.literal("'"), P.sym('columnName'),
+            P.optional(P.literal("'")), wsc)),
           wsc, P.optional(P.literal(']'))),
         searchColumnsEntry: P.seq(topKey('searchColumns'), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.literal("'"), P.sym('columnName'),
-            P.optional(P.literal("'")), wsc), comma)),
+          repeatList(P.seq(wsc, P.literal("'"), P.sym('columnName'),
+            P.optional(P.literal("'")), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         // Context marker: the sug here always fails (matches \u0002 which
@@ -616,22 +812,21 @@ foam.CLASS({
             text: '__ctx_columnName__', category: 'columnName', hint: 'property name'
           })),
           P.msg(
-            P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-              P.range('0', '9'), P.chars('_.')), null, 1)),
+            P.str(P.repeat(P.alt(alphaNum, P.chars('_.')), null, 1)),
             { type: 'columnName' }
           )
         ),
 
-        importsEntry: P.seq(key('imports'), wsc, P.literal(':'), wsc, P.sym('array')),
+        importsEntry: P.seq(key('imports', topHint('imports')), wsc, P.literal(':'), wsc, P.sym('array')),
 
         // exports: [ 'axiomName', 'axiomName as alias' ] — emit an 'exportName'
         // context marker per value so the LSP handler can suggest axiom names
         // (properties, methods, actions, listeners) from the enclosing model
         // instead of the class-ref fallback list.
-        exportsEntry: P.seq(key('exports'), wsc, P.literal(':'), wsc,
+        exportsEntry: P.seq(key('exports', topHint('exports')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.literal("'"), P.sym('exportName'),
-            P.optional(P.literal("'")), wsc), comma)),
+          repeatList(P.seq(wsc, P.literal("'"), P.sym('exportName'),
+            P.optional(P.literal("'")), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         exportName: P.alt(
@@ -639,19 +834,32 @@ foam.CLASS({
             text: '__ctx_exportName__', category: 'exportName', hint: 'axiom name'
           })),
           P.msg(
-            P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-              P.range('0', '9'), P.chars('_ $')), null, 1)),
+            P.str(P.repeat(P.alt(alphaNum, P.chars('_ $')), null, 1)),
             { type: 'exportName' }
           )
         ),
 
-        javaImportsEntry: P.seq(key('javaImports'), wsc, P.literal(':'), wsc,
+        javaImportsEntry: P.seq(key('javaImports', topHint('javaImports')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('javaImport'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('javaImport'), wsc)),
           wsc, P.optional(P.literal(']'))),
 
         javaImport: P.seq1(1, P.literal("'"), P.sym('javaImportRef'), P.optional(P.literal("'"))),
+        // Full Java FQ-name first — must consume the entire qualified name
+        // including any wildcard `.*` suffix and the optional `static `
+        // prefix used for static-method imports
+        // (`'static foo.MLang.AND'`). The sug() arms below match common
+        // prefixes (foam.lang., java.util., …) and emit completion
+        // suggestions; they're ordered AFTER the full-id regex so they
+        // only fire when collectSuggestionsAt() runs against a sentinel
+        // — never during a real parse where they'd otherwise greedily
+        // consume just the prefix and leave the rest un-parsed (which
+        // silently bailed the whole class body downstream).
         javaImportRef: P.alt(
+          P.seq(
+            P.optional(P.seq(P.literal('static'), P.repeat(P.chars(' \t')))),
+            P.str(P.repeat(P.alt(alphaNum, P.chars('._*')), null, 1))
+          ),
           P.sug(P.literal('foam.lang.'), foam.parse.Suggestion.create({
             text: 'foam.lang.', category: 'class',
             hint: 'FOAM lang package (FObject, X, PropertyInfo)'
@@ -666,33 +874,25 @@ foam.CLASS({
           })),
           P.sug(P.literal('java.io.'), foam.parse.Suggestion.create({
             text: 'java.io.', category: 'class', hint: 'Java IO'
-          })),
-          P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-            P.range('0', '9'), P.chars('._*')), null, 1))
+          }))
         ),
 
-        propertiesEntry: P.seq(key('properties'), wsc, P.literal(':'), wsc,
+        propertiesEntry: P.seq(key('properties', topHint('properties')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.sym('propertyDef'), comma)),
+          repeatList(P.sym('propertyDef')),
           wsc, P.optional(P.literal(']'))),
 
-        methodsEntry: P.seq(key('methods'), wsc, P.literal(':'), wsc,
+        methodsEntry: P.seq(key('methods', topHint('methods')), wsc, P.literal(':'), wsc,
           P.literal('['), wsc,
-          P.optional(P.repeat(P.sym('methodDef'), comma)),
+          repeatList(P.sym('methodDef')),
           wsc, P.optional(P.literal(']'))),
 
-        topLevelKey: P.alt(
-          topKey('package'), topKey('name'), topKey('extends'), topKey('requires'),
-          topKey('imports'), topKey('exports'), topKey('properties'), topKey('methods'),
-          topKey('actions'), topKey('documentation'), topKey('abstract'),
-          topKey('implements'), topKey('javaImports'), topKey('axioms'),
-          topKey('css'), topKey('messages'), topKey('topics'), topKey('listeners'),
-          topKey('constants'), topKey('sections'), topKey('flags'),
-          topKey('tableColumns'), topKey('searchColumns'),
-          topKey('refines'), topKey('label'), topKey('plural'), topKey('order'),
-          topKey('ids'), topKey('javaCode'), topKey('cssTokens'), topKey('mixins'),
-          topKey('static'), topKey('of'), topKey('values')
-        ),
+        // topLevelKey is a FULL entry: suggests known top-level keys AND
+        // consumes their `: <value>` so the outer classEntries repeat keeps
+        // progressing. The list of slots + descriptions comes from
+        // AxiomCatalog so grammar hints and HoverHandler hover text share
+        // the same source.
+        topLevelKey: P.seq(catalogAlt('topKey'), wsc, P.literal(':'), wsc, anyValue),
 
         // === CLASS REFERENCES (dynamic) ===
         // The permissive fallback is wrapped in msg() so diagnostic collection
@@ -701,8 +901,7 @@ foam.CLASS({
         classRef: P.alt(
           self.classRefParser_,
           P.msg(
-            P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-              P.range('0', '9'), P.chars('._')), null, 1)),
+            P.str(P.repeat(P.alt(alphaNum, P.chars('._')), null, 1)),
             { type: 'unknownClassRef' }
           )
         ),
@@ -712,33 +911,32 @@ foam.CLASS({
         propertyDef: P.alt(stringLiteral, P.sym('propertyObject'), P.sym('balancedBraces')),
         propertyObject: P.seq(P.literal('{'), wsc,
           P.optional(P.sym('propEntries')), wsc, P.optional(P.literal('}'))),
-        propEntries: P.repeat(P.sym('propEntry'), comma),
+        propEntries: repeatList(P.sym('propEntry')),
 
         propEntry: P.alt(
+          // class: 'String'  → propType (short name, matches String/Long/etc.)
+          // class: 'foo.X.Y' → classRef (dotted full class id)
+          // Order matters: propType is `literalIC` of short names, so it
+          // declines on dotted input and we fall through to classRef.
+          // quoted() accepts " too, with a style hint diagnostic.
           P.seq(P.sug(P.literal('class'), foam.parse.Suggestion.create({
             text: 'class', category: 'key' })),
-            wsc, P.literal(':'), wsc, P.literal("'"), P.sym('propType'),
-            P.optional(P.literal("'"))),
+            wsc, P.literal(':'), wsc,
+            quoted(P.alt(P.sym('propType'), P.sym('classRef')))),
           P.seq(P.sug(P.literal('name'), foam.parse.Suggestion.create({
             text: 'name', category: 'key' })),
             wsc, P.literal(':'), wsc,
-            P.literal("'"), P.sym('propertyNameValue'), P.optional(P.literal("'"))),
-          P.seq(P.sug(P.literal('name'), foam.parse.Suggestion.create({
-            text: 'name', category: 'key' })),
-            wsc, P.literal(':'), wsc,
-            P.literal('"'), P.sym('propertyNameValue'), P.optional(P.literal('"'))),
+            quotedAny(P.sym('propertyNameValue'))),
           P.seq(P.sug(P.literal('of'), foam.parse.Suggestion.create({
             text: 'of', category: 'key' })),
-            wsc, P.literal(':'), wsc, P.literal("'"), P.sym('classRef'),
-            P.optional(P.literal("'"))),
+            wsc, P.literal(':'), wsc, quoted(P.sym('classRef'))),
           // view: 'com.acme.MyView' — treat the string form exactly like `of:`
           // so class suggestions (including view classes) surface in viewSpec
           // positions. The { class: '...' } object form is covered by the
           // normal propEntry/class rule inside that object.
           P.seq(P.sug(P.literal('view'), foam.parse.Suggestion.create({
             text: 'view', category: 'key' })),
-            wsc, P.literal(':'), wsc, P.literal("'"), P.sym('classRef'),
-            P.optional(P.literal("'"))),
+            wsc, P.literal(':'), wsc, quoted(P.sym('classRef'))),
           P.seq(P.sug(P.literal('documentation'), foam.parse.Suggestion.create({
             text: 'documentation', category: 'key' })),
             wsc, P.literal(':'), wsc, stringLiteral),
@@ -752,27 +950,15 @@ foam.CLASS({
           P.sym('genericEntry')
         ),
 
-        propKey: P.alt(
-          propKey('class'), propKey('name'), propKey('of'), propKey('documentation'),
-          propKey('hidden'), propKey('transient'),
-          propKey('value'), propKey('factory'), propKey('expression'),
-          propKey('javaCode'), propKey('javaGetter'), propKey('javaPostSet'),
-          propKey('javaPreSet'), propKey('javaFactory'),
-          propKey('aliases'), propKey('label'), propKey('section'), propKey('visibility'),
-          propKey('view'), propKey('adapt'), propKey('preSet'), propKey('postSet'),
-          propKey('required'), propKey('width'), propKey('placeholder'), propKey('help'),
-          propKey('gridColumns'), propKey('tableCellFormatter'), propKey('labelFormatter'),
-          propKey('shortName'), propKey('readPermissionRequired'), propKey('writePermissionRequired'),
-          propKey('validateObj'), propKey('tableWidth'), propKey('storageTransient'),
-          propKey('cloneProperty'), propKey('networkTransient'), propKey('readOnly'),
-          propKey('permissionRequired'), propKey('javaSetter'), propKey('javaInfoType')
-        ),
+        // propKey is a full entry — suggests the prop slot AND consumes
+        // its `: <value>`. List + hints come from AxiomCatalog (shared
+        // with HoverHandler).
+        propKey: P.seq(catalogAlt('propKey'), wsc, P.literal(':'), wsc, anyValue),
 
         propType: P.alt(
           self.propTypeParser_,
           P.msg(
-            P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-              P.range('0', '9'), P.chars('._')), null, 1)),
+            P.str(P.repeat(P.alt(alphaNum, P.chars('._')), null, 1)),
             { type: 'unknownPropType' }
           )
         ),
@@ -797,33 +983,36 @@ foam.CLASS({
         ),
 
         methodObject: P.seq(P.literal('{'), wsc,
-          P.optional(P.repeat(P.sym('methodObjEntry'), comma)),
+          repeatList(P.sym('methodObjEntry')),
           wsc, P.optional(P.literal('}'))),
 
+        // The first two arms emit a 'method' axiom position from the
+        // string value (used by buildLocationAtMethod). Catalog-driven
+        // entry handles every other method-object slot AND consumes its
+        // `: <value>` so the loop keeps progressing across mixed forms
+        // (`{ name: 'm', args: 'X x', javaCode: ` ... `, documentation: '...' }`).
+        // The trailing genericEntry remains as a safety net for keys we
+        // haven't catalogued.
         methodObjEntry: P.alt(
-          P.seq(propKey('name'), wsc, P.literal(':'), wsc,
-            P.literal("'"), P.sym('methodNameValue'), P.optional(P.literal("'"))),
-          P.seq(propKey('name'), wsc, P.literal(':'), wsc,
-            P.literal('"'), P.sym('methodNameValue'), P.optional(P.literal('"'))),
+          P.seq(propKey('name', catalog.getHint('methodKey', 'name')),
+            wsc, P.literal(':'), wsc,
+            quotedAny(P.sym('methodNameValue'))),
+          P.seq(catalogAlt('methodKey'), wsc, P.literal(':'), wsc, anyValue),
           P.sym('genericEntry')
         ),
 
-        methodNameValue: P.msg(
-          P.str(P.repeat(P.alt(P.range('a', 'z'), P.range('A', 'Z'),
-            P.range('0', '9'), P.chars('_$')), null, 1)),
-          { kind: 'method' }
-        ),
+        methodNameValue: identMsg('method'),
 
         // === GENERIC CATCH-ALL ===
         genericEntry: P.seq(identifier, wsc, P.literal(':'), wsc, anyValue),
 
         // === STRUCTURAL ===
         array: P.seq(P.literal('['), wsc,
-          P.optional(P.repeat(P.seq(wsc, anyValue, wsc), comma)),
+          repeatList(P.seq(wsc, anyValue, wsc)),
           wsc, P.optional(P.literal(']'))),
 
         object: P.seq(P.literal('{'), wsc,
-          P.optional(P.repeat(P.seq(wsc, P.sym('genericEntry'), wsc), comma)),
+          repeatList(P.seq(wsc, P.sym('genericEntry'), wsc)),
           wsc, P.optional(P.literal('}'))),
 
         functionBody: P.seq(

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -79,6 +79,39 @@ foam.CLASS({
       return types;
     },
 
+    function getClassTypedPropertyNames() {
+      /**
+       * Names of axiom slots whose string value is a class id. Used by
+       * FoamClassGrammar's classTypedSlotEntry rule.
+       *
+       * Returns the canonical eight slots that the FOAM JSON serializer
+       * (foam/lang/JSON.js) treats as class-id-typed:
+       *
+       *   extends, implements, of, class, view, refines, sourceModel,
+       *   targetModel
+       *
+       * An earlier version walked the registry to also include any axiom
+       * whose property class was Class/Reference/FObjectProperty/
+       * FObjectArray. That over-broad set caused false positives on
+       * extremely common slot names (`label`, `name`, etc.) that happen
+       * to be class-typed in some obscure model — e.g., `label:
+       * 'Transaction Details'` was misparsed as a class ref. Stick to
+       * the canonical list so the grammar doesn't fight content that
+       * isn't a class id.
+       *
+       * If a custom axiom slot needs to be navigable as a class id,
+       * define an explicit grammar entry for it (see refinesEntry /
+       * sourceModelEntry / targetModelEntry as templates).
+       */
+      if ( this.cache_.classTypedNames ) return this.cache_.classTypedNames;
+      var names = [
+        'extends', 'implements', 'of', 'class', 'view',
+        'sourceModel', 'targetModel', 'refines'
+      ];
+      this.cache_.classTypedNames = names;
+      return names;
+    },
+
     function getAxioms(classId) {
       /** Returns all axioms for a class including inherited. */
       var cls = this.getClass(classId);

--- a/tools/lsp/JavaGrammar.js
+++ b/tools/lsp/JavaGrammar.js
@@ -26,6 +26,11 @@ foam.CLASS({
   methods: [
     function grammar(alt, anyChar, chars, literal, notChars, optional, range, repeat, seq, str, substring, sym, until, plus, msg) {
       return {
+        // Top-level patterns. Rule order is significant — first match wins.
+        // The body-level patterns (qualifiedCall, castExpr, newExpr,
+        // localDecl) fire inside method bodies AND in field initializers
+        // because START is a flat scan. `skip` is the catch-all so unmatched
+        // input never blocks parsing.
         START: repeat(alt(
           sym('lineComment'),
           sym('blockComment'),
@@ -34,6 +39,13 @@ foam.CLASS({
           msg(sym('importDecl'),  { kind: 'import' }),
           msg(sym('classDecl'),   { kind: 'classDecl' }),
           msg(sym('methodSig'),   { kind: 'methodSig' }),
+          // === Body-level patterns ===
+          msg(sym('castExpr'),       { kind: 'castExpr' }),
+          msg(sym('newExpr'),        { kind: 'newExpr' }),
+          msg(sym('qualifiedCall'),  { kind: 'qualifiedCall' }),
+          msg(sym('varDecl'),        { kind: 'varDecl' }),
+          msg(sym('localDecl'),      { kind: 'localDecl' }),
+          msg(sym('plainIdent'),     { kind: 'plainIdent' }),
           sym('skip')
         )),
 
@@ -137,6 +149,107 @@ foam.CLASS({
         qualifiedName: seq(
           sym('identifier'),
           repeat(seq('.', alt(sym('identifier'), '*')))
+        ),
+
+        // ===== Body-level patterns (method bodies, field initializers) =====
+        // Emit position-tagged identifiers for go-to-def / hover / semantic
+        // tokens. These rules don't try to fully parse Java — they just
+        // surface the offsets of identifiers that benefit from navigation.
+        // Each rule consumes its match exactly; mismatched input falls
+        // through to the broader patterns above and finally to `skip`.
+
+        // `<recv>.<method>(args` — method call on a receiver. Receiver may
+        // be a Type (UpperCamelCase, e.g. `Loggers.logger(...)`) or a
+        // variable (`disputeCase.getId()`). Only the LAST segment is
+        // tagged; chains like `a.b.c.method()` resolve segment-by-segment
+        // as the parser sweeps START's alt list. Sub-positions are
+        // recovered by the parser from the matched span — using inner
+        // msg() decorators here would emit false positives on failed
+        // outer attempts (apply-callback isn't transactional).
+        qualifiedCall: seq(
+          sym('identifier'),
+          '.',
+          sym('identifier'),
+          sym('ws'),
+          '('
+        ),
+
+        // `new <Type>(args)` — instance creation. Emit the type position.
+        // upperTypeName so Java conventional capitalization protects
+        // against `new x(...)` false positives.
+        newExpr: seq(
+          literal('new'),
+          sym('ws1'),
+          sym('upperTypeName'),
+          optional(sym('generics')),
+          sym('ws'),
+          alt(literal('('), literal('['), literal('{'))
+        ),
+
+        // `(<Type>) expr` — cast target. upperTypeName eliminates the
+        // common false positive `(x)` from `foo(x)` argument lists.
+        // Double-paren forms `((<Type>) expr).method()` resolve naturally:
+        // the outer `(` is consumed by `skip`, then the inner cast matches.
+        castExpr: seq(
+          literal('('),
+          sym('ws'),
+          sym('upperTypeName'),
+          optional(sym('generics')),
+          sym('ws'),
+          literal(')')
+        ),
+
+        // `<Type> [<generics>] <name>` followed by `=` or `;` — local var
+        // declaration. The TypeTracker uses this to resolve identifiers.
+        // Restrict typeName to start with an uppercase letter so
+        // statements like `disputeCase.getId();` (where `disputeCase` is a
+        // lowercase identifier) don't accidentally match.
+        localDecl: seq(
+          sym('upperTypeName'),
+          optional(sym('generics')),
+          sym('ws1'),
+          sym('identifier'),
+          sym('ws'),
+          alt(literal('='), literal(';'), literal(','))
+        ),
+
+        // `var <name> = <rhs>` — Java 10+ inferred-type declaration. The
+        // RHS shape (new T(), (T) expr, T.staticMethod(), literal class,
+        // method ref) determines the variable's type. Consume up to the
+        // first non-whitespace token after `=` so JavaParser sees the
+        // beginning of the RHS in the matched span.
+        varDecl: seq(
+          literal('var'),
+          sym('ws1'),
+          sym('identifier'),
+          sym('ws'),
+          literal('='),
+          sym('ws'),
+          // Capture enough of the RHS to extract a type. We grab up to a
+          // statement terminator or end-of-line so `extractVarDecl_` can
+          // pattern-match `new T(...)`, `(T) ...`, or `T.staticMethod(`.
+          sym('varDeclRhs')
+        ),
+
+        // RHS of var-decl: scan forward until ; or newline, but limited
+        // so we don't swallow whole method bodies.
+        varDeclRhs: seq(
+          repeat(notChars(';\n\r'), null, 1),
+          optional(literal(';'))
+        ),
+
+        upperTypeName: seq(
+          range('A', 'Z'),
+          repeat(alt(range('a', 'z'), range('A', 'Z'), range('0', '9'),
+            literal('_'), literal('$'))),
+          repeat(seq('.', sym('identifier')))
+        ),
+
+        // Catch-all bare identifier. Emitted so dot-prefixed enum constants
+        // like `Foo.BAR` get the trailing `BAR` tagged (after the
+        // `qualifiedCall` arm declines because no `(` follows).
+        plainIdent: seq(
+          msg(sym('identifier'), { kind: 'identTok' })
         )
       };
     }

--- a/tools/lsp/JavaParser.js
+++ b/tools/lsp/JavaParser.js
@@ -21,8 +21,17 @@ foam.CLASS({
     before and after, then convert to line numbers.
 
     parseFile(text) returns:
-      { package, imports, classes, methods }
-    where methods is [{ name, sig, returnType, params, modifiers, doc, line }].
+      { package, imports, classes, methods, calls, casts, news, locals, idents }
+    where:
+      methods = [{ name, sig, returnType, params, modifiers, doc, line }]
+      calls   = [{ receiver, methodName, line, col, recvCol, methodCol }]
+      casts   = [{ typeName, line, col }]
+      news    = [{ typeName, line, col }]
+      locals  = [{ typeName, varName, line, col }]
+      idents  = [{ name, line, col }]   // bare identifiers — used for enum constants
+
+    parseBlock(text, baseLine, baseCol) returns the same shape but with
+    per-token positions offset so positions land in the host file.
   `,
 
   requires: [
@@ -44,7 +53,10 @@ foam.CLASS({
         return lo;
       };
 
-      var result = { 'package': null, imports: [], classes: [], methods: [] };
+      var result = {
+        'package': null, imports: [], classes: [], methods: [],
+        calls: [], casts: [], news: [], locals: [], idents: []
+      };
       var captured = []; // { kind, startPos, endPos, value }
 
       // The apply callback observes every parser application. We watch
@@ -76,36 +88,131 @@ foam.CLASS({
         this.parseString(text, 'START', apply);
       } catch (e) {}
 
+      // Map line offsets to col-of-first-char so we can compute column.
+      var offsetToCol = function(offset) {
+        var ln = offsetToLine(offset);
+        return offset - lineOffsets[ln];
+      };
+
       // Process captured nodes
       var seen = {}; // dedup by startPos+kind
+
       for ( var n = 0 ; n < captured.length ; n++ ) {
         var node = captured[n];
         var key = node.kind + ':' + node.startPos;
         if ( seen[key] ) continue;
         seen[key] = true;
         var line = offsetToLine(node.startPos);
+        var col  = offsetToCol(node.startPos);
 
         if ( node.kind === 'package' ) {
-          var name = this.extractPackageName_(node.text);
-          if ( name ) result['package'] = name;
+          var pname = this.extractPackageName_(node.text);
+          if ( pname ) result['package'] = pname;
         } else if ( node.kind === 'import' ) {
-          var name = this.extractImportName_(node.text);
-          if ( name ) result.imports.push({ name: name, line: line });
+          var iname = this.extractImportName_(node.text);
+          if ( iname ) result.imports.push({ name: iname, line: line });
         } else if ( node.kind === 'classDecl' ) {
-          var info = this.extractClassInfo_(node.text);
-          if ( info ) { info.line = line; result.classes.push(info); }
+          var cinfo = this.extractClassInfo_(node.text);
+          if ( cinfo ) { cinfo.line = line; result.classes.push(cinfo); }
         } else if ( node.kind === 'methodSig' ) {
-          var info = this.extractMethodInfo_(node.text);
-          if ( ! info ) continue;
-          if ( /^(if|for|while|switch|catch|return|throw|do|else|try)$/.test(info.name) ) continue;
-          if ( info.name === 'getName' || info.name === 'call' ) continue;
-          info.line = line;
-          info.doc = this.findJavadoc_(text, node.startPos);
-          result.methods.push(info);
+          var minfo = this.extractMethodInfo_(node.text);
+          if ( ! minfo ) continue;
+          if ( /^(if|for|while|switch|catch|return|throw|do|else|try)$/.test(minfo.name) ) continue;
+          if ( minfo.name === 'getName' || minfo.name === 'call' ) continue;
+          minfo.line = line;
+          minfo.doc = this.findJavadoc_(text, node.startPos);
+          result.methods.push(minfo);
+        } else if ( node.kind === 'qualifiedCall' ) {
+          var qc = this.extractQualifiedCall_(node.text, node.startPos,
+            offsetToLine, offsetToCol);
+          if ( qc ) result.calls.push(qc);
+        } else if ( node.kind === 'castExpr' ) {
+          var ce = this.extractTypeFromSpan_(node.text, /\(\s*([A-Z][\w.$]*)/,
+            node.startPos, offsetToLine, offsetToCol);
+          if ( ce ) result.casts.push(ce);
+        } else if ( node.kind === 'newExpr' ) {
+          var ne = this.extractTypeFromSpan_(node.text, /new\s+([A-Z][\w.$]*)/,
+            node.startPos, offsetToLine, offsetToCol);
+          if ( ne ) result.news.push(ne);
+        } else if ( node.kind === 'localDecl' ) {
+          var ldExt = this.extractLocalDecl_(node.text, node.startPos,
+            offsetToLine, offsetToCol);
+          if ( ldExt ) result.locals.push(ldExt);
+        } else if ( node.kind === 'varDecl' ) {
+          var vdExt = this.extractVarDecl_(node.text, node.startPos,
+            offsetToLine, offsetToCol);
+          if ( vdExt ) result.locals.push(vdExt);
+        } else if ( node.kind === 'identTok' ) {
+          // Bare identifiers — useful for enum-constant detection (a
+          // standalone TypeName.UPPER_VALUE shows up as two adjacent
+          // identTok captures).
+          result.idents.push({ name: node.text, line: line, col: col });
         }
       }
 
       return result;
+    },
+
+    function parseBlock(text, baseLine, baseCol) {
+      /**
+       * Parse a Java fragment (e.g., the contents of a javaCode: backtick
+       * block) and return parseFile()'s structure with all positions
+       * shifted so they land in the host file.
+       *
+       * baseLine/baseCol point at the first character of `text` in the
+       * host file. Newlines within `text` push following positions to
+       * line baseLine + N, with col reset to that line's offset within
+       * the block. The first line is offset by baseCol; subsequent lines
+       * start at column 0.
+       */
+      var raw = this.parseFile(text);
+
+      var shift = function(ln, c) {
+        return {
+          line: baseLine + ln,
+          col:  ln === 0 ? baseCol + c : c
+        };
+      };
+
+      var arrShift = function(arr, lineKey, colKey) {
+        for ( var i = 0 ; i < arr.length ; i++ ) {
+          var s = shift(arr[i][lineKey || 'line'], arr[i][colKey || 'col']);
+          arr[i][lineKey || 'line'] = s.line;
+          arr[i][colKey  || 'col']  = s.col;
+        }
+      };
+
+      arrShift(raw.imports);
+      arrShift(raw.classes);
+      arrShift(raw.methods);
+      arrShift(raw.casts);
+      arrShift(raw.news);
+      arrShift(raw.idents);
+
+      // calls have receiver + method positions
+      for ( var i = 0 ; i < raw.calls.length ; i++ ) {
+        var c = raw.calls[i];
+        if ( c.recvLine != null ) {
+          var rs = shift(c.recvLine, c.recvCol);
+          c.recvLine = rs.line; c.recvCol = rs.col;
+        }
+        var ms = shift(c.line, c.col);
+        c.line = ms.line; c.col = ms.col;
+        c.methodCol = c.col;
+      }
+
+      // locals have type + name positions
+      for ( var i = 0 ; i < raw.locals.length ; i++ ) {
+        var l = raw.locals[i];
+        var ts = shift(l.line, l.col);
+        l.line = ts.line; l.col = ts.col;
+        if ( l.nameLine != null ) {
+          var ns = shift(l.nameLine, l.nameCol);
+          l.nameLine = ns.line; l.nameCol = ns.col;
+        }
+      }
+
+      return raw;
     },
 
     // ===== Helpers to extract structured info from grammar-validated text =====
@@ -191,6 +298,118 @@ foam.CLASS({
       }
       if ( current ) tokens.push(current);
       return tokens;
+    },
+
+    function extractQualifiedCall_(span, spanStart, offsetToLine, offsetToCol) {
+      /**
+       * span looks like "Loggers.logger(" (whitespace allowed). The outer
+       * `qualifiedCall` rule guarantees the shape <ident>.<ident> ws? `(`.
+       * Recover receiver and method positions by re-locating each in span.
+       */
+      var m = span.match(/^([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*)/);
+      if ( ! m ) return null;
+      var recvName   = m[1];
+      var methodName = m[2];
+      var recvOff    = spanStart + span.indexOf(recvName);
+      var methodOff  = spanStart + span.indexOf(methodName, span.indexOf(recvName) + recvName.length);
+      return {
+        receiver:   recvName,
+        methodName: methodName,
+        line:       offsetToLine(methodOff),
+        col:        offsetToCol(methodOff),
+        recvLine:   offsetToLine(recvOff),
+        recvCol:    offsetToCol(recvOff),
+        methodCol:  offsetToCol(methodOff)
+      };
+    },
+
+    function extractTypeFromSpan_(span, regex, spanStart, offsetToLine, offsetToCol) {
+      /**
+       * Generic helper: regex captures a single type identifier inside the
+       * outer span. Returns position info for the captured type. Used for
+       * castExpr and newExpr where the upper-case-typed slot is the only
+       * navigation target.
+       */
+      var m = span.match(regex);
+      if ( ! m ) return null;
+      var typeName = m[1];
+      var typeOff  = spanStart + span.indexOf(typeName);
+      return {
+        typeName: typeName,
+        line: offsetToLine(typeOff),
+        col:  offsetToCol(typeOff)
+      };
+    },
+
+    function extractVarDecl_(span, spanStart, offsetToLine, offsetToCol) {
+      /**
+       * span looks like "var v = new Foo();" or "var x = (Foo) bar;"
+       * or "var y = Foo.create()".
+       * Recovers: var name + inferred type from the RHS shape. Tries
+       * (in order): `new T(`, `(T)`, `T.method(`, literal `T.class`.
+       * Returns null if no type can be inferred — we don't want to add
+       * a typeless entry to result.locals.
+       */
+      var nameMatch = span.match(/^var\s+([A-Za-z_$][\w$]*)\s*=/);
+      if ( ! nameMatch ) return null;
+      var varName = nameMatch[1];
+      var rhs = span.substring(nameMatch[0].length);
+
+      // RHS type inference — order matters (most specific first).
+      var typeName = null;
+      var newM = rhs.match(/^\s*new\s+([A-Z][\w.$]*)/);
+      if ( newM ) {
+        typeName = newM[1];
+      } else {
+        // Cast accepts optional generics between the type and `)`:
+        // `(Foo)`, `(Foo<String>)`, `(Foo<Map<K,V>>)`. Strip generics
+        // for the result so the typeName is the bare class.
+        var castM = rhs.match(/^\s*\(\s*([A-Z][\w.$]*)\s*(?:<[^()]*>)?\s*\)/);
+        if ( castM ) {
+          typeName = castM[1];
+        } else {
+          var staticM = rhs.match(/^\s*([A-Z][\w.$]*)\s*\.[A-Za-z_$][\w$]*\s*\(/);
+          if ( staticM ) typeName = staticM[1];
+          else {
+            var classLitM = rhs.match(/^\s*([A-Z][\w.$]*)\s*\.class\b/);
+            if ( classLitM ) typeName = classLitM[1] + '.class';
+          }
+        }
+      }
+      if ( ! typeName ) return null;
+
+      var nameOff = spanStart + span.indexOf(varName);
+      // For inferred-type vars, `line/col` points at the `var` keyword
+      // (so go-to-def lands on the declaration), and nameLine/nameCol
+      // point at the name itself.
+      return {
+        typeName: typeName, varName: varName,
+        line: offsetToLine(spanStart),
+        col:  offsetToCol(spanStart),
+        nameLine: offsetToLine(nameOff),
+        nameCol:  offsetToCol(nameOff),
+        inferred_: true
+      };
+    },
+
+    function extractLocalDecl_(span, spanStart, offsetToLine, offsetToCol) {
+      /**
+       * span looks like "Logger logger =", "List<String> items;", or
+       * "ConfigMatrix configMatrix=". Recover type and var name positions.
+       */
+      var m = span.match(/^([A-Z][\w.$]*)(?:\s*<[^>]*>)?\s+([A-Za-z_$][\w$]*)/);
+      if ( ! m ) return null;
+      var typeName = m[1];
+      var varName  = m[2];
+      var typeOff  = spanStart + span.indexOf(typeName);
+      var nameOff  = spanStart + span.indexOf(varName, typeOff - spanStart + typeName.length);
+      return {
+        typeName: typeName, varName: varName,
+        line:     offsetToLine(typeOff),
+        col:      offsetToCol(typeOff),
+        nameLine: offsetToLine(nameOff),
+        nameCol:  offsetToCol(nameOff)
+      };
     },
 
     function findJavadoc_(text, beforeOffset) {

--- a/tools/lsp/editors/vscode/syntaxes/foam-js.tmLanguage.json
+++ b/tools/lsp/editors/vscode/syntaxes/foam-js.tmLanguage.json
@@ -40,8 +40,8 @@
       ]
     },
     {
-      "comment": "FOAM model keys highlighted as types: extends, of, package values",
-      "match": "(?<=[:\\s])(extends|of|package)(\\s*:\\s*)('[^']*'|\"[^\"]*\")",
+      "comment": "FOAM model keys whose value is a class id: extends, of, package, refines, sourceModel, targetModel, view, class, implements item",
+      "match": "(?<=[:\\s\\[,])(extends|of|package|refines|sourceModel|targetModel|view|class|implements)(\\s*:\\s*)('[^']*'|\"[^\"]*\")",
       "captures": {
         "1": { "name": "support.type.property-name.foam" },
         "2": { "name": "punctuation.separator.key-value.js" },
@@ -49,8 +49,8 @@
       }
     },
     {
-      "comment": "FOAM class declarations: foam.CLASS, foam.ENUM, foam.INTERFACE",
-      "match": "(foam)\\s*\\.\\s*(CLASS|ENUM|INTERFACE|RELATIONSHIP)\\s*(?=\\()",
+      "comment": "FOAM model declarations: foam.<UPPER>(...) — generic so foam.FSM and any future model type are highlighted without grammar changes",
+      "match": "(foam)\\s*\\.\\s*([A-Z][A-Z0-9_]*)\\s*(?=\\()",
       "captures": {
         "1": { "name": "support.class.foam" },
         "2": { "name": "entity.name.function.foam" }

--- a/tools/lsp/editors/zed-foam3/languages/foam-javascript/highlights.scm
+++ b/tools/lsp/editors/zed-foam3/languages/foam-javascript/highlights.scm
@@ -8,11 +8,27 @@
 ; Properties
 ;-----------
 
-; FOAM class/package references highlighted as types
+; FOAM class-id slots highlighted as types — generic on slot name so
+; foam.RELATIONSHIP source/target, foam.CLASS refines, view:'...', and
+; class:'foo.X' all surface as type tokens. Add new slot names here when
+; FoamIndex.getClassTypedPropertyNames() grows; the LSP itself drives the
+; canonical list off the registry, so this matches that behavior.
 (pair
   key: (property_identifier) @property
-  (#any-of? @property "of" "extends" "package")
+  (#any-of? @property "of" "extends" "package" "refines"
+                       "sourceModel" "targetModel" "view" "class")
   value: (string (string_fragment) @type))
+
+; foam.<UPPER>(...) — FOAM model declarations. Generic on the call name so
+; foam.FSM, foam.RELATIONSHIP, and any future model type are recognized
+; without changing this grammar. The receiver identifier captures `foam`,
+; the property identifier captures the type call (CLASS/ENUM/FSM/...).
+(call_expression
+  function: (member_expression
+    object: (identifier) @support.class
+    property: (property_identifier) @function.macro)
+  (#eq? @support.class "foam")
+  (#match? @function.macro "^[A-Z][A-Z0-9_]*$"))
 
 (property_identifier) @property
 

--- a/tools/lsp/handlers/CompletionHandler.js
+++ b/tools/lsp/handlers/CompletionHandler.js
@@ -1051,12 +1051,25 @@ foam.CLASS({
     },
 
     function toCompletionItem(suggestion) {
+      // sortText prefix decides ordering relative to VS Code's built-in
+      // JS/TS suggestions:
+      //   '!' = top of the list (FOAM-axiom keys, class refs, prop types)
+      //   '"' = just below '!'
+      //   '~' = bottom (rarely useful catch-alls)
+      // Without sortText, VS Code's default JS suggestions outrank ours
+      // because they include kind=Keyword/Variable matches that the
+      // editor weights more heavily than our Keyword=14 emissions.
+      var prefix = suggestion.category === 'class' ? '!' : '!';
+      var label = suggestion.text || suggestion.label;
       return this.CompletionItem.create({
-        label: suggestion.text || suggestion.label,
+        label: label,
         kind: this.categoryToKind(suggestion.category),
         detail: suggestion.hint || '',
         documentation: suggestion.tooltip || '',
-        insertText: suggestion.text
+        insertText: suggestion.text,
+        sortText: prefix + (label || '').toLowerCase(),
+        // Preselect the first axiom-key match in editors that honor it.
+        preselect: suggestion.category && suggestion.category.indexOf('Key') !== -1
       });
     },
 
@@ -1080,10 +1093,21 @@ foam.CLASS({
         case 'class':    return 7;
         case 'property': return 10;
         case 'method':   return 2;
+        // All key categories — top-level, property, POM, and inner-object
+        // scopes (methodKey/actionKey/sectionKey/messageKey/valueKey/
+        // listenerKey) — render as Keyword (14). Keep them in one branch
+        // so adding a new scope auto-routes here.
         case 'key':
         case 'topKey':
         case 'propKey':
-        case 'pomKey':   return 14;
+        case 'pomKey':
+        case 'methodKey':
+        case 'actionKey':
+        case 'sectionKey':
+        case 'messageKey':
+        case 'valueKey':
+        case 'listenerKey':
+                         return 14;
         case 'enum':     return 13;
         case 'operator': return 24;
         default:         return 1;

--- a/tools/lsp/handlers/DefinitionHandler.js
+++ b/tools/lsp/handlers/DefinitionHandler.js
@@ -311,9 +311,19 @@ foam.CLASS({
     function buildLocationAtMethod(filePath, classId, methodName) {
       /**
        * Jump to a method definition within the correct class in the file.
-       * Uses the grammar's axiom-position index (`kind: 'method'` emitted by
-       * `methodNameValue` in FoamClassGrammar) and constrains the match to
-       * the target class's source range via FileModelCache.
+       * Pure grammar-based: relies on `kind: 'method'` positions emitted
+       * by `methodNameValue` in FoamClassGrammar.
+       *
+       * Resolution order:
+       *   1. Grammar map constrained to the requested class's source range.
+       *      Wins when the file has multiple class blocks.
+       *   2. Unconstrained grammar map — for single-class files or when
+       *      parseFileModels didn't capture the class section under the
+       *      expected classId (refines, generic foam.<X> calls).
+       *
+       * If both miss, that means the grammar didn't emit a method
+       * position — a grammar bug to fix in FoamClassGrammar.js, not
+       * something to paper over with a regex here.
        */
       try {
         var fs_ = require('fs');
@@ -332,21 +342,27 @@ foam.CLASS({
           }
         }
 
-        // Grammar emits all method positions; pick the one inside [startLine, endLine).
         var map = this.grammar_().collectAxiomPositions(content);
         var positions = map && map.method ? map.method : null;
         var hit = positions ? positions[methodName] : null;
         if ( hit && hit.line >= startLine && hit.line < endLine ) {
-          return {
-            uri: 'file://' + filePath,
-            range: {
-              start: { line: hit.line, character: hit.col },
-              end:   { line: hit.line, character: hit.col + methodName.length }
-            }
-          };
+          return this.buildMethodPosLocation_(filePath, hit, methodName);
+        }
+        if ( hit ) {
+          return this.buildMethodPosLocation_(filePath, hit, methodName);
         }
       } catch ( e ) {}
       return this.buildLocation(filePath, classId);
+    },
+
+    function buildMethodPosLocation_(filePath, pos, methodName) {
+      return {
+        uri: 'file://' + filePath,
+        range: {
+          start: { line: pos.line, character: pos.col || 0 },
+          end:   { line: pos.line, character: (pos.col || 0) + methodName.length }
+        }
+      };
     },
 
     function buildLocationAtMessage_(filePath, msgName) {
@@ -390,6 +406,11 @@ foam.CLASS({
        * axiom-position index (`kind: 'property'` emitted by `propertyNameValue`
        * in FoamClassGrammar) so the lookup respects multi-class files and
        * matches how messages are located.
+       *
+       * Pure grammar-based: trusts `propertyNameValue` in
+       * FoamClassGrammar.js to emit position info for every property
+       * declaration. If a property isn't being found, the grammar rule
+       * needs a missing case — fix it there, not with a regex here.
        */
       try {
         var fs_ = require('fs');
@@ -425,20 +446,24 @@ foam.CLASS({
         if ( filePath ) return this.buildLocation(filePath, typeClassId);
       }
 
-      // 2. variable.method() — resolve variable type, then find method definition
+      // 2. variable.method() — resolve variable type, then find method
+      //    definition. CRITICAL: when the click is a chained call
+      //    (`<recv>.<seg>` with a non-`this` receiver), this branch is
+      //    AUTHORITATIVE — we never fall through to step 3 because step 3
+      //    would search the *current* class (e.g., the enclosing FSM)
+      //    and silently land on the wrong file. Better to return null
+      //    (no navigation) than to navigate to an unrelated symbol.
       if ( word && word.indexOf('.') !== -1 ) {
         var parts = word.split('.');
         var varName = parts[parts.length - 2];
         var methodName = parts[parts.length - 1];
 
         if ( varName !== 'this' ) {
-          // Resolve the variable's type
           var varClassId = this.analyzer.resolveJavaVariableType(text, position, varName, model, this.index);
           if ( ! varClassId ) {
             varClassId = this.analyzer.resolveJavaTypeName(varName, model, this.index);
           }
           if ( varClassId ) {
-            // getter/setter → navigate to the property's defining class
             var gsMatch = methodName.match(/^(get|set)([A-Z]\w*)$/);
             if ( gsMatch ) {
               var propName = gsMatch[2].charAt(0).toLowerCase() + gsMatch[2].substring(1);
@@ -452,24 +477,28 @@ foam.CLASS({
               }
             }
 
-            // FOAM method
-            var cls = this.index.getClass(varClassId);
-            if ( cls ) {
-              var defClass = this.findMethodDefiner_(cls, methodName);
-              if ( defClass ) {
-                var filePath = this.index.getFilePath(defClass);
-                if ( filePath ) return this.buildLocationAtMethod(filePath, defClass, methodName);
+            var cls2 = this.index.getClass(varClassId);
+            if ( cls2 ) {
+              var mDefClass = this.findMethodDefiner_(cls2, methodName);
+              if ( mDefClass ) {
+                var mFilePath = this.index.getFilePath(mDefClass);
+                if ( mFilePath ) return this.buildLocationAtMethod(mFilePath, mDefClass, methodName);
               }
             }
 
-            // Java-only method → navigate to .java file
             var javaLoc = this.findJavaMethodLocation_(varClassId, methodName);
             if ( javaLoc ) return javaLoc;
           }
+          // Authoritative: a chained-call click never falls through to
+          // step 3 (current-model search). The receiver is what
+          // determines the target — even if we can't resolve it, the
+          // current model is almost certainly NOT the answer.
+          return null;
         }
       }
 
       // 3. Standalone method name (e.g., getProperty on current model)
+      //    Only reached for non-chained clicks or `this.method` clicks.
       var currentClassId = this.cache.getClassId(model);
       if ( currentClassId ) {
         var javaLoc = this.findJavaMethodLocation_(currentClassId, segment);

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -124,6 +124,14 @@ foam.CLASS({
             this.addDiag_(diagnostics, text, r.startPos, matched.length, 2,
               "Unknown class: '" + matched + "'");
           }
+        } else if ( r.msg && r.msg.type === 'doubleQuotedClassRef' ) {
+          // FOAM convention is single-quoted class refs. Parse the value
+          // anyway (lenient) but surface a hint with the corrected form so
+          // the CodeAction in server.js can offer a one-click fix.
+          // `matched` here is the WHOLE "..." span including the quotes.
+          var inner = matched.replace(/^"/, '').replace(/"$/, '');
+          this.addDiag_(diagnostics, text, r.startPos, matched.length, 4,
+            "Use single quotes for FOAM class references: '" + inner + "'");
         } else if ( r.msg && r.msg.type === 'unknownPropType' ) {
           if ( ! this.validTypes_[matched] && ! this.classKnown_(matched) ) {
             this.addDiag_(diagnostics, text, r.startPos, matched.length, 3,

--- a/tools/lsp/handlers/HoverHandler.js
+++ b/tools/lsp/handlers/HoverHandler.js
@@ -9,6 +9,7 @@ foam.CLASS({
   name: 'HoverHandler',
 
   requires: [
+    'foam.parse.lsp.AxiomCatalog',
     'foam.parse.lsp.FoamIndex',
     'foam.parse.lsp.FileModelCache',
     'foam.parse.lsp.CursorAnalyzer',
@@ -51,6 +52,12 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.parse.lsp.CSSTokenResolver',
       name: 'cssTokenResolver'
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.parse.lsp.AxiomCatalog',
+      name: 'axiomCatalog',
+      factory: function() { return this.AxiomCatalog.create(); }
     }
   ],
 
@@ -60,6 +67,12 @@ foam.CLASS({
 
       var word = this.analyzer.getDottedWordAtPosition(text, position);
       if ( ! word ) return null;
+
+      // Axiom key hover: cursor on `requires:`, `properties:`, `messages:`,
+      // `sections:`, `searchColumns:`, etc. — show the description from
+      // AxiomCatalog (single source of truth shared with the grammar).
+      var axiomKeyHover = this.axiomKeyHover_(text, position);
+      if ( axiomKeyHover ) return axiomKeyHover;
 
       // Try Java block hover — getters, variables, type references inside javaCode
       var javaHover = this.javaBlockHover_(text, position, opt_uri);
@@ -195,6 +208,116 @@ foam.CLASS({
       if ( ! model ) return null;
       var requiresMap = this.cache.buildRequiresMap(model);
       return requiresMap[shortName] || null;
+    },
+
+    function axiomKeyHover_(text, position) {
+      /**
+       * Hover on an axiom key like `requires:`, `properties:`, `javaCode:`,
+       * etc. Pulls the description from AxiomCatalog. The same key (e.g.,
+       * `javaCode`) appears in multiple scopes (top-level, property,
+       * method-object) — we use the surrounding container to pick the
+       * RIGHT scope so the hover description matches what the key
+       * actually does at that position.
+       *
+       * Detection: cursor must sit on an identifier immediately followed
+       * by `:` (allowing whitespace). This guards against matching the
+       * same word used as a value or inside a string.
+       */
+      var segment = this.analyzer.getSegmentAtPosition(text, position);
+      if ( ! segment ) return null;
+
+      var lines = text.split('\n');
+      var line = lines[position.line] || '';
+      var afterCursor = line.substring(position.character);
+      if ( ! /^[A-Za-z0-9_$]*\s*:/.test(afterCursor) ) return null;
+
+      // Determine scope from surrounding container. Inner-object scopes
+      // (methodKey/actionKey/etc.) take precedence so a `javaCode:` key
+      // inside a method object reports as method-level, not class-level.
+      var scope = this.detectKeyScope_(text, position);
+      var hint = scope ? this.axiomCatalog.getHint(scope, segment) : '';
+      if ( ! hint ) hint = this.axiomCatalog.findHint(segment);
+      if ( ! hint ) return null;
+
+      var md = '**' + segment + '** — ' + hint;
+      return { contents: { kind: 'markdown', value: md } };
+    },
+
+    function detectKeyScope_(text, position) {
+      /**
+       * Walk backwards from `position` and find the nearest enclosing
+       * `<axiomKey>: [` array opener. Inner-object containers are
+       * `<axiom>: [ { ... } ]` shape — so we need to step OUT of the
+       * inner `{` first, then OUT of the array's `[`, and finally
+       * inspect the key word that precedes the `[`.
+       *
+       * Returns 'methodKey' / 'actionKey' / 'sectionKey' / 'messageKey'
+       * / 'valueKey' / 'listenerKey' for the recognized inner scopes,
+       * 'propKey' inside a property object, or 'topKey' as the default.
+       *
+       * String / comment bodies are skipped so cursors inside javaCode
+       * blocks don't false-match brackets in the code.
+       */
+      var scopeMap = {
+        methods:    'methodKey',
+        actions:    'actionKey',
+        sections:   'sectionKey',
+        messages:   'messageKey',
+        values:     'valueKey',
+        listeners:  'listenerKey',
+        properties: 'propKey'
+      };
+      var offset = this.analyzer.positionToOffset(text, position);
+
+      // Walk back skipping strings/comments. Track [ and { depth
+      // separately so we can step out of the inner `{` and then look
+      // for an enclosing `[`. The first unmatched `[` we cross is the
+      // axiom-array opener; check the preceding key word.
+      var braceDepth = 0;
+      var bracketDepth = 0;
+      for ( var i = offset - 1 ; i >= 0 ; i-- ) {
+        var ch = text[i];
+        // Skip backwards through string literals.
+        if ( ch === "'" || ch === '"' || ch === '`' ) {
+          var q = ch;
+          for ( i-- ; i >= 0 ; i-- ) {
+            if ( text[i] === q && text[i - 1] !== '\\' ) { i--; break; }
+          }
+          continue;
+        }
+        // Skip block comments: */ ... /*
+        if ( ch === '/' && i > 0 && text[i - 1] === '*' ) {
+          i -= 2;
+          while ( i >= 1 && ! ( text[i - 1] === '/' && text[i] === '*' ) ) i--;
+          i -= 2;
+          continue;
+        }
+        if ( ch === '}' ) braceDepth++;
+        else if ( ch === '{' ) {
+          if ( braceDepth > 0 ) { braceDepth--; continue; }
+          // Stepped out of the innermost `{`. Keep walking — we want
+          // the enclosing `[` if there is one.
+          continue;
+        }
+        else if ( ch === ']' ) bracketDepth++;
+        else if ( ch === '[' ) {
+          if ( bracketDepth > 0 ) { bracketDepth--; continue; }
+          // Found the array opener. Look back for `<key>:`.
+          var j = i - 1;
+          while ( j >= 0 && /\s/.test(text[j]) ) j--;
+          if ( j >= 0 && text[j] === ':' ) {
+            j--;
+            while ( j >= 0 && /\s/.test(text[j]) ) j--;
+            var nameEnd = j + 1;
+            while ( j >= 0 && /[A-Za-z0-9_$]/.test(text[j]) ) j--;
+            var name = text.substring(j + 1, nameEnd);
+            if ( name && scopeMap[name] ) return scopeMap[name];
+          }
+          // Array isn't one we know about — treat as top-level for now.
+          return 'topKey';
+        }
+      }
+      return 'topKey';
     },
 
     function resolveCurrentClass_(text, position, opt_uri) {

--- a/tools/lsp/handlers/JrlHandler.js
+++ b/tools/lsp/handlers/JrlHandler.js
@@ -1051,7 +1051,7 @@ foam.CLASS({
        * Inside a serviceScript Java code block. Two registry-driven modes:
        *
        *   1. Dotted class/package path — `foam.dao.E<cursor>` or
-       *      `com.paytic.<cursor>` → suggest every class id that starts
+       *      `com.example.<cursor>` → suggest every class id that starts
        *      with the prefix. No hardcoded names.
        *
        *   2. Member access on a resolvable receiver — `<expr>.<partial>`

--- a/tools/lsp/handlers/SemanticTokenHandler.js
+++ b/tools/lsp/handlers/SemanticTokenHandler.js
@@ -539,6 +539,37 @@ foam.CLASS({
           }
         }
 
+        // Method-call positions via JavaGrammar parseBlock — emits token
+        // type 8 (method) at the methodName offset. Receiver position is
+        // already covered above by the type regex when the receiver is an
+        // UpperCamelCase type. This catches the otherwise-invisible
+        // method names: `Loggers.logger(...)` → `logger` highlighted.
+        try {
+          var jParser = self.javaParser_;
+          if ( ! jParser ) {
+            jParser = self.javaParser_ = foam.parse.lsp.JavaParser
+              ? foam.parse.lsp.JavaParser.create() : null;
+          }
+          if ( jParser ) {
+            // baseLine/baseCol are 0/0 because we re-locate by absolute
+            // offset using lineOffsets — easier than juggling per-block
+            // base positions through the recursive sweep.
+            var blockResult = jParser.parseFile(javaStr);
+            for ( var ci = 0 ; ci < blockResult.calls.length ; ci++ ) {
+              var call = blockResult.calls[ci];
+              // Reconstruct offset from line/col within javaStr.
+              var blockLineOffsets = [0];
+              for ( var k = 0 ; k < javaStr.length ; k++ ) {
+                if ( javaStr[k] === '\n' ) blockLineOffsets.push(k + 1);
+              }
+              if ( call.line >= blockLineOffsets.length ) continue;
+              var methodOffsetInBlock = blockLineOffsets[call.line] + call.col;
+              addToken(baseOffset + methodOffsetInBlock,
+                call.methodName.length, 8);
+            }
+          }
+        } catch (e) { /* parseBlock is best-effort — fail silently */ }
+
         // Java variable declarations + usage tracking
         // Track declared variables so we can highlight their usage throughout the block
         // 'x' is always available as the FOAM context (foam.lang.X)

--- a/tools/lsp/pom.js
+++ b/tools/lsp/pom.js
@@ -12,7 +12,8 @@ foam.POM({
     { name: 'CSSTokenResolver', flags: 'js' },
     { name: 'JrlLoader', flags: 'js' },
     { name: 'JavaGrammar', flags: 'js' },
-    { name: 'JavaParser', flags: 'js' }
+    { name: 'JavaParser', flags: 'js' },
+    { name: 'AxiomCatalog', flags: 'js' }
   ],
   projects: [
     { name: 'handlers/pom' },

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -255,6 +255,27 @@ function start() {
         }
       }
 
+      // For "Use single quotes" hints, offer a one-click fix that rewrites
+      // the entire matched span ("foo.X") to single-quoted form ('foo.X').
+      var dqMatch = diag.message.match(/Use single quotes for FOAM class references:\s*'([^']+)'/);
+      if ( dqMatch ) {
+        var inner = dqMatch[1];
+        actions.push({
+          title: "Convert to single quotes: '" + inner + "'",
+          kind: 'quickfix',
+          isPreferred: true,
+          diagnostics: [diag],
+          edit: {
+            changes: {
+              [uri]: [{
+                range: diag.range,
+                newText: "'" + inner + "'"
+              }]
+            }
+          }
+        });
+      }
+
       // For raw color diagnostics, offer a $token replacement if available.
       // Matches both new message ("raw color 'X'") and legacy phrasing.
       var rawColorMatch = diag.message.match(/raw color[^']*'([^']+)'/);

--- a/tools/tests/lsp/completion.js
+++ b/tools/tests/lsp/completion.js
@@ -594,6 +594,65 @@ var exportCtx = completionHandler.detectContext_(exportText, exportPos);
 test(exportCtx.exportName === true, 'detectContext_: exportName flag set inside exports array');
 test(exportCtx.classRef === false, 'detectContext_: classRef flag NOT set inside exports array');
 
+// === Inner-object axiom-key completion (catalog-driven) ===
+// Inside `methods: [ { | } ]`, `actions: [ { | } ]`, `sections: [ { | } ]`,
+// `messages: [ { | } ]`, `values: [ { | } ]`, and `listeners: [ { | } ]`
+// the grammar should suggest the relevant axiom keys for THAT inner-object
+// scope. Earlier this only worked at top-level, so completion inside a
+// method/action/etc. block returned just `name:` (the only hardcoded arm).
+section('CompletionHandler — inner-object axiom-key suggestions');
+
+function _suggestKeys(src, line, character) {
+  var r = completionHandler.handle(src, { line: line, character: character });
+  return r.items.map(function(i) { return (i.label || i.insertText || '').replace(/:.*$/, '').trim(); });
+}
+
+[
+  ['methods',   ['name', 'code', 'args', 'javaCode', 'documentation']],
+  ['actions',   ['name', 'label', 'isAvailable', 'isEnabled', 'code']],
+  ['sections',  ['name', 'title', 'help', 'view']],
+  ['messages',  ['name', 'message']],
+  ['listeners', ['name', 'code', 'isFramed', 'isMerged']]
+].forEach(function(row) {
+  var slot = row[0], expected = row[1];
+  var src = "foam.CLASS({\n  package: 'x',\n  name: 'Y',\n  " + slot + ": [\n    {\n      \n    }\n  ]\n});";
+  var keys = _suggestKeys(src, 5, 6);
+  expected.forEach(function(k) {
+    test(keys.indexOf(k) !== -1,
+      slot + ': { } suggests "' + k + '" (saw: ' + keys.slice(0, 6).join(',') + ')');
+  });
+});
+
+// foam.ENUM values: [ { } ] — different top-level call
+var enumValuesSrc = "foam.ENUM({\n  package: 'x',\n  name: 'Y',\n  values: [\n    {\n      \n    }\n  ]\n});";
+var enumValueKeys = _suggestKeys(enumValuesSrc, 5, 6);
+['name', 'label', 'documentation'].forEach(function(k) {
+  test(enumValueKeys.indexOf(k) !== -1,
+    'foam.ENUM values: { } suggests "' + k + '"');
+});
+
+// === Inner-object grammar parses without breaking outer parse ===
+// Inner-object rules must not stop classEntries from completing. A method
+// with extra keys like `args:` and `javaCode:` should still parse fully
+// and emit position info for properties/methods after it.
+var innerHeavySrc =
+  "foam.CLASS({\n" +
+  "  package: 'x',\n" +
+  "  name: 'Y',\n" +
+  "  methods: [\n" +
+  "    { name: 'm1', args: 'X x', javaCode: `return;`, documentation: 'doc' },\n" +
+  "    function m2() {}\n" +
+  "  ],\n" +
+  "  properties: [{ name: 'tail' }]\n" +
+  "});";
+var innerPositions = grammar.collectAxiomPositions(innerHeavySrc);
+test(innerPositions.method && innerPositions.method.m1,
+  'method m1 (with args/javaCode/documentation) emits position');
+test(innerPositions.method && innerPositions.method.m2,
+  'method m2 (bare function form) emits position');
+test(innerPositions.property && innerPositions.property.tail,
+  'property "tail" after a methods block with rich inner objects still emits');
+
 // === SUMMARY ===
 
 

--- a/tools/tests/lsp/grammar.js
+++ b/tools/tests/lsp/grammar.js
@@ -302,5 +302,375 @@ test(pmMap.method && pmMap.method.greet && pmMap.method.greet.line === 8,
 test(pmMap.method && pmMap.method.farewell && pmMap.method.farewell.line === 9,
   'Grammar axiom-pos: method farewell at line 9 (object form)');
 
+// === Regression: top-level/property keys with values must NOT abort the parse ===
+// Earlier `topKey()` and `propKey()` only matched the key word, leaving
+// the `: <value>` for the next iteration to choke on. Result: ANY class
+// using `label:`, `plural:`, or per-property `label:`/`visibility:`/etc.
+// silently dropped every downstream property/method position emission,
+// so go-to-def fell through to file-top.
+section('Grammar: top-level + property keys consume their values');
+
+var noisySrc = [
+  'foam.CLASS({',
+  "  package: 'test',",
+  "  name: 'Noisy',",
+  "  label: 'Noisy Display',",                                    // L3
+  "  plural: 'Noisys',",                                          // L4
+  "  documentation: 'A docstring with spaces and \"quotes\"',",   // L5
+  '  properties: [',
+  "    { name: 'alpha', label: 'Alpha Display', visibility: 'RO' },",   // L7
+  "    { name: 'beta', help: 'Type a beta value' },",                   // L8
+  "    { name: 'gamma' }",                                              // L9
+  '  ],',
+  '  methods: [',
+  '    function delta() {},',                                            // L12
+  "    { name: 'epsilon', code: function() {} }",                        // L13
+  '  ]',
+  '});'
+].join('\n');
+
+var noisyPositions = axiomGrammar.collectAxiomPositions(noisySrc);
+['alpha', 'beta', 'gamma'].forEach(function(p) {
+  test(noisyPositions.property && noisyPositions.property[p],
+    'Property "' + p + '" position emitted past noisy class-level + property-level slots');
+});
+['delta', 'epsilon'].forEach(function(m) {
+  test(noisyPositions.method && noisyPositions.method[m],
+    'Method "' + m + '" position emitted past noisy class-level + property-level slots');
+});
+test(noisyPositions.property && noisyPositions.property.alpha && noisyPositions.property.alpha.line === 7,
+  'Property alpha is on line 7 (positions stay accurate)');
+test(noisyPositions.method && noisyPositions.method.epsilon && noisyPositions.method.epsilon.line === 13,
+  'Method epsilon is on line 13 (positions stay accurate)');
+
+// === Regression: longest-first sort for property type alts ===
+// The propTypeParser was matching `Double` before `DoubleUnitValue`, so
+// `class: 'DoubleUnitValue'` consumed only `Double` and left `UnitValue`
+// to choke the outer rule — silently bailing every downstream property
+// emission. Sort propTypes longest-first.
+section('Grammar: prop-type alt ordered longest-first');
+
+var dblSrc =
+  "foam.CLASS({\n" +
+  "  package: 'test',\n" +
+  "  name: 'D',\n" +
+  "  properties: [\n" +
+  "    { class: 'DoubleUnitValue', name: 'amount' },\n" +
+  "    { class: 'String',          name: 'label' }\n" +
+  "  ]\n" +
+  "});";
+var dblMap = axiomGrammar.collectAxiomPositions(dblSrc);
+test(dblMap.property && dblMap.property.amount,
+  'DoubleUnitValue property emits position (longer prop type not prefix-clobbered by Double)');
+test(dblMap.property && dblMap.property.label,
+  'Property after a long-type entry still emits — parse keeps progressing');
+
+// === Regression: javaImports with `static ` prefix and wildcard `.*` ===
+// Java static-method imports look like `'static foo.MLang.AND'`. Wildcard
+// imports look like `'foo.bar.*'`. Both must parse without aborting the
+// outer class body.
+section('Grammar: javaImports static + wildcard tolerated');
+
+var jiSrc =
+  "foam.CLASS({\n" +
+  "  package: 'test',\n" +
+  "  name: 'JI',\n" +
+  "  javaImports: [\n" +
+  "    'java.util.List',\n" +
+  "    'foo.bar.*',\n" +
+  "    'static foo.MLang.AND',\n" +
+  "    'static foo.MLang.EQ'\n" +
+  "  ],\n" +
+  "  properties: [{ name: 'marker' }]\n" +
+  "});";
+var jiMap = axiomGrammar.collectAxiomPositions(jiSrc);
+test(jiMap.property && jiMap.property.marker,
+  'Property after javaImports with static + wildcard still emits');
+
+// === Regression: trailing commas in arrays / object literals must parse ===
+// JS allows trailing commas; the FOAM JSON serializer emits them too.
+// Without `repeatList` tolerating them, the parser bails on the trailing
+// comma and silently drops every downstream property/method emission.
+section('Grammar: trailing commas tolerated in lists');
+
+[
+  ['no trailing comma',     "foam.CLASS({ package: 'x', name: 'Y', requires: ['foam.u2.View'], properties: [{ name: 'a' }] });"],
+  ['trailing in requires',  "foam.CLASS({ package: 'x', name: 'Y', requires: ['foam.u2.View',], properties: [{ name: 'a' }] });"],
+  ['trailing in properties',"foam.CLASS({ package: 'x', name: 'Y', properties: [{ name: 'a' },] });"],
+  ['trailing in methods',
+    "foam.CLASS({ package: 'x', name: 'Y', methods: [function _ignored(){}, function _ignored2(){},], properties: [{ name: 'a' }] });"],
+  ['trailing in implements',"foam.CLASS({ package: 'x', name: 'Y', implements: ['foam.u2.View',], properties: [{ name: 'a' }] });"],
+  ['trailing in imports',   "foam.CLASS({ package: 'x', name: 'Y', imports: ['ctrl?', 'userDAO?',], properties: [{ name: 'a' }] });"],
+  ['trailing in tableCols', "foam.CLASS({ package: 'x', name: 'Y', tableColumns: ['a', 'b',], properties: [{ name: 'a' }] });"],
+  ['trailing in messages',  "foam.CLASS({ package: 'x', name: 'Y', messages: [{ name: 'M', message: 'hi' },], properties: [{ name: 'a' }] });"],
+  ['trailing in sections',  "foam.CLASS({ package: 'x', name: 'Y', sections: [{ name: 's', title: 'S' },], properties: [{ name: 'a' }] });"],
+  ['multi-line + trailing',
+    "foam.CLASS({\n" +
+    "  package: 'x',\n" +
+    "  name: 'Y',\n" +
+    "  requires: [\n" +
+    "    'foam.u2.View',\n" +
+    "    'foam.lang.X',\n" +    // ← trailing comma after this entry
+    "  ],\n" +
+    "  properties: [\n" +
+    "    { name: 'a' },\n" +
+    "    { name: 'b' },\n" +    // ← trailing comma in properties
+    "  ],\n" +
+    "  methods: [\n" +
+    "    function m1() {},\n" +
+    "    function m2() {},\n" + // ← trailing comma in methods
+    "  ]\n" +
+    "});"]
+].forEach(function(row) {
+  var label = row[0], src = row[1];
+  var p = axiomGrammar.collectAxiomPositions(src);
+  test(p.property && p.property.a,
+    label + ': property "a" emits position (parse keeps progressing)');
+});
+
+// And the negative-direction check: a property declared AFTER a list
+// with a trailing comma must still emit, not get swallowed by a parser
+// that bailed out on the comma.
+var afterTrail =
+  "foam.CLASS({\n" +
+  "  package: 'x',\n" +
+  "  name: 'Y',\n" +
+  "  requires: ['foam.u2.View',],\n" +    // trailing comma
+  "  properties: [{ name: 'shouldEmit' }]\n" +
+  "});";
+var afterMap = axiomGrammar.collectAxiomPositions(afterTrail);
+test(afterMap.property && afterMap.property.shouldEmit,
+  'Property after a list with trailing comma still emits its position');
+
+// === Generic foam.<X>(...) detection — covers FSM and any future model type ===
+section('Grammar: generic foam.<X> top-level call');
+
+[
+  ['foam.FSM({ package: ' + Q + 'com.example.fsm' + Q + ', name: ' + Q + 'TrafficLight' + Q + ' });', 'FSM',          'com.example.fsm.TrafficLight'],
+  ['foam.RELATIONSHIP({ sourceModel: ' + Q + 'foam.u2.View' + Q + ', targetModel: ' + Q + 'foam.lang.Property' + Q + ', forwardName: ' + Q + 'a' + Q + ', inverseName: ' + Q + 'b' + Q + ' });', 'RELATIONSHIP', null],
+  ['foam.CLASS({ package: ' + Q + 'com.example' + Q + ', name: ' + Q + 'X' + Q + ' });', 'CLASS', 'com.example.X'],
+  ['foam.ENUM({ package: ' + Q + 'com.example' + Q + ', name: ' + Q + 'E' + Q + ', values: [{name: ' + Q + 'A' + Q + '}] });', 'ENUM', 'com.example.E']
+].forEach(function(row) {
+  var src = row[0], expectedType = row[1], expectedClassId = row[2];
+  test(analyzer.isFoamFile(src),
+    'isFoamFile recognizes foam.' + expectedType + '(...)');
+  var models = cache.parseFileModels(src);
+  test(models.length === 1,
+    'parseFileModels captures one model from foam.' + expectedType);
+  test(models.length === 1 && models[0].type_ === expectedType,
+    'Captured model has type_=' + expectedType);
+  if ( expectedClassId ) {
+    test(models.length === 1 && cache.getClassId(models[0]) === expectedClassId,
+      'Captured classId for foam.' + expectedType + ' is ' + expectedClassId);
+  }
+});
+
+// Hypothetical custom model type — proves the LSP doesn't need to know
+// the call name to track the file. Use a name unlikely to clash.
+var customSrc = "foam.NEWMODELTYPE_X9({ package: " + Q + "com.example.x9" + Q + ", name: " + Q + "Demo" + Q + " });";
+test(analyzer.isFoamFile(customSrc),
+  'isFoamFile recognizes any uppercase foam.<X> call');
+var customModels = cache.parseFileModels(customSrc);
+test(customModels.length === 1 && customModels[0].type_ === 'NEWMODELTYPE_X9',
+  'Generic capture preserves the call name as type_');
+
+// POM is excluded from default isFoamFile (different body shape, no diagnostics)
+var pomSrc = "foam.POM({ name: " + Q + "test" + Q + ", projects: [] });";
+test(! analyzer.isFoamFile(pomSrc),
+  'isFoamFile() (default) excludes foam.POM');
+test(analyzer.isFoamFile(pomSrc, true),
+  'isFoamFile(text, true) includes foam.POM for completion paths');
+
+// === Class-id slot recognition (axiom-driven) ===
+section('Grammar: class-id slot recognition');
+
+// refines: parses as a first-class entry, not just a topLevelKey suggestion
+var refinesSrc = "foam.CLASS({ refines: " + Q + "foam.u2.View" + Q + ", properties: [] });";
+var refinesDiags = diagHandler.handle(refinesSrc);
+test(refinesDiags.filter(function(d) { return d.message.indexOf('Unknown') >= 0 }).length === 0,
+  'refines: with known class produces no Unknown-class diagnostic');
+
+var refinesBogus = "foam.CLASS({ refines: " + Q + "foo.bar.NoSuchClass" + Q + " });";
+var refinesBogusDiags = diagHandler.handle(refinesBogus);
+test(refinesBogusDiags.filter(function(d) { return d.message.indexOf('Unknown class') >= 0 }).length === 1,
+  'refines: with unknown class produces exactly 1 Unknown-class diagnostic');
+
+// sourceModel/targetModel — RELATIONSHIP class-id slots
+var relSrc = "foam.RELATIONSHIP({ sourceModel: " + Q + "foam.u2.View" + Q + ", targetModel: " + Q + "foam.lang.Property" + Q + ", forwardName: " + Q + "a" + Q + ", inverseName: " + Q + "b" + Q + " });";
+test(diagHandler.handle(relSrc).filter(function(d) { return d.message.indexOf('Unknown') >= 0 }).length === 0,
+  'RELATIONSHIP with known sourceModel/targetModel: no diagnostics');
+
+var relBogus = "foam.RELATIONSHIP({ sourceModel: " + Q + "foo.bar.None" + Q + ", targetModel: " + Q + "foam.lang.Property" + Q + ", forwardName: " + Q + "a" + Q + ", inverseName: " + Q + "b" + Q + " });";
+test(diagHandler.handle(relBogus).filter(function(d) { return d.message.indexOf('Unknown class') >= 0 }).length === 1,
+  'RELATIONSHIP with bogus sourceModel: 1 Unknown-class diagnostic');
+
+// class: 'foam.x.Y' — dotted class id parses as classRef, not propType
+var dottedClassSrc = "foam.CLASS({ package: " + Q + "com.example" + Q + ", name: " + Q + "X" + Q + ", properties: [{ class: " + Q + "foam.u2.view.RichChoiceView" + Q + ", name: " + Q + "v" + Q + " }] });";
+var dottedDiags = diagHandler.handle(dottedClassSrc);
+test(dottedDiags.filter(function(d) { return d.message.indexOf('Unknown') >= 0 }).length === 0,
+  'class: with dotted real class produces no Unknown-class diagnostic');
+
+// class: 'String' — short propType still works (no false positive)
+var shortClassSrc = "foam.CLASS({ package: " + Q + "com.example" + Q + ", name: " + Q + "X" + Q + ", properties: [{ class: " + Q + "String" + Q + ", name: " + Q + "s" + Q + " }] });";
+test(diagHandler.handle(shortClassSrc).filter(function(d) { return d.message.indexOf('Unknown') >= 0 }).length === 0,
+  'class: with short propType String produces no diagnostic');
+
+// === Double-quote tolerance + style hint ===
+section('Grammar: double-quote tolerance for class refs');
+
+var dqExtSrc = 'foam.CLASS({ refines: "foam.u2.View" });';
+var dqDiags = diagHandler.handle(dqExtSrc);
+var hints = dqDiags.filter(function(d) { return d.severity === 4 && d.message.indexOf('single quotes') >= 0 });
+test(hints.length === 1,
+  'Double-quoted refines: emits 1 hint diagnostic (severity 4)');
+test(diagHandler.handle(dqExtSrc).filter(function(d) { return d.severity === 1 || d.severity === 2 }).length === 0,
+  'Double-quoted real class: no error/warning, only the style hint');
+
+// `name:` should NOT trigger the class-ref hint when double-quoted
+var dqNameSrc = 'foam.CLASS({ package: "com.example", name: "MyClass" });';
+test(diagHandler.handle(dqNameSrc).filter(function(d) { return d.message.indexOf('single quotes') >= 0 }).length === 0,
+  'Double-quoted name:/package: emits NO class-ref style hint');
+
+// Mismatched quotes (open " close ') still parse leniently
+var mismatchSrc = 'foam.CLASS({ refines: "foam.u2.View' + Q + ' });';
+test(diagHandler.handle(mismatchSrc).length >= 0,
+  'Mismatched-quote refines: parses without throwing (lenient)');
+
+// === Regression: plain-string slots must NOT be misparsed as class refs ===
+// `label`, `documentation`, etc. carry human-readable strings that often
+// start with a capitalized word ("Transaction Details"). An over-broad
+// class-typed slot list would mis-flag these as Unknown-class diagnostics.
+section('Grammar: plain-string slots stay plain');
+
+[
+  ['label',         "'Transaction Details'"],
+  ['documentation', "'Reason Code on the Dispute Case'"],
+  ['help',          "'Choose a Country to filter'"],
+  ['placeholder',   "'Card Number'"]
+].forEach(function(row) {
+  var slotName = row[0], stringValue = row[1];
+  var src = 'foam.CLASS({ package: ' + Q + 'com.example' + Q + ', name: ' + Q + 'X' + Q +
+    ', properties: [{ class: ' + Q + 'String' + Q + ', name: ' + Q + 'p' + Q +
+    ', ' + slotName + ': ' + stringValue + ' }] });';
+  var diags = diagHandler.handle(src);
+  var classDiags = diags.filter(function(d) { return d.message.indexOf('Unknown class') >= 0; });
+  test(classDiags.length === 0,
+    slotName + ': ' + stringValue + ' does NOT trigger Unknown-class diagnostic');
+});
+
+// === Generic class-typed slot detection ===
+section('Grammar: generic class-typed property slots');
+
+var classTypedNames = index.getClassTypedPropertyNames();
+test(classTypedNames.indexOf('of') >= 0, 'getClassTypedPropertyNames includes "of"');
+test(classTypedNames.indexOf('extends') >= 0, 'getClassTypedPropertyNames includes "extends"');
+test(classTypedNames.indexOf('view') >= 0, 'getClassTypedPropertyNames includes "view"');
+test(classTypedNames.indexOf('refines') >= 0, 'getClassTypedPropertyNames includes "refines"');
+test(classTypedNames.indexOf('sourceModel') >= 0, 'getClassTypedPropertyNames includes "sourceModel"');
+test(classTypedNames.indexOf('targetModel') >= 0, 'getClassTypedPropertyNames includes "targetModel"');
+test(classTypedNames.length === 8,
+  'getClassTypedPropertyNames returns the canonical 8 (no over-broad registry walk that would false-positive on `label`/`name`/etc.)');
+['label', 'name', 'documentation'].forEach(function(n) {
+  test(classTypedNames.indexOf(n) === -1,
+    'getClassTypedPropertyNames does NOT include "' + n + '" (would mis-flag plain-string slots)');
+});
+
+// === topLevelKey / propKey / pomKey suggestions carry description hints ===
+section('Grammar: completion suggestions carry hint text');
+
+var hintGrammar = foam.parse.lsp.FoamClassGrammar.create({ index: index });
+var hintSentinel = foam.parse.lsp.CursorSentinel.create();
+
+// Top-level keys with hints — cursor at the start of an empty class body.
+// At this position the explicit-entry suggestions (category='key') fire
+// first; they go through key()/topKey() which both carry hints.
+var topSrc = 'foam.CLASS({\n  \n});';
+var topIns = hintSentinel.insertAt(topSrc, { line: 1, character: 2 });
+var topSugs = hintGrammar.collectSuggestionsAt(topIns.text, topIns.offset);
+var topHinted = topSugs.filter(function(s) {
+  return (s.category === 'topKey' || s.category === 'key') && s.hint;
+});
+test(topHinted.length > 10,
+  'class-body key suggestions ship with hint text (' + topHinted.length + ' have hints)');
+var packageHint = topSugs.filter(function(s) { return s.text && s.text.indexOf('package') === 0; })[0];
+test(packageHint && packageHint.hint && packageHint.hint.length > 0,
+  'package: suggestion has a description hint');
+var refinesHint = topSugs.filter(function(s) { return s.text && s.text.indexOf('refines') === 0; })[0];
+test(refinesHint && refinesHint.hint && refinesHint.hint.toLowerCase().indexOf('refinement') >= 0,
+  'refines: suggestion describes refinement target');
+
+// New RELATIONSHIP-only keys (forwardName/inverseName/cardinality)
+['forwardName', 'inverseName', 'cardinality', 'sourceProperty', 'targetProperty'].forEach(function(k) {
+  var hit = topSugs.filter(function(s) { return s.text && s.text.indexOf(k) === 0; })[0];
+  test(hit, 'topLevelKey alt includes "' + k + '"');
+});
+
+// Property keys carry hints too
+var propSrc = "foam.CLASS({\n  properties: [\n    { \n  ]\n});";
+var propIns = hintSentinel.insertAt(propSrc, { line: 2, character: 6 });
+var propSugs = hintGrammar.collectSuggestionsAt(propIns.text, propIns.offset);
+var propHinted = propSugs.filter(function(s) { return s.category === 'propKey' && s.hint; });
+test(propHinted.length > 10,
+  'propKey suggestions ship with hint text (' + propHinted.length + ' have hints)');
+var classKeyHint = propSugs.filter(function(s) { return s.text && s.text.indexOf('class:') === 0 && s.category === 'propKey'; })[0];
+test(classKeyHint && classKeyHint.hint && classKeyHint.hint.toLowerCase().indexOf('property type') >= 0,
+  'class: prop-key hint mentions property type');
+
+// POM keys carry hints
+var pomSrc = "foam.POM({\n  \n});";
+var pomIns = hintSentinel.insertAt(pomSrc, { line: 1, character: 2 });
+var pomSugs = hintGrammar.collectSuggestionsAt(pomIns.text, pomIns.offset);
+var filesHint = pomSugs.filter(function(s) { return s.text && s.text.indexOf('files:') === 0; })[0];
+test(filesHint && filesHint.hint && filesHint.hint.length > 0,
+  'POM files: suggestion has a description hint');
+var projectsHint = pomSugs.filter(function(s) { return s.text && s.text.indexOf('projects:') === 0; })[0];
+test(projectsHint && projectsHint.hint && projectsHint.hint.length > 0,
+  'POM projects: suggestion has a description hint');
+
+// === Tree-sitter grammar parity (VS Code TextMate + Zed scm) ===
+// The LSP grammar handles foam.<X> generically AND treats refines /
+// sourceModel / targetModel / view / class as class-id slots. The
+// VS Code TextMate grammar and the Zed tree-sitter highlights MUST
+// follow suit so syntax highlighting matches LSP behavior. These
+// regex/text checks pin the grammar files so future grammar tweaks
+// can't silently drop coverage.
+section('Tree-sitter parity: foam.<X> highlight + class-id slots');
+
+var fs_ts  = require('fs');
+var path_ts = require('path');
+
+// VS Code TextMate grammar
+var vscodeJs = JSON.parse(fs_ts.readFileSync(
+  path_ts.join(__dirname, '../../lsp/editors/vscode/syntaxes/foam-js.tmLanguage.json'),
+  'utf8'));
+var vscodePatterns = (vscodeJs.patterns || []).map(function(p) { return p.match || ''; }).join('\n');
+
+test(/foam.+\[A-Z\].*A-Z0-9_/.test(vscodePatterns),
+  'VS Code foam-js grammar matches generic foam.<UPPER>(...) call (not hardcoded names)');
+test(! /CLASS\|ENUM\|INTERFACE\|RELATIONSHIP\)\\\\s\*\(\?=/.test(vscodePatterns) ||
+     /\[A-Z\]\[A-Z0-9_\]\*/.test(vscodePatterns),
+  'VS Code foam-js grammar no longer hardcodes the model-type list');
+
+['refines', 'sourceModel', 'targetModel', 'view', 'class'].forEach(function(slot) {
+  test(vscodePatterns.indexOf(slot) >= 0,
+    'VS Code foam-js grammar lists "' + slot + '" as a class-id slot');
+});
+
+// Zed tree-sitter highlights
+var zedHi = fs_ts.readFileSync(
+  path_ts.join(__dirname, '../../lsp/editors/zed-foam3/languages/foam-javascript/highlights.scm'),
+  'utf8');
+
+test(/#match\?\s+@function\.macro\s+"\^\[A-Z\]\[A-Z0-9_\]\*\$"/.test(zedHi) ||
+     /\[A-Z\]\[A-Z0-9_\]\*/.test(zedHi),
+  'Zed foam-javascript highlights match generic foam.<UPPER> call');
+test(/foam.*function\.macro/.test(zedHi.replace(/\s+/g, ' ')) ||
+     /\(\#eq\?\s+@\S+\s+"foam"\)/.test(zedHi),
+  'Zed foam-javascript highlights bind the receiver `foam` for the macro');
+['refines', 'sourceModel', 'targetModel', 'view', 'class'].forEach(function(slot) {
+  test(new RegExp('"' + slot + '"').test(zedHi),
+    'Zed foam-javascript highlights list "' + slot + '" as a class-id slot');
+});
+
 // === Migration coverage: buildLocationAtProperty uses the grammar path ===
 

--- a/tools/tests/lsp/hover.js
+++ b/tools/tests/lsp/hover.js
@@ -197,5 +197,104 @@ if ( index.classExists(SFV) ) {
     'Message go-to-def: has a valid range');
 }
 
+// === Axiom-key hover from AxiomCatalog ===
+// Single source of truth: HoverHandler reads from AxiomCatalog, the
+// same place FoamClassGrammar pulls suggestion hints from. So hovering
+// an axiom key (`requires:`, `sections:`, `messages:`, `searchColumns:`,
+// `properties:`, etc.) shows the same text the completion popup would.
+section('HoverHandler — axiom-key hover from AxiomCatalog');
+
+var axiomSrc =
+  "foam.CLASS({\n" +
+  "  package: 'test',\n" +
+  "  name: 'A',\n" +
+  "  extends: 'foam.lang.FObject',\n" +
+  "  requires: [],\n" +
+  "  imports: [],\n" +
+  "  properties: [],\n" +
+  "  methods: [],\n" +
+  "  actions: [],\n" +
+  "  listeners: [],\n" +
+  "  messages: [],\n" +
+  "  sections: [],\n" +
+  "  tableColumns: [],\n" +
+  "  searchColumns: [],\n" +
+  "  javaImports: [],\n" +
+  "  documentation: 'doc'\n" +
+  "});";
+
+[
+  'package', 'name', 'extends', 'requires', 'imports', 'properties',
+  'methods', 'actions', 'listeners', 'messages', 'sections',
+  'tableColumns', 'searchColumns', 'javaImports', 'documentation'
+].forEach(function(slot) {
+  var aLines = axiomSrc.split('\n');
+  var ln = -1, cl = -1;
+  for ( var i = 0 ; i < aLines.length ; i++ ) {
+    var idx = aLines[i].indexOf(slot + ':');
+    if ( idx !== -1 ) { ln = i; cl = idx; break; }
+  }
+  if ( ln === -1 ) {
+    test(false, 'fixture missing slot ' + slot);
+    return;
+  }
+  // Cursor in the middle of the axiom key
+  var h = hoverHandler.handle(axiomSrc, { line: ln, character: cl + 2 });
+  test(h && h.contents && typeof h.contents.value === 'string' && h.contents.value.indexOf(slot) !== -1,
+    'Hover on `' + slot + ':` returns axiom description');
+});
+
+// Negative case: cursor on a value (not a key) should not show axiom hover
+var noKeySrc = "foam.CLASS({ package: 'x', name: 'Y' });";
+var nameValueHover = hoverHandler.handle(noKeySrc, { line: 0, character: noKeySrc.indexOf("'Y'") + 2 });
+// This should not be the axiom-key hover ("**name** — Class name (CamelCase)")
+var noKeyOk = ! nameValueHover || ! (nameValueHover.contents && nameValueHover.contents.value && nameValueHover.contents.value.indexOf('Class name (CamelCase)') !== -1);
+test(noKeyOk, 'Cursor on a string value does NOT trigger axiom-key hover');
+
+// === Scope-aware axiom hover ===
+// The same key (e.g. `javaCode`, `name`) appears at multiple scopes:
+// top-level, per-property, per-method, per-action, etc. The hover
+// must use the scope that matches the cursor's container, not the
+// first scope alphabetically. Otherwise hovering `javaCode:` inside a
+// methods: [{ }] block would wrongly say "Class-level Java code".
+section('HoverHandler — scope-aware axiom hover');
+
+var BTQ = String.fromCharCode(96);
+var scopeCases = [
+  // [label, src, line, col, expected substring in hover]
+  ['javaCode @ top-level',
+   "foam.CLASS({\n  javaCode: " + BTQ + "static {}" + BTQ + "\n});",
+   1, 4, 'Class-level'],
+  ['javaCode @ method',
+   "foam.CLASS({\n  methods: [\n    {\n      javaCode: " + BTQ + "x" + BTQ + "\n    }\n  ]\n});",
+   3, 8, 'Java implementation body'],
+  ['javaCode @ property',
+   "foam.CLASS({\n  properties: [\n    { javaCode: " + BTQ + "x" + BTQ + " }\n  ]\n});",
+   2, 8, 'Java statement'],
+  ['name @ section',
+   "foam.CLASS({\n  sections: [\n    { name: 's' }\n  ]\n});",
+   2, 8, 'Section identifier'],
+  ['label @ action',
+   "foam.CLASS({\n  actions: [\n    { label: 'L' }\n  ]\n});",
+   2, 8, 'action button'],
+  ['name @ message',
+   "foam.CLASS({\n  messages: [\n    { name: 'M' }\n  ]\n});",
+   2, 8, 'Message identifier'],
+  ['name @ enum value',
+   "foam.ENUM({\n  values: [\n    { name: 'V' }\n  ]\n});",
+   2, 8, 'Enum value identifier'],
+  ['code @ listener',
+   "foam.CLASS({\n  listeners: [\n    { code: function() {} }\n  ]\n});",
+   2, 8, 'listener body']
+];
+
+scopeCases.forEach(function(c) {
+  var label = c[0], src = c[1], ln = c[2], col = c[3], needle = c[4];
+  var h = hoverHandler.handle(src, { line: ln, character: col });
+  var got = h && h.contents && h.contents.value || '';
+  test(got.indexOf(needle) !== -1,
+    label + ' hover mentions "' + needle + '" (got: ' + got.slice(0, 90) + ')');
+});
+
 // === GRAMMAR-DRIVEN AXIOM POSITIONS ===
 

--- a/tools/tests/lsp/java.js
+++ b/tools/tests/lsp/java.js
@@ -529,5 +529,288 @@ var bareTypes = tt2.getVariableTypes(bareArrow, { line: 5, character: 55 }, bare
 test(bareTypes.r === 'foam.mlang.sink.Count',
   '.then(r => …) bare-arrow param typed from preceding .select');
 
+// === JAVA BODY PARSING: parseFile + parseBlock ===
+// JavaGrammar emits position-tagged tokens for method calls, casts, new
+// expressions, and local variable declarations inside method bodies and
+// javaCode template literals. These tests pin the behavior so future
+// grammar changes don't silently regress the body-parsing feature.
+
+section('JavaParser: method-body extraction');
+
+var JavaParser = foam.lookup('foam.parse.lsp.JavaParser');
+var jParser = JavaParser.create();
+
+// A representative javaCode block — patterns mirror real ptv3 FSM/javaCode
+// usage but with generic class names so the test stays foam-only.
+var javaBody = [
+  'Logger logger = Loggers.logger(x, this, "demo");',
+  'Config config = registry.findConfig(x);',
+  'DAO theDAO = (DAO) x.get("demoDAO");',
+  'Parser p = new Parser(Demo.getOwnClassInfo());',
+  'if ( status == DemoLifecycle.QUEUED ) return;'
+].join('\n');
+
+var jr = jParser.parseFile(javaBody);
+test(jr.calls.length === 4,
+  'parseFile: 4 method calls extracted (Loggers.logger, registry.findConfig, x.get, Demo.getOwnClassInfo)');
+test(jr.calls.some(function(c) { return c.receiver === 'Loggers' && c.methodName === 'logger'; }),
+  'parseFile: Loggers.logger captured');
+test(jr.calls.some(function(c) { return c.receiver === 'registry' && c.methodName === 'findConfig'; }),
+  'parseFile: registry.findConfig captured (lowercase receiver)');
+test(! jr.calls.some(function(c) { return c.methodName === 'QUEUED'; }),
+  'parseFile: enum constants are NOT false-positive method calls');
+test(jr.casts.length === 1 && jr.casts[0].typeName === 'DAO',
+  'parseFile: 1 cast (DAO), no false positives from `(x)` argument lists');
+test(jr.news.length === 1 && jr.news[0].typeName === 'Parser',
+  'parseFile: 1 newExpr (new Parser)');
+test(jr.locals.length === 4,
+  'parseFile: 4 local declarations');
+test(jr.locals.some(function(l) { return l.typeName === 'Logger' && l.varName === 'logger'; }),
+  'parseFile: Logger logger captured');
+test(jr.locals.some(function(l) { return l.typeName === 'Parser' && l.varName === 'p'; }),
+  'parseFile: Parser p captured (single-char var name)');
+
+// parseBlock offsets — same body but pretend it lives at line 10 col 4
+section('JavaParser: parseBlock offsets');
+
+var jb = jParser.parseBlock(javaBody, 10, 4);
+test(jb.calls.length === 4,
+  'parseBlock: same call count as parseFile');
+test(jb.calls.every(function(c) { return c.line >= 10; }),
+  'parseBlock: all call lines shifted by baseLine');
+var firstLine0Call = jb.calls.filter(function(c) { return c.line === 10; });
+// First line cols are shifted by baseCol (4)
+test(firstLine0Call.length === 0 || firstLine0Call.every(function(c) { return c.col >= 4; }),
+  'parseBlock: line-0 calls shifted by baseCol');
+test(jb.locals.every(function(l) { return l.line >= 10; }),
+  'parseBlock: locals lines shifted by baseLine');
+
+// Multi-line javaCode mirroring a real javaCode: backtick block. The block
+// lives at line 5 col 8 (typical 4-space FOAM indent + javaCode: prefix).
+var multiBody = [
+  'String name = config.getName();',
+  'if ( SafetyUtil.isEmpty(name) ) return null;',
+  'return name;'
+].join('\n');
+var multi = jParser.parseBlock(multiBody, 5, 8);
+test(multi.calls.length >= 2,
+  'parseBlock multi-line: >= 2 calls');
+// First-line call (config.getName) on line 5 with col offset
+var lineFiveCalls = multi.calls.filter(function(c) { return c.line === 5; });
+test(lineFiveCalls.length === 1 && lineFiveCalls[0].col >= 8,
+  'parseBlock multi-line: first-line call honors baseCol');
+// Second-line call (SafetyUtil.isEmpty) — line 6, recv col reset (no baseCol)
+// recv `SafetyUtil` is at source col 5; if buggy and offset, would be 13.
+var lineSixCalls = multi.calls.filter(function(c) { return c.line === 6; });
+test(lineSixCalls.length === 1 && lineSixCalls[0].recvCol === 5,
+  'parseBlock multi-line: subsequent-line recvCol is NOT offset by baseCol (raw col 5)');
+
+// === SemanticTokenHandler: method-name tokens inside javaCode ===
+// SemanticTokenHandler now consumes JavaParser to surface methodName
+// tokens (type 8) for receiver.method(args) patterns inside javaCode
+// blocks. Without this, method names were invisible to syntax highlighting.
+section('SemanticTokenHandler: method tokens inside javaCode');
+
+var BTQ = String.fromCharCode(96);
+var stSrc = [
+  'foam.CLASS({',
+  '  package: ' + Q + 'com.example' + Q + ',',
+  '  name: ' + Q + 'STDemo' + Q + ',',
+  '  javaImports: [' + Q + 'foam.core.logger.Loggers' + Q + ',' + Q + 'foam.core.logger.Logger' + Q + '],',
+  '  methods: [',
+  '    {',
+  '      name: ' + Q + 'doIt' + Q + ',',
+  '      javaCode: ' + BTQ + 'Logger logger = Loggers.logger(x, this, "demo"); logger.info("hi");' + BTQ,
+  '    }',
+  '  ]',
+  '})'
+].join('\n');
+
+var stTokens = semanticHandler.handle(stSrc);
+test(stTokens && stTokens.data && stTokens.data.length > 0,
+  'SemanticTokenHandler returns tokens for foam.CLASS with javaCode');
+
+// The token stream is delta-encoded by the LSP. Decode to absolute positions
+// and look for any token of type 8 (method) — proves Java method-call
+// extraction is wired into the highlighter.
+var streamData = stTokens.data || [];
+var hasMethodToken = false;
+var lineCursor = 0, colCursor = 0;
+for ( var ti = 0 ; ti < streamData.length ; ti += 5 ) {
+  var deltaLine = streamData[ti], deltaCol = streamData[ti+1];
+  var len = streamData[ti+2], type = streamData[ti+3];
+  if ( deltaLine > 0 ) { lineCursor += deltaLine; colCursor = deltaCol; }
+  else { colCursor += deltaCol; }
+  if ( type === 8 ) { hasMethodToken = true; break; }
+}
+test(hasMethodToken,
+  'SemanticTokenHandler emits at least one method token (type 8) for `Loggers.logger(...)` inside javaCode');
+
+// === var-decl type inference (Java 10+ `var` keyword) ===
+// `var <name> = ...` is invisible to the upper-typed `localDecl` rule.
+// JavaParser infers the type from the RHS shape: `new T(...)`, `(T) ...`,
+// `T.staticMethod(`, or `T.class`. Each form gets a regression test so
+// future RHS-pattern additions can't silently regress.
+section('JavaParser: var-decl type inference');
+
+var varBody = [
+  'var a = new Foo();',                                    // new T(...)
+  'var b = (Bar) src.something(x);',                       // (T) ...
+  'a.doSomething(x);',
+  'var c = Baz.create();',                                 // T.staticMethod(
+  'var d = Demo.class;',                                   // T.class literal
+  'var e = (Quux<String>) registry.get("q");',             // generics in cast
+  'a = (Foo) src.refresh(x);'                              // reassignment, not decl
+].join('\n');
+
+var vr = jParser.parseFile(varBody);
+var byVar = {};
+vr.locals.forEach(function(l) { byVar[l.varName] = l; });
+
+test(byVar.a && byVar.a.typeName === 'Foo' && byVar.a.inferred_,
+  'var a = new Foo() → typeName=Foo (inferred from new)');
+test(byVar.b && byVar.b.typeName === 'Bar' && byVar.b.inferred_,
+  'var b = (Bar) ... → typeName=Bar (inferred from cast)');
+test(byVar.c && byVar.c.typeName === 'Baz' && byVar.c.inferred_,
+  'var c = Baz.create() → typeName=Baz (inferred from static call)');
+test(byVar.d && byVar.d.typeName === 'Demo.class' && byVar.d.inferred_,
+  'var d = Demo.class → typeName=Demo.class (inferred from class literal)');
+test(byVar.e && byVar.e.typeName === 'Quux' && byVar.e.inferred_,
+  'var e = (Quux<String>) ... → typeName=Quux (cast strips generics)');
+
+// Reassignment to a var (without `var` keyword) must NOT be picked up as
+// a new local. `a = (Foo) ...` has only one `a` entry — from the original
+// `var a = new Foo()` line.
+var aLocals = vr.locals.filter(function(l) { return l.varName === 'a'; });
+test(aLocals.length === 1,
+  'Reassignment `a = (Foo) ...` is not added as a duplicate local');
+
+// Method calls on a var-declared receiver still resolve in the calls list.
+// `a.doSomething(x)` produces a qualifiedCall with receiver=a.
+test(vr.calls.some(function(c) { return c.receiver === 'a' && c.methodName === 'doSomething'; }),
+  'qualifiedCall captured on a var-declared receiver (a.doSomething)');
+
+// === resolveJavaVariableType: var-decl + cycle guard ===
+// `var x = new T()` is the most common Java 10+ pattern in javaCode blocks
+// — without this, hovering on a var-typed receiver couldn't resolve the
+// method receiver's class. The cycle guard tests that mutually-referential
+// var-decls (`var a = b.x(); var b = a.y();`) terminate cleanly.
+section('CursorAnalyzer: var-decl resolution');
+
+var fObjModel = { package: 'com.example', name: 'X', javaImports: ['foam.lang.FObject'] };
+
+// resolveJavaTypeName returns either the short or fully-qualified id
+// depending on what foam.isRegistered() answers — both are valid; the
+// test only asserts a non-null resolution that includes "FObject".
+var newT = 'var t = new FObject();\nt.toString();';
+var newTType = analyzer.resolveJavaVariableType(newT, { line: 1, character: 0 }, 't', fObjModel, index);
+test(newTType && newTType.indexOf('FObject') >= 0,
+  'resolveJavaVariableType: var t = new FObject() resolves to an FObject id (got ' + newTType + ')');
+
+var castT = 'var c = (FObject) src.something();\nc.toString();';
+var castTType = analyzer.resolveJavaVariableType(castT, { line: 1, character: 0 }, 'c', fObjModel, index);
+test(castTType && castTType.indexOf('FObject') >= 0,
+  'resolveJavaVariableType: var c = (FObject) ... resolves to an FObject id (got ' + castTType + ')');
+
+var castGenerics = 'var c = (FObject<String>) src.something();\nc.toString();';
+var castGenType = analyzer.resolveJavaVariableType(castGenerics, { line: 1, character: 0 }, 'c', fObjModel, index);
+test(castGenType && castGenType.indexOf('FObject') >= 0,
+  'resolveJavaVariableType: cast with generics still resolves to an FObject id');
+
+// Cycle: a depends on b, b depends on a — must terminate, not infinite-loop.
+var cyclic = 'var a = b.foo();\nvar b = a.bar();\na.method();';
+var startCyc = Date.now();
+var cycResult = analyzer.resolveJavaVariableType(cyclic, { line: 2, character: 0 }, 'a', fObjModel, index);
+var elapsedCyc = Date.now() - startCyc;
+test(cycResult === null,
+  'resolveJavaVariableType cycle (a↔b mutual references) returns null, no infinite recursion');
+test(elapsedCyc < 1000,
+  'resolveJavaVariableType cycle terminates fast (took ' + elapsedCyc + 'ms)');
+
+// Self-reference: `var x = x.method();` — pathological but must not loop.
+var selfRef = 'var x = x.method();\nx.toString();';
+var startSelf = Date.now();
+var selfResult = analyzer.resolveJavaVariableType(selfRef, { line: 1, character: 0 }, 'x', fObjModel, index);
+var elapsedSelf = Date.now() - startSelf;
+test(elapsedSelf < 1000,
+  'resolveJavaVariableType self-reference terminates fast (took ' + elapsedSelf + 'ms)');
+
+// === FOAM method `args:` parameter resolution ===
+// In FOAM models, method parameters are declared in the `args:` axiom,
+// not in the javaCode body. Without recognizing this, hovering or
+// going-to-def on a parameter receiver (e.g., `disputeCase.getId()`)
+// in the body would fail to resolve.
+section('CursorAnalyzer: FOAM method args parameter resolution');
+
+var argsStringForm = [
+  'foam.CLASS({',
+  '  package: ' + Q + 'com.example' + Q + ',',
+  '  name: ' + Q + 'D' + Q + ',',
+  '  methods: [',
+  '    {',
+  '      name: ' + Q + 'doIt' + Q + ',',
+  '      args: ' + Q + 'X x, FObject obj' + Q + ',',
+  '      javaCode: `obj.toString();`',
+  '    }',
+  '  ]',
+  '})'
+].join('\n');
+var argsLines = argsStringForm.split('\n');
+for ( var ai = 0 ; ai < argsLines.length ; ai++ ) {
+  if ( argsLines[ai].indexOf('obj.toString') !== -1 ) {
+    var argType = analyzer.resolveJavaVariableType(argsStringForm,
+      { line: ai, character: 8 }, 'obj', { package: 'com.example', name: 'D' }, index);
+    test(argType && argType.indexOf('FObject') >= 0,
+      'String-form args: parameter `obj` resolves to FObject (got ' + argType + ')');
+  }
+}
+
+var argsArrayForm = [
+  'foam.CLASS({',
+  '  package: ' + Q + 'com.example' + Q + ',',
+  '  name: ' + Q + 'D' + Q + ',',
+  '  methods: [',
+  '    {',
+  '      name: ' + Q + 'doIt' + Q + ',',
+  '      args: [{ name: ' + Q + 'obj' + Q + ', javaType: ' + Q + 'FObject' + Q + ' }],',
+  '      javaCode: `obj.toString();`',
+  '    }',
+  '  ]',
+  '})'
+].join('\n');
+var arrLines = argsArrayForm.split('\n');
+for ( var ai2 = 0 ; ai2 < arrLines.length ; ai2++ ) {
+  if ( arrLines[ai2].indexOf('obj.toString') !== -1 ) {
+    var arrType = analyzer.resolveJavaVariableType(argsArrayForm,
+      { line: ai2, character: 8 }, 'obj', { package: 'com.example', name: 'D' }, index);
+    test(arrType && arrType.indexOf('FObject') >= 0,
+      'Array-form args: parameter `obj` resolves to FObject (got ' + arrType + ')');
+  }
+}
+
+// Generics in args param type strip cleanly: `List<String> items` → List
+var argsGenerics = [
+  'foam.CLASS({',
+  '  package: ' + Q + 'com.example' + Q + ',',
+  '  name: ' + Q + 'D' + Q + ',',
+  '  methods: [',
+  '    {',
+  '      name: ' + Q + 'doIt' + Q + ',',
+  '      args: ' + Q + 'List<String> items, FObject obj' + Q + ',',
+  '      javaCode: `obj.toString();`',
+  '    }',
+  '  ]',
+  '})'
+].join('\n');
+var genLines = argsGenerics.split('\n');
+for ( var ai3 = 0 ; ai3 < genLines.length ; ai3++ ) {
+  if ( genLines[ai3].indexOf('obj.toString') !== -1 ) {
+    var genType = analyzer.resolveJavaVariableType(argsGenerics,
+      { line: ai3, character: 8 }, 'obj', { package: 'com.example', name: 'D' }, index);
+    test(genType && genType.indexOf('FObject') >= 0,
+      'args with generics on a sibling param: still resolves obj to FObject');
+  }
+}
+
 // === MESSAGE AXIOM: hover + go-to-definition ===
 

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -436,28 +436,30 @@ section('JRL embedded block — triple-quote + escaped double-quote');
 var jrlH2 = foam.parse.lsp.handlers.JrlHandler.create({ index: index });
 jrlH2.buildJournalClassMap();
 
-// Escaped double-quoted client: "client": "{\"of\":\"com.paytic.Transaction\"}"
+// Escaped double-quoted client: "client": "{\"of\":\"com.example.Transaction\"}"
+// Class name is intentionally generic (com.example.*) — do not introduce
+// any internal/business-domain names into the FOAM3 test suite.
 var escSrc = [
   'p({',
   '  "class": "foam.core.boot.CSpec",',
   '  "name": "txDAO",',
-  '  "client": "{\\"of\\":\\"com.paytic.Transaction\\"}"',
+  '  "client": "{\\"of\\":\\"com.example.Transaction\\"}"',
   '})'
 ].join('\n');
 // Cursor inside the empty space after `"of":"` (line 3)
-var escLine = '  "client": "{\\"of\\":\\"com.paytic.Transaction\\"}"';
+var escLine = '  "client": "{\\"of\\":\\"com.example.Transaction\\"}"';
 // Test detection fires for escaped form
 var escCtx = jrlH2.detectEmbeddedBlockContext_(escSrc, { line: 3, character: 30 });
 test(escCtx && escCtx.key === 'client' && escCtx.escaped === true,
   'detectEmbeddedBlockContext_: detects escaped client form');
-test(escCtx && escCtx.content.indexOf('"of":"com.paytic.Transaction"') !== -1,
+test(escCtx && escCtx.content.indexOf('"of":"com.example.Transaction"') !== -1,
   'detectEmbeddedBlockContext_: unescapes the content correctly');
 
 // Triple-quote client still works through the unified detector
 var tripleClient = [
   'p({',
   '  "client": """',
-  '    { "of": "com.paytic.Transaction" }',
+  '    { "of": "com.example.Transaction" }',
   '  """',
   '})'
 ].join('\n');
@@ -581,16 +583,18 @@ var c1 = jrlH3.handleCompletion(simpleScript, { line: 2, character: 20 });
 test(c1.items.length > 5,
   'serviceScript completion: simple `return foam.dao.` yields class-id matches');
 
-// Java-like builder chain
+// Java-like builder chain. Use a generic com.example.* prefix so the test
+// stays foam-only — completion items list is content-agnostic; we just
+// assert that the handler returns an items array without throwing.
 var complexScript = [
   'p({',
   '  "serviceScript": """',
-  '    return new foam.dao.EasyDAO.Builder(x).setOf(com.paytic.',
+  '    return new foam.dao.EasyDAO.Builder(x).setOf(com.example.',
   '  """',
   '})'
 ].join('\n');
-var c2 = jrlH3.handleCompletion(complexScript, { line: 2, character: 62 });
-test(c2.items.length >= 0 /* zero is acceptable when no classes match com.paytic in this env */,
+var c2 = jrlH3.handleCompletion(complexScript, { line: 2, character: 63 });
+test(c2.items.length >= 0 /* zero is acceptable when no classes match com.example in this env */,
   'serviceScript completion: Java-style builder chain still returns an items array');
 
 // Escaped-double-quote serviceScript (rarer but valid)

--- a/tools/tests/lsp/navigation.js
+++ b/tools/tests/lsp/navigation.js
@@ -382,6 +382,36 @@ try {
   try { tmpFs.unlinkSync(tmpFile2); } catch ( e ) {}
 }
 
+// === buildLocationAtMethod unconstrained grammar fallback ===
+// When the grammar's axiom map for a specific classId yields no match
+// (e.g., the supplied classId doesn't appear in the file), the handler
+// must still try the unconstrained grammar map. This relies purely on
+// FoamClassGrammar.methodNameValue emissions — no regex.
+var tmpFile3 = tmpPath2.join(tmpOs.tmpdir(), 'lsp-method-unconstrained.js');
+tmpFs.writeFileSync(tmpFile3,
+  "foam.CLASS({\n" +
+  "  package: 'test',\n" +
+  "  name: 'Unconstrained',\n" +
+  "  methods: [\n" +
+  "    {\n" +
+  "      name: 'normalize',\n" +
+  "      args: 'X x',\n" +
+  "      type: 'String',\n" +
+  "      javaCode: " + String.fromCharCode(96) + "return \"hi\";" + String.fromCharCode(96) + "\n" +
+  "    }\n" +
+  "  ]\n" +
+  "});\n");
+try {
+  // Pass a wrong classId. The class-range constraint check fails, but
+  // the unconstrained grammar map still has `normalize` — handler must
+  // return that position rather than file top.
+  var rxLoc = defHandler.buildLocationAtMethod(tmpFile3, 'wrong.ClassId', 'normalize');
+  test(rxLoc && rxLoc.range && rxLoc.range.start.line === 5,
+    'buildLocationAtMethod unconstrained fallback lands on method-name line (got line ' + (rxLoc && rxLoc.range && rxLoc.range.start.line) + ')');
+} finally {
+  try { tmpFs.unlinkSync(tmpFile3); } catch ( e ) {}
+}
+
 // === Migration coverage: LIB + POM eval recovery ===
 
 


### PR DESCRIPTION
Support JS only modelled tests via the 'source' property

JS only modelled tests which do not support java (perhaps because of base classes),
extend foam.core.test.JSTest,
and entries in tests.jrl should be configured as follows:
class: foam.core.test.JSTest
source: modelled test class id.
If the class id is used for the class: property then the model will
fail journal replay with a missing Java class.

Manually tested from the UI. Both JS tests with 'code' and those without 'code', but with 'source' configured. 