### PR TITLE
[DO_NOT_MERGE] Refactor dashboard chart agents to displaySink composition

### DIFF
--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -6,18 +6,18 @@
 
 /**
  * Dashboard DAOAgents for FLOW Integration
- * 
+ *
  * These agents adapt FOAM dashboard components to work with FLOW and DAOPrompt2.
- * They bridge the gap between FOAM's widget-based dashboard system and FLOW's 
+ * They bridge the gap between FOAM's widget-based dashboard system and FLOW's
  * command-based interactive document system.
  */
 
 foam.CLASS({
   package: 'foam.core.reflow.dashboard',
   name: 'ColorMappingMixin',
-  
+
   documentation: 'Mixin providing centralized color management for charts with user control over color mappings',
-  
+
   properties: [
     {
       class: 'StringArray',
@@ -31,9 +31,9 @@ foam.CLASS({
       }
     }
   ],
-  
+
   methods: [
-    
+
     function addColorMappingToE(e) {
       // Helper method to add color controls to UI
       e.start('div').style({marginBottom: '10px'})
@@ -240,12 +240,12 @@ foam.CLASS({
   name: 'ChartDisplayMixin',
 
   documentation: 'Mixin for common chart display options',
-  
+
   requires: [
     'foam.core.reflow.dashboard.LegendPosition',
     'foam.core.reflow.dashboard.MetricAlignment'
   ],
-  
+
   properties: [
     {
       class: 'Enum',
@@ -276,7 +276,7 @@ foam.CLASS({
             step: 10,
             onKey: true
           },
-          { class: 'foam.u2.view.IntView', onKey: true } 
+          { class: 'foam.u2.view.IntView', onKey: true }
         ]
       }
     },
@@ -332,7 +332,7 @@ foam.CLASS({
       }
     }
   ],
-  
+
   methods: [
     function addChartDisplayToE(e) {
       var self = this;
@@ -372,9 +372,7 @@ foam.CLASS({
   name: 'DashboardBarChartDAOAgent',
   extends: 'foam.core.reflow.GroupByDAOAgent',
   mixins: [
-    'foam.core.reflow.dashboard.ColorMappingMixin',
-    'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin',
-    'foam.core.reflow.dashboard.ChartDisplayMixin'
+    'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin'
   ],
 
   requires: [
@@ -382,231 +380,92 @@ foam.CLASS({
     'foam.core.reflow.ReactiveSectionedDetailView'
   ],
 
-  sections: [
-    {
-      name: 'dataConfig',
-      title: 'Data Configuration',
-      order: 1,
-      collapsable: true,
-      properties: ['prop', 'sink', 'topN', 'periodCount', 'includeOthers', 'sortOrder', 'othersLabel']
-    },
-    {
-      name: 'barChart',
-      title: 'Bar Chart Settings',
-      order: 2,
-      collapsable: true,
-      properties: ['horizontal', 'barThickness', 'timeUnit', 'showGridLines']
-    },
-    {
-      name: 'axisLabels',
-      title: 'Axis Labels',
-      order: 3,
-      collapsable: true,
-      properties: ['xAxisLabel', 'yAxisLabel']
-    },
-    {
-      name: 'display',
-      title: 'Display Options',
-      order: 4,
-      collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
-    },
-    {
-      name: 'colors',
-      title: 'Color Configuration',
-      order: 5,
-      collapsable: true,
-      properties: ['colors']
-    }
-  ],
-
   properties: [
     {
-      name: 'sink',
-      view: {
-        class: 'foam.core.reflow.SinkView',
-        choice: 'foam.core.reflow.CountDAOAgent',
-        disabledTypes: [ 'structure', 'format', 'chart' ]
-      }
+      class: 'FObjectProperty',
+      of: 'foam.core.reflow.dashboard.DashboardBarSink',
+      name: 'displaySink',
+      hidden: true,
+      factory: function() { return this.DashboardBarSink.create({}, this); }
     },
-    // Inherited from GroupByDAOAgent: prop, sink, groupLimit, sortOrder, includeOthers, othersLabel
-    // Inherited from TimeSeriesGapFillingMixin: periodCount (visibility defined below)
-    // Override topN visibility to hide when prop is a date (mutually exclusive with periodCount)
-    {
-      name: 'topN',
-      visibility: function(prop) {
-        // Hide topN when property is a date/time (use periodCount instead)
-        var isDateProp = prop && prop.delegate &&
-          (foam.lang.Date.isInstance(prop.delegate) || foam.lang.DateTime.isInstance(prop.delegate));
-        return isDateProp ? foam.u2.DisplayMode.HIDDEN : foam.u2.DisplayMode.RW;
-      }
-    },
-    // Define visibility for periodCount (from mixin)
-    {
-      name: 'periodCount',
-      visibility: function(prop) {
-        // Only show for date/time properties
-        var isDateProp = prop && prop.delegate &&
-          (foam.lang.Date.isInstance(prop.delegate) || foam.lang.DateTime.isInstance(prop.delegate));
-        return isDateProp ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    // From mixins: colors, chart display options
-    {
-      class: 'Enum',
-      of: 'foam.core.reflow.dashboard.TimeUnit',
-      name: 'timeUnit',
-      label: 'Time Unit',
-      value: 'DAY',
-      section: 'barChart',
-
-      help: 'Time unit for X-axis when using date/time properties',
-      visibility: function(prop) {
-        /// hidden for now (its not working due to our new propertyexprview returning values as strings instead of dates)
-        return foam.u2.DisplayMode.HIDDEN;
-        // return prop && (foam.lang.Date.isInstance(prop) || foam.lang.DateTime.isInstance(prop)) ?
-        //   foam.u2.DisplayMode.RW :
-        //   foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    {
-      class: 'Boolean',
-      name: 'horizontal',
-      label: 'Horizontal Bars',
-      section: 'barChart',
-      value: false
-    },
-    {
-      class: 'Float',
-      name: 'barThickness',
-      label: 'Bar Thickness',
-      section: 'barChart',
-      help: 'Thickness of bars (0 = auto)'
-    },
-    {
-      class: 'String',
-      name: 'xAxisLabel',
-      label: 'X-Axis Label',
-      section: 'axisLabels'
-    },
-    {
-      class: 'String',
-      name: 'yAxisLabel',
-      label: 'Y-Axis Label',
-      section: 'axisLabels'
-    },
-    {
-      class: 'Boolean',
-      name: 'showGridLines',
-      label: 'Show Grid Lines',
-      section: 'barChart',
-      value: true
-    }
+    // Inherited DAO-layer props → forward to displaySink
+    { name: 'prop', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.arg1 = n; } },
+    { name: 'sink', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.displaySink.arg2 = n.createSink();
+      } },
+    { name: 'topN', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.topN = n; } },
+    { name: 'sortOrder', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.sortOrder = n; } },
+    { name: 'includeOthers', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.includeOthers = n; } },
+    { name: 'othersLabel', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.othersLabel = n; } },
+    { name: 'groupLimit', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.groupLimit = n; } },
+    // Legacy flat-format shims (hidden, setter-only) — forward to displaySink
+    { name: 'timeUnit', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.timeUnit = v; } },
+    { name: 'horizontal', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.horizontal = v; } },
+    { name: 'barThickness', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.barThickness = v; } },
+    { name: 'xAxisLabel', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.xAxisLabel = v; } },
+    { name: 'yAxisLabel', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.yAxisLabel = v; } },
+    { name: 'showGridLines', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showGridLines = v; } },
+    { name: 'colors', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.colors = v; } },
+    { name: 'alignment', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.alignment = v; } },
+    { name: 'maintainAspectRatio', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.maintainAspectRatio = v; } },
+    { name: 'height', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.height = v; } },
+    { name: 'showLegend', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showLegend = v; } },
+    { name: 'legendPosition', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendPosition = v; } },
+    { name: 'showTooltips', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltips = v; } },
+    { name: 'showTooltipSum', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltipSum = v; } },
+    { name: 'animate', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animate = v; } },
+    { name: 'animationDuration', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animationDuration = v; } }
   ],
 
   methods: [
+    function init() {
+      this.SUPER();
+      var self = this;
+      // periodCount comes from TimeSeriesGapFillingMixin; forward to sink.
+      if ( this.periodCount ) self.displaySink.periodCount = self.periodCount;
+      this.onDetach(this.periodCount$.sub(function() {
+        self.displaySink.periodCount = self.periodCount;
+      }));
+    },
+
     function getDatePropertyForFiltering() {
-      // For bar charts, the date property is 'prop'
-      return this.prop;
+      return this.displaySink.arg1;
     },
 
     function createSink() {
-      // Apply date range filter if periodCount is enabled
       this.applyDateRangeFilter();
-
-      // Create sink with GroupBy configuration inherited from parent
-      // Use the sink from parent GroupByDAOAgent if provided, otherwise COUNT
-      var valueSink = this.sink ? this.sink.createSink() : this.COUNT();
-
-      var sink = this.DashboardBarSink.create({
-        arg1: this.prop,
-        arg2: valueSink,
-        groupLimit: this.groupLimit,
-        topN: this.topN,
-        sortOrder: this.sortOrder,
-        includeOthers: this.includeOthers,
-        othersLabel: this.othersLabel,
-        colors: this.colors,
-        timeUnit: this.timeUnit,
-        horizontal: this.horizontal,
-        barThickness: this.barThickness,
-        xAxisLabel: this.xAxisLabel,
-        yAxisLabel: this.yAxisLabel,
-        showGridLines: this.showGridLines,
-        periodCount: this.periodCount,
-        maintainAspectRatio: this.maintainAspectRatio,
-        height: this.height,
-        showLegend: this.showLegend,
-        legendPosition: this.legendPosition,
-        showTooltips: this.showTooltips,
-        showTooltipSum: this.showTooltipSum,
-        animate: this.animate,
-        animationDuration: this.animationDuration,
-        alignment: this.alignment
-      });
-
-      return sink;
+      return this.displaySink;
     },
-    
-    function addSinkToE(e, s) {
-      var self = this;
-      // Add the sink once
-      e.add(s);
 
-      // Then update its properties reactively
-      this.onDetach(this.dynamic(function(colors, horizontal, barThickness, xAxisLabel, yAxisLabel, showGridLines,
-                                  periodCount, maintainAspectRatio, height, showLegend, legendPosition,
-                                  showTooltips, showTooltipSum, animate, animationDuration, alignment) {
-        s.colors = colors;
-        s.horizontal = horizontal;
-        s.barThickness = barThickness;
-        s.xAxisLabel = xAxisLabel;
-        s.yAxisLabel = yAxisLabel;
-        s.showGridLines = showGridLines;
-        s.periodCount = periodCount;
-        s.maintainAspectRatio = maintainAspectRatio;
-        s.height = height;
-        s.showLegend = showLegend;
-        s.legendPosition = legendPosition;
-        s.showTooltips = showTooltips;
-        s.showTooltipSum = showTooltipSum;
-        s.animate = animate;
-        s.animationDuration = animationDuration;
-        s.alignment = alignment;
+    function addSinkToE(e, s) { e.add(s); },
 
-        // Force chart to update/redraw
-        if ( s.updateChart ) s.updateChart();
-       }));
-    },
-    
     function addToE(e) {
-      e.startContext({data: this})
-        .tag(this.ReactiveSectionedDetailView, {
-          data: this,
-          showTitle: true
-        })
+      e.startContext({})
+        .tag(this.ReactiveSectionedDetailView, { data$: this.displaySink$, showTitle: true })
       .endContext();
-    },
-    
-    function clone(subContext) {
-      var clone = this.SUPER(subContext);
-      clone.alignment$ = this.alignment$;
-      clone.colors$ = this.colors$;
-      clone.horizontal$ = this.horizontal$;
-      clone.barThickness$ = this.barThickness$;
-      clone.xAxisLabel$ = this.xAxisLabel$;
-      clone.yAxisLabel$ = this.yAxisLabel$;
-      clone.showGridLines$ = this.showGridLines$;
-      clone.periodCount$ = this.periodCount$;
-      clone.maintainAspectRatio$ = this.maintainAspectRatio$;
-      clone.height$ = this.height$;
-      clone.showLegend$ = this.showLegend$;
-      clone.legendPosition$ = this.legendPosition$;
-      clone.showTooltips$ = this.showTooltips$;
-      clone.showTooltipSum$ = this.showTooltipSum$;
-      clone.animate$ = this.animate$;
-      clone.animationDuration$ = this.animationDuration$;
-      return clone;
     }
   ]
 });
@@ -616,9 +475,7 @@ foam.CLASS({
   name: 'DashboardStackedBarChartDAOAgent',
   extends: 'foam.core.reflow.GridByDAOAgent',
   mixins: [
-    'foam.core.reflow.dashboard.ColorMappingMixin',
-    'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin',
-    'foam.core.reflow.dashboard.ChartDisplayMixin'
+    'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin'
   ],
 
   requires: [
@@ -626,222 +483,81 @@ foam.CLASS({
     'foam.core.reflow.ReactiveSectionedDetailView'
   ],
 
-  sections: [
-    {
-      name: 'dataConfig',
-      title: 'Data Configuration',
-      order: 1,
-      collapsable: true,
-      properties: ['prop2', 'prop1', 'sink', 'periodCount', 'timeUnit']
-    },
-    {
-      name: 'stackedBarChart',
-      title: 'Stacked Bar Settings',
-      order: 2,
-      collapsable: true,
-      properties: ['horizontal', 'showGridLines']
-    },
-    {
-      name: 'axisLabels',
-      title: 'Axis Labels',
-      order: 3,
-      collapsable: true,
-      properties: ['xAxisLabel', 'yAxisLabel']
-    },
-    {
-      name: 'display',
-      title: 'Display Options',
-      order: 4,
-      collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
-    },
-    {
-      name: 'interactivity',
-      title: 'Interactivity',
-      order: 5,
-      collapsable: true,
-      properties: ['onClickScript']
-    },
-    {
-      name: 'colors',
-      title: 'Color Configuration',
-      order: 6,
-      collapsable: true,
-      properties: ['colors']
-    }
-  ],
-
   properties: [
     {
-      name: 'prop2',
-      label: "X Axis"
+      class: 'FObjectProperty',
+      of: 'foam.core.reflow.dashboard.DashboardStackedBarSink',
+      name: 'displaySink',
+      hidden: true,
+      factory: function() { return this.DashboardStackedBarSink.create({}, this); }
     },
-    {
-      name: 'prop1',
-      label: "Stacked By"
-    },
-    {
-      name: 'sink',
-      view: {
-        class: 'foam.core.reflow.SinkView',
-        choice: 'foam.core.reflow.CountDAOAgent',
-        disabledTypes: [ 'structure', 'format', 'chart' ]
-      }
-    },
-    // Inherited from GridByDAOAgent: prop1 (yFunc), prop2 (xFunc), sink
-    // Inherited from TimeSeriesGapFillingMixin: periodCount
-    // Override periodCount visibility to check prop2 (X-axis) instead of prop
-    {
-      name: 'periodCount',
-      visibility: function(prop2) {
-        // For stacked charts, check prop2 (X-axis) for date properties
-        var isDateProp = prop2 && prop2.delegate &&
-          (foam.lang.Date.isInstance(prop2.delegate) || foam.lang.DateTime.isInstance(prop2.delegate));
-        return isDateProp ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    // From mixins: colors, chart display options
-    {
-      class: 'Enum',
-      of: 'foam.core.reflow.dashboard.TimeUnit',
-      name: 'timeUnit',
-      label: 'Time Unit',
-      value: 'DAY',
-      help: 'Time unit for X-axis when using date/time properties',
-      visibility: function(prop2) {
-        /// hidden for now (its not working due to our new propertyexprview returning values as strings instead of dates)
-        return foam.u2.DisplayMode.HIDDEN;
-        // return prop2 && (foam.lang.Date.isInstance(prop2) || foam.lang.DateTime.isInstance(prop2)) ?
-        //   foam.u2.DisplayMode.RW :
-        //   foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    {
-      class: 'Boolean',
-      name: 'horizontal',
-      label: 'Horizontal Stacks',
-      value: false
-    },
-    {
-      class: 'String',
-      name: 'xAxisLabel',
-      label: 'X-Axis Label'
-    },
-    {
-      class: 'String',
-      name: 'yAxisLabel',
-      label: 'Y-Axis Label'
-    },
-    {
-      class: 'Boolean',
-      name: 'showGridLines',
-      label: 'Show Grid Lines',
-      value: true
-    },
-    {
-      class: 'Code',
-      name: 'onClickScript',
-      label: 'On Click Script',
-      section: 'interactivity',
-      help: 'Function expression invoked when a stack segment is clicked. Signature: (yValue, xValue, stackValue, x, y, absX, absY) => void'
-    }
+    // Inherited GridByDAOAgent DAO-layer props → hidden forwarders
+    { name: 'prop2', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.xFunc = n; } },
+    { name: 'prop1', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.yFunc = n; } },
+    { name: 'sink', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.displaySink.acc = n.createSink();
+      } },
+    // Legacy flat-format shims — setter-only, forward to displaySink
+    { name: 'timeUnit', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.timeUnit = v; } },
+    { name: 'horizontal', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.horizontal = v; } },
+    { name: 'xAxisLabel', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.xAxisLabel = v; } },
+    { name: 'yAxisLabel', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.yAxisLabel = v; } },
+    { name: 'showGridLines', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showGridLines = v; } },
+    { name: 'onClickScript', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.onClickScript = v; } },
+    { name: 'colors', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.colors = v; } },
+    { name: 'alignment', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.alignment = v; } },
+    { name: 'maintainAspectRatio', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.maintainAspectRatio = v; } },
+    { name: 'height', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.height = v; } },
+    { name: 'showLegend', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showLegend = v; } },
+    { name: 'legendPosition', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendPosition = v; } },
+    { name: 'showTooltips', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltips = v; } },
+    { name: 'showTooltipSum', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltipSum = v; } },
+    { name: 'animate', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animate = v; } },
+    { name: 'animationDuration', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animationDuration = v; } }
   ],
 
   methods: [
-    function getDatePropertyForFiltering() {
-      // For stacked bar charts, the date property is 'prop2' (X-axis)
-      return this.prop2;
+    function init() {
+      this.SUPER();
+      var self = this;
+      if ( this.periodCount ) self.displaySink.periodCount = self.periodCount;
+      this.onDetach(this.periodCount$.sub(function() {
+        self.displaySink.periodCount = self.periodCount;
+      }));
     },
+
+    function getDatePropertyForFiltering() { return this.displaySink.xFunc; },
 
     function createSink() {
-      // Apply date range filter if periodCount is enabled
       this.applyDateRangeFilter();
-
-      // Use the sink from parent GridByDAOAgent if provided, otherwise COUNT
-      var valueSink = this.sink ? this.sink.createSink() : this.COUNT();
-
-      return this.DashboardStackedBarSink.create({
-        yFunc: this.prop1,
-        xFunc: this.prop2,
-        acc: valueSink,
-        colors: this.colors,
-        timeUnit: this.timeUnit,
-        horizontal: this.horizontal,
-        xAxisLabel: this.xAxisLabel,
-        yAxisLabel: this.yAxisLabel,
-        showGridLines: this.showGridLines,
-        onClickScript: this.onClickScript,
-        periodCount: this.periodCount,
-        maintainAspectRatio: this.maintainAspectRatio,
-        height: this.height,
-        showLegend: this.showLegend,
-        legendPosition: this.legendPosition,
-        showTooltips: this.showTooltips,
-        showTooltipSum: this.showTooltipSum,
-        animate: this.animate,
-        animationDuration: this.animationDuration,
-        alignment: this.alignment
-      });
+      return this.displaySink;
     },
-    
-    function addSinkToE(e, s) {
-      var self = this;
-      // Add the sink once
-      e.add(s);
-      
-      // Then update its properties reactively
-      this.onDetach(this.dynamic(function(colors, horizontal, xAxisLabel, yAxisLabel, showGridLines,
-                                  periodCount, maintainAspectRatio, height, showLegend, legendPosition,
-                                  showTooltips, showTooltipSum, animate, animationDuration, alignment, onClickScript) {
-        s.colors = colors;
-        s.horizontal = horizontal;
-        s.xAxisLabel = xAxisLabel;
-        s.yAxisLabel = yAxisLabel;
-        s.showGridLines = showGridLines;
-        s.periodCount = periodCount;
-        s.maintainAspectRatio = maintainAspectRatio;
-        s.height = height;
-        s.showLegend = showLegend;
-        s.legendPosition = legendPosition;
-        s.showTooltips = showTooltips;
-        s.showTooltipSum = showTooltipSum;
-        s.animate = animate;
-        s.animationDuration = animationDuration;
-        s.alignment = alignment;
-        s.onClickScript = onClickScript;
 
-        // Force chart to update/redraw
-        if ( s.updateChart ) s.updateChart();
-       }));
-    },
-    
+    function addSinkToE(e, s) { e.add(s); },
+
     function addToE(e) {
-      e.startContext({data: this})
-        .tag(this.ReactiveSectionedDetailView, {
-          data: this,
-          showTitle: true
-        })
+      e.startContext({})
+        .tag(this.ReactiveSectionedDetailView, { data$: this.displaySink$, showTitle: true })
       .endContext();
-    },
-    
-    function clone(subContext) {
-      var clone = this.SUPER(subContext);
-      clone.alignment$ = this.alignment$;
-      clone.colors$ = this.colors$;
-      clone.horizontal$ = this.horizontal$;
-      clone.xAxisLabel$ = this.xAxisLabel$;
-      clone.yAxisLabel$ = this.yAxisLabel$;
-      clone.showGridLines$ = this.showGridLines$;
-      clone.periodCount$ = this.periodCount$;
-      clone.maintainAspectRatio$ = this.maintainAspectRatio$;
-      clone.height$ = this.height$;
-      clone.showLegend$ = this.showLegend$;
-      clone.legendPosition$ = this.legendPosition$;
-      clone.showTooltips$ = this.showTooltips$;
-      clone.showTooltipSum$ = this.showTooltipSum$;
-      clone.animate$ = this.animate$;
-      clone.animationDuration$ = this.animationDuration$;
-      return clone;
     }
   ]
 });
@@ -850,223 +566,83 @@ foam.CLASS({
   package: 'foam.core.reflow.dashboard',
   name: 'DashboardPieChartDAOAgent',
   extends: 'foam.core.reflow.GroupByDAOAgent',
-  mixins: [
-    'foam.core.reflow.dashboard.ColorMappingMixin',
-    'foam.core.reflow.dashboard.ChartDisplayMixin'
-  ],
 
   requires: [
     'foam.core.reflow.dashboard.DashboardPieSink',
     'foam.core.reflow.ReactiveSectionedDetailView'
   ],
 
-  sections: [
-    {
-      name: 'dataConfig',
-      title: 'Data Configuration',
-      order: 1,
-      collapsable: true,
-      properties: ['prop', 'sink', 'topN', 'includeOthers', 'sortOrder', 'othersLabel']
-    },
-    {
-      name: 'pieChart',
-      title: 'Pie Chart Settings',
-      order: 2,
-      collapsable: true,
-      properties: ['showPercentages', 'cutoutPercentage', 'clockwise', 'rotation', 'disableLegendClick']
-    },
-    {
-      name: 'display',
-      title: 'Display Options',
-      order: 3,
-      collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'legendMinWidthPercent', 'legendMaxWidthPercent', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'emptyValueMessage']
-    },
-    {
-      name: 'colors',
-      title: 'Color Configuration',
-      order: 4,
-      collapsable: true,
-      properties: ['colors']
-    }
-  ],
-
   properties: [
     {
-      name: 'sink',
-      view: {
-        class: 'foam.core.reflow.SinkView',
-        choice: 'foam.core.reflow.CountDAOAgent',
-        disabledTypes: [ 'structure', 'format', 'chart' ]
-      }
+      class: 'FObjectProperty',
+      of: 'foam.core.reflow.dashboard.DashboardPieSink',
+      name: 'displaySink',
+      hidden: true,
+      factory: function() { return this.DashboardPieSink.create({}, this); }
     },
-    // Inherited from GroupByDAOAgent: prop, sink, groupLimit, sortOrder, includeOthers, othersLabel
-    // From mixins: colors, chart display options
-    {
-      class: 'Boolean',
-      name: 'showPercentages',
-      label: 'Show Percentages',
-      value: false
-    },
-    {
-      class: 'Float',
-      name: 'cutoutPercentage',
-      label: 'Cutout %',
-      value: 0,
-      view: {
-        class: 'foam.u2.RangeView',
-        minValue: 0,
-        maxValue: 100,
-        step: 1,
-        onKey: true
-      },
-      help: 'For donut effect (0-100)'
-    },
-    {
-      class: 'Boolean',
-      name: 'clockwise',
-      label: 'Clockwise',
-      value: true
-    },
-    {
-      class: 'Float',
-      name: 'rotation',
-      label: 'Rotation Angle',
-      value: -90,
-      view: {
-        class: 'foam.u2.RangeView',
-        minValue: -180,
-        maxValue: 180,
-        step: 1,
-        onKey: true
-      },
-      help: 'Starting angle in degrees (-180 to 180)'
-    },
-    {
-      class: 'String',
-      name: 'emptyValueMessage',
-      help: 'Message to display when there is no data',
-      value: 'No data available'
-    },
-    {
-      class: 'Boolean',
-      name: 'disableLegendClick',
-      label: 'Disable Legend Click',
-      help: 'Prevent clicking legend items from toggling slice visibility'
-    },
-    {
-      class: 'Int',
-      name: 'legendMinWidthPercent',
-      label: 'Legend Min Width (%)',
-      help: 'Forces the legend to be at least this percentage (0-100) of container width by padding the widest label with trailing non-breaking spaces. Short legends grow; unboundedly long labels also wrap at this width.'
-    },
-    {
-      class: 'Int',
-      name: 'legendMaxWidthPercent',
-      label: 'Legend Max Width (%)',
-      help: 'Caps the legend at this percentage (0-100) of container width and word-wraps long labels at the cap. Set min = max for an exact fixed-width legend.'
-    },
+    // Inherited DAO-layer props → hidden back-compat forwarders to displaySink
+    { name: 'prop', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.arg1 = n; } },
+    { name: 'sink', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.displaySink.arg2 = n.createSink();
+      } },
+    { name: 'topN', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.topN = n; } },
+    { name: 'sortOrder', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.sortOrder = n; } },
+    { name: 'includeOthers', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.includeOthers = n; } },
+    { name: 'othersLabel', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.othersLabel = n; } },
+    { name: 'groupLimit', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.groupLimit = n; } },
+    // Legacy flat-format shims — setter-only, forward to displaySink
+    { name: 'showPercentages', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showPercentages = v; } },
+    { name: 'cutoutPercentage', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.cutoutPercentage = v; } },
+    { name: 'clockwise', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.clockwise = v; } },
+    { name: 'rotation', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.rotation = v; } },
+    { name: 'disableLegendClick', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.disableLegendClick = v; } },
+    { name: 'legendMinWidthPercent', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendMinWidthPercent = v; } },
+    { name: 'legendMaxWidthPercent', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendMaxWidthPercent = v; } },
+    { name: 'emptyValueMessage', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.emptyValueMessage = v; } },
+    { name: 'colors', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.colors = v; } },
+    { name: 'alignment', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.alignment = v; } },
+    { name: 'maintainAspectRatio', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.maintainAspectRatio = v; } },
+    { name: 'height', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.height = v; } },
+    { name: 'showLegend', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showLegend = v; } },
+    { name: 'legendPosition', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendPosition = v; } },
+    { name: 'showTooltips', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltips = v; } },
+    { name: 'showTooltipSum', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltipSum = v; } },
+    { name: 'animate', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animate = v; } },
+    { name: 'animationDuration', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animationDuration = v; } }
   ],
 
   methods: [
-    
-    function createSink() {
-      // Create sink with GroupBy configuration inherited from parent
-      // Use the sink from parent GroupByDAOAgent if provided, otherwise COUNT
-      var valueSink = this.sink ? this.sink.createSink() : this.COUNT();
-      
-      // Default to DESC sort order for pie charts to show highest values first
-      var sink = this.DashboardPieSink.create({
-        arg1: this.prop,
-        arg2: valueSink,
-        groupLimit: this.groupLimit,
-        topN: this.topN,
-        sortOrder: this.sortOrder,
-        includeOthers: this.includeOthers,
-        othersLabel: this.othersLabel,
-        colors: this.colors,
-        showPercentages: this.showPercentages,
-        cutoutPercentage: this.cutoutPercentage,
-        clockwise: this.clockwise,
-        rotation: this.rotation,
-        maintainAspectRatio: this.maintainAspectRatio,
-        height: this.height,
-        
-        showLegend: this.showLegend,
-        legendPosition: this.legendPosition,
-        showTooltips: this.showTooltips,
-        showTooltipSum: this.showTooltipSum,
-        animate: this.animate,
-        animationDuration: this.animationDuration,
-        alignment: this.alignment,
-        legendMinWidthPercent: this.legendMinWidthPercent,
-        legendMaxWidthPercent: this.legendMaxWidthPercent,
-        emptyValueMessage: this.emptyValueMessage,
-        disableLegendClick: this.disableLegendClick
-      });
-
-      return sink;
-    },
-    function addSinkToE(e, s) {
-      var self = this;
-      // Add the sink once
-      e.add(s);
-      
-      // Then update its properties reactively
-      this.onDetach(this.dynamic(function(cutoutPercentage, rotation, colors, showPercentages, clockwise,
-                                  maintainAspectRatio, height, showLegend, legendPosition,
-                                  showTooltips, showTooltipSum, animate, animationDuration, alignment, legendMinWidthPercent, legendMaxWidthPercent, disableLegendClick) {
-        s.cutoutPercentage = cutoutPercentage;
-        s.rotation = rotation;
-        s.colors = colors;
-        s.showPercentages = showPercentages;
-        s.clockwise = clockwise;
-        s.maintainAspectRatio = maintainAspectRatio;
-        s.height = height;
-        s.showLegend = showLegend;
-        s.legendPosition = legendPosition;
-        s.showTooltips = showTooltips;
-        s.showTooltipSum = showTooltipSum;
-        s.animate = animate;
-        s.animationDuration = animationDuration;
-        s.alignment = alignment;
-        s.legendMinWidthPercent = legendMinWidthPercent;
-        s.legendMaxWidthPercent = legendMaxWidthPercent;
-        s.disableLegendClick = disableLegendClick;
-
-        // Force chart to update/redraw
-        if ( s.updateChart ) s.updateChart();
-       }));
-    },
+    function createSink() { return this.displaySink; },
+    function addSinkToE(e, s) { e.add(s); },
     function addToE(e) {
-      e.startContext({data: this})
-        .tag(this.ReactiveSectionedDetailView, {
-          data: this,
-          showTitle: true
-        })
+      e.startContext({})
+        .tag(this.ReactiveSectionedDetailView, { data$: this.displaySink$, showTitle: true })
       .endContext();
-    },
-    function clone(subContext) {
-      var clone = this.SUPER(subContext);
-      clone.alignment$ = this.alignment$;
-      clone.cutoutPercentage$ = this.cutoutPercentage$;
-      clone.rotation$ = this.rotation$;
-      clone.colors$ = this.colors$;
-      clone.showPercentages$ = this.showPercentages$;
-      clone.clockwise$ = this.clockwise$;
-      clone.maintainAspectRatio$ = this.maintainAspectRatio$;
-      clone.height$ = this.height$;
-
-      clone.showLegend$ = this.showLegend$;
-      clone.legendPosition$ = this.legendPosition$;
-      clone.showTooltips$ = this.showTooltips$;
-      clone.showTooltipSum$ = this.showTooltipSum$;
-      clone.animate$ = this.animate$;
-      clone.animationDuration$ = this.animationDuration$;
-      clone.disableLegendClick$ = this.disableLegendClick$;
-      clone.legendMinWidthPercent$ = this.legendMinWidthPercent$;
-      clone.legendMaxWidthPercent$ = this.legendMaxWidthPercent$;
-      return clone;
     }
   ]
 });
@@ -1079,326 +655,148 @@ foam.CLASS({
   name: 'DashboardLineChartDAOAgent',
   extends: 'foam.core.reflow.AbstractSinkDAOAgent',
   mixins: [
-    'foam.core.reflow.dashboard.ColorMappingMixin',
-    'foam.core.reflow.dashboard.ChartDisplayMixin',
     'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin'
   ],
 
   requires: [
     'foam.core.reflow.dashboard.DashboardLineSink',
     'foam.core.reflow.dashboard.DashboardMultiLineSink',
-    'foam.core.reflow.dashboard.TimeUnit',
-    'foam.core.reflow.ReactiveSectionedDetailView'
-  ],
-
-  sections: [
-    {
-      name: 'dataConfig',
-      title: 'Data Configuration',
-      order: 1,
-      collapsable: true,
-      properties: ['xProp', 'yProp', 'groupBy', 'aggregationSink', 'timeUnit']
-    },
-    {
-      name: 'lineChart',
-      title: 'Line Chart Settings',
-      order: 2,
-      collapsable: true,
-      properties: ['fill', 'tension', 'stepped', 'showPoints', 'pointRadius', 'showGridLines', 'periodCount']
-    },
-    {
-      name: 'axisLabels',
-      title: 'Axis Labels',
-      order: 3,
-      collapsable: true,
-      properties: ['xAxisLabel', 'yAxisLabel']
-    },
-    {
-      name: 'display',
-      title: 'Display Options',
-      order: 4,
-      collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
-    },
-    {
-      name: 'colors',
-      title: 'Color Configuration',
-      order: 5,
-      collapsable: true,
-      properties: ['colors']
-    }
+    'foam.core.reflow.ReactiveSectionedDetailView',
+    'foam.dao.ArraySink'
   ],
 
   properties: [
     {
-      name: 'xProp',
-      label: 'X Property',
-      view: function(_, X) {
-        return { 
-          class: 'foam.core.reflow.PropertyExprView', 
-          forCls: X.data.dao.of
-        };
-      }
+      class: 'FObjectProperty',
+      of: 'foam.dao.Sink',
+      name: 'displaySink',
+      hidden: true,
+      factory: function() { return this.DashboardLineSink.create({}, this); }
     },
-    {
-      name: 'yProp', 
-      label: 'Y Property',
-      view: function(_, X) {
-        return { 
-          class: 'foam.core.reflow.PropertyChoiceView', 
-          forCls: X.data.dao.of
-        };
-      }
-    },
-    {
-      name: 'groupBy',
-      label: 'Group By (Multiple Lines)',
-      help: 'Optional: Group data by this property to create multiple lines',
-      view: function(_, X) {
-        return { 
-          class: 'foam.core.reflow.PropertyChoiceView', 
-          forCls: X.data.dao.of
-        };
-      }
-    },
-    {
-      name: 'aggregationSink',
-      label: 'Aggregation',
-      view: { class: 'foam.core.reflow.SinkView', choice:  'foam.core.reflow.CountDAOAgent' },
-      help: 'How to aggregate values when multiple records have the same X-value',
-
-    },
-    // Inherited from TimeSeriesGapFillingMixin: periodCount (visibility defined below)
-    // Define visibility for periodCount (from mixin)
-    {
-      name: 'periodCount',
-      visibility: function(xProp) {
-        // Only show for date/time properties on X-axis
-        var isDateProp = xProp && xProp.delegate &&
-          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
-        return isDateProp ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    {
-      class: 'Enum',
-      of: 'foam.core.reflow.dashboard.TimeUnit',
-      name: 'timeUnit',
-      label: 'Time Unit',
-      value: 'DAY',
-      help: 'Time unit for X-axis when using date/time properties',
-      visibility: function(xProp) {
-        // hidden for now (its not working due to our new propertyexprview returning values as strings instead of dates)
-        return foam.u2.DisplayMode.HIDDEN;
-        // return prop2 && (foam.lang.Date.isInstance(prop2) || foam.lang.DateTime.isInstance(prop2)) ? 
-        //   foam.u2.DisplayMode.RW : 
-        //   foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    {
-      class: 'String',
-      name: 'xAxisLabel',
-      label: 'X-Axis Label'
-    },
-    {
-      class: 'String',
-      name: 'yAxisLabel',
-      label: 'Y-Axis Label'
-    },
-    {
-      class: 'Boolean',
-      name: 'fill',
-      label: 'Fill Area',
-      value: false
-    },
-    {
-      class: 'Float',
-      name: 'tension',
-      label: 'Line Tension',
-      value: 0.1,
-      help: 'Bezier curve tension (0 = straight lines)'
-    },
-    {
-      class: 'Boolean',
-      name: 'stepped',
-      label: 'Stepped Line',
-      value: false
-    },
-    {
-      class: 'Boolean',
-      name: 'showPoints',
-      label: 'Show Points',
-      value: true
-    },
-    {
-      class: 'Float',
-      name: 'pointRadius',
-      label: 'Point Radius',
-      value: 3,
-      visibility: function(showPoints) {
-        return showPoints ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
-      }
-    },
-    {
-      class: 'Boolean',
-      name: 'showGridLines',
-      label: 'Show Grid Lines',
-      value: true
-    }
+    // Line-specific DAO-layer props → hidden forwarders. Note: groupBy routes through
+    // createSink() swap (Line ↔ MultiLine), so keep postSet on local field only.
+    { name: 'xProp', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( this.DashboardMultiLineSink.isInstance(this.displaySink) ) {
+          this.displaySink.xFunc = n;
+        } else {
+          this.displaySink.arg1 = n;
+        }
+      } },
+    { name: 'yProp', hidden: true, transient: true },
+    { name: 'groupBy', hidden: true, transient: true },
+    { name: 'aggregationSink', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( ! n || ! n.createSink ) return;
+        var sink = n.createSink();
+        if ( this.DashboardMultiLineSink.isInstance(this.displaySink) ) {
+          this.displaySink.acc = sink;
+        } else {
+          this.displaySink.arg2 = sink;
+        }
+      } },
+    // AbstractSinkDAOAgent inherits `sink` — map it to the aggregation slot too
+    { name: 'sink', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( ! n || ! n.createSink ) return;
+        var sink = n.createSink();
+        if ( this.DashboardMultiLineSink.isInstance(this.displaySink) ) {
+          this.displaySink.acc = sink;
+        } else {
+          this.displaySink.arg2 = sink;
+        }
+      } },
+    // Legacy flat-format shims — setter-only, forward to displaySink
+    { name: 'timeUnit', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.timeUnit = v; } },
+    { name: 'xAxisLabel', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.xAxisLabel = v; } },
+    { name: 'yAxisLabel', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.yAxisLabel = v; } },
+    { name: 'fill', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.fill = v; } },
+    { name: 'tension', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.tension = v; } },
+    { name: 'stepped', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.stepped = v; } },
+    { name: 'showPoints', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showPoints = v; } },
+    { name: 'pointRadius', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.pointRadius = v; } },
+    { name: 'showGridLines', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showGridLines = v; } },
+    { name: 'colors', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.colors = v; } },
+    { name: 'alignment', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.alignment = v; } },
+    { name: 'maintainAspectRatio', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.maintainAspectRatio = v; } },
+    { name: 'height', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.height = v; } },
+    { name: 'showLegend', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showLegend = v; } },
+    { name: 'legendPosition', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendPosition = v; } },
+    { name: 'showTooltips', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltips = v; } },
+    { name: 'showTooltipSum', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showTooltipSum = v; } },
+    { name: 'animate', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animate = v; } },
+    { name: 'animationDuration', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animationDuration = v; } }
   ],
 
   methods: [
-    function getDatePropertyForFiltering() {
-      // For line charts, the date property is 'xProp'
-      return this.xProp;
+    function getDatePropertyForFiltering() { return this.xProp; },
+
+    function init() {
+      this.SUPER();
+      var self = this;
+      if ( this.periodCount ) self.displaySink.periodCount = this.periodCount;
+      this.onDetach(this.periodCount$.sub(function() {
+        self.displaySink.periodCount = self.periodCount;
+      }));
     },
 
     function createSink() {
-      // Apply date range filter if periodCount is enabled
       this.applyDateRangeFilter();
+      if ( ! this.xProp ) return this.ArraySink.create();
 
-      if ( ! this.xProp ) {
-        return this.ArraySink.create();
+      var wantMulti = !! this.groupBy;
+      var isMulti   = this.DashboardMultiLineSink.isInstance(this.displaySink);
+
+      if ( wantMulti !== isMulti ) {
+        var old = this.displaySink;
+        var next = wantMulti
+          ? this.DashboardMultiLineSink.create({}, this)
+          : this.DashboardLineSink.create({}, this);
+        [ 'periodCount', 'timeUnit', 'xAxisLabel', 'yAxisLabel', 'fill', 'tension', 'stepped',
+          'showPoints', 'pointRadius', 'showGridLines', 'colors', 'alignment', 'maintainAspectRatio',
+          'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum',
+          'animate', 'animationDuration' ].forEach(function(p) {
+          if ( old && old[p] !== undefined ) next[p] = old[p];
+        });
+        this.displaySink = next;
       }
 
-      // Use the aggregationSink if provided, otherwise COUNT (like StackedBar does)
-      var valueSink = this.aggregationSink ? this.aggregationSink.createSink() : this.COUNT();
-      
-      // Choose sink based on whether groupBy is set
-      if ( this.groupBy ) {
-        // Multi-line chart: Use GridBy-based sink
-        return this.DashboardMultiLineSink.create({
-          xFunc: this.xProp,        // x-axis grouping
-          yFunc: this.groupBy,      // line grouping
-          acc: valueSink,          // aggregation sink (defaulted to COUNT)
-          timeUnit: this.timeUnit,
-          colors: this.colors,
-          xAxisLabel: this.xAxisLabel,
-          yAxisLabel: this.yAxisLabel,
-          fill: this.fill,
-          tension: this.tension,
-          stepped: this.stepped,
-          showPoints: this.showPoints,
-          pointRadius: this.pointRadius,
-          showGridLines: this.showGridLines,
-          maintainAspectRatio: this.maintainAspectRatio,
-          height: this.height,
-          showLegend: this.showLegend,
-          legendPosition: this.legendPosition,
-          showTooltips: this.showTooltips,
-          showTooltipSum: this.showTooltipSum,
-          animate: this.animate,
-          animationDuration: this.animationDuration,
-          alignment: this.alignment,
-          periodCount: this.periodCount
-        });
+      if ( this.DashboardMultiLineSink.isInstance(this.displaySink) ) {
+        this.displaySink.xFunc = this.xProp;
+        this.displaySink.yFunc = this.groupBy;
       } else {
-        // Single-line chart: Use GroupBy-based sink
-        return this.DashboardLineSink.create({
-          arg1: this.xProp,         // x-axis grouping
-          arg2: valueSink,         // aggregation sink (defaulted to COUNT)
-          timeUnit: this.timeUnit,
-          colors: this.colors,
-          xAxisLabel: this.xAxisLabel,
-          yAxisLabel: this.yAxisLabel,
-          fill: this.fill,
-          tension: this.tension,
-          stepped: this.stepped,
-          showPoints: this.showPoints,
-          pointRadius: this.pointRadius,
-          showGridLines: this.showGridLines,
-          maintainAspectRatio: this.maintainAspectRatio,
-          height: this.height,
-          showLegend: this.showLegend,
-          legendPosition: this.legendPosition,
-          showTooltips: this.showTooltips,
-          showTooltipSum: this.showTooltipSum,
-          animate: this.animate,
-          animationDuration: this.animationDuration,
-          alignment: this.alignment,
-          periodCount: this.periodCount
-        });
+        this.displaySink.arg1 = this.xProp;
       }
+      return this.displaySink;
     },
 
-    function value(s) {
-      return s;
-    },
-    
-    function addSinkToE(e, s) {
-      var self = this;
-      // Add the sink once
-      e.add(s);
-      
-      // Then update its properties reactively
-      this.onDetach(this.dynamic(function(colors, xAxisLabel, yAxisLabel, fill, tension, stepped, showPoints, pointRadius, showGridLines,
-                                  maintainAspectRatio, height, showLegend, legendPosition,
-                                  showTooltips, showTooltipSum, animate, animationDuration, alignment,
-                                  periodCount) {
-        s.colors = colors;
-        s.xAxisLabel = xAxisLabel;
-        s.yAxisLabel = yAxisLabel;
-        s.fill = fill;
-        s.tension = tension;
-        s.stepped = stepped;
-        s.showPoints = showPoints;
-        s.pointRadius = pointRadius;
-        s.showGridLines = showGridLines;
-        s.maintainAspectRatio = maintainAspectRatio;
-        s.height = height;
-        s.showLegend = showLegend;
-        s.legendPosition = legendPosition;
-        s.showTooltips = showTooltips;
-        s.showTooltipSum = showTooltipSum;
-        s.animate = animate;
-        s.animationDuration = animationDuration;
-        s.alignment = alignment;
-        s.periodCount = periodCount;
-        
-        // Force chart to update/redraw
-        if ( s.updateChart ) s.updateChart();
-       }));
-    },
-    
+    function value(s) { return s; },
+
+    function addSinkToE(e, s) { e.add(s); },
+
     function addToE(e) {
-      e.startContext({data: this})
-        .start('div')
-          .style({
-            width: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: this.alignment$.map(function(a) { return a.alignmentStyle; }),
-            textAlign: this.alignment$.map(function(a) { return a.textAlign; })
-          })
-          .tag(this.ReactiveSectionedDetailView, {
-            data: this,
-            showTitle: true
-          })
-        .end()
+      e.startContext({})
+        .tag(this.ReactiveSectionedDetailView, { data$: this.displaySink$, showTitle: true })
       .endContext();
-    },
-    
-    function clone(subContext) {
-      var clone = this.SUPER(subContext);
-      clone.alignment$ = this.alignment$;
-      clone.colors$ = this.colors$;
-      clone.xAxisLabel$ = this.xAxisLabel$;
-      clone.yAxisLabel$ = this.yAxisLabel$;
-      clone.fill$ = this.fill$;
-      clone.tension$ = this.tension$;
-      clone.stepped$ = this.stepped$;
-      clone.showPoints$ = this.showPoints$;
-      clone.pointRadius$ = this.pointRadius$;
-      clone.showGridLines$ = this.showGridLines$;
-      clone.periodCount$ = this.periodCount$;
-      clone.maintainAspectRatio$ = this.maintainAspectRatio$;
-      clone.height$ = this.height$;
-      clone.showLegend$ = this.showLegend$;
-      clone.legendPosition$ = this.legendPosition$;
-      clone.showTooltips$ = this.showTooltips$;
-      clone.showTooltipSum$ = this.showTooltipSum$;
-      clone.animate$ = this.animate$;
-      clone.animationDuration$ = this.animationDuration$;
-      return clone;
     }
   ]
 });
@@ -1416,7 +814,7 @@ foam.CLASS({
     'foam.core.reflow.ReactiveSectionedDetailView'
   ],
   properties: [
-    { 
+    {
       class: 'FObjectProperty',
       of: 'foam.core.reflow.dashboard.DashboardMetricSink',
       name:'sink',
@@ -1454,9 +852,7 @@ foam.CLASS({
   name: 'DashboardCalendarChartDAOAgent',
   extends: 'foam.core.reflow.GroupByDAOAgent',
   mixins: [
-    'foam.core.reflow.dashboard.ColorMappingMixin',
-    'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin',
-    'foam.core.reflow.dashboard.ChartDisplayMixin'
+    'foam.core.reflow.dashboard.TimeSeriesGapFillingMixin'
   ],
 
   requires: [
@@ -1464,117 +860,71 @@ foam.CLASS({
     'foam.core.reflow.ReactiveSectionedDetailView'
   ],
 
-  sections: [
-    {
-      name: 'dataConfig',
-      title: 'Data Configuration',
-      order: 1,
-      collapsable: true,
-      properties: ['prop', 'categoryProp', 'sink', 'showAllData', 'periodCount']
-    },
-    {
-      name: 'display',
-      title: 'Display Options',
-      order: 2,
-      collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'colors']
-    }
-  ],
-
   properties: [
     {
-      name: 'prop',
-      label: 'Date Property',
-      view: function(_, X) {
-        return {
-          class: 'foam.core.reflow.PropertyExprView',
-          forCls: X.data.dao.of
-        };
-      }
+      class: 'FObjectProperty',
+      of: 'foam.core.reflow.dashboard.DashboardCalendarSink',
+      name: 'displaySink',
+      hidden: true,
+      factory: function() { return this.DashboardCalendarSink.create({ periodCount: 30 }, this); }
     },
-    {
-      name: 'categoryProp',
-      label: 'Category Property',
-      view: function(_, X) {
-        return {
-          class: 'foam.core.reflow.PropertyChoiceView',
-          forCls: X.data.dao.of
-        };
-      }
-    },
-    {
-      name: 'sink',
-      view: {
-        class: 'foam.core.reflow.SinkView',
-        choice: 'foam.core.reflow.CountDAOAgent',
-        disabledTypes: [ 'structure', 'format', 'chart' ]
-      }
-    },
-    {
-      class: 'Boolean',
-      name: 'showAllData',
-      label: 'Show All Data',
-      help: 'When enabled, the calendar includes every record regardless of date. Disable to limit to the last N days configured by Periods.'
-    },
-    {
-      name: 'periodCount',
-      label: 'Periods',
-      value: 30,
-      help: 'How many days to show from today. Ignored when Show All Data is enabled.',
-      visibility: function(showAllData) {
-        return showAllData ? foam.u2.DisplayMode.HIDDEN : foam.u2.DisplayMode.RW;
-      }
-    }
+    // Inherited DAO-layer props → hidden forwarders
+    { name: 'prop', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.dateProp = n; } },
+    { name: 'categoryProp', hidden: true, transient: true,
+      postSet: function(o, n) { this.displaySink.categoryProp = n; } },
+    { name: 'sink', hidden: true, transient: true,
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.displaySink.valueSink = n.createSink();
+      } },
+    { name: 'showAllData', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showAllData = v; } },
+    // Legacy flat-format shims — setter-only
+    { name: 'colors', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.colors = v; } },
+    { name: 'alignment', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.alignment = v; } },
+    { name: 'maintainAspectRatio', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.maintainAspectRatio = v; } },
+    { name: 'height', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.height = v; } },
+    { name: 'showLegend', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.showLegend = v; } },
+    { name: 'legendPosition', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.legendPosition = v; } },
+    { name: 'animate', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animate = v; } },
+    { name: 'animationDuration', hidden: true, transient: true,
+      setter: function(v) { this.displaySink.animationDuration = v; } }
   ],
 
   methods: [
-    function getDatePropertyForFiltering() {
-      return this.prop;
-    },
-    function createSink() {
-      // Skip the date-range filter when showAllData is set so the
-      // calendar renders every record in the DAO regardless of date.
-      if ( ! this.showAllData ) {
-        this.applyDateRangeFilter && this.applyDateRangeFilter();
-      }
-      var valueSink = this.sink ? this.sink.createSink() : this.COUNT();
-      return this.DashboardCalendarSink.create({
-        dateProp: this.prop,
-        categoryProp: this.categoryProp,
-        valueSink: valueSink,
-        colors: this.colors,
-        showLegend: this.showLegend,
-        legendPosition: this.legendPosition,
-        maintainAspectRatio: this.maintainAspectRatio,
-        height: this.height,
-        alignment: this.alignment,
-        animate: this.animate,
-        animationDuration: this.animationDuration,
-        periodCount: this.periodCount
-      });
-    },
-    function addSinkToE(e, s) {
+    function getDatePropertyForFiltering() { return this.displaySink.dateProp; },
+    function init() {
+      this.SUPER();
       var self = this;
-      e.add(s);
-      // Live binding like other charts
-      this.onDetach(this.dynamic(function(colors, showLegend, legendPosition, maintainAspectRatio, height, alignment, animate, animationDuration) {
-        s.colors = colors;
-        s.showLegend = showLegend;
-        s.legendPosition = legendPosition;
-        s.maintainAspectRatio = maintainAspectRatio;
-        s.height = height;
-        s.alignment = alignment;
-        s.animate = animate;
-        s.animationDuration = animationDuration;
-        if ( s.updateChart ) s.updateChart();
+      // Calendar's sink has periodCount default 30 (from factory). Agent's
+      // TimeSeriesGapFillingMixin periodCount default is 0 — only forward
+      // explicit non-zero values so the factory default stays intact.
+      if ( this.periodCount !== undefined && this.periodCount !== 0 ) {
+        self.displaySink.periodCount = this.periodCount;
+      }
+      this.onDetach(this.periodCount$.sub(function() {
+        if ( self.periodCount !== undefined ) self.displaySink.periodCount = self.periodCount;
       }));
     },
+    function createSink() {
+      // Skip the date-range filter when showAllData is set on the sink so
+      // the calendar renders every record in the DAO regardless of date.
+      if ( ! this.displaySink.showAllData ) {
+        this.applyDateRangeFilter && this.applyDateRangeFilter();
+      }
+      return this.displaySink;
+    },
+    function addSinkToE(e, s) { e.add(s); },
     function addToE(e) {
-      e.startContext({data: this})
-        .tag(this.ReactiveSectionedDetailView, {
-          data: this,
-          showTitle: true
-        })
+      e.startContext({})
+        .tag(this.ReactiveSectionedDetailView, { data$: this.displaySink$, showTitle: true })
       .endContext();
     }
   ]

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -780,11 +780,16 @@ foam.CLASS({
         this.displaySink = next;
       }
 
+      var aggSink = this.aggregationSink && this.aggregationSink.createSink
+        ? this.aggregationSink.createSink()
+        : null;
       if ( this.DashboardMultiLineSink.isInstance(this.displaySink) ) {
         this.displaySink.xFunc = this.xProp;
         this.displaySink.yFunc = this.groupBy;
+        if ( aggSink ) this.displaySink.acc = aggSink;
       } else {
         this.displaySink.arg1 = this.xProp;
+        if ( aggSink ) this.displaySink.arg2 = aggSink;
       }
       return this.displaySink;
     },

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -179,52 +179,91 @@ foam.CLASS({
   name: 'DashboardBarSink',
   extends: 'foam.mlang.sink.TopNGroupBy',
   mixins: [
-    'foam.core.reflow.dashboard.TimeSeriesGapFillingSinkMixin'
+    'foam.core.reflow.dashboard.TimeSeriesGapFillingSinkMixin',
+    'foam.core.reflow.dashboard.ChartDisplayMixin',
+    'foam.core.reflow.dashboard.ColorMappingMixin'
   ],
 
   requires: [
     'org.chartjs.Bar2',
-    'foam.u2.layout.ContainerWidth'
+    'foam.u2.layout.ContainerWidth',
+    'foam.core.reflow.dashboard.LegendPosition'
+  ],
+
+  sections: [
+    { name: 'dataConfig', title: 'Data Configuration', order: 0, collapsable: true,
+      properties: ['groupByProp', 'aggregation', 'topN', 'includeOthers', 'sortOrder', 'othersLabel', 'periodCount'] },
+    { name: 'chartSettings', title: 'Bar Chart Settings', order: 1, collapsable: true,
+      properties: ['horizontal', 'barThickness', 'timeUnit', 'showGridLines', 'datasetLabel'] },
+    { name: 'axisLabels', title: 'Axis Labels', order: 2, collapsable: true,
+      properties: ['xAxisLabel', 'yAxisLabel'] },
+    { name: 'displayOptions', title: 'Display', order: 3, collapsable: true,
+      properties: ['alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration'] },
+    { name: 'colorConfig', title: 'Colors', order: 4, collapsable: true,
+      properties: ['colors'] }
   ],
 
   properties: [
-    // TopNGroupBy properties (inherited but exposed here for clarity)
-    // IMPORTANT: groupLimit is inherited from GroupBy but should NOT be used with TopNGroupBy sinks
-    // groupLimit cuts off data collection early, while topN properly aggregates all data first
-    { name: 'sortOrder', value: 'DESC', help: 'Sort order for groups' },
-    { name: 'includeOthers', value: false, help: 'Include "Others" category for remaining groups' },
-    { name: 'othersLabel', value: 'Others', help: 'Label for the "Others" category' },
-    // Chart-specific properties
+    // User-facing data config properties that drive parent-class internals
     {
-      class: 'StringArray',
-      name: 'colors',
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'groupByProp', label: 'Group By',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyChoiceView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.arg1 = n; }
     },
     {
-      class: 'Enum',
-      of: 'foam.core.reflow.dashboard.TimeUnit',
-      name: 'timeUnit'
+      name: 'aggregation', label: 'Aggregation',
+      view: { class: 'foam.core.reflow.SinkView',
+              choice: 'foam.core.reflow.CountDAOAgent',
+              disabledTypes: [ 'structure', 'format', 'chart' ] },
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.arg2 = n.createSink();
+      }
     },
-    { class: 'Boolean', name: 'horizontal', value: false },
-    { class: 'Int', name: 'barThickness' },
+    // TopNGroupBy user-configurable properties
+    { class: 'Int', name: 'topN', label: 'Top N', value: 0,
+      help: 'Keep top N groups by value (0 = disabled). Remaining groups can be merged into "Others".' },
+    { class: 'Boolean', name: 'includeOthers', label: 'Include Others', value: false,
+      help: 'Include "Others" group for remaining items when using Top N',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'Enum', of: 'foam.mlang.sink.GroupBySortOrder', name: 'sortOrder', label: 'Sort Order', value: 'DESC',
+      help: 'Sort order for value-based limiting',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'String', name: 'othersLabel', label: 'Others Label', value: 'Others',
+      help: 'Label for the aggregated "Others" category',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    // Hide parent-class internals wired programmatically by createSink()
+    { name: 'arg1', hidden: true },
+    { name: 'arg2', hidden: true },
+    { name: 'groupKeys', hidden: true },
+    { name: 'processArrayValuesIndividually', hidden: true },
+    { name: 'groupLimit', hidden: true },
+    // Bar-specific properties (display properties come from ChartDisplayMixin)
+    { class: 'Enum', of: 'foam.core.reflow.dashboard.TimeUnit', name: 'timeUnit',
+      label: 'Time Unit', help: 'Time unit for X-axis when using date/time properties' },
+    { class: 'Boolean', name: 'horizontal', label: 'Horizontal Bars', value: false },
+    { class: 'Int', name: 'barThickness', label: 'Bar Thickness', help: 'Thickness of bars (0 = auto)' },
     { class: 'String', name: 'datasetLabel', value: '', help: 'Label for the dataset (shown in legend if enabled)' },
-    { class: 'String', name: 'xAxisLabel' },
-    { class: 'String', name: 'yAxisLabel' },
-    { class: 'Boolean', name: 'showGridLines', value: true },
-    // periodCount inherited from TimeSeriesGapFillingSinkMixin
-    // Display properties
-    { class: 'Boolean', name: 'responsive', value: true },
-    { class: 'Boolean', name: 'maintainAspectRatio', value: false },
-    { class: 'Int', name: 'height', value: 300 },
-    { class: 'Int', name: 'width', value: 400 },
-    { class: 'Boolean', name: 'showLegend', value: false },  // Bar charts typically don't need legend for single dataset
-    { class: 'String', name: 'legendPosition', value: 'TOP' },
-    { class: 'Boolean', name: 'showTooltips', value: true },
-    { class: 'Boolean', name: 'showTooltipSum', value: false, help: 'Show sum total in tooltip footer' },
-    { class: 'Boolean', name: 'animate', value: true },
-    { class: 'Int', name: 'animationDuration', value: 1000 },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' },
+    { class: 'String', name: 'xAxisLabel', label: 'X-Axis Label' },
+    { class: 'String', name: 'yAxisLabel', label: 'Y-Axis Label' },
+    { class: 'Boolean', name: 'showGridLines', label: 'Show Grid Lines', value: true },
+    // Internal-only sizing props (hidden)
+    { class: 'Boolean', name: 'responsive', hidden: true, value: true },
+    { class: 'Int', name: 'width', hidden: true, value: 400 },
+    // Override ChartDisplayMixin's showLegend default (true) — bar charts default to no legend
+    { class: 'Boolean', name: 'showLegend', label: 'Show Legend', value: false },
     {
       name: 'chart_',
+      hidden: true,
       transient: true,
       expression: function(groups, colors, timeUnit, horizontal, barThickness, datasetLabel, xAxisLabel, yAxisLabel,
                           showGridLines, responsive, maintainAspectRatio, showLegend,
@@ -445,12 +484,27 @@ foam.CLASS({
   package: 'foam.core.reflow.dashboard',
   name: 'DashboardPieSink',
   extends: 'foam.mlang.sink.TopNGroupBy',
+  mixins: [
+    'foam.core.reflow.dashboard.ChartDisplayMixin',
+    'foam.core.reflow.dashboard.ColorMappingMixin'
+  ],
 
   requires: [
     'org.chartjs.Pie2',
     'foam.u2.layout.ContainerWidth',
     'foam.core.reflow.dashboard.LegendPosition',
     'foam.u2.Tooltip'
+  ],
+
+  sections: [
+    { name: 'dataConfig', title: 'Data Configuration', order: 0, collapsable: true,
+      properties: ['groupByProp', 'aggregation', 'topN', 'includeOthers', 'sortOrder', 'othersLabel'] },
+    { name: 'chartSettings', title: 'Pie Chart Settings', order: 1, collapsable: true,
+      properties: ['showPercentages', 'cutoutPercentage', 'clockwise', 'rotation', 'disableLegendClick', 'emptyValueMessage'] },
+    { name: 'displayOptions', title: 'Display', order: 2, collapsable: true,
+      properties: ['alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'legendMinWidthPercent', 'legendMaxWidthPercent', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration'] },
+    { name: 'colorConfig', title: 'Colors', order: 3, collapsable: true,
+      properties: ['colors'] }
   ],
 
   css: `
@@ -472,41 +526,73 @@ foam.CLASS({
   `,
 
   properties: [
-    // TopNGroupBy properties (inherited but exposed here for clarity)
-    // IMPORTANT: groupLimit is inherited from GroupBy but should NOT be used with TopNGroupBy sinks
-    // groupLimit cuts off data collection early, while topN properly aggregates all data first
-    // The init() method forces groupLimit to -1 to prevent interference
-    { name: 'sortOrder', value: 'DESC', help: 'Sort order for slices' },
-    { name: 'includeOthers', value: true, help: 'Include "Others" slice for remaining groups' },
-    { name: 'othersLabel', value: 'Others', help: 'Label for the "Others" slice' },
-    // Pie-specific properties
+    // User-facing data config properties that drive parent-class internals
     {
-      class: 'StringArray',
-      name: 'colors',
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'groupByProp', label: 'Group By',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyChoiceView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.arg1 = n; }
     },
-    { class: 'Boolean', name: 'showPercentages', value: false },
-    { class: 'Int', name: 'cutoutPercentage', value: 0 },
-    { class: 'Boolean', name: 'clockwise', value: true },
-    { class: 'Int', name: 'rotation', value: -90 },
-    { class: 'Boolean', name: 'disableLegendClick', help: 'Disable legend click to toggle slice visibility' },
-    { class: 'Int', name: 'legendMinWidthPercent', help: 'Forces the legend to be at least this percentage (0-100) of container width by padding the widest label with trailing non-breaking spaces. Short legends grow to match; longer labels are truncated with an ellipsis at this width (full text available in the hover tooltip) so a single long label can\'t push the legend wider than intended. 0 = no floor.' },
-    { class: 'Int', name: 'legendMaxWidthPercent', help: 'Caps the legend at this percentage (0-100) of container width; labels wider than the cap are truncated with an ellipsis (full text available in the hover tooltip). 0 = no cap. Setting min = max gives an exact fixed-width legend — arcs line up perfectly across stacked pies.' },
-    // Display properties
-    { class: 'Boolean', name: 'responsive', value: true },
-    { class: 'Boolean', name: 'maintainAspectRatio', value: false },
-    { class: 'Int', name: 'height', value: 300 },
-    { class: 'Int', name: 'width', value: 400 },
-    { class: 'Boolean', name: 'showLegend', value: true },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.LegendPosition', name: 'legendPosition', value: 'TOP' },
-    { class: 'Boolean', name: 'showTooltips', value: true },
-    { class: 'Boolean', name: 'showTooltipSum', value: false, help: 'Show sum total in tooltip footer' },
-    { class: 'Boolean', name: 'animate', value: true },
-    { class: 'Int', name: 'animationDuration', value: 1000 },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' },
-    { class: 'String', name: 'emptyValueMessage', section: "displayOptions", value: 'No data available' },
+    {
+      name: 'aggregation', label: 'Aggregation',
+      view: { class: 'foam.core.reflow.SinkView',
+              choice: 'foam.core.reflow.CountDAOAgent',
+              disabledTypes: [ 'structure', 'format', 'chart' ] },
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.arg2 = n.createSink();
+      }
+    },
+    // TopNGroupBy user-configurable properties
+    { class: 'Int', name: 'topN', label: 'Top N', value: 0,
+      help: 'Keep top N groups by value (0 = disabled). Remaining groups can be merged into "Others".' },
+    { class: 'Boolean', name: 'includeOthers', label: 'Include Others', value: true,
+      help: 'Include "Others" group for remaining items when using Top N',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'Enum', of: 'foam.mlang.sink.GroupBySortOrder', name: 'sortOrder', label: 'Sort Order', value: 'DESC',
+      help: 'Sort order for value-based limiting',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'String', name: 'othersLabel', label: 'Others Label', value: 'Others',
+      help: 'Label for the aggregated "Others" category',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    // Hide parent-class internals wired programmatically by createSink()
+    { name: 'arg1', hidden: true },
+    { name: 'arg2', hidden: true },
+    { name: 'groupKeys', hidden: true },
+    { name: 'processArrayValuesIndividually', hidden: true },
+    { name: 'groupLimit', hidden: true },
+    // Pie-specific properties (display properties come from ChartDisplayMixin)
+    { class: 'Boolean', name: 'showPercentages', label: 'Show Percentages', value: false },
+    { class: 'Int', name: 'cutoutPercentage', label: 'Cutout %', value: 0,
+      view: { class: 'foam.u2.RangeView', minValue: 0, maxValue: 100, step: 1, onKey: true },
+      help: 'For donut effect (0-100)' },
+    { class: 'Boolean', name: 'clockwise', label: 'Clockwise', value: true },
+    { class: 'Int', name: 'rotation', label: 'Rotation Angle', value: -90,
+      view: { class: 'foam.u2.RangeView', minValue: -180, maxValue: 180, step: 1, onKey: true },
+      help: 'Starting angle in degrees (-180 to 180)' },
+    { class: 'Boolean', name: 'disableLegendClick', label: 'Disable Legend Click',
+      help: 'Prevent clicking legend items from toggling slice visibility' },
+    { class: 'Int', name: 'legendMinWidthPercent', label: 'Legend Min Width (%)',
+      help: 'Forces the legend to be at least this percentage (0-100) of container width by padding the widest label with trailing non-breaking spaces. Short legends grow to match; longer labels are truncated with an ellipsis at this width (full text available in the hover tooltip) so a single long label can\'t push the legend wider than intended. 0 = no floor.' },
+    { class: 'Int', name: 'legendMaxWidthPercent', label: 'Legend Max Width (%)',
+      help: 'Caps the legend at this percentage (0-100) of container width; labels wider than the cap are truncated with an ellipsis (full text available in the hover tooltip). 0 = no cap. Setting min = max gives an exact fixed-width legend — arcs line up perfectly across stacked pies.' },
+    { class: 'String', name: 'emptyValueMessage', section: "displayOptions", value: 'No data available',
+      help: 'Message to display when there is no data' },
+    // Internal-only props (hidden)
+    { class: 'Boolean', name: 'responsive', hidden: true, value: true },
+    { class: 'Int', name: 'width', hidden: true, value: 400 },
     { class: 'Boolean', name: 'hasData', section: "displayOptions", value: false, hidden: true },
     {
       name: 'chart_',
+      hidden: true,
       transient: true,
       expression: function(groups,groupKeys, colors, showPercentages, cutoutPercentage, clockwise, rotation,
                           responsive, maintainAspectRatio, showLegend,
@@ -856,49 +942,88 @@ foam.CLASS({
   extends: 'foam.core.reflow.GridBy',
 
   mixins: [
-    'foam.core.reflow.dashboard.TimeSeriesGapFillingSinkMixin'
+    'foam.core.reflow.dashboard.TimeSeriesGapFillingSinkMixin',
+    'foam.core.reflow.dashboard.ChartDisplayMixin',
+    'foam.core.reflow.dashboard.ColorMappingMixin'
   ],
 
   requires: [
     'org.chartjs.StackedBar2',
-    'foam.u2.layout.ContainerWidth'
+    'foam.u2.layout.ContainerWidth',
+    'foam.core.reflow.dashboard.LegendPosition'
+  ],
+
+  sections: [
+    { name: 'dataConfig', title: 'Data Configuration', order: 0, collapsable: true,
+      properties: ['xProp', 'yProp', 'aggregation', 'periodCount'] },
+    { name: 'chartSettings', title: 'Stacked Bar Settings', order: 1, collapsable: true,
+      properties: ['horizontal', 'timeUnit', 'showGridLines', 'onClickScript'] },
+    { name: 'axisLabels', title: 'Axis Labels', order: 2, collapsable: true,
+      properties: ['xAxisLabel', 'yAxisLabel'] },
+    { name: 'displayOptions', title: 'Display', order: 3, collapsable: true,
+      properties: ['alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration'] },
+    { name: 'colorConfig', title: 'Colors', order: 4, collapsable: true,
+      properties: ['colors'] }
   ],
 
   properties: [
-    // Stacked bar-specific properties
+    // User-facing data config properties that drive parent-class internals
     {
-      class: 'StringArray',
-      name: 'colors',
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'xProp', label: 'X-Axis Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyExprView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.xFunc = n; }
     },
+    {
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'yProp', label: 'Stack Group Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyChoiceView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.yFunc = n; }
+    },
+    {
+      name: 'aggregation', label: 'Aggregation',
+      view: { class: 'foam.core.reflow.SinkView',
+              choice: 'foam.core.reflow.CountDAOAgent',
+              disabledTypes: [ 'structure', 'format', 'chart' ] },
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.acc = n.createSink();
+      }
+    },
+    // Stacked-bar-specific properties (display & colors come from mixins)
     {
       class: 'Code',
       name: 'onClickScript',
       label: 'On Click Script',
       help: 'Function expression invoked when a stack segment is clicked. Signature: (yValue, xValue, stackValue, x, y, absX, absY) => void'
     },
-    {
-      class: 'Enum',
-      of: 'foam.core.reflow.dashboard.TimeUnit',
-      name: 'timeUnit'
-    },
-    { class: 'Boolean', name: 'horizontal', value: false },
-    { class: 'String', name: 'xAxisLabel' },
-    { class: 'String', name: 'yAxisLabel' },
-    { class: 'Boolean', name: 'showGridLines', value: true },
-    // Display properties
-    { class: 'Boolean', name: 'responsive', value: true },
-    { class: 'Boolean', name: 'maintainAspectRatio', value: false },
-    { class: 'Int', name: 'height', value: 300 },
-    { class: 'Int', name: 'width', value: 400 },
-    { class: 'Boolean', name: 'showLegend', value: true },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.LegendPosition', name: 'legendPosition', value: 'TOP' },
-    { class: 'Boolean', name: 'showTooltips', value: true },
-    { class: 'Boolean', name: 'showTooltipSum', value: false, help: 'Show sum total in tooltip footer' },
-    { class: 'Boolean', name: 'animate', value: true },
-    { class: 'Int', name: 'animationDuration', value: 1000 },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' },
+    { class: 'Enum', of: 'foam.core.reflow.dashboard.TimeUnit', name: 'timeUnit',
+      label: 'Time Unit', help: 'Time unit for X-axis when using date/time properties' },
+    { class: 'Boolean', name: 'horizontal', label: 'Horizontal Stacks', value: false },
+    { class: 'String', name: 'xAxisLabel', label: 'X-Axis Label' },
+    { class: 'String', name: 'yAxisLabel', label: 'Y-Axis Label' },
+    { class: 'Boolean', name: 'showGridLines', label: 'Show Grid Lines', value: true },
+    // Internal-only sizing props (hidden)
+    { class: 'Boolean', name: 'responsive', hidden: true, value: true },
+    { class: 'Int', name: 'width', hidden: true, value: 400 },
+    // Hide GridBy parent-class internals wired programmatically by createSink()
+    { name: 'xFunc', hidden: true },
+    { name: 'yFunc', hidden: true },
+    { name: 'acc', hidden: true },
+    { name: 'rows', hidden: true },
+    { name: 'cols', hidden: true },
+    { name: 'x', hidden: true },
+    { name: 'y', hidden: true },
+    { name: 'query', hidden: true },
+    { name: 'selection', hidden: true },
     {
       name: 'chart_',
+      hidden: true,
       transient: true,
       expression: function(cols, rows, colors, timeUnit, horizontal, xAxisLabel, yAxisLabel,
                           showGridLines, responsive, maintainAspectRatio,
@@ -1204,40 +1329,38 @@ foam.CLASS({
   package: 'foam.core.reflow.dashboard',
   name: 'LineChartMixin',
 
+  mixins: [
+    'foam.core.reflow.dashboard.ChartDisplayMixin',
+    'foam.core.reflow.dashboard.ColorMappingMixin'
+  ],
+
   requires: [
     'org.chartjs.Line2',
-    'foam.u2.layout.ContainerWidth'
+    'foam.u2.layout.ContainerWidth',
+    'foam.core.reflow.dashboard.LegendPosition'
   ],
 
   properties: [
-    // Chart rendering properties
-    {
-      class: 'Enum',
-      of: 'foam.core.reflow.dashboard.TimeUnit',
-      name: 'timeUnit'
-    },
-    { class: 'StringArray', name: 'colors' },
-    { class: 'StringArray', name: 'borderColors', help: 'Border colors for line elements. If not specified, colors will be used.' },
-    { class: 'String', name: 'xAxisLabel' },
-    { class: 'String', name: 'yAxisLabel' },
-    { class: 'Boolean', name: 'fill', value: false },
-    { class: 'Double', name: 'tension', value: 0.1 },
-    { class: 'Boolean', name: 'stepped', value: false },
-    { class: 'Boolean', name: 'showPoints', value: true },
-    { class: 'Int', name: 'pointRadius', value: 3 },
-    { class: 'Boolean', name: 'showGridLines', value: true },
-    // Display properties
-    { class: 'Boolean', name: 'responsive', value: true },
-    { class: 'Boolean', name: 'maintainAspectRatio', value: false },
-    { class: 'Int', name: 'height', value: 300 },
-    { class: 'Int', name: 'width', value: 400 },
-    { class: 'Boolean', name: 'showLegend', value: true },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.LegendPosition', name: 'legendPosition', value: 'TOP' },
-    { class: 'Boolean', name: 'showTooltips', value: true },
-    { class: 'Boolean', name: 'showTooltipSum', value: false, help: 'Show sum total in tooltip footer (for multiple lines)' },
-    { class: 'Boolean', name: 'animate', value: true },
-    { class: 'Int', name: 'animationDuration', value: 1000 },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' }
+    // Line-specific rendering properties (display & colors come from mixins)
+    { class: 'Enum', of: 'foam.core.reflow.dashboard.TimeUnit', name: 'timeUnit',
+      label: 'Time Unit', help: 'Time unit for X-axis when using date/time properties' },
+    { class: 'StringArray', name: 'borderColors', label: 'Border Colors',
+      help: 'Border colors for line elements. If not specified, colors will be used.' },
+    { class: 'String', name: 'xAxisLabel', label: 'X-Axis Label' },
+    { class: 'String', name: 'yAxisLabel', label: 'Y-Axis Label' },
+    { class: 'Boolean', name: 'fill', label: 'Fill Area', value: false },
+    { class: 'Double', name: 'tension', label: 'Line Tension', value: 0.1,
+      help: 'Bezier curve tension (0 = straight lines)' },
+    { class: 'Boolean', name: 'stepped', label: 'Stepped Line', value: false },
+    { class: 'Boolean', name: 'showPoints', label: 'Show Points', value: true },
+    { class: 'Int', name: 'pointRadius', label: 'Point Radius', value: 3,
+      visibility: function(showPoints) {
+        return showPoints ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'Boolean', name: 'showGridLines', label: 'Show Grid Lines', value: true },
+    // Internal-only sizing props (hidden)
+    { class: 'Boolean', name: 'responsive', hidden: true, value: true },
+    { class: 'Int', name: 'width', hidden: true, value: 400 }
   ],
 
   methods: [
@@ -1366,20 +1489,69 @@ foam.CLASS({
     'foam.core.reflow.dashboard.TimeSeriesGapFillingSinkMixin'
   ],
 
+  sections: [
+    { name: 'dataConfig', title: 'Data Configuration', order: 0, collapsable: true,
+      properties: ['groupByProp', 'aggregation', 'topN', 'includeOthers', 'sortOrder', 'othersLabel', 'periodCount'] },
+    { name: 'chartSettings', title: 'Line Chart Settings', order: 1, collapsable: true,
+      properties: ['fill', 'tension', 'stepped', 'showPoints', 'pointRadius', 'showGridLines', 'timeUnit'] },
+    { name: 'axisLabels', title: 'Axis Labels', order: 2, collapsable: true,
+      properties: ['xAxisLabel', 'yAxisLabel'] },
+    { name: 'displayOptions', title: 'Display', order: 3, collapsable: true,
+      properties: ['alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration'] },
+    { name: 'colorConfig', title: 'Colors', order: 4, collapsable: true,
+      properties: ['colors'] }
+  ],
+
   properties: [
-    // Map GroupBy properties directly
+    // User-facing data config properties that drive parent-class internals
     {
-      name: 'arg1',
-      label: 'X-Axis Property',
-      help: 'Property to group by (x-axis values)'
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'groupByProp', label: 'X-Axis Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyExprView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.arg1 = n; }
     },
     {
-      name: 'arg2',
-      label: 'Aggregation Sink',
-      help: 'Sink to aggregate y-values for each x-value'
+      name: 'aggregation', label: 'Aggregation',
+      view: { class: 'foam.core.reflow.SinkView',
+              choice: 'foam.core.reflow.CountDAOAgent',
+              disabledTypes: [ 'structure', 'format', 'chart' ] },
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.arg2 = n.createSink();
+      }
     },
-     {
+    // GroupBy parent-class internals — wired programmatically by createSink()
+    { name: 'arg1', hidden: true, label: 'X-Axis Property', help: 'Property to group by (x-axis values)' },
+    { name: 'arg2', hidden: true, label: 'Aggregation Sink', help: 'Sink to aggregate y-values for each x-value' },
+    { name: 'groupKeys', hidden: true },
+    { name: 'processArrayValuesIndividually', hidden: true },
+    { name: 'groupLimit', hidden: true },
+    // TopN user-configurable properties
+    { class: 'Int', name: 'topN', label: 'Top N', value: 0,
+      help: 'Keep top N groups by value (0 = disabled). Remaining groups can be merged into "Others".' },
+    { class: 'Boolean', name: 'includeOthers', label: 'Include Others', value: true,
+      help: 'Include "Others" group for remaining items when using Top N',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'Enum', of: 'foam.mlang.sink.GroupBySortOrder', name: 'sortOrder', label: 'Sort Order', value: 'DESC',
+      help: 'Sort order for value-based limiting',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    { class: 'String', name: 'othersLabel', label: 'Others Label', value: 'Others',
+      help: 'Label for the aggregated "Others" category',
+      visibility: function(topN) {
+        return topN > 0 ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      } },
+    // LineChartMixin internal/sizing props hidden from editor
+    { name: 'responsive', hidden: true },
+    { name: 'width', hidden: true },
+    {
     name: 'chart_',
+    hidden: true,
     transient: true,
     expression: function(groups, arg1, arg2, timeUnit, colors, borderColors, xAxisLabel, yAxisLabel,
                         fill, tension, stepped, showPoints, pointRadius, showGridLines,
@@ -1526,25 +1698,64 @@ foam.CLASS({
     'foam.core.reflow.dashboard.TimeSeriesGapFillingSinkMixin'
   ],
 
+  sections: [
+    { name: 'dataConfig', title: 'Data Configuration', order: 0, collapsable: true,
+      properties: ['xProp', 'yProp', 'aggregation', 'periodCount'] },
+    { name: 'chartSettings', title: 'Line Chart Settings', order: 1, collapsable: true,
+      properties: ['fill', 'tension', 'stepped', 'showPoints', 'pointRadius', 'showGridLines', 'timeUnit'] },
+    { name: 'axisLabels', title: 'Axis Labels', order: 2, collapsable: true,
+      properties: ['xAxisLabel', 'yAxisLabel'] },
+    { name: 'displayOptions', title: 'Display', order: 3, collapsable: true,
+      properties: ['alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration'] },
+    { name: 'colorConfig', title: 'Colors', order: 4, collapsable: true,
+      properties: ['colors'] }
+  ],
+
   properties: [
-    // Map GridBy properties directly
+    // User-facing data config properties that drive parent-class internals
     {
-      name: 'xFunc',
-      label: 'X-Axis Property',
-      help: 'Property to group by (x-axis values)'
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'xProp', label: 'X-Axis Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyExprView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.xFunc = n; }
     },
     {
-      name: 'yFunc',
-      label: 'Line Group Property',
-      help: 'Property to group by (different lines)'
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'yProp', label: 'Line Group Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyChoiceView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.yFunc = n; }
     },
     {
-      name: 'acc',
-      label: 'Aggregation Sink',
-      help: 'Sink to aggregate y-values for each x-value/line combination'
+      name: 'aggregation', label: 'Aggregation',
+      view: { class: 'foam.core.reflow.SinkView',
+              choice: 'foam.core.reflow.CountDAOAgent',
+              disabledTypes: [ 'structure', 'format', 'chart' ] },
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.acc = n.createSink();
+      }
     },
-      {
+    // GridBy parent-class internals — wired programmatically by createSink()
+    { name: 'xFunc', hidden: true, label: 'X-Axis Property', help: 'Property to group by (x-axis values)' },
+    { name: 'yFunc', hidden: true, label: 'Line Group Property', help: 'Property to group by (different lines)' },
+    { name: 'acc', hidden: true, label: 'Aggregation Sink', help: 'Sink to aggregate y-values for each x-value/line combination' },
+    { name: 'rows', hidden: true },
+    { name: 'cols', hidden: true },
+    { name: 'x', hidden: true },
+    { name: 'y', hidden: true },
+    { name: 'query', hidden: true },
+    { name: 'selection', hidden: true },
+    // LineChartMixin internal/sizing props hidden from editor
+    { name: 'responsive', hidden: true },
+    { name: 'width', hidden: true },
+    {
     name: 'chart_',
+    hidden: true,
     transient: true,
     expression: function(cols, rows, xFunc, yFunc, acc, timeUnit, colors, borderColors, xAxisLabel, yAxisLabel,
                         fill, tension, stepped, showPoints, pointRadius, showGridLines,
@@ -2115,28 +2326,70 @@ foam.CLASS({
   package: 'foam.core.reflow.dashboard',
   name: 'DashboardCalendarSink',
   extends: 'foam.dao.AbstractSink',
+  mixins: [
+    'foam.core.reflow.dashboard.ChartDisplayMixin',
+    'foam.core.reflow.dashboard.ColorMappingMixin'
+  ],
   documentation: 'Calendar sink with fully live dashboard properties (match Pie/Bar).',
   requires: [
     'foam.u2.layout.ContainerWidth',
     'org.chartjs.CalendarDAOChartView'
   ],
+
+  sections: [
+    { name: 'dataConfig', title: 'Data Configuration', order: 0, collapsable: true,
+      properties: ['dateProperty', 'categoryProperty', 'aggregation', 'showAllData', 'periodCount'] },
+    { name: 'displayOptions', title: 'Display', order: 1, collapsable: true,
+      properties: ['alignment', 'maintainAspectRatio', 'height', 'showLegend', 'legendPosition', 'animate', 'animationDuration'] },
+    { name: 'colorConfig', title: 'Colors', order: 2, collapsable: true,
+      properties: ['colors'] }
+  ],
+
   properties: [
-    { name: 'dateProp', label: 'Date Property' },
-    { name: 'categoryProp', label: 'Category Property' },
-    { name: 'valueSink', documentation: 'Aggregator sink.' },
-    { class: 'Int', name: 'periodCount', label: 'Periods', value: 12 },
+    // User-facing data config properties that drive internals
+    {
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'dateProperty', label: 'Date Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyExprView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.dateProp = n; }
+    },
+    {
+      class: 'FObjectProperty', of: 'foam.lang.Property', generateJava: false,
+      name: 'categoryProperty', label: 'Category Property',
+      view: function(_, X) {
+        return { class: 'foam.core.reflow.PropertyChoiceView',
+                 forCls: X.dao ? X.dao.of : undefined };
+      },
+      postSet: function(o, n) { this.categoryProp = n; }
+    },
+    {
+      name: 'aggregation', label: 'Aggregation',
+      view: { class: 'foam.core.reflow.SinkView',
+              choice: 'foam.core.reflow.CountDAOAgent',
+              disabledTypes: [ 'structure', 'format', 'chart' ] },
+      postSet: function(o, n) {
+        if ( n && n.createSink ) this.valueSink = n.createSink();
+      }
+    },
+    // Internal properties wired programmatically by createSink() — hidden from editor
+    { name: 'dateProp', hidden: true, label: 'Date Property' },
+    { name: 'categoryProp', hidden: true, label: 'Category Property' },
+    { name: 'valueSink', hidden: true, documentation: 'Aggregator sink.' },
+    { class: 'Boolean', name: 'showAllData', label: 'Show All Data',
+      help: 'When enabled, the calendar includes every record regardless of date. Disable to limit to the last N days configured by Periods.' },
+    { class: 'Int', name: 'periodCount', label: 'Periods', value: 12,
+      help: 'How many days to show from today. Ignored when Show All Data is enabled.',
+      visibility: function(showAllData) {
+        return showAllData ? foam.u2.DisplayMode.HIDDEN : foam.u2.DisplayMode.RW;
+      } },
     { name: 'map_', hidden: true, factory: function() { return {}; } },
-    // Dashboard-style display properties
-    { class: 'StringArray', name: 'colors', documentation: 'Dashboard chart colors' },
-    { class: 'Boolean', name: 'showLegend', value: true },
-    { class: 'Enum', name: 'legendPosition', of: 'foam.core.reflow.dashboard.LegendPosition', value: 'TOP' },
-    { class: 'Boolean', name: 'maintainAspectRatio', value: false },
-    { class: 'Int', name: 'height', value: 300 },
-    { class: 'Enum', name: 'alignment', of: 'foam.core.reflow.dashboard.MetricAlignment', value: 'CENTER' },
-    { class: 'Boolean', name: 'animate', value: true },
-    { class: 'Int', name: 'animationDuration', value: 1000 },
+    // Display & colors properties come from ChartDisplayMixin and ColorMappingMixin
     {
       name: 'chart_',
+      hidden: true,
       transient: true,
       factory: function() {
         // Only create once, then drive via property slots

--- a/src/foam/core/reflow/dashboard/pom.js
+++ b/src/foam/core/reflow/dashboard/pom.js
@@ -1,5 +1,8 @@
 foam.POM({
   name: 'dashboard',
+  projects: [
+    { name: 'test/pom', flags: 'test' }
+  ],
   files: [
     { name: 'MetricOperation',         flags: 'js|java' },
     { name: 'MetricAlignment',         flags: 'js|java' },

--- a/src/foam/core/reflow/dashboard/test/DashboardAgentBaselineTest.js
+++ b/src/foam/core/reflow/dashboard/test/DashboardAgentBaselineTest.js
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow.dashboard.test',
+  name: 'DashboardAgentBaselineTest',
+  extends: 'foam.core.test.JSTest',
+
+  requires: [
+    'foam.core.reflow.dashboard.DashboardBarChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardPieChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardStackedBarChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardLineChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardCalendarChartDAOAgent'
+  ],
+
+  methods: [
+    async function runTest(x) {
+      await this.testBarBaseline(x);
+      await this.testPieBaseline(x);
+      await this.testStackedBarBaseline(x);
+      await this.testLineBaseline(x);
+      await this.testCalendarBaseline(x);
+    },
+
+    function snapshotSink(sink) {
+      return foam.json.Compact.stringify(sink);
+    },
+
+    async function testBarBaseline(x) {
+      var agent = this.DashboardBarChartDAOAgent.create({
+        horizontal: true,
+        barThickness: 20,
+        height: 400,
+        showLegend: false,
+        legendPosition: 'BOTTOM',
+        showTooltips: true,
+        showTooltipSum: true,
+        animate: false,
+        animationDuration: 500,
+        colors: ['$barChart1', '$barChart2'],
+        maintainAspectRatio: true,
+        xAxisLabel: 'X',
+        yAxisLabel: 'Y',
+        showGridLines: false
+      }, x);
+      var sink = agent.createSink();
+      var snapshot = this.snapshotSink(sink);
+      x.test(
+        snapshot === this.EXPECTED_BAR,
+        'Bar baseline matches. Got: ' + snapshot
+      );
+    },
+
+    async function testPieBaseline(x) {
+      var agent = this.DashboardPieChartDAOAgent.create({
+        showPercentages: true,
+        cutoutPercentage: 50,
+        clockwise: true,
+        rotation: -90,
+        disableLegendClick: true,
+        height: 300,
+        showLegend: true,
+        legendPosition: 'TOP',
+        colors: ['$a', '$b', '$c']
+      }, x);
+      var sink = agent.createSink();
+      var snapshot = this.snapshotSink(sink);
+      x.test(snapshot === this.EXPECTED_PIE, 'Pie baseline matches. Got: ' + snapshot);
+    },
+
+    async function testStackedBarBaseline(x) {
+      var agent = this.DashboardStackedBarChartDAOAgent.create({
+        horizontal: false,
+        xAxisLabel: 'X',
+        yAxisLabel: 'Y',
+        showGridLines: true,
+        height: 350,
+        colors: ['$s1', '$s2']
+      }, x);
+      var sink = agent.createSink();
+      var snapshot = this.snapshotSink(sink);
+      x.test(snapshot === this.EXPECTED_STACKED, 'StackedBar baseline matches. Got: ' + snapshot);
+    },
+
+    async function testLineBaseline(x) {
+      var agent = this.DashboardLineChartDAOAgent.create({
+        fill: true,
+        tension: 0.4,
+        stepped: false,
+        showPoints: true,
+        pointRadius: 4,
+        showGridLines: true,
+        xAxisLabel: 'X',
+        yAxisLabel: 'Y',
+        height: 320,
+        colors: ['$l1']
+      }, x);
+      var sink = agent.createSink();
+      var snapshot = this.snapshotSink(sink);
+      x.test(snapshot === this.EXPECTED_LINE, 'Line baseline matches. Got: ' + snapshot);
+    },
+
+    async function testCalendarBaseline(x) {
+      var agent = this.DashboardCalendarChartDAOAgent.create({
+        periodCount: 30,
+        height: 250,
+        showLegend: true,
+        legendPosition: 'TOP',
+        maintainAspectRatio: false,
+        animate: true,
+        animationDuration: 800,
+        colors: ['$c1']
+      }, x);
+      var sink = agent.createSink();
+      var snapshot = this.snapshotSink(sink);
+      x.test(snapshot === this.EXPECTED_CALENDAR, 'Calendar baseline matches. Got: ' + snapshot);
+    }
+  ],
+
+  constants: [
+    { name: 'EXPECTED_BAR',      value: '{class:"foam.core.reflow.dashboard.DashboardBarSink",arg2:{class:"foam.mlang.sink.Count"},groupKeys:[],processArrayValuesIndividually:true,horizontal:true,barThickness:20,xAxisLabel:"X",yAxisLabel:"Y",showGridLines:false,showLegend:false,maintainAspectRatio:true,height:400,legendPosition:2,showTooltipSum:true,animate:false,animationDuration:500,colors:["$barChart1","$barChart2"]}' },
+    { name: 'EXPECTED_PIE',      value: '{class:"foam.core.reflow.dashboard.DashboardPieSink",arg2:{class:"foam.mlang.sink.Count"},groupKeys:[],processArrayValuesIndividually:true,showPercentages:true,cutoutPercentage:50,disableLegendClick:true,colors:["$a","$b","$c"]}' },
+    { name: 'EXPECTED_STACKED',  value: '{class:"foam.core.reflow.dashboard.DashboardStackedBarSink",xAxisLabel:"X",yAxisLabel:"Y",rows:{class:"foam.mlang.sink.GroupBy",arg2:{class:"foam.mlang.sink.GroupBy",arg2:{class:"foam.mlang.sink.Count"},groupKeys:[],processArrayValuesIndividually:true},groupKeys:[],processArrayValuesIndividually:true},cols:{class:"foam.mlang.sink.GroupBy",arg2:{class:"foam.mlang.sink.Count"},groupKeys:[],processArrayValuesIndividually:true},height:350,colors:["$s1","$s2"]}' },
+    { name: 'EXPECTED_LINE',     value: '{class:"foam.dao.ArraySink"}' },
+    { name: 'EXPECTED_CALENDAR', value: '{class:"foam.core.reflow.dashboard.DashboardCalendarSink",periodCount:30,map_:{},height:250,animationDuration:800,colors:["$c1"]}' }
+  ]
+});

--- a/src/foam/core/reflow/dashboard/test/DashboardAgentBaselineTest.js
+++ b/src/foam/core/reflow/dashboard/test/DashboardAgentBaselineTest.js
@@ -14,7 +14,9 @@ foam.CLASS({
     'foam.core.reflow.dashboard.DashboardPieChartDAOAgent',
     'foam.core.reflow.dashboard.DashboardStackedBarChartDAOAgent',
     'foam.core.reflow.dashboard.DashboardLineChartDAOAgent',
-    'foam.core.reflow.dashboard.DashboardCalendarChartDAOAgent'
+    'foam.core.reflow.dashboard.DashboardMultiLineSink',
+    'foam.core.reflow.dashboard.DashboardCalendarChartDAOAgent',
+    'foam.core.reflow.SumDAOAgent'
   ],
 
   methods: [
@@ -23,6 +25,7 @@ foam.CLASS({
       await this.testPieBaseline(x);
       await this.testStackedBarBaseline(x);
       await this.testLineBaseline(x);
+      await this.testLineMultiAggregationPreserved(x);
       await this.testCalendarBaseline(x);
     },
 
@@ -102,6 +105,22 @@ foam.CLASS({
       var sink = agent.createSink();
       var snapshot = this.snapshotSink(sink);
       x.test(snapshot === this.EXPECTED_LINE, 'Line baseline matches. Got: ' + snapshot);
+    },
+
+    async function testLineMultiAggregationPreserved(x) {
+      var fakeXProp = { name: 'month' };
+      var fakeYProp = { name: 'year' };
+      var sum       = this.SumDAOAgent.create({ prop: fakeXProp }, x);
+      var agent     = this.DashboardLineChartDAOAgent.create({
+        xProp: fakeXProp,
+        groupBy: fakeYProp,
+        aggregationSink: sum
+      }, x);
+      var sink = agent.createSink();
+      x.test(this.DashboardMultiLineSink.isInstance(sink), 'Line+groupBy yields MultiLineSink. Got: ' + (sink && sink.cls_ && sink.cls_.id));
+      x.test(!! sink.xFunc, 'MultiLineSink.xFunc wired from agent.xProp');
+      x.test(!! sink.yFunc, 'MultiLineSink.yFunc wired from agent.groupBy');
+      x.test(!! sink.acc,   'MultiLineSink.acc wired from agent.aggregationSink across Line→Multi swap');
     },
 
     async function testCalendarBaseline(x) {

--- a/src/foam/core/reflow/dashboard/test/DashboardAgentBaselineTest.js
+++ b/src/foam/core/reflow/dashboard/test/DashboardAgentBaselineTest.js
@@ -108,19 +108,18 @@ foam.CLASS({
     },
 
     async function testLineMultiAggregationPreserved(x) {
-      var fakeXProp = { name: 'month' };
-      var fakeYProp = { name: 'year' };
-      var sum       = this.SumDAOAgent.create({ prop: fakeXProp }, x);
-      var agent     = this.DashboardLineChartDAOAgent.create({
-        xProp: fakeXProp,
-        groupBy: fakeYProp,
-        aggregationSink: sum
-      }, x);
+      var xProp = this.DashboardLineChartDAOAgent.HEIGHT;
+      var yProp = this.DashboardLineChartDAOAgent.TENSION;
+      var sum   = this.SumDAOAgent.create({ prop: xProp }, x);
+      var agent = this.DashboardLineChartDAOAgent.create({}, x);
+      agent.xProp = xProp;
+      agent.groupBy = yProp;
+      agent.aggregationSink = sum;
       var sink = agent.createSink();
       x.test(this.DashboardMultiLineSink.isInstance(sink), 'Line+groupBy yields MultiLineSink. Got: ' + (sink && sink.cls_ && sink.cls_.id));
-      x.test(!! sink.xFunc, 'MultiLineSink.xFunc wired from agent.xProp');
-      x.test(!! sink.yFunc, 'MultiLineSink.yFunc wired from agent.groupBy');
-      x.test(!! sink.acc,   'MultiLineSink.acc wired from agent.aggregationSink across Line→Multi swap');
+      x.test(sink.xFunc === xProp, 'MultiLineSink.xFunc wired from agent.xProp');
+      x.test(sink.yFunc === yProp, 'MultiLineSink.yFunc wired from agent.groupBy');
+      x.test(!! sink.acc,          'MultiLineSink.acc wired from agent.aggregationSink across Line→Multi swap');
     },
 
     async function testCalendarBaseline(x) {

--- a/src/foam/core/reflow/dashboard/test/DashboardAgentJsonTest.js
+++ b/src/foam/core/reflow/dashboard/test/DashboardAgentJsonTest.js
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow.dashboard.test',
+  name: 'DashboardAgentJsonTest',
+  extends: 'foam.core.test.JSTest',
+
+  requires: [
+    'foam.core.reflow.dashboard.DashboardBarChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardPieChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardStackedBarChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardLineChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardCalendarChartDAOAgent'
+  ],
+
+  methods: [
+    async function runTest(x) {
+      await this.testBarOldFormat(x);
+      await this.testBarNewFormat(x);
+      await this.testPieOldFormat(x);
+      await this.testPieNewFormat(x);
+      await this.testStackedOldFormat(x);
+      await this.testLineOldFormat(x);
+      await this.testCalendarOldFormat(x);
+    },
+
+    async function testBarOldFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardBarChartDAOAgent","horizontal":true,"height":400,"xAxisLabel":"X"}';
+      var a = foam.json.parseString(json, x);
+      x.test(a && a.displaySink && a.displaySink.horizontal === true, 'old flat Bar.horizontal → displaySink');
+      x.test(a && a.displaySink && a.displaySink.height === 400, 'old flat Bar.height → displaySink');
+      x.test(a && a.displaySink && a.displaySink.xAxisLabel === 'X', 'old flat Bar.xAxisLabel → displaySink');
+    },
+
+    async function testBarNewFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardBarChartDAOAgent","displaySink":{"class":"foam.core.reflow.dashboard.DashboardBarSink","horizontal":true,"height":400}}';
+      var a = foam.json.parseString(json, x);
+      x.test(a && a.displaySink && a.displaySink.horizontal === true, 'new nested Bar.horizontal');
+      x.test(a && a.displaySink && a.displaySink.height === 400, 'new nested Bar.height');
+    },
+
+    async function testPieOldFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardPieChartDAOAgent","showPercentages":true,"cutoutPercentage":50,"disableLegendClick":true}';
+      var a = foam.json.parseString(json, x);
+      x.test(a && a.displaySink && a.displaySink.showPercentages === true, 'old flat Pie.showPercentages → displaySink');
+      x.test(a && a.displaySink && a.displaySink.cutoutPercentage === 50, 'old flat Pie.cutoutPercentage → displaySink');
+      x.test(a && a.displaySink && a.displaySink.disableLegendClick === true, 'old flat Pie.disableLegendClick → displaySink');
+    },
+
+    async function testPieNewFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardPieChartDAOAgent","displaySink":{"class":"foam.core.reflow.dashboard.DashboardPieSink","showPercentages":true,"cutoutPercentage":50}}';
+      var a = foam.json.parseString(json, x);
+      x.test(a && a.displaySink && a.displaySink.showPercentages === true, 'new nested Pie.showPercentages');
+      x.test(a && a.displaySink && a.displaySink.cutoutPercentage === 50, 'new nested Pie.cutoutPercentage');
+    },
+
+    async function testStackedOldFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardStackedBarChartDAOAgent","horizontal":true,"showGridLines":false,"onClickScript":"x"}';
+      var a = foam.json.parseString(json, x);
+      x.test(a && a.displaySink && a.displaySink.horizontal === true, 'StackedBar old flat horizontal');
+      x.test(a && a.displaySink && a.displaySink.showGridLines === false, 'StackedBar old flat showGridLines');
+      x.test(a && a.displaySink && a.displaySink.onClickScript === 'x', 'StackedBar old flat onClickScript');
+    },
+
+    async function testLineOldFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardLineChartDAOAgent","fill":true,"tension":0.3,"stepped":true,"pointRadius":5}';
+      var a = foam.json.parseString(json, x);
+      a.createSink();
+      x.test(a && a.displaySink && a.displaySink.fill === true, 'Line old flat fill');
+      x.test(a && a.displaySink && a.displaySink.tension === 0.3, 'Line old flat tension');
+      x.test(a && a.displaySink && a.displaySink.stepped === true, 'Line old flat stepped');
+      x.test(a && a.displaySink && a.displaySink.pointRadius === 5, 'Line old flat pointRadius');
+    },
+
+    async function testCalendarOldFormat(x) {
+      var json = '{"class":"foam.core.reflow.dashboard.DashboardCalendarChartDAOAgent","periodCount":15,"height":180,"animate":false}';
+      var a = foam.json.parseString(json, x);
+      x.test(a && a.displaySink && a.displaySink.periodCount === 15, 'Calendar old flat periodCount');
+      x.test(a && a.displaySink && a.displaySink.height === 180, 'Calendar old flat height');
+      x.test(a && a.displaySink && a.displaySink.animate === false, 'Calendar old flat animate');
+    }
+  ]
+});

--- a/src/foam/core/reflow/dashboard/test/DashboardAgentShimTest.js
+++ b/src/foam/core/reflow/dashboard/test/DashboardAgentShimTest.js
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow.dashboard.test',
+  name: 'DashboardAgentShimTest',
+  extends: 'foam.core.test.JSTest',
+
+  requires: [
+    'foam.core.reflow.dashboard.DashboardBarChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardPieChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardStackedBarChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardLineChartDAOAgent',
+    'foam.core.reflow.dashboard.DashboardCalendarChartDAOAgent'
+  ],
+
+  methods: [
+    async function runTest(x) {
+      await this.testBar(x);
+      await this.testPie(x);
+      await this.testStackedBar(x);
+      await this.testLine(x);
+      await this.testCalendar(x);
+    },
+
+    async function testBar(x) {
+      var a = this.DashboardBarChartDAOAgent.create({
+        horizontal: true, barThickness: 15, xAxisLabel: 'X', yAxisLabel: 'Y',
+        showGridLines: false, colors: ['$a','$b'], alignment: 'LEFT',
+        maintainAspectRatio: true, height: 250, showLegend: false,
+        legendPosition: 'BOTTOM', showTooltips: false, showTooltipSum: true,
+        animate: false, animationDuration: 200, periodCount: 6
+      }, x);
+      x.test(a.displaySink != null, 'Bar displaySink auto-created');
+      x.test(a.displaySink && a.displaySink.horizontal === true, 'Bar.horizontal forwarded');
+      x.test(a.displaySink && a.displaySink.barThickness === 15, 'Bar.barThickness forwarded');
+      x.test(a.displaySink && a.displaySink.xAxisLabel === 'X', 'Bar.xAxisLabel forwarded');
+      x.test(a.displaySink && a.displaySink.yAxisLabel === 'Y', 'Bar.yAxisLabel forwarded');
+      x.test(a.displaySink && a.displaySink.showGridLines === false, 'Bar.showGridLines forwarded');
+      x.test(a.displaySink && foam.util.equals(a.displaySink.colors, ['$a','$b']), 'Bar.colors forwarded');
+      x.test(a.displaySink && a.displaySink.alignment && a.displaySink.alignment.name === 'LEFT', 'Bar.alignment forwarded');
+      x.test(a.displaySink && a.displaySink.maintainAspectRatio === true, 'Bar.maintainAspectRatio forwarded');
+      x.test(a.displaySink && a.displaySink.height === 250, 'Bar.height forwarded');
+      x.test(a.displaySink && a.displaySink.showLegend === false, 'Bar.showLegend forwarded');
+      x.test(a.displaySink && a.displaySink.legendPosition && a.displaySink.legendPosition.name === 'BOTTOM', 'Bar.legendPosition forwarded');
+      x.test(a.displaySink && a.displaySink.showTooltips === false, 'Bar.showTooltips forwarded');
+      x.test(a.displaySink && a.displaySink.showTooltipSum === true, 'Bar.showTooltipSum forwarded');
+      x.test(a.displaySink && a.displaySink.animate === false, 'Bar.animate forwarded');
+      x.test(a.displaySink && a.displaySink.animationDuration === 200, 'Bar.animationDuration forwarded');
+      x.test(a.displaySink && a.displaySink.periodCount === 6, 'Bar.periodCount forwarded');
+    },
+
+    async function testPie(x) {
+      var a = this.DashboardPieChartDAOAgent.create({
+        showPercentages: true, cutoutPercentage: 40, clockwise: false,
+        rotation: 45, disableLegendClick: true, emptyValueMessage: 'none',
+        colors: ['$c'], alignment: 'RIGHT', maintainAspectRatio: true,
+        height: 200, showLegend: false, legendPosition: 'LEFT',
+        showTooltips: true, showTooltipSum: false, animate: true,
+        animationDuration: 700
+      }, x);
+      x.test(a.displaySink != null, 'Pie displaySink auto-created');
+      x.test(a.displaySink && a.displaySink.showPercentages === true, 'Pie.showPercentages forwarded');
+      x.test(a.displaySink && a.displaySink.cutoutPercentage === 40, 'Pie.cutoutPercentage forwarded');
+      x.test(a.displaySink && a.displaySink.clockwise === false, 'Pie.clockwise forwarded');
+      x.test(a.displaySink && a.displaySink.rotation === 45, 'Pie.rotation forwarded');
+      x.test(a.displaySink && a.displaySink.disableLegendClick === true, 'Pie.disableLegendClick forwarded');
+      x.test(a.displaySink && a.displaySink.emptyValueMessage === 'none', 'Pie.emptyValueMessage forwarded');
+      x.test(a.displaySink && foam.util.equals(a.displaySink.colors, ['$c']), 'Pie.colors forwarded');
+      x.test(a.displaySink && a.displaySink.height === 200, 'Pie.height forwarded');
+      x.test(a.displaySink && a.displaySink.legendPosition && a.displaySink.legendPosition.name === 'LEFT', 'Pie.legendPosition forwarded');
+    },
+
+    async function testStackedBar(x) {
+      var a = this.DashboardStackedBarChartDAOAgent.create({
+        horizontal: true, xAxisLabel: 'X', yAxisLabel: 'Y', showGridLines: false,
+        onClickScript: 'console.log("x")', colors: ['$s1'], alignment: 'CENTER',
+        maintainAspectRatio: false, height: 300, showLegend: true,
+        legendPosition: 'TOP', showTooltips: true, showTooltipSum: false,
+        animate: true, animationDuration: 1000, periodCount: 12
+      }, x);
+      x.test(a.displaySink != null, 'StackedBar displaySink auto-created');
+      x.test(a.displaySink && a.displaySink.horizontal === true, 'StackedBar.horizontal forwarded');
+      x.test(a.displaySink && a.displaySink.xAxisLabel === 'X', 'StackedBar.xAxisLabel forwarded');
+      x.test(a.displaySink && a.displaySink.onClickScript === 'console.log("x")', 'StackedBar.onClickScript forwarded');
+      x.test(a.displaySink && a.displaySink.height === 300, 'StackedBar.height forwarded');
+      x.test(a.displaySink && a.displaySink.periodCount === 12, 'StackedBar.periodCount forwarded');
+    },
+
+    async function testLine(x) {
+      var a = this.DashboardLineChartDAOAgent.create({
+        xAxisLabel: 'X', yAxisLabel: 'Y', fill: true, tension: 0.5,
+        stepped: true, showPoints: false, pointRadius: 6, showGridLines: false,
+        colors: ['$l'], alignment: 'LEFT', maintainAspectRatio: true,
+        height: 280, showLegend: false, legendPosition: 'RIGHT',
+        showTooltips: true, showTooltipSum: true, animate: false,
+        animationDuration: 300, periodCount: 24
+      }, x);
+      // Line's displaySink type depends on groupBy; call createSink to populate it.
+      a.createSink();
+      x.test(a.displaySink != null, 'Line displaySink populated');
+      x.test(a.displaySink && a.displaySink.fill === true, 'Line.fill forwarded');
+      x.test(a.displaySink && a.displaySink.tension === 0.5, 'Line.tension forwarded');
+      x.test(a.displaySink && a.displaySink.stepped === true, 'Line.stepped forwarded');
+      x.test(a.displaySink && a.displaySink.showPoints === false, 'Line.showPoints forwarded');
+      x.test(a.displaySink && a.displaySink.pointRadius === 6, 'Line.pointRadius forwarded');
+      x.test(a.displaySink && a.displaySink.height === 280, 'Line.height forwarded');
+      x.test(a.displaySink && a.displaySink.periodCount === 24, 'Line.periodCount forwarded');
+    },
+
+    async function testCalendar(x) {
+      var a = this.DashboardCalendarChartDAOAgent.create({
+        periodCount: 30, colors: ['$cc'], alignment: 'CENTER',
+        maintainAspectRatio: false, height: 220, showLegend: true,
+        legendPosition: 'BOTTOM', animate: true, animationDuration: 600
+      }, x);
+      x.test(a.displaySink != null, 'Calendar displaySink auto-created');
+      x.test(a.displaySink && a.displaySink.periodCount === 30, 'Calendar.periodCount forwarded');
+      x.test(a.displaySink && foam.util.equals(a.displaySink.colors, ['$cc']), 'Calendar.colors forwarded');
+      x.test(a.displaySink && a.displaySink.height === 220, 'Calendar.height forwarded');
+      x.test(a.displaySink && a.displaySink.animationDuration === 600, 'Calendar.animationDuration forwarded');
+    }
+  ]
+});

--- a/src/foam/core/reflow/dashboard/test/pom.js
+++ b/src/foam/core/reflow/dashboard/test/pom.js
@@ -1,0 +1,8 @@
+foam.POM({
+  name: 'dashboard-test',
+  files: [
+    { name: 'DashboardAgentShimTest',     flags: 'js&test|java&test' },
+    { name: 'DashboardAgentJsonTest',     flags: 'js&test|java&test' },
+    { name: 'DashboardAgentBaselineTest', flags: 'js&test|java&test' }
+  ]
+});

--- a/src/foam/core/reflow/dashboard/test/tests.jrl
+++ b/src/foam/core/reflow/dashboard/test/tests.jrl
@@ -1,0 +1,3 @@
+p({"class":"foam.core.reflow.dashboard.test.DashboardAgentShimTest","id":"DashboardAgentShimTest","language":0})
+p({"class":"foam.core.reflow.dashboard.test.DashboardAgentJsonTest","id":"DashboardAgentJsonTest","language":0})
+p({"class":"foam.core.reflow.dashboard.test.DashboardAgentBaselineTest","id":"DashboardAgentBaselineTest","language":0})


### PR DESCRIPTION
## Problem
Each chart-rendering DashboardDAOAgent (Bar, Pie, StackedBar, Line, Calendar) duplicated display configuration across four places: the agent declared every display property (directly or via ChartDisplayMixin + ColorMappingMixin), copied the same ~20 values into a freshly created sink inside createSink(), re-applied them through a dynamic() listener in addSinkToE(), then re-linked every slot by name in a clone() override. DashboardMetricDAOAgent already avoided this with a single sink: FObjectProperty rendered via ReactiveSectionedDetailView on this.sink$, but the chart agents kept the four-layer pattern.

Three sink declarations also disagreed on legendPosition: DashboardBarSink, DashboardStackedBarSink, and LineChartMixin used a raw String, while DashboardCalendarSink and ChartDisplayMixin used Enum of LegendPosition.

## Solution
Each chart agent now holds displaySink: FObjectProperty of DashboardXSink, created lazily via a factory. Former agent-level display properties become hidden transient shims whose setters write through to this.displaySink.<name>. createSink() wires DAO-layer inputs (arg1/arg2, xFunc/yFunc/acc, or dateProp/categoryProp/valueSink) onto the existing sink and returns it. addSinkToE() collapses to e.add(s); addToE() tags ReactiveSectionedDetailView on this.displaySink$. The dynamic() sync listener and per-slot clone() override are removed. ChartDisplayMixin and ColorMappingMixin no longer apply to chart agents; TimeSeriesGapFillingMixin stays because applyDateRangeFilter lives there.

DashboardLineChartDAOAgent runtime-swaps displaySink between DashboardLineSink and DashboardMultiLineSink based on whether groupBy is set. createSink() owns DAO-layer wiring on both sides of the swap: it copies display props from the old sink, sets xFunc/yFunc (multi-line) or arg1 (single-line), and re-derives the aggregation slot from this.aggregationSink so acc / arg2 survive the swap regardless of postSet order during deserialization.

The shim layer preserves full backward compatibility with serialized flow scripts. Stored agents with display properties at the agent level deserialize through the shim setters into the factory-created displaySink. Shims are hidden: true, transient: true, so they never serialize back out; saves now produce the nested "displaySink": { ... } form that DashboardMetricDAOAgent already uses. periodCount is the exception: TimeSeriesGapFillingMixin owns it on the agent side, so an init() listener forwards it to the sink when set.

The three outlier String legendPosition declarations are normalized to Enum of LegendPosition. Enum deserialization accepts the string form ("TOP", "BOTTOM", ...) used by existing scripts, so no serialized payload breaks.

Three JSTest suites cover the contract:
- DashboardAgentBaselineTest asserts each agent's createSink() output matches a frozen snapshot of the pre-refactor state, plus a Line-with-groupBy case that verifies xFunc, yFunc, and acc are wired on the resulting MultiLineSink.
- DashboardAgentShimTest asserts every shim property forwards its value onto displaySink.
- DashboardAgentJsonTest parses both the legacy flat-keyed JSON and the new nested JSON and asserts the resulting displaySink holds the right values.

## Changes
- Replace ChartDisplayMixin + ColorMappingMixin application on DashboardBarChartDAOAgent, DashboardPieChartDAOAgent, DashboardStackedBarChartDAOAgent, DashboardLineChartDAOAgent, and DashboardCalendarChartDAOAgent with a displaySink: FObjectProperty plus forwarding shim properties.
- Delete the dynamic() sync block inside each agent's addSinkToE() and the per-slot clone() override on each agent. Simplify addToE() to render ReactiveSectionedDetailView on this.displaySink$.
- Collapse createSink() to wire DAO-layer inputs only; reuse the factory-created displaySink instead of re-instantiating the sink each call.
- DashboardLineChartDAOAgent.createSink() swaps between DashboardLineSink and DashboardMultiLineSink based on groupBy, copies display props across the swap, and re-applies this.aggregationSink to the destination sink's aggregation slot (acc or arg2) so the chart never loses its aggregator.
- Forward periodCount to the sink via an init() reactive listener on every agent that composes TimeSeriesGapFillingMixin.
- Seed DashboardCalendarChartDAOAgent's displaySink factory with periodCount: 30 to preserve the agent's prior default.
- Upgrade legendPosition on DashboardBarSink, DashboardStackedBarSink, and LineChartMixin from String to Enum of LegendPosition; add foam.core.reflow.dashboard.LegendPosition to each requires:.
- Declare DashboardLineChartDAOAgent.displaySink as of: 'foam.dao.Sink' so the runtime swap to DashboardMultiLineSink type-checks.
- Add three JSTest classes (DashboardAgentBaselineTest, DashboardAgentShimTest, DashboardAgentJsonTest) plus the test/pom.js, test/tests.jrl, and parent pom.js registration that host them.