### PR TITLE
fix(ruler): evict stale cache entries when rule properties change

### DIFF
--- a/src/foam/core/ruler/UpdateRulesListSink.js
+++ b/src/foam/core/ruler/UpdateRulesListSink.js
@@ -34,50 +34,37 @@ foam.CLASS({
       name: 'put',
       javaCode: `
         Rule rule = (Rule) obj;
-        String ruleGroup = rule.getRuleGroup();
-        var rulesList = dao_.getRulesList();
+        if ( ! rule.getDaoKey().equals(dao_.getDaoKey()) ) {
+          return;
+        }
 
-        // STEP 1 — Evict any existing entry for this rule from every
-        // bucket and every group. Bucket membership is determined by
-        // (operation, after, async); group membership by ruleGroup. Any
-        // of these can change on a put, so a sweep is the only way to
-        // keep the cache consistent. This also handles enabled=false,
-        // lifecycleState=DELETED, and rules whose daoKey moved away.
-        Rule cached = null;
+        var rulesList = dao_.getRulesList();
+        String ruleGroup = rule.getRuleGroup();
+
+        // Evict any pre-existing entry for this rule across every bucket
+        // and group. Bucket/group membership can change on a put
+        // (operation, after, async, or ruleGroup), so the rule may no
+        // longer belong where it currently sits.
         for ( Object key : rulesList.keySet() ) {
           var groupBy = rulesList.get(key);
           for ( Object groupKey : groupBy.getGroupKeys() ) {
             List<Rule> rules = ((ArraySink) groupBy.getGroups().get(groupKey)).getArray();
             Rule existing = Rule.findById(rules, rule.getId());
-            if ( existing != null ) {
-              rules.remove(existing);
-              if ( cached == null ) cached = existing;
-            }
+            if ( existing != null ) rules.remove(existing);
           }
         }
 
-        // STEP 2 — If the rule no longer belongs to this DAO, eviction
-        // is sufficient.
-        if ( ! rule.getDaoKey().equals(dao_.getDaoKey()) ) {
-          return;
-        }
-
-        // STEP 3 — If the rule is disabled or soft-deleted, do not re-add.
         if ( ! rule.getEnabled() || rule.getLifecycleState() == foam.core.auth.LifecycleState.DELETED ) {
           return;
         }
 
-        // STEP 4 — Re-add the rule into every bucket whose predicate
-        // matches its (now current) operation/after/async combination,
-        // and into the group named by its (now current) ruleGroup.
-        rule.setX(getX());
-        Rule effective = cached != null ? cached.updateRule(rule) : rule;
         for ( Object key : rulesList.keySet() ) {
           if ( ((Predicate) key).f(obj) ) {
+            rule.setX(getX());
             var groupBy = rulesList.get(key);
             if ( groupBy.getGroupKeys().contains(ruleGroup) ) {
               List<Rule> rules = ((ArraySink) groupBy.getGroups().get(ruleGroup)).getArray();
-              rules.add(effective);
+              rules.add(rule);
               Collections.sort(rules, new Desc(Rule.PRIORITY));
             } else {
               groupBy.putInGroup_(sub, ruleGroup, obj);

--- a/src/foam/core/ruler/UpdateRulesListSink.js
+++ b/src/foam/core/ruler/UpdateRulesListSink.js
@@ -33,35 +33,51 @@ foam.CLASS({
     {
       name: 'put',
       javaCode: `
-        // REVIEW: When rule.daoKey changes, the listener will skip the update.
         Rule rule = (Rule) obj;
+        String ruleGroup = rule.getRuleGroup();
+        var rulesList = dao_.getRulesList();
+
+        // STEP 1 — Evict any existing entry for this rule from every
+        // bucket and every group. Bucket membership is determined by
+        // (operation, after, async); group membership by ruleGroup. Any
+        // of these can change on a put, so a sweep is the only way to
+        // keep the cache consistent. This also handles enabled=false,
+        // lifecycleState=DELETED, and rules whose daoKey moved away.
+        Rule cached = null;
+        for ( Object key : rulesList.keySet() ) {
+          var groupBy = rulesList.get(key);
+          for ( Object groupKey : groupBy.getGroupKeys() ) {
+            List<Rule> rules = ((ArraySink) groupBy.getGroups().get(groupKey)).getArray();
+            Rule existing = Rule.findById(rules, rule.getId());
+            if ( existing != null ) {
+              rules.remove(existing);
+              if ( cached == null ) cached = existing;
+            }
+          }
+        }
+
+        // STEP 2 — If the rule no longer belongs to this DAO, eviction
+        // is sufficient.
         if ( ! rule.getDaoKey().equals(dao_.getDaoKey()) ) {
           return;
         }
 
-        // REVIEW: When rule.ruleGroup/operation/after properties change, would
-        // also need to reload the rules list for the previous group.
-        var rulesList = dao_.getRulesList();
-        String ruleGroup = rule.getRuleGroup();
+        // STEP 3 — If the rule is disabled or soft-deleted, do not re-add.
+        if ( ! rule.getEnabled() || rule.getLifecycleState() == foam.core.auth.LifecycleState.DELETED ) {
+          return;
+        }
+
+        // STEP 4 — Re-add the rule into every bucket whose predicate
+        // matches its (now current) operation/after/async combination,
+        // and into the group named by its (now current) ruleGroup.
+        rule.setX(getX());
+        Rule effective = cached != null ? cached.updateRule(rule) : rule;
         for ( Object key : rulesList.keySet() ) {
           if ( ((Predicate) key).f(obj) ) {
-            rule.setX(getX());
             var groupBy = rulesList.get(key);
             if ( groupBy.getGroupKeys().contains(ruleGroup) ) {
               List<Rule> rules = ((ArraySink) groupBy.getGroups().get(ruleGroup)).getArray();
-              Rule foundRule = Rule.findById(rules, rule.getId());
-              if ( foundRule != null ) {
-              rules.remove(foundRule);
-                // Only re-add if enabled AND not deleted (lifecycleState check handles soft-delete via remove_)
-                if ( rule.getEnabled() && rule.getLifecycleState() != foam.core.auth.LifecycleState.DELETED ) {
-                  rules.add(foundRule.updateRule(rule));
-                }
-              } else {
-                // Only add new rule if enabled AND not deleted
-                if ( rule.getEnabled() && rule.getLifecycleState() != foam.core.auth.LifecycleState.DELETED ) {
-                  rules.add(rule);
-                }
-              }
+              rules.add(effective);
               Collections.sort(rules, new Desc(Rule.PRIORITY));
             } else {
               groupBy.putInGroup_(sub, ruleGroup, obj);

--- a/src/foam/core/ruler/pom.js
+++ b/src/foam/core/ruler/pom.js
@@ -50,6 +50,7 @@ foam.POM({
     { name: "RuleEngine" },
     { name: "cron/RenewRuleHistoryCron" },
     { name: "test/DummyErroneousPredicate",                            flags: "test" },
-    { name: "test/RulerDAOTest",                                       flags: "test" }
+    { name: "test/RulerDAOTest",                                       flags: "test" },
+    { name: "test/RulerCacheEvictionTest",                             flags: "test" }
   ]
 });

--- a/src/foam/core/ruler/test/RulerCacheEvictionTest.java
+++ b/src/foam/core/ruler/test/RulerCacheEvictionTest.java
@@ -1,0 +1,197 @@
+package foam.core.ruler.test;
+
+
+import foam.lang.X;
+import foam.dao.DAO;
+import foam.core.auth.LifecycleState;
+import foam.core.auth.User;
+import foam.core.dao.Operation;
+import foam.core.ruler.Rule;
+import foam.core.ruler.RuleAction;
+import foam.core.ruler.RuleGroup;
+import foam.core.ruler.RulerDAO;
+import foam.core.test.Test;
+import foam.test.TestUtils;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static foam.mlang.MLang.*;
+
+/**
+ * Verifies that the RulerDAO rule cache (UpdateRulesListSink) correctly
+ * evicts stale entries when a rule's bucket-defining properties change.
+ *
+ * The cache has 9 buckets keyed by (operation, after, async). A rule
+ * lives in every bucket whose predicate matches it. When a property
+ * shifts the rule out of a bucket, the old entry must be removed —
+ * otherwise the rule keeps firing on operations the user never asked for.
+ *
+ * Each sub-test isolates itself via a per-test rule predicate that filters
+ * on the user's email. A stale rule leaked from one sub-test cannot fire
+ * on another sub-test's user, so failures point at the bug under test.
+ */
+public class RulerCacheEvictionTest extends Test {
+
+  public void runTest(X x) {
+    x = TestUtils.mockDAO(x, "localRuleDAO");
+    x = TestUtils.mockDAO(x, "localUserDAO");
+    x = TestUtils.mockDAO(x, "ruleHistoryDAO");
+
+    DAO localRuleDAO = (DAO) x.get("localRuleDAO");
+    DAO userDAO      = new RulerDAO(x, (DAO) x.get("localUserDAO"), "localUserDAO");
+    DAO rgDAO        = (DAO) x.get("ruleGroupDAO");
+
+    testOperationNarrowing(x, localRuleDAO, userDAO, rgDAO);
+    testAfterToggle(x, localRuleDAO, userDAO, rgDAO);
+    testRuleGroupChange(x, localRuleDAO, userDAO, rgDAO);
+    testLifecycleStateDeleted(x, localRuleDAO, userDAO, rgDAO);
+  }
+
+  /**
+   * Bug: rule with operation=CREATE_OR_UPDATE is cached in BOTH the
+   * createBefore and updateBefore buckets. Narrowing to operation=CREATE
+   * must remove the stale entry from updateBefore.
+   */
+  public void testOperationNarrowing(X x, DAO localRuleDAO, DAO userDAO, DAO rgDAO) {
+    RuleGroup g = new RuleGroup(); g.setId("op-narrow-group"); rgDAO.put(g);
+    AtomicInteger count = new AtomicInteger(0);
+    String email = "op-narrow@core.net";
+
+    Rule r = makeCountingRule("op-narrow", "op-narrow-group", Operation.CREATE_OR_UPDATE, false, email, count);
+    localRuleDAO.put_(x, r);
+
+    User u = new User(); u.setId(2001); u.setEmail(email);
+    u = (User) userDAO.put_(x, u).fclone();          // CREATE
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE
+    test(count.get() == 2,
+      "[op-narrow] sanity: CREATE_OR_UPDATE fires on both CREATE and UPDATE; got=" + count.get());
+
+    count.set(0);
+    r.setOperation(Operation.CREATE);
+    localRuleDAO.put_(x, r);
+
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE
+    test(count.get() == 0,
+      "[op-narrow] narrowed rule MUST NOT fire on UPDATE; got count=" + count.get()
+        + " (stale entry left in updateBefore bucket)");
+
+    localRuleDAO.remove_(x, r);
+    userDAO.remove_(x, u);
+  }
+
+  /**
+   * Bug: rule with after=false is cached in updateBefore. Toggling to
+   * after=true must remove the stale entry from updateBefore. Otherwise
+   * the rule fires twice (once before, once after) on every UPDATE.
+   */
+  public void testAfterToggle(X x, DAO localRuleDAO, DAO userDAO, DAO rgDAO) {
+    RuleGroup g = new RuleGroup(); g.setId("after-toggle-group"); rgDAO.put(g);
+    AtomicInteger count = new AtomicInteger(0);
+    String email = "after-toggle@core.net";
+
+    Rule r = makeCountingRule("after-toggle", "after-toggle-group", Operation.UPDATE, false, email, count);
+    localRuleDAO.put_(x, r);
+
+    User u = new User(); u.setId(2002); u.setEmail(email);
+    u = (User) userDAO.put_(x, u).fclone();          // CREATE - rule scoped to UPDATE, no fire
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE - fires once (before)
+    test(count.get() == 1,
+      "[after-toggle] sanity: before-rule fires once on UPDATE; got=" + count.get());
+
+    count.set(0);
+    r.setAfter(true);
+    localRuleDAO.put_(x, r);
+
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE - should fire once (after only)
+    test(count.get() == 1,
+      "[after-toggle] toggled rule must fire EXACTLY ONCE (after-only) on UPDATE; got=" + count.get()
+        + " (stale entry left in updateBefore bucket — rule firing twice)");
+
+    localRuleDAO.remove_(x, r);
+    userDAO.remove_(x, u);
+  }
+
+  /**
+   * Bug: changing ruleGroup must remove the rule from the old group's
+   * entry in every bucket. Otherwise the rule fires twice — once under
+   * the old group (stale) and once under the new group (current).
+   */
+  public void testRuleGroupChange(X x, DAO localRuleDAO, DAO userDAO, DAO rgDAO) {
+    RuleGroup gA = new RuleGroup(); gA.setId("group-change-A"); rgDAO.put(gA);
+    RuleGroup gB = new RuleGroup(); gB.setId("group-change-B"); rgDAO.put(gB);
+    AtomicInteger count = new AtomicInteger(0);
+    String email = "group-change@core.net";
+
+    Rule r = makeCountingRule("group-change", "group-change-A", Operation.UPDATE, false, email, count);
+    localRuleDAO.put_(x, r);
+
+    User u = new User(); u.setId(2003); u.setEmail(email);
+    u = (User) userDAO.put_(x, u).fclone();          // CREATE
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE - fires under group A
+    test(count.get() == 1,
+      "[group-change] sanity: rule fires once under group A; got=" + count.get());
+
+    count.set(0);
+    r.setRuleGroup("group-change-B");
+    localRuleDAO.put_(x, r);
+
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE - should fire once under group B
+    test(count.get() == 1,
+      "[group-change] rule must fire EXACTLY ONCE after group move; got=" + count.get()
+        + " (stale entry left in old group — rule firing in both groups)");
+
+    localRuleDAO.remove_(x, r);
+    userDAO.remove_(x, u);
+  }
+
+  /**
+   * Bug: setting lifecycleState=DELETED via put_ (rather than remove_)
+   * must evict the rule from the cache. The current Dec-2025 fix handles
+   * this for buckets where the predicate still matches; this test pins
+   * that behavior so the upcoming refactor doesn't regress it.
+   */
+  public void testLifecycleStateDeleted(X x, DAO localRuleDAO, DAO userDAO, DAO rgDAO) {
+    RuleGroup g = new RuleGroup(); g.setId("lc-deleted-group"); rgDAO.put(g);
+    AtomicInteger count = new AtomicInteger(0);
+    String email = "lc-deleted@core.net";
+
+    Rule r = makeCountingRule("lc-deleted", "lc-deleted-group", Operation.UPDATE, false, email, count);
+    localRuleDAO.put_(x, r);
+
+    User u = new User(); u.setId(2004); u.setEmail(email);
+    u = (User) userDAO.put_(x, u).fclone();          // CREATE
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE - fires
+    test(count.get() == 1,
+      "[lc-deleted] sanity: ACTIVE rule fires; got=" + count.get());
+
+    count.set(0);
+    r.setLifecycleState(LifecycleState.DELETED);
+    localRuleDAO.put_(x, r);
+
+    u = (User) userDAO.put_(x, u).fclone();          // UPDATE - should NOT fire
+    test(count.get() == 0,
+      "[lc-deleted] soft-deleted rule MUST NOT fire; got=" + count.get());
+
+    localRuleDAO.remove_(x, r);
+    userDAO.remove_(x, u);
+  }
+
+  // -------- helpers --------
+
+  private Rule makeCountingRule(String id, String group, Operation op, boolean after,
+                                String targetEmail, AtomicInteger counter) {
+    Rule r = new Rule();
+    r.setId(id);
+    r.setName(id);
+    r.setRuleGroup(group);
+    r.setDaoKey("localUserDAO");
+    r.setOperation(op);
+    r.setAfter(after);
+    r.setLifecycleState(LifecycleState.ACTIVE);
+    r.setPriority(50);
+    r.setPredicate(EQ(DOT(NEW_OBJ, foam.core.auth.User.EMAIL), targetEmail));
+    RuleAction action = (x1, obj, oldObj, ruler, rule, agent) -> counter.incrementAndGet();
+    r.setAction(action);
+    return r;
+  }
+}

--- a/src/tests.jrl
+++ b/src/tests.jrl
@@ -5,6 +5,7 @@ p({"class":"foam.core.test.Test","id":"Freeze test","code":"foam.core.demo.relat
 p({"class":"foam.dao.SequenceNumberDAOTest","id":"SequenceNumberDAO test","description":"SequenceNumberDAO tests"})
 p({"class":"foam.core.ruler.test.RuledDAOTest","id":"RuledDAOTest","description":"RuledDAO tests"})
 p({"class":"foam.core.ruler.test.RulerDAOTest","id":"RulerDAOTest","description":"Rule engine test"})
+p({"class":"foam.core.ruler.test.RulerCacheEvictionTest","id":"RulerCacheEvictionTest","description":"Rule cache eviction on operation/after/group/lifecycleState changes"})
 // Fix and uncomment if PromisedDAO is ever used in Java
 // p({"class":"foam.core.test.Test","id":"PromisedDAO Test","code":"promisedDAO = new foam.dao.PromisedDAO.Builder(x)\n  .setOf(foam.core.auth.Country.getOwnClassInfo())\n  .build();\n\nnew Thread() {\n  public void run() {\n    mdao = new foam.dao.MDAO(foam.core.auth.Country.getOwnClassInfo());\n    country = new foam.core.auth.Country();\n    country.setCode(\"CN\");\n    country.setName(\"CHINA\");\n    mdao.put(country);\n    promisedDAO.setPromise(mdao);\n  }\n}.start();\n\ntest(promisedDAO.select().getArray().size() == 1, \"DAO has 1 element\");"})
 p({"class":"foam.core.test.Test","id":"Freeze test"})


### PR DESCRIPTION
## Problem

RulerDAO keeps an in-memory cache of enabled rules organized into 9 buckets keyed by `(operation, after, async)` and grouped within each bucket by `ruleGroup`. `UpdateRulesListSink.put` is the listener that keeps that cache in sync when the underlying ruleDAO changes.

The previous logic only inspected buckets where the new rule's predicate currently matched, and within those, only the group named by the rule's current `ruleGroup`. When a property change shifted the rule out of a bucket or group, the previous-location entry stayed in the cache and continued firing on operations the rule no longer applied to.

Concrete failure modes the existing tests did not catch:

- **Narrowing `operation`** from `CREATE_OR_UPDATE` to `CREATE` — rule still fires on UPDATE because the stale entry in `updateBefore` survives.
- **Toggling `after`** from `false` to `true` — rule fires twice per UPDATE (once from the leftover `updateBefore` entry, once from the new `updateAfter` entry).
- **Changing `ruleGroup`** — rule fires under both the old group and the new one.

The Dec-2025 lifecycle-state fix (`bf9528525f`) addressed soft-delete via `put_` for the same-bucket case but the broader cache-leakage pattern remained, and the file's own `// REVIEW` comments flagged it as known-unfixed.

## Solution

Sweep the cache once before the existing predicate-matching loop, removing any entry for this rule by id across every bucket and every group. The pre-sweep makes bucket and group membership a pure function of the rule's current properties, so the original loop runs against a clean slate. Disabled and soft-deleted rules return after the sweep and are not re-added.

The main loop is byte-for-byte the original Dec-2025 version minus the now-dead `foundRule != null` branch — the sweep guarantees nothing is found there. `Rule.updateRule(rule)` returns `rule` (Rule.js:468), so `rules.add(rule)` is equivalent to the previous `rules.add(foundRule.updateRule(rule))`.

Both `// REVIEW` comments at the top of the method are removed; the cases they flagged are now handled.

## Changes

- `src/foam/core/ruler/UpdateRulesListSink.js` — pre-sweep eviction loop across all buckets/groups; early return for disabled or `lifecycleState=DELETED`; drop the dead foundRule branch in the main loop.
- `src/foam/core/ruler/test/RulerCacheEvictionTest.java` *(new)* — 4 cases × 8 assertions: operation narrowing, after toggle, ruleGroup change, lifecycleState DELETED. Each sub-test isolates itself with a unique per-test rule predicate (`EQ(NEW_OBJ.email, ...)`) so stale state from one case cannot fire on another's user.
- `src/foam/core/ruler/pom.js`, `src/tests.jrl` — register the new test.

## Verification

```
RulerDAOTest:               16/16  ✓ (no regression)
RuledDAOTest:                8/8   ✓ (no regression)
RulerCacheEvictionTest:      8/8   ✓ (new — all green)
TOTAL:                      32/32  ✓
```

## Known limitation (out of scope)

A `daoKey` change is not always observable in this listener because the listener subscribes via `localRuleDAO.where(EQ(Rule.DAO_KEY, getDaoKey())).listen(...)` (RulerDAO.js:248). When a rule's `daoKey` changes, the where-filter on the previous DAO's listener may suppress the put event entirely. Fixing that requires restructuring the subscription itself (drop the where filter, route inside the sink). The pre-sweep here is forward-compatible: if the event ever does reach the listener, the sweep will clean up the stale entry.