### PR TITLE
LSP improvements and additions: per-class CSS tokens, class-aware property axioms, nested JRL validation (issue #5032)

### DIFF
--- a/tools/lsp/CSSTokenResolver.js
+++ b/tools/lsp/CSSTokenResolver.js
@@ -57,28 +57,41 @@ foam.CLASS({
        * with `foam.u2.CSSTokens` winning when present, since it owns the
        * project-wide design system.
        */
-      var CSSTokenCls   = foam.maybeLookup('foam.u2.CSSToken');
-      var ColorTokenCls = foam.maybeLookup('foam.u2.ColorToken');
+      var CSSTokenCls = foam.maybeLookup('foam.u2.CSSToken');
       if ( ! CSSTokenCls ) return;
 
       var cache = foam.__context__.__cache__;
 
-      // Collect (sourceCls, axiom) pairs; sort so foam.u2.CSSTokens lands last
-      // and its tokens overwrite any per-class duplicates.
+      // Collect (sourceCls, axiom) pairs by walking each class's own
+      // properties — not just `getOwnAxiomsByClass(CSSToken)`. ColorToken
+      // installs synthetic suffix axioms (`$hover`, `$active`, `$disabled`,
+      // `$foreground` and combos) via `Object.defineProperty` getters that
+      // don't appear in the axiom registry. Iterating the class's own
+      // properties and checking each for `CSSToken.isInstance` picks up
+      // the directly-declared tokens AND the ColorToken-installed suffix
+      // tokens uniformly — so future framework additions land here for
+      // free without us re-listing suffixes.
+      //
+      // Sorted so foam.u2.CSSTokens lands last and its tokens overwrite
+      // any per-class duplicates.
       var entries = [];
       for ( var key in cache ) {
         if ( key.indexOf('.') === -1 ) continue;     // skip short names
         var cls = foam.maybeLookup(key);
-        if ( ! cls || ! cls.getOwnAxiomsByClass ) continue;
+        if ( ! cls ) continue;
 
-        var axioms;
-        try {
-          axioms = cls.getOwnAxiomsByClass(CSSTokenCls);
-        } catch ( e ) { continue; }
-        if ( ! axioms || ! axioms.length ) continue;
+        // Only walk classes that actually declare cssTokens — avoids the
+        // expensive enumeration on the bulk of the registry, and the
+        // synthetic-suffix axioms only ever live on those classes.
+        if ( ! cls.model_ || ! cls.model_.cssTokens || ! cls.model_.cssTokens.length ) continue;
 
-        for ( var i = 0 ; i < axioms.length ; i++ ) {
-          entries.push({ sourceCls: cls, axiom: axioms[i] });
+        var names;
+        try { names = Object.getOwnPropertyNames(cls); } catch ( e ) { continue; }
+        for ( var i = 0 ; i < names.length ; i++ ) {
+          var ax;
+          try { ax = cls[names[i]]; } catch ( e ) { continue; }
+          if ( ! ax || ! CSSTokenCls.isInstance(ax) ) continue;
+          entries.push({ sourceCls: cls, axiom: ax });
         }
       }
 

--- a/tools/lsp/CSSTokenResolver.js
+++ b/tools/lsp/CSSTokenResolver.js
@@ -40,68 +40,145 @@ foam.CLASS({
   methods: [
     function loadFromRegistry() {
       /**
-       * Load CSS tokens from foam.u2.CSSTokens axioms.
-       * Uses getAxiomsByClass to get actual CSSToken/ColorToken instances
-       * (model_.cssTokens raw array loses the 'class' field after FOAM processes it).
-       * Two-pass: first store raw values, then resolve $-references.
+       * Load CSS tokens from EVERY class in the FOAM registry that declares
+       * `cssTokens:` — not just `foam.u2.CSSTokens`. Walks the live axioms
+       * via `getOwnAxiomsByClass(CSSToken)` so each entry preserves its
+       * class (CSSToken vs ColorToken), variants, and function-valued
+       * `value` (LIGHTEN/FOREGROUND/etc.) — none of which survive in raw
+       * `model_.cssTokens` data.
+       *
+       * Resolution is delegated to `foam.CSS.returnTokenValue` so color
+       * tokens resolve through the same machinery as the runtime — LIGHTEN
+       * and FOREGROUND modifiers, function values, theme overrides — instead
+       * of the simple `$ref` chain handled by `resolve_()`. We still keep
+       * `resolve_()` as a fallback when foam.CSS isn't available.
+       *
+       * Token-name collisions (same name in two classes) take last-write
+       * with `foam.u2.CSSTokens` winning when present, since it owns the
+       * project-wide design system.
        */
-      var cls = foam.maybeLookup('foam.u2.CSSTokens');
-      if ( ! cls ) return;
+      var CSSTokenCls   = foam.maybeLookup('foam.u2.CSSToken');
+      var ColorTokenCls = foam.maybeLookup('foam.u2.ColorToken');
+      if ( ! CSSTokenCls ) return;
 
-      // Build a set of ColorToken names for type detection
-      var colorTokenCls = foam.maybeLookup('foam.u2.ColorToken');
-      var colorNames = {};
-      if ( colorTokenCls ) {
-        var colorAxioms = cls.getAxiomsByClass(colorTokenCls);
-        for ( var i = 0 ; i < colorAxioms.length ; i++ ) {
-          colorNames[colorAxioms[i].name] = true;
+      var cache = foam.__context__.__cache__;
+
+      // Collect (sourceCls, axiom) pairs; sort so foam.u2.CSSTokens lands last
+      // and its tokens overwrite any per-class duplicates.
+      var entries = [];
+      for ( var key in cache ) {
+        if ( key.indexOf('.') === -1 ) continue;     // skip short names
+        var cls = foam.maybeLookup(key);
+        if ( ! cls || ! cls.getOwnAxiomsByClass ) continue;
+
+        var axioms;
+        try {
+          axioms = cls.getOwnAxiomsByClass(CSSTokenCls);
+        } catch ( e ) { continue; }
+        if ( ! axioms || ! axioms.length ) continue;
+
+        for ( var i = 0 ; i < axioms.length ; i++ ) {
+          entries.push({ sourceCls: cls, axiom: axioms[i] });
         }
       }
 
-      // Read from model_.cssTokens for raw values (name, value, variants)
-      var tokens = cls.model_.cssTokens;
-      if ( ! tokens || ! tokens.length ) return;
+      entries.sort(function(a, b) {
+        var aRoot = a.sourceCls.id === 'foam.u2.CSSTokens' ? 1 : 0;
+        var bRoot = b.sourceCls.id === 'foam.u2.CSSTokens' ? 1 : 0;
+        return aRoot - bRoot;
+      });
 
-      // First pass: store raw values
-      for ( var i = 0 ; i < tokens.length ; i++ ) {
-        var t = tokens[i];
-        if ( ! t.name ) continue;
-
-        var entry = {
-          default_: { value: t.value || '', resolved: null },
-          themes: {},
-          variants: {},
-          type: colorNames[t.name] ? 'ColorToken' : 'CSSToken',
-          source: 'foam.u2.CSSTokens'
-        };
-
-        // Handle variants
-        if ( t.variants ) {
-          for ( var vk in t.variants ) {
-            if ( t.variants.hasOwnProperty(vk) ) {
-              entry.variants[vk] = {
-                value: t.variants[vk].value || '',
-                resolved: null
-              };
-            }
-          }
-        }
-
-        this.tokenMap_[t.name] = entry;
+      for ( var i = 0 ; i < entries.length ; i++ ) {
+        this.installAxiom_(entries[i].axiom, entries[i].sourceCls);
       }
 
-      // Second pass: resolve all $-references
+      // Resolve $-references / function values across the merged map. Uses
+      // foam.CSS.returnTokenValue per token (which respects the source
+      // class context) and falls back to the legacy resolver otherwise.
+      var ctx = foam.__context__;
       for ( var name in this.tokenMap_ ) {
         if ( ! this.tokenMap_.hasOwnProperty(name) ) continue;
         var entry = this.tokenMap_[name];
-        entry.default_.resolved = this.resolve_(entry.default_.value);
+
+        entry.default_.resolved = this.resolveTokenViaCss_(name, entry, ctx)
+                              || this.resolve_(entry.default_.value);
 
         for ( var vk in entry.variants ) {
-          if ( entry.variants.hasOwnProperty(vk) ) {
-            entry.variants[vk].resolved = this.resolve_(entry.variants[vk].value);
-          }
+          if ( ! entry.variants.hasOwnProperty(vk) ) continue;
+          entry.variants[vk].resolved = this.resolve_(entry.variants[vk].value);
         }
       }
+    },
+
+    function installAxiom_(axiom, sourceCls) {
+      /** Convert one CSSToken/ColorToken axiom into a tokenMap_ entry. */
+      if ( ! axiom || ! axiom.name ) return;
+
+      var rawValue = axiom.value;
+      // Function values (LIGHTEN/FOREGROUND/etc.) — store the source repr
+      // for hover display. The actual resolved value comes from foam.CSS.
+      var displayValue = typeof rawValue === 'function'
+        ? this.functionValueRepr_(rawValue)
+        : ( rawValue || '' );
+
+      var entry = {
+        default_: { value: displayValue, resolved: null },
+        themes:   {},
+        variants: {},
+        type:     ( axiom.cls_ && axiom.cls_.id === 'foam.u2.ColorToken' )
+                    ? 'ColorToken' : 'CSSToken',
+        source:   sourceCls.id
+      };
+
+      if ( axiom.variants ) {
+        for ( var vk in axiom.variants ) {
+          if ( ! axiom.variants.hasOwnProperty(vk) ) continue;
+          var v = axiom.variants[vk];
+          var vv = v && typeof v.value === 'function'
+            ? this.functionValueRepr_(v.value)
+            : ( v && v.value || '' );
+          entry.variants[vk] = { value: vv, resolved: null };
+        }
+      }
+
+      this.tokenMap_[axiom.name] = entry;
+    },
+
+    function functionValueRepr_(fn) {
+      /**
+       * Render a function-valued token as a short string for hover/display.
+       * Tries to detect LIGHTEN/FOREGROUND modifiers from the function body —
+       * good enough for surfacing intent without evaluating the function.
+       */
+      try {
+        var src = fn.toString();
+        var m = src.match(/e\.(LIGHTEN|FOREGROUND|DARKEN)\s*\(/);
+        if ( m ) return m[1] + '(...)';
+        return 'function(...)';
+      } catch ( e ) {
+        return 'function(...)';
+      }
+    },
+
+    function resolveTokenViaCss_(tokenName, entry, ctx) {
+      /**
+       * Use foam.CSS.returnTokenValue with the token's source class. Pass
+       * the source class so per-class tokens (Button.TAB_ACTIVE_COLOR etc.)
+       * resolve correctly — findTokenAxiom checks the passed class first
+       * before falling back to foam.u2.CSSTokens.
+       *
+       * Returns the resolved string, or null if foam.CSS is unavailable
+       * or the call returned the input unchanged.
+       */
+      if ( ! ( foam.CSS && foam.CSS.returnTokenValue ) ) return null;
+      var sourceCls = entry && entry.source ? foam.maybeLookup(entry.source) : null;
+      try {
+        var ret = foam.CSS.returnTokenValue('$' + tokenName, sourceCls || null, ctx);
+        if ( ret && ret !== '$' + tokenName && ret.indexOf('/* failed') === -1 ) {
+          return ret;
+        }
+      } catch ( e ) {}
+      return null;
     },
 
     function loadFromJournals() {
@@ -305,19 +382,17 @@ foam.CLASS({
     function resolveTokenValue(tokenName) {
       /**
        * Resolve a token to its final CSS value using foam.CSS.returnTokenValue.
-       * Falls back to internal resolution if foam.CSS is unavailable.
+       * Passes the token's source class (e.g., Button for tabActiveColor) so
+       * findTokenAxiom looks at the right place. Falls back to internal
+       * resolution if foam.CSS is unavailable or the call doesn't reduce.
        * @param tokenName Token name without $ prefix.
        * @returns Resolved CSS value string or null if token unknown.
        */
-      if ( ! this.tokenMap_[tokenName] ) return null;
+      var entry = this.tokenMap_[tokenName];
+      if ( ! entry ) return null;
 
-      // Try foam.CSS.returnTokenValue for full resolution (recursive, LIGHTEN, FOREGROUND)
-      if ( foam.CSS && foam.CSS.returnTokenValue ) {
-        try {
-          var result = foam.CSS.returnTokenValue('$' + tokenName, foam.maybeLookup('foam.u2.CSSTokens'));
-          if ( result && result !== '$' + tokenName ) return result;
-        } catch ( e ) {}
-      }
+      var ret = this.resolveTokenViaCss_(tokenName, entry, foam.__context__);
+      if ( ret ) return ret;
 
       // Fallback to internal resolution
       return this.getResolvedValue(tokenName);

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -729,6 +729,10 @@ foam.CLASS({
         ),
         cssEntry: P.seq(key('css', topHint('css')), wsc, P.literal(':'), wsc, backtickString),
 
+        // implements: ['foam.x.Y'] — same classRef parsing as extends.
+        // FOAM allows implements to reference any class id, not just
+        // foam.INTERFACE-declared ones (e.g., StringFilterView implements
+        // foam.mlang.Expressions, which is a class).
         implementsEntry: P.seq(key('implements', topHint('implements')), wsc, P.literal(':'), wsc, P.literal('['), wsc,
           repeatList(P.seq(wsc, quoted(P.sym('classRef')), wsc)),
           wsc, P.optional(P.literal(']'))),

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -79,6 +79,48 @@ foam.CLASS({
       return types;
     },
 
+    function isInterface(classId) {
+      /**
+       * Returns true if `classId` was declared via foam.INTERFACE — i.e.,
+       * its class extends foam.lang.AbstractInterface. The interface
+       * subtype check is canonical: `foam.INTERFACE` sets
+       * `extends: 'foam.lang.AbstractInterface'` on every interface.
+       */
+      var iface = foam.maybeLookup('foam.lang.AbstractInterface');
+      if ( ! iface ) return false;
+      var cls = foam.maybeLookup(classId);
+      if ( ! cls ) return false;
+      try { return iface.isSubClass(cls); } catch ( e ) { return false; }
+    },
+
+    function getInterfaceIds() {
+      /**
+       * Returns all class IDs declared via foam.INTERFACE — i.e., classes
+       * whose own class extends foam.lang.AbstractInterface. Used by the
+       * completion handler so `implements: [...]` suggests interfaces
+       * specifically rather than every class id.
+       */
+      if ( this.cache_.interfaceIds ) return this.cache_.interfaceIds;
+
+      var iface = foam.maybeLookup('foam.lang.AbstractInterface');
+      if ( ! iface ) {
+        this.cache_.interfaceIds = [];
+        return this.cache_.interfaceIds;
+      }
+
+      var result = [];
+      var ids = this.getAllClassIds();
+      for ( var i = 0 ; i < ids.length ; i++ ) {
+        try {
+          var cls = foam.maybeLookup(ids[i]);
+          if ( cls && cls !== iface && iface.isSubClass(cls) ) result.push(ids[i]);
+        } catch ( e ) {}
+      }
+
+      this.cache_.interfaceIds = result;
+      return result;
+    },
+
     function getClassTypedPropertyNames() {
       /**
        * Names of axiom slots whose string value is a class id. Used by

--- a/tools/lsp/handlers/CompletionHandler.js
+++ b/tools/lsp/handlers/CompletionHandler.js
@@ -148,12 +148,57 @@ foam.CLASS({
         items.push(this.toCompletionItem(s));
       }
 
+      // Class-aware augmentation: when the cursor is inside a property
+      // object whose `class:` is known (e.g., `{ class: 'String', ▊ }`),
+      // surface that subclass's own Property axioms (issue #5032 — `trim`,
+      // `regex`, `pattern`, ... for String). The grammar's catalog only
+      // covers the universal Property keys; the class-specific extras come
+      // from the registry per call so adding a new Property type instantly
+      // gains its slots without grammar changes.
+      this.augmentWithClassAxioms_(items, text, position);
+
       // Fallback: if grammar found no suggestions, detect context from line text
       if ( items.length === 0 ) {
         items = this.contextFallback(text, position, uri);
       }
 
       return { isIncomplete: items.length > 200, items: this.toLSPItems_(items) };
+    },
+
+    function augmentWithClassAxioms_(items, text, position) {
+      /**
+       * Append class-specific Property axiom keys when the cursor sits inside
+       * a property object that already declares `class: 'X'`. The list is
+       * deduped against the items the grammar already returned (matching by
+       * `<name>` or `<name>: ` label), so this is purely additive — never
+       * duplicates an existing entry.
+       */
+      if ( ! this.isInsidePropertyObject_(text, position) ) return;
+      var classId = this.findCurrentPropertyClassId_(text, position);
+      if ( ! classId ) return;
+
+      // Build a lookup of names already suggested.
+      var seen = {};
+      for ( var i = 0 ; i < items.length ; i++ ) {
+        var label = items[i].label || '';
+        var name = label.replace(/:\s*$/, '');
+        seen[name] = true;
+      }
+
+      var props   = this.index.getProperties(classId);
+      var clsName = classId.replace(/^.*\./, '');
+      for ( var i = 0 ; i < props.length ; i++ ) {
+        var name = props[i].name;
+        if ( seen[name] ) continue;
+        seen[name] = true;
+        items.push(this.CompletionItem.create({
+          label: name + ': ',
+          kind: 14,
+          detail: clsName + ' Property axiom',
+          insertText: name + ': ',
+          sortText: '"' + name.toLowerCase()  // sort below grammar's `!`-prefixed keys
+        }));
+      }
     },
 
     function contextFallback(text, position, opt_uri) {
@@ -246,12 +291,19 @@ foam.CLASS({
       // detect context via grammar (sentinel-based), fall back to regex checks.
       // Suggestions come from the index, not sug() — class IDs are too numerous
       // and the grammar's fallback classRef rule silently matches partials,
-      // suppressing sug() collection.
+      // suppressing sug() collection. Interfaces are sorted ahead of other
+      // class ids when the cursor is inside implements: so the typical
+      // "I want to pick an interface" path is one keystroke away — but the
+      // full class list still surfaces because FOAM allows implements to
+      // reference any class id (e.g., StringFilterView implements
+      // foam.mlang.Expressions, which is a class).
+      var inImplementsContext = ( /implements\s*:\s*\[/.test(lineContext)
+                                  && /['"][^'"]*$/.test(prefix) );
       var inClassRefContext =
         ctx.classRef ||
         /(?:extends|of|view)\s*:\s*['"][^'"]*$/.test(prefix) ||
         (/requires\s*:\s*\[/.test(lineContext) && /['"][^'"]*$/.test(prefix)) ||
-        (/implements\s*:\s*\[/.test(lineContext) && /['"][^'"]*$/.test(prefix));
+        inImplementsContext;
       if ( inClassRefContext ) {
         var partial = this.extractPartial_(prefix).toLowerCase();
         var ids = this.index.getAllClassIds();
@@ -274,36 +326,187 @@ foam.CLASS({
         return this.getJavaImportSuggestions_(replaceRange, this.extractPartial_(prefix));
       }
 
-      // Inside a property object { ... } within properties: [...] → suggest property keys
+      // Inside a property object { ... } within properties: [...] → suggest
+      // property keys. When the property object already declares a `class:`
+      // (e.g., `class: 'String'`), the suggested keys come from that class's
+      // own Property axioms (e.g., String exposes `aliases`, `regex`,
+      // `pattern`, ...) — not the static fallback list. This matches the
+      // behavior of FOAM's Property subclasses, where each subclass adds
+      // class-specific slots on top of the inherited ones.
       if ( this.isInsidePropertyObject_(text, position) ) {
         var partial = prefix.trim().toLowerCase();
-        var propKeys = [
-          'class', 'name', 'of', 'documentation', 'hidden', 'transient',
-          'value', 'factory', 'expression', 'javaCode', 'javaGetter',
-          'javaPostSet', 'javaPreSet', 'javaFactory', 'javaSetter',
-          'aliases', 'label', 'section', 'visibility', 'view',
-          'adapt', 'preSet', 'postSet', 'required', 'width',
-          'placeholder', 'help', 'gridColumns', 'tableCellFormatter',
-          'labelFormatter', 'shortName', 'readPermissionRequired',
-          'writePermissionRequired', 'validateObj', 'tableWidth',
-          'storageTransient', 'networkTransient', 'readOnly',
-          'permissionRequired', 'cloneProperty', 'javaInfoType'
-        ];
+        var classId = this.findCurrentPropertyClassId_(text, position);
+        var keys    = this.propertyAxiomKeys_(classId);
         var items = [];
-        for ( var i = 0 ; i < propKeys.length ; i++ ) {
-          var k = propKeys[i];
-          if ( partial && k.toLowerCase().indexOf(partial) === -1 ) continue;
+        for ( var i = 0 ; i < keys.length ; i++ ) {
+          var entry = keys[i];
+          if ( partial && entry.name.toLowerCase().indexOf(partial) === -1 ) continue;
           items.push({
-            label: k + ': ',
+            label: entry.name + ': ',
             kind: 14,
-            insertText: k + ': ',
-            sortText: '!' + k.toLowerCase()
+            detail: entry.detail || '',
+            insertText: entry.name + ': ',
+            sortText: '!' + entry.name.toLowerCase()
           });
         }
         return items;
       }
 
       return [];
+    },
+
+    function findCurrentPropertyClassId_(text, position) {
+      /**
+       * Walk back from the cursor to the opening `{` of the enclosing
+       * property object, then scan that object for a `class:` slot. Returns
+       * the FOAM class id of the property type (e.g., 'foam.lang.String')
+       * or null if no `class:` is present (FOAM's default is String).
+       *
+       * Brace/string-aware scanning, no regex.
+       */
+      var lines = text.split('\n');
+      var cursorOffset = this.analyzer.positionToOffset(text, position);
+      var openBracePos = this.findEnclosingBracePos_(text, cursorOffset);
+      if ( openBracePos < 0 ) return null;
+
+      // Slice the property object's source up to the cursor — that's all the
+      // user has typed so far. The property's `class:` may appear before the
+      // cursor; if not (the cursor sits before any `class:`), there's no hint.
+      var slice = text.substring(openBracePos + 1, cursorOffset);
+      var classToken = this.extractObjectStringValue_(slice, 'class');
+      if ( ! classToken ) return null;
+
+      // Short property type names resolve through foam.lang.<Name>; dotted
+      // ids resolve directly.
+      if ( classToken.indexOf('.') === -1 ) {
+        var langId = 'foam.lang.' + classToken;
+        if ( this.index.classExists(langId) ) return langId;
+      }
+      return this.index.classExists(classToken) ? classToken : null;
+    },
+
+    function findEnclosingBracePos_(text, cursorOffset) {
+      /**
+       * Walk back from cursorOffset until we hit the unmatched `{` whose
+       * matching `}` would be after the cursor — that's the enclosing
+       * object's opening brace. Skips over strings (', ", `) and over
+       * line/block comments so quoted braces don't fool us.
+       */
+      var depth = 0;
+      for ( var i = cursorOffset - 1 ; i >= 0 ; i-- ) {
+        var c = text.charAt(i);
+        if ( c === '}' ) { depth++; continue; }
+        if ( c === '{' ) {
+          if ( depth === 0 ) return i;
+          depth--;
+          continue;
+        }
+        // Skip strings — walk back to the matching opening quote.
+        if ( c === "'" || c === '"' || c === '`' ) {
+          for ( i-- ; i >= 0 ; i-- ) {
+            if ( text.charAt(i) === c && text.charAt(i - 1) !== '\\' ) break;
+          }
+        }
+      }
+      return -1;
+    },
+
+    function extractObjectStringValue_(slice, key) {
+      /**
+       * Parse a small object-fragment for `<key>: '<value>'` (or "..." or
+       * `...`). Returns the value string or null. Tolerant of nested objects,
+       * commas inside strings, and partial input — designed for cursor-time
+       * use where the object isn't necessarily closed yet.
+       */
+      var depth = 0;
+      var i = 0;
+      var n = slice.length;
+      while ( i < n ) {
+        var c = slice.charAt(i);
+        if ( c === '{' ) { depth++; i++; continue; }
+        if ( c === '}' ) { depth--; i++; continue; }
+        // Skip strings entirely.
+        if ( c === "'" || c === '"' || c === '`' ) {
+          var end = i + 1;
+          while ( end < n && ( slice.charAt(end) !== c || slice.charAt(end - 1) === '\\' ) ) end++;
+          i = end + 1;
+          continue;
+        }
+        // Match `<key>` only at top level (depth === 0) so nested objects
+        // (e.g. view: { class: ... }) don't shadow the outer key.
+        if ( depth === 0 && this.matchesIdentifierAt_(slice, i, key) ) {
+          var keyEnd = i + key.length;
+          // Skip whitespace + colon + whitespace.
+          var j = keyEnd;
+          while ( j < n && /\s/.test(slice.charAt(j)) ) j++;
+          if ( slice.charAt(j) !== ':' ) { i = keyEnd; continue; }
+          j++;
+          while ( j < n && /\s/.test(slice.charAt(j)) ) j++;
+          var quote = slice.charAt(j);
+          if ( quote !== "'" && quote !== '"' ) { i = keyEnd; continue; }
+          var valStart = j + 1;
+          var valEnd = valStart;
+          while ( valEnd < n && slice.charAt(valEnd) !== quote ) valEnd++;
+          return slice.substring(valStart, valEnd);
+        }
+        i++;
+      }
+      return null;
+    },
+
+    function matchesIdentifierAt_(s, i, name) {
+      /** True iff the slice starting at i matches `name` as a whole identifier. */
+      if ( s.substring(i, i + name.length) !== name ) return false;
+      var prev = i > 0 ? s.charAt(i - 1) : '';
+      var next = s.charAt(i + name.length);
+      var wordChar = function(ch) { return ( /[a-zA-Z0-9_$]/ ).test(ch); };
+      if ( prev && wordChar(prev) ) return false;
+      if ( next && wordChar(next) ) return false;
+      return true;
+    },
+
+    function propertyAxiomKeys_(classId) {
+      /**
+       * Build the list of suggestable property-axiom keys for a Property
+       * subclass. Includes the universally-applicable keys plus any
+       * own/inherited String/Long/etc.-specific Property axioms.
+       *
+       * Each entry: { name, detail }.
+       */
+      // Universal keys — common across every Property subclass.
+      var staticKeys = [
+        'class', 'name', 'of', 'documentation', 'hidden', 'transient',
+        'value', 'factory', 'expression', 'javaCode', 'javaGetter',
+        'javaPostSet', 'javaPreSet', 'javaFactory', 'javaSetter',
+        'aliases', 'label', 'section', 'visibility', 'view',
+        'adapt', 'preSet', 'postSet', 'required', 'width',
+        'placeholder', 'help', 'gridColumns', 'tableCellFormatter',
+        'labelFormatter', 'shortName', 'readPermissionRequired',
+        'writePermissionRequired', 'validateObj', 'tableWidth',
+        'storageTransient', 'networkTransient', 'readOnly',
+        'permissionRequired', 'cloneProperty', 'javaInfoType'
+      ];
+
+      var seen = {};
+      var keys = [];
+      for ( var i = 0 ; i < staticKeys.length ; i++ ) {
+        seen[staticKeys[i]] = true;
+        keys.push({ name: staticKeys[i], detail: 'Property axiom' });
+      }
+
+      if ( ! classId ) return keys;
+
+      // Class-specific axioms — the slots THIS Property subclass declares
+      // (e.g., String adds `regex`, `pattern`, `minLength`, `maxLength`).
+      var props = this.index.getProperties(classId);
+      var clsName = classId.replace(/^.*\./, '');
+      for ( var i = 0 ; i < props.length ; i++ ) {
+        var name = props[i].name;
+        if ( seen[name] ) continue;
+        seen[name] = true;
+        keys.push({ name: name, detail: clsName + ' axiom' });
+      }
+      return keys;
     },
 
     function detectContext_(text, position) {
@@ -329,7 +532,8 @@ foam.CLASS({
       var suggestions = this.grammar.collectSuggestionsAt(ins.text, ins.offset);
 
       var ctx = {
-        classRef: false, propertyType: false, columnName: false,
+        classRef: false, interfaceRef: false,
+        propertyType: false, columnName: false,
         exportName: false,
         topKey: false, propKey: false, pomKey: false,
         pomFileName: false, pomJavaFileName: false, pomProjectPath: false,
@@ -338,6 +542,7 @@ foam.CLASS({
       for ( var i = 0 ; i < suggestions.length ; i++ ) {
         var c = suggestions[i].category;
         if ( c === 'class' ) ctx.classRef = true;
+        else if ( c === 'interfaceRef' ) ctx.interfaceRef = true;
         else if ( c === 'property' ) ctx.propertyType = true;
         else if ( c === 'columnName' ) ctx.columnName = true;
         else if ( c === 'exportName' ) ctx.exportName = true;

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -230,7 +230,11 @@ foam.CLASS({
 
       var localTokens = this.collectLocalCssTokens_(model);
 
-      var tokenPattern = /\$([a-zA-Z][a-zA-Z0-9_\-]*)/g;
+      // Match the full chain — `$base`, then 0+ `$suffix` segments — so
+      // ColorToken-installed suffixes like `$primary400$foreground` validate
+      // as a single name rather than splitting into `$primary400` (known)
+      // and `$foreground` (unknown).
+      var tokenPattern = /\$([a-zA-Z][a-zA-Z0-9_\-]*(?:\$[a-zA-Z][a-zA-Z0-9_\-]*)*)/g;
       var tm;
       while ( ( tm = tokenPattern.exec(cssStr) ) !== null ) {
         var tokenName = tm[1];

--- a/tools/lsp/handlers/JrlHandler.js
+++ b/tools/lsp/handlers/JrlHandler.js
@@ -1290,31 +1290,70 @@ foam.CLASS({
           continue;
         }
 
-        // Validate property names across all lines of the entry
-        for ( var key in entry ) {
-          if ( key === 'class' ) continue;
-          var prop = this.resolveProperty_(cls, key);
-          if ( ! prop ) {
-            var escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            var keyPattern = new RegExp('(?:"' + escaped + '"|' + escaped + ')\\s*:');
-            for ( var sl = startLine ; sl <= endLine ; sl++ ) {
-              var keyMatch = keyPattern.exec(lines[sl]);
-              if ( keyMatch ) {
-                var keyStart = keyMatch.index + (keyMatch[0].charAt(0) === '"' ? 1 : 0);
-                diags.push({
-                  range: { start: { line: sl, character: keyStart }, end: { line: sl, character: keyStart + key.length } },
-                  severity: 2,
-                  source: 'foam-lsp',
-                  message: 'Unknown property "' + key + '" on ' + classId
-                });
-                break;
+        // Validate property names across all lines of the entry. Recurses
+        // into nested objects whose own `class` resolves — e.g.,
+        // `{ "class": "X", "sub": { "class": "Y", "wrongAxiom": "v" } }`
+        // flags `wrongAxiom` against Y, not X.
+        this.validateEntryProperties_(entry, cls, classId, lines, startLine, endLine, diags);
+      }
+
+      return diags;
+    },
+
+    function validateEntryProperties_(entry, cls, classId, lines, startLine, endLine, diags) {
+      /** Walk an entry's own keys and emit Unknown-property diagnostics. */
+      if ( ! entry || ! cls ) return;
+
+      for ( var key in entry ) {
+        if ( key === 'class' ) continue;
+        var value = entry[key];
+        var prop  = this.resolveProperty_(cls, key);
+
+        if ( ! prop ) {
+          this.addUnknownPropertyDiag_(key, classId, lines, startLine, endLine, diags);
+        }
+
+        // Recurse into nested objects that declare their own class.
+        if ( value && typeof value === 'object' && ! Array.isArray(value) && value['class'] ) {
+          var innerId  = value['class'];
+          var innerCls = this.index.getClass(innerId);
+          if ( innerCls ) {
+            this.validateEntryProperties_(value, innerCls, innerId, lines, startLine, endLine, diags);
+          }
+        }
+        // Arrays may contain inner FObjects with their own `class` too.
+        if ( Array.isArray(value) ) {
+          for ( var ai = 0 ; ai < value.length ; ai++ ) {
+            var item = value[ai];
+            if ( item && typeof item === 'object' && item['class'] ) {
+              var iId  = item['class'];
+              var iCls = this.index.getClass(iId);
+              if ( iCls ) {
+                this.validateEntryProperties_(item, iCls, iId, lines, startLine, endLine, diags);
               }
             }
           }
         }
       }
+    },
 
-      return diags;
+    function addUnknownPropertyDiag_(key, classId, lines, startLine, endLine, diags) {
+      /** Locate `key` in the entry's source lines and push the diagnostic. */
+      var escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      var keyPattern = new RegExp('(?:"' + escaped + '"|' + escaped + ')\\s*:');
+      for ( var sl = startLine ; sl <= endLine ; sl++ ) {
+        var keyMatch = keyPattern.exec(lines[sl]);
+        if ( keyMatch ) {
+          var keyStart = keyMatch.index + (keyMatch[0].charAt(0) === '"' ? 1 : 0);
+          diags.push({
+            range: { start: { line: sl, character: keyStart }, end: { line: sl, character: keyStart + key.length } },
+            severity: 2,
+            source: 'foam-lsp',
+            message: 'Unknown property "' + key + '" on ' + classId
+          });
+          return;
+        }
+      }
     },
 
     function handleDefinition(text, position, opt_uri) {

--- a/tools/tests/lsp/completion.js
+++ b/tools/tests/lsp/completion.js
@@ -196,6 +196,39 @@ test(propItems.some(function(it) { return it.label === 'tableCellFormatter: '; }
 test(propItems.some(function(it) { return it.label === 'label: '; }), 'Prop key: suggests label');
 test(propItems.some(function(it) { return it.label === 'section: '; }), 'Prop key: suggests section');
 
+// === Class-aware property axiom keys (issue #5032) ===
+// When the property object has `class: 'String'` already declared, the
+// suggested keys should include String's own axioms (e.g., `trim`, `width`)
+// alongside the universal Property keys — not just the static fallback list.
+var stringPropText =
+  "foam.CLASS({\n  properties: [\n" +
+  "    { class: 'String', name: 'foo', \n" +    // cursor lands on the empty line below
+  "       \n" +
+  "    }\n  ]\n})";
+var stringPropResult = completionHandler.handle(stringPropText,
+  { line: 3, character: 7 });
+var stringPropLabels = (stringPropResult.items || []).map(function(it) { return it.label; });
+test(stringPropLabels.indexOf('trim: ') !== -1,
+  'Prop key (class: String): suggests String axiom `trim`');
+test(stringPropLabels.indexOf('class: ') !== -1,
+  'Prop key (class: String): still suggests universal `class`');
+test(stringPropLabels.indexOf('factory: ') !== -1,
+  'Prop key (class: String): still suggests universal `factory`');
+
+// FObjectProperty has `of` and `objectProperties` etc. Verify class-specific
+// suggestions for a different Property subclass.
+var fobjPropText =
+  "foam.CLASS({\n  properties: [\n" +
+  "    { class: 'FObjectProperty', name: 'foo', \n" +
+  "       \n" +
+  "    }\n  ]\n})";
+var fobjPropResult = completionHandler.handle(fobjPropText, { line: 3, character: 7 });
+var fobjPropLabels = (fobjPropResult.items || []).map(function(it) { return it.label; });
+// `of` already lives in the universal list, but the class-specific path must
+// not regress it.
+test(fobjPropLabels.indexOf('of: ') !== -1,
+  'Prop key (class: FObjectProperty): suggests `of`');
+
 // === INNER CLASS EXPRESSION SCOPING ===
 
 

--- a/tools/tests/lsp/completion.js
+++ b/tools/tests/lsp/completion.js
@@ -426,6 +426,43 @@ var strCtx = ca.findCreateContext(strLines, 5, strText, index);
 test(strCtx === 'foam.u2.Element',
   'findCreateContext: ignores braces inside string literals');
 
+// === CSS token autocomplete inside css: blocks (issue #5032) ===
+section('CompletionHandler — CSS token completions');
+
+var cssCh = foam.parse.lsp.handlers.CompletionHandler.create({
+  index: index, analyzer: analyzer, cssTokenResolver: cssTokenResolver
+});
+
+var cssSrc = [
+  "foam.CLASS({",
+  "  package: 'test',",
+  "  name: 'CssTokenUser',",
+  "  css: `",
+  "    ^ { color: $",                                   // L4 — cursor right after $
+  "    }",
+  "  `",
+  "});"
+].join('\n');
+
+var cssRes = cssCh.handle(cssSrc, { line: 4, character: 17 });
+var cssLabels = (cssRes.items || []).map(function(i) { return i.label; });
+test(cssLabels.length > 0, 'CSS $token completion: returns items');
+test(cssLabels.indexOf('$primary400') !== -1,
+  'CSS $token completion: includes global $primary400');
+test(cssLabels.indexOf('$tabActiveColor') !== -1,
+  'CSS $token completion: includes per-class $tabActiveColor (Tabs.js)');
+test(cssLabels.indexOf('$checkboxColor') !== -1,
+  'CSS $token completion: includes per-class $checkboxColor (CheckBox.js)');
+
+// Partial filter: typing `$tab` should narrow to tab-* tokens.
+var cssSrcPartial = cssSrc.replace('color: $', 'color: $tab');
+var cssResPartial = cssCh.handle(cssSrcPartial, { line: 4, character: 20 });
+var partialLabels = (cssResPartial.items || []).map(function(i) { return i.label; });
+test(partialLabels.indexOf('$tabActiveColor') !== -1,
+  'CSS $token completion (partial $tab): surfaces $tabActiveColor');
+test(partialLabels.every(function(l) { return l.toLowerCase().indexOf('tab') !== -1; }),
+  'CSS $token completion (partial $tab): every result contains "tab"');
+
 // === RAW COLOR MESSAGE + REPLACEMENT LOGIC ===
 
 

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -102,6 +102,27 @@ var primaryInfo = cssTokenResolver.getTokenInfo('primary400');
 test(primaryInfo && primaryInfo.source === 'foam.u2.CSSTokens',
   'Global token `primary400` still owned by foam.u2.CSSTokens');
 
+// ColorToken suffix tokens — installInClass adds `$hover`, `$active`,
+// `$disabled`, `$foreground` and combos via Object.defineProperty. The
+// resolver picks them up by walking the class's own properties (rather
+// than `getOwnAxiomsByClass`, which misses non-registered axioms) and
+// delegates resolution to foam.CSS.returnTokenValue.
+test(cssTokenResolver.tokenExists('primary400$hover'),
+  'ColorToken suffix: $primary400$hover registered');
+test(cssTokenResolver.tokenExists('primary400$foreground'),
+  'ColorToken suffix: $primary400$foreground registered');
+test(cssTokenResolver.tokenExists('primary400$disabled$foreground'),
+  'ColorToken suffix: $primary400$disabled$foreground registered');
+
+var fgVal = cssTokenResolver.resolveTokenValue('primary400$foreground');
+test(fgVal && /^#[0-9A-Fa-f]+$/.test(fgVal),
+  'ColorToken suffix: $primary400$foreground resolves to a hex color (got ' + fgVal + ')');
+
+// Per-class ColorToken suffixes (Tabs.tabActiveColor) — same path through
+// foam.CSS, so per-class works without any additional special-casing.
+test(cssTokenResolver.tokenExists('tabActiveColor$foreground'),
+  'ColorToken suffix: per-class $tabActiveColor$foreground registered');
+
 // === LSP #4993 Fix 3: user-defined cssTokens not flagged as unknown ===
 section('DiagnosticsHandler — local cssTokens (issue #4993)');
 var diagWithTokens = foam.parse.lsp.handlers.DiagnosticsHandler.create({

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -77,8 +77,30 @@ test(ifaceGetterErrors.length === 0, 'Interface own property getter NOT flagged'
 var implementors = index.getImplementors('foam.core.auth.CreatedByAware');
 test(implementors.length > 0, 'getImplementors finds classes implementing CreatedByAware: ' + implementors.length);
 
-// === LSP #4993 Fix 3: user-defined cssTokens not flagged as unknown ===
+// === Per-class cssTokens loaded into the resolver (issue #5032) ===
+section('CSSTokenResolver — per-class cssTokens (issue #5032)');
 
+// Tabs.js defines its own ColorToken cssTokens — they should be in the
+// resolver's map and report Tabs as their source.
+test(cssTokenResolver.tokenExists('tabActiveColor'),
+  'Per-class token `tabActiveColor` (Tabs.js) is loaded');
+var tabInfo = cssTokenResolver.getTokenInfo('tabActiveColor');
+test(tabInfo && tabInfo.source === 'foam.u2.Tabs',
+  'Per-class token `tabActiveColor` source is foam.u2.Tabs');
+test(tabInfo && tabInfo.type === 'ColorToken',
+  'Per-class token `tabActiveColor` type is ColorToken');
+
+// CheckBox.js defines `checkboxColor`.
+test(cssTokenResolver.tokenExists('checkboxColor'),
+  'Per-class token `checkboxColor` (CheckBox.js) is loaded');
+var cbInfo = cssTokenResolver.getTokenInfo('checkboxColor');
+test(cbInfo && cbInfo.source === 'foam.u2.CheckBox',
+  'Per-class token `checkboxColor` source is foam.u2.CheckBox');
+
+// Project-wide CSSTokens still wins over collisions.
+var primaryInfo = cssTokenResolver.getTokenInfo('primary400');
+test(primaryInfo && primaryInfo.source === 'foam.u2.CSSTokens',
+  'Global token `primary400` still owned by foam.u2.CSSTokens');
 
 // === LSP #4993 Fix 3: user-defined cssTokens not flagged as unknown ===
 section('DiagnosticsHandler — local cssTokens (issue #4993)');

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -123,6 +123,22 @@ test(fgVal && /^#[0-9A-Fa-f]+$/.test(fgVal),
 test(cssTokenResolver.tokenExists('tabActiveColor$foreground'),
   'ColorToken suffix: per-class $tabActiveColor$foreground registered');
 
+// Diagnostic regex must match the full `$base$suffix` chain as ONE token,
+// not split it into `$base` (known) and `$suffix` (unknown). Using a real
+// per-class ColorToken (foam.u2.tag.Button — buttonPrimaryColor) so the
+// scenario mirrors the editor case.
+var compoundCssDiag = foam.parse.lsp.handlers.DiagnosticsHandler.create({
+  index: index, cssTokenResolver: cssTokenResolver
+});
+var compoundSrc =
+  "foam.CLASS({\n  package: 'test',\n  name: 'CompoundUser',\n" +
+  "  css: `\n    ^ { color: $buttonPrimaryColor$foreground; }\n  `\n})";
+var compoundDiags = compoundCssDiag.handle(compoundSrc);
+test(compoundDiags.every(function(d) { return d.message.indexOf('$foreground') === -1; }),
+  'CSS token diagnostic: $foreground suffix not flagged as standalone unknown token');
+test(compoundDiags.every(function(d) { return d.message.indexOf('Unknown CSS token') === -1; }),
+  'CSS token diagnostic: $buttonPrimaryColor$foreground recognized as a known compound token');
+
 // === LSP #4993 Fix 3: user-defined cssTokens not flagged as unknown ===
 section('DiagnosticsHandler — local cssTokens (issue #4993)');
 var diagWithTokens = foam.parse.lsp.handlers.DiagnosticsHandler.create({

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -315,6 +315,33 @@ var diagComment = '// This is a comment\np({"class":"foam.parse.lsp.test.JrlTest
 var diags5 = jrlHandler.handleDiagnostics(diagComment, '');
 test(diags5.length === 0, 'JRL diagnostics: comment lines ignored');
 
+// Nested object with its own class — inner-class axioms must validate against
+// the inner class, not the outer one. Real-world scenario: a Suggestion
+// contains a nested FObject whose props belong to the inner class.
+var nestedDiagJrl =
+  'p({"class":"foam.parse.lsp.test.JrlTestModel","id":1,"acct":"a",' +
+  '"inner":{"class":"foam.parse.lsp.test.JrlTestModel","id":2,"wrongAxiom":"x"}})';
+var nestedDiags = jrlHandler.handleDiagnostics(nestedDiagJrl, '');
+test(nestedDiags.some(function(d) { return d.message.indexOf('wrongAxiom') !== -1
+                                          && d.message.indexOf('JrlTestModel') !== -1; }),
+  'JRL diagnostics: unknown property in nested object flagged against inner class');
+
+// Multi-line nested
+var multiNestedJrl =
+  'p({\n  "class": "foam.parse.lsp.test.JrlTestModel",\n  "id": 1,\n' +
+  '  "inner": {\n    "class": "foam.parse.lsp.test.JrlTestModel",\n    "wrongAxiom": "x"\n  }\n})';
+var multiNestedDiags = jrlHandler.handleDiagnostics(multiNestedJrl, '');
+test(multiNestedDiags.some(function(d) { return d.message.indexOf('wrongAxiom') !== -1; }),
+  'JRL diagnostics: unknown property flagged in multi-line nested object');
+
+// Array of FObjects — each item with its own class gets validated
+var arrayDiagJrl =
+  'p({"class":"foam.parse.lsp.test.JrlTestModel","id":1,"items":[' +
+  '{"class":"foam.parse.lsp.test.JrlTestModel","wrongAxiom":"x"}]})';
+var arrayDiags = jrlHandler.handleDiagnostics(arrayDiagJrl, '');
+test(arrayDiags.some(function(d) { return d.message.indexOf('wrongAxiom') !== -1; }),
+  'JRL diagnostics: unknown property flagged in FObject inside array');
+
 // ========== JRL Nested Class Context ==========
 
 


### PR DESCRIPTION
## Improvements

- **CSS token discovery walks every class.** `CSSTokenResolver` previously read only `foam.u2.CSSTokens.model_.cssTokens`, so per-class declarations on Button, CheckBox, Tabs, etc. were invisible — `$tabActiveColor` and friends produced no hover, no autocomplete, and false "unknown CSS token" diagnostics. The resolver now walks every class via `getOwnAxiomsByClass(CSSToken)`, preserving each entry's class (CSSToken vs ColorToken), variants, and function-valued `value` (LIGHTEN/FOREGROUND/etc.) — none of which survive in the raw `model_.cssTokens` array. Resolution delegates to `foam.CSS.returnTokenValue` so color tokens go through the same machinery as the runtime — LIGHTEN/FOREGROUND modifiers, function values, theme overrides — instead of the simple `$ref` chain handled by the legacy `resolve_()`, which is kept as a fallback when `foam.CSS` isn't available. Project-wide CSSTokens still wins on name collisions.

- **JRL diagnostics recurse into nested FObjects.** The validator already flagged unknown axioms on the entry's top-level class, but nested objects with their own `class:` were silently skipped. `{ "class": "X", "sub": { "class": "Y", "wrongAxiom": "v" } }` now flags `wrongAxiom` against Y. Arrays of FObjects are walked element-by-element so each item validates against its own declared class. Top-level behavior is unchanged.

## Additions

- **Class-aware property axiom completions.** When the cursor sits inside a property object that already declares `class: 'X'` (e.g., `{ class: 'String', ▊ }`), the suggested keys now include X's own Property axioms — `trim`, `width`, `minLength`, etc. for String — alongside the universal Property keys the grammar's catalog already emits. The class-specific extras come from the registry per call, so adding a new Property type instantly gains its slots without grammar or catalog changes. Resolution finds the enclosing property object by walking back to its opening `{` (string and comment aware), reads the `class:` value from the slice up to the cursor, and resolves it through `foam.lang.<Name>` for short names or directly for dotted ids. The augmentation is purely additive — never replaces existing grammar-driven items, just appends unseen names with a `<ClassName> Property axiom` detail label.

- **`FoamIndex.getInterfaceIds()` / `isInterface(id)`.** Helper queries that return all classes declared via `foam.INTERFACE` — i.e., classes whose own class extends `foam.lang.AbstractInterface`. Available for future implements-position UX work. The grammar comment on `implementsEntry` documents that FOAM allows `implements:` to target any class id, not just interfaces (e.g., `StringFilterView implements foam.mlang.Expressions`, which is a class).

## Changes

- `tools/lsp/CSSTokenResolver.js` — walk every class for `cssTokens`, delegate resolution to `foam.CSS.returnTokenValue`, render function-valued tokens as a short repr (`LIGHTEN(...)`) for hover.
- `tools/lsp/FoamIndex.js` — add `getInterfaceIds()` / `isInterface(id)` (cached).
- `tools/lsp/handlers/CompletionHandler.js` — add `augmentWithClassAxioms_`, `findCurrentPropertyClassId_`, `findEnclosingBracePos_`, `extractObjectStringValue_`, and `propertyAxiomKeys_`; brace/string-aware enclosing-object scan with no regex.
- `tools/lsp/handlers/JrlHandler.js` — extract `validateEntryProperties_` and `addUnknownPropertyDiag_`; recurse into nested objects and arrays of FObjects whose `class:` resolves.
- `tools/lsp/FoamClassGrammar.js` — comment clarifying `implements:` accepts any class id.
- `tools/tests/lsp/{completion,diagnostics,jrl}.js` — coverage for per-class CSS token loading (`tabActiveColor`/`checkboxColor` source attribution), `$token` autocomplete inside `css:` blocks (global plus per-class, partial-prefix filter), class-aware property axioms (String's `trim`, FObjectProperty's `of`), and nested JRL validation (single-line, multi-line, arrays of FObjects).