### PR TITLE
Fix flow save crash from reaction dependency check

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -2049,10 +2049,11 @@ foam.CLASS({
       let fc = this.flowChildren;
 
       function hasReactionDependency(c1, c2) {
-        if ( c2.value ) {
+        if ( c2.value && c2.value.reactions_ ) {
           for ( let r in c2.value.reactions_ ) {
-            let str = Function.prototype.toString.call(c2.value.reactions_.text);
-            if ( str.indexOf(c1.flowName) != -1 )
+            let v   = c2.value.reactions_[r];
+            let str = typeof v === 'function' ? v.toString() : v;
+            if ( typeof str === 'string' && str.indexOf(c1.flowName) != -1 )
               return true;
           }
         }


### PR DESCRIPTION
## Problem

`Console.updateDependencies` runs every time `flowChildren` changes and calls `hasReactionDependency` for every pair of children. The current implementation:

```javascript
let str = Function.prototype.toString.call(c2.value.reactions_.text);
```

has two defects that prevent any flow with `reactions_` from saving:

1. `reactions_` is a `Map` keyed by property name (`ReactiveDetailView.js:14`); it has no `.text` field. The intended access is `reactions_[r]` from the loop variable.
2. Each entry can be a formula string (before `startReaction_`'s `setTimeout` runs) or a wrapper function whose `toString` is overridden to return the formula (`ReactiveDetailView.js:70`). `Function.prototype.toString.call(<string>)` throws "requires that 'this' be a Function" — the user-reported error. Even on a function it would bypass the override and return the raw source instead of the formula.

Coercing through `String(...)` instead is also unsafe: when `formula` was ever passed as a non-string, the override returns a non-primitive and `String` falls through to `valueOf` (which returns the function itself), throwing "Cannot convert object to primitive value".

The exception escapes through `generateScript` and blocks every flow save once any block holds a reaction.

## Solution

Index `reactions_` by the loop key, branch on type, and only call `indexOf` when the result is actually a string:

- `function` → invoke its overridden `toString` (returns the formula text)
- `string` → use directly
- anything else → skip

This restores the dependency check for the common cases (string formula on first save, wrapped function after `startReaction_` runs) and stays safe if a non-string formula ever reaches the map.

## Changes

- `src/foam/core/reflow/Console.js` — replace `Function.prototype.toString.call(reactions_.text)` with a typed branch over `reactions_[r]`; guard the outer access on `c2.value.reactions_` and the `indexOf` call on `typeof str === 'string'`.