### PR TITLE
Restore name-based fallback in Java enum string cast

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1479,8 +1479,22 @@ foam.CLASS({
       });
 
       var cast = info.getMethod('cast');
+      // String input first resolves by external `value` axiom (added in
+      // commit 0a90b12cc7 — enum constants may define a stable serialized
+      // value), then falls back to standard Java enum-by-name lookup.
+      // Without the fallback, legacy data using the constant name (e.g.
+      // "DAY") returned null from forValue, silently setting the enum
+      // field to null and NPE-ing later. Mirrors the JS adapt chain in
+      // foam/lang/Enum.js (constantize → forValue).
       cast.body = `if ( o instanceof Integer ) return forOrdinal((int) o);
-  if ( o instanceof String ) return forValue((String) o);
+  if ( o instanceof String ) {
+    ${this.of.id} ret = forValue((String) o);
+    if ( ret == null ) {
+      try { ret = Enum.valueOf(${this.of.id}.class, (String) o); }
+      catch ( IllegalArgumentException e ) { ret = null; }
+    }
+    return ret;
+  }
   return (${this.of.id})o;`;
 
       return info;

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1489,10 +1489,7 @@ foam.CLASS({
       cast.body = `if ( o instanceof Integer ) return forOrdinal((int) o);
   if ( o instanceof String ) {
     ${this.of.id} ret = forValue((String) o);
-    if ( ret == null ) {
-      try { ret = Enum.valueOf(${this.of.id}.class, (String) o); }
-      catch ( IllegalArgumentException e ) { ret = null; }
-    }
+    if ( ret == null ) ret = Enum.valueOf(${this.of.id}.class, (String) o);
     return ret;
   }
   return (${this.of.id})o;`;

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1479,13 +1479,6 @@ foam.CLASS({
       });
 
       var cast = info.getMethod('cast');
-      // String input first resolves by external `value` axiom (added in
-      // commit 0a90b12cc7 — enum constants may define a stable serialized
-      // value), then falls back to standard Java enum-by-name lookup.
-      // Without the fallback, legacy data using the constant name (e.g.
-      // "DAY") returned null from forValue, silently setting the enum
-      // field to null and NPE-ing later. Mirrors the JS adapt chain in
-      // foam/lang/Enum.js (constantize → forValue).
       cast.body = `if ( o instanceof Integer ) return forOrdinal((int) o);
   if ( o instanceof String ) {
     ${this.of.id} ret = forValue((String) o);


### PR DESCRIPTION
## Problem

Java enum `cast()` resolves String inputs by calling `forValue(s)`, which switches on the explicit `value` axiom on each enum constant. Constants without an explicit `value:` get an auto-generated default of `String.valueOf(getOrdinal())` (`"0"`, `"1"`, …), so `forValue("DAY")` returns null when the input is the constant name rather than a numeric value or a custom-defined value. The setter then accepts the null, silently leaving the enum field null and NPE-ing on later reads.

Before commit `0a90b12cc7` ("add ability to supply value to ordinal for serialization"), `cast()` called `Enum.valueOf(class, name)`, which matched the constant name directly. Replacing that with `forValue` regressed name-based parsing for any consumer with serialized data using enum names — common where a journal or external payload was hand-edited or written by an older outputter.

## Solution

Try `forValue(s)` first to preserve the value-based serialization contract introduced in `0a90b12cc7`, then fall back to `Enum.valueOf(class, s)` for standard enum-by-name lookup. Mirrors the existing JS adapt chain in `foam/lang/Enum.js` (constantize → forValue → values-by-value).

Every input shape now resolves correctly:

- numeric ordinal (`Integer`) → `forOrdinal`
- ordinal-as-string (`"3"`) or custom value → `forValue`
- constant name (`"DAY"`) → `Enum.valueOf` fallback

## Changes

- `src/foam/java/refinements.js` — `EnumJavaRefinement.createJavaPropertyInfo_`: extend the `cast()` body so the String branch tries `forValue` first and falls back to `Enum.valueOf` when `forValue` returns null.
