### PR TITLE
Make copyFrom failures less verbose.

### DIFF
--- a/src/foam/lang/FObject.java
+++ b/src/foam/lang/FObject.java
@@ -310,8 +310,7 @@ public interface FObject
           }
         }
       } catch (ClassCastException ignore) {
-        StdoutLogger.instance().warning("FObject.copyFrom", p.getName(), p, p2, obj, ignore.getMessage(), ignore);
-        ignore.printStackTrace();
+        StdoutLogger.instance().debug("FObject.copyFrom", p.getName(), p, p2, obj, ignore.getMessage());
       }
     }
     return this;


### PR DESCRIPTION
On copyFrom failure output debug without stacktrace rather than warning and stacktrace. Also, stacktrace was output twice. When using copyFrom to copy from a very similar object, the ClassCastException output is excessive and unnecessary as the message output indicates the two object types.