### PR TITLE
LSP - vscode grammar avoid highlighting comment blocks

### DIFF
--- a/tools/lsp/editors/vscode/syntaxes/foam-js.tmLanguage.json
+++ b/tools/lsp/editors/vscode/syntaxes/foam-js.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/tc39-proposal-tagged-template-literal-grammars/master/vscode-extension/schema.json",
   "scopeName": "foam.js.injection",
-  "injectionSelector": "L:source.js",
+  "injectionSelector": "L:source.js -comment -string",
   "patterns": [
     {
       "comment": "Java injection into backtick template literals for all FOAM Java properties",


### PR DESCRIPTION
Fixes highlighting. Disables highlighting of comments blocks in javacode. 
<img width="1106" height="998" alt="image" src="https://github.com/user-attachments/assets/aff02afd-17b0-41de-a737-816165d2e0e0" />
