### PR TITLE
update UI permission checks for consistency with server layer

### DIFF
--- a/src/foam/core/auth/permissions.jrl
+++ b/src/foam/core/auth/permissions.jrl
@@ -4,5 +4,5 @@ p({class:"foam.core.auth.Permission",id:"user.action.activate",description:"Acce
 p({class:"foam.core.auth.Permission",id:"lifecyclestate.deleted.user",description:"Access to retrieve deleted users from userDAO"})
 p({class:"foam.core.auth.Permission",id:"lifecyclestate.disabled.user",description:"Access to retrieve disabled users from userDAO"})
 p({class:"foam.core.auth.Permission",id:"lifecyclestate.rejected.user",description:"Access to retrieve rejected users from userDAO"})
-p({class:"foam.core.auth.Permission",id:"user.column.lifecycleState",description:"Access to view lifecyclestate in table views"})
+p({class:"foam.core.auth.Permission",id:"user.column.lifecyclestate",description:"Access to view lifecyclestate in table views"})
 p({class:"foam.core.auth.Permission",id:"strategyreference.read.foam_core_auth_UserLifecycleTicket",description:"Access to create UserLifecycleTicket"})

--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -374,8 +374,8 @@ foam.CLASS({
       }
 
       var perms =  await Promise.all(permissionedProperties.map( async p =>
-        await this.auth.check(ctrl.__subContext__, modelName + '.rw.' + p) ||
-        await this.auth.check(ctrl.__subContext__, modelName + '.ro.' + p)
+        await this.auth.check(ctrl.__subContext__, modelName + '.rw.' + p.toLowerCase()) ||
+        await this.auth.check(ctrl.__subContext__, modelName + '.ro.' + p.toLowerCase())
       ));
       var grantedProperties   = permissionedProperties.filter((_v, index) => perms[index]);
       var unorderedProperties = grantedProperties.concat(unpermissionedProperties);


### PR DESCRIPTION
Could go the other way - make the server not use lowerCase - but permissions were already in repo with the dao layer style. This was the minimal fix.

Fixed issue:
foam3/src/foam/u2/filter/FilterView.js (line 376) 
was checking **user.ro.lifecycleState / user.rw.lifecycleState** 

The corresponding conflicting server/shared auth paths:
foam3/src/foam/core/auth/PermissionedPropertyDAO.js (line 163)
foam3/src/foam/lib/PermissionedPropertyPredicate.js (line 22) 
foam3/src/foam/u2/Element2.js (line 1874) 