### PR TITLE
AQL: adding a value position matcher using regex

### DIFF
--- a/src/foam/lib/json/RegexParser.java
+++ b/src/foam/lib/json/RegexParser.java
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.lib.json;
+
+import foam.lib.parse.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class RegexParser
+  extends ProxyParser
+{
+  private static Parser instance__ = new RegexParser();
+  private static final Map<Character, Integer> FLAGS = new HashMap<>();
+
+  static {
+    FLAGS.put('i', Pattern.CASE_INSENSITIVE);
+    FLAGS.put('m', Pattern.MULTILINE);
+    FLAGS.put('s', Pattern.DOTALL);
+    FLAGS.put('x', Pattern.COMMENTS);
+  }
+
+  public static Parser instance() {
+    return instance__ == null ? new ProxyParser() { public Parser getDelegate() { return instance__; } } : instance__;
+  }
+
+  private RegexParser() {
+    setDelegate(StringParser.instance());
+  }
+
+  @Override
+  public PStream parse(PStream ps, ParserContext x) {
+    ps = super.parse(ps, x);
+    if ( ps == null ) return null;
+
+    Object value = ps.value();
+    if ( ! ( value instanceof String ) ) return ps;
+
+    try {
+      return ps.setValue(toPattern((String) value));
+    } catch ( PatternSyntaxException e ) {
+      return null;
+    }
+  }
+
+  protected Pattern toPattern(String value) {
+    if ( value == null ) return null;
+
+    int length = value.length();
+    if ( length >= 2 && value.charAt(0) == '/' ) {
+      int closingSlash = findClosingSlash(value);
+      if ( closingSlash > 0 && closingSlash < length ) {
+        String pattern = value.substring(1, closingSlash);
+        int flags = parseFlags(value.substring(closingSlash + 1));
+        return flags == 0 ? Pattern.compile(pattern) : Pattern.compile(pattern, flags);
+      }
+    }
+
+    return Pattern.compile(value);
+  }
+
+  protected int findClosingSlash(String value) {
+    for ( int i = value.length() - 1 ; i > 0 ; i-- ) {
+      if ( value.charAt(i) != '/' ) continue;
+      if ( isEscaped(value, i) ) continue;
+      return i;
+    }
+
+    return -1;
+  }
+
+  protected boolean isEscaped(String value, int index) {
+    int slashCount = 0;
+    for ( int i = index - 1 ; i >= 0 && value.charAt(i) == '\\' ; i-- ) {
+      slashCount++;
+    }
+
+    return slashCount % 2 == 1;
+  }
+
+  protected int parseFlags(String rawFlags) {
+    int flags = 0;
+    for ( int i = 0 ; i < rawFlags.length() ; i++ ) {
+      Integer flag = FLAGS.get(rawFlags.charAt(i));
+      if ( flag != null ) flags |= flag;
+    }
+    return flags;
+  }
+}

--- a/src/foam/mlang/predicate/RegExp.js
+++ b/src/foam/mlang/predicate/RegExp.js
@@ -18,6 +18,7 @@ foam.CLASS({
       type: 'Regex',
       javaInfoType: 'foam.lang.AbstractObjectPropertyInfo',
       name: 'regExp',
+      javaJSONParser: 'foam.lib.json.RegexParser.instance()',
       gridColumns: 6
     }
   ],

--- a/src/foam/parse/SimpleQueryParser.java
+++ b/src/foam/parse/SimpleQueryParser.java
@@ -18,6 +18,7 @@ import foam.util.SafetyUtil;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static foam.mlang.MLang.*;
 
@@ -27,7 +28,7 @@ import static foam.mlang.MLang.*;
  * predicates based on the properties of the specified ClassInfo.
  *
  * Each property type gets its own set of operators:
- *   String:      =, !=, >=, >, <=, <, :, ~, CONTAINS, IN(), NOT IN(), IS EMPTY, IS NOT EMPTY
+ *   String:      =, !=, >=, >, <=, <, :, ~, CONTAINS, MATCH(), IN(), NOT IN(), IS EMPTY, IS NOT EMPTY
  *   StringArray: =, HAS, !=, IN(), NOT IN()
  *   Number/Long: =, !=, >=, >, <=, <, IN(), NOT IN()
  *   Float/Double:=, !=, >=, >, <=, <, IN RANGE(), NOT IN RANGE()
@@ -207,6 +208,15 @@ public class SimpleQueryParser
     // stringArray: ws strings ws )
     g.addSymbol("strings", new Repeat(g.sym("string"), Literal.create(","), 1));
     g.addSymbol("stringArray", new Seq1(1, g.sym("ws"), g.sym("strings"), g.sym("ws"), Literal.create(")")));
+    g.addSymbol("position match", new Seq(
+      g.sym("ws"),
+      g.sym("digits"),
+      g.sym("ws"),
+      Literal.create(","),
+      g.sym("string"),
+      g.sym("ws"),
+      Literal.create(")")
+    ));
 
     // ── Date symbols ──
     // literal date: YYYY-MM-DD or YYYY-MM or YYYY (with - or / separator)
@@ -359,6 +369,7 @@ public class SimpleQueryParser
       new Seq(operatorNoSpace(g, ":"), g.sym("string")),
       new Seq(operatorNoSpace(g, "~"), g.sym("string")),
       new Seq(operator(g, "CONTAINS"), g.sym("string")),
+      new Seq(operatorIn(g, "MATCH"), g.sym("position match")),
       new Seq(operatorIn(g, "IN"), g.sym("stringArray")),
       new Seq(operatorIn(g, "NOT IN"), g.sym("stringArray")),
       new Seq(operator(g, "IS EMPTY")),
@@ -747,6 +758,14 @@ public class SimpleQueryParser
       return new Object[] { values[0], values.length > 1 ? values[1] : null };
     });
 
+    g.addAction("position match", (val, x) -> {
+      Object[] values = (Object[]) val;
+      Map<String, Object> match = new HashMap<>();
+      match.put("position", values[1]);
+      match.put("value", values[4]);
+      return match;
+    });
+
     g.addAction("compareStringArray", (val, x) -> {
       Object[] values = (Object[]) val;
       return new Object[] { values[0], values.length > 1 ? values[1] : null };
@@ -838,6 +857,9 @@ public class SimpleQueryParser
       case "~":
         return CONTAINS_IC(prop, value);
 
+      case "MATCH":
+        return buildPositionMatchPredicate(prop, value);
+
       case "IS EMPTY":
         return NOT(HAS(prop));
 
@@ -847,6 +869,27 @@ public class SimpleQueryParser
       default:
         return null;
     }
+  }
+
+  private Predicate buildPositionMatchPredicate(Expr prop, Object value) {
+    if ( ! ( value instanceof Map ) ) return new False();
+
+    Map match = (Map) value;
+    Object positionValue = match.get("position");
+    Object stringValue = match.get("value");
+
+    if ( ! ( positionValue instanceof Number ) || ! ( stringValue instanceof String ) ) {
+      return new False();
+    }
+
+    int position = ((Number) positionValue).intValue();
+    if ( position < 1 || SafetyUtil.isEmpty((String) stringValue) ) return new False();
+
+    String pattern = "^.{" + ( position - 1 ) + "}" + Pattern.quote((String) stringValue) + ".*$";
+    RegExp regExp = new RegExp();
+    regExp.setArg1(prop);
+    regExp.setRegExp(Pattern.compile(pattern));
+    return regExp;
   }
 
   /**

--- a/src/foam/parse/SimpleQueryParser.js
+++ b/src/foam/parse/SimpleQueryParser.js
@@ -34,6 +34,8 @@ foam.CLASS({
     'foam.mlang.predicate.Lte',
     'foam.mlang.predicate.Not',
     'foam.mlang.predicate.Or',
+    'foam.mlang.predicate.RegExp',
+    'foam.mlang.predicate.False',
     'foam.mlang.predicate.True',
     'foam.parse.Alternate',
     'foam.parse.Grammar',
@@ -169,6 +171,7 @@ foam.CLASS({
             seq(operator(':'), sym('string')),
             seq(operator('~'), sym('string')),
             seq(operator('CONTAINS'), sym('string')),
+            seq(operatorIn('MATCH'), sym('position match')),
             seq(operatorIn('IN'), sym('stringArray')),
             seq(operatorIn('NOT IN'), sym('stringArray')),
             seq(operator('IS EMPTY')),
@@ -285,7 +288,9 @@ foam.CLASS({
 
           stringArray: seq1(1, sym('ws'), sym('strings'), sym('ws'), ')'),
 
-          strings: repeat(sym('string'), ',', 1)
+          strings: repeat(sym('string'), ',', 1),
+
+          'position match': seq(sym('ws'), sym('digits'), sym('ws'), ',', sym('string'), sym('ws'), ')')
         };
       }
     },
@@ -456,6 +461,23 @@ foam.CLASS({
         function rangeValue(v) {
           return [ v[0][0], v[1][1] ]; // [start of first, end of second]
         }
+        function positionMatchValue(v) {
+          return {
+            position: v[1],
+            value: v[4]
+          };
+        }
+        function escapeRegExp(s) {
+          return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        }
+        function buildPositionMatchPattern(v) {
+          var position = parseInt(v.position, 10);
+          var match = v.value;
+
+          if ( ! Number.isInteger(position) || position < 1 || ! match ) return null;
+
+          return '^.{' + ( position - 1 ) + '}' + escapeRegExp(match) + '.*$';
+        }
         let actions    = {
           START: function(v) {
             if ( v && v.partialEval ) v = v.partialEval();
@@ -523,6 +545,10 @@ foam.CLASS({
 
           compareStringArray: function(v) {
             return simpleOpValue(v);
+          },
+
+          'position match': function(v) {
+            return positionMatchValue(v);
           },
 
           date: function(v) {
@@ -597,6 +623,11 @@ foam.CLASS({
               case ':':
               case '~':
                 return self.ContainsIC.create({ arg1: prop, arg2: value });
+              case 'MATCH':
+                let pattern = buildPositionMatchPattern(value);
+                return pattern ?
+                  self.RegExp.create({ arg1: prop, regExp: new RegExp(pattern) }) :
+                  self.False.create();
               case 'IS EMPTY':
                 return self.Not.create({arg1: self.Has.create({ arg1: prop })});
               case 'IS NOT EMPTY':

--- a/src/foam/parse/test/SimpleQueryParserJavaTest.js
+++ b/src/foam/parse/test/SimpleQueryParserJavaTest.js
@@ -97,6 +97,32 @@ foam.CLASS({
         test(result == null, message + " — expected null, got: " + result);
       `
     },
+    {
+      name: 'assertMatchesQuery',
+      args: [
+        { name: 'query',     type: 'String' },
+        { name: 'firstName', type: 'String' },
+        { name: 'expected',  type: 'Boolean' },
+        { name: 'message',   type: 'String' }
+      ],
+      javaCode: `
+        SimpleQueryParser parser = new SimpleQueryParser(User.getOwnClassInfo());
+        Predicate pred = parser.parseString(query);
+        if ( pred == null ) {
+          test(false, message + " — got null predicate");
+          return;
+        }
+
+        User user = new User();
+        user.setFirstName(firstName);
+
+        boolean actual = pred.f(user);
+        test(
+          actual == expected,
+          message + " — expected: " + expected + ", got: " + actual
+        );
+      `
+    },
 
     // ───────── String property tests (matches JS Test8-Test15) ─────────
     {
@@ -131,6 +157,18 @@ foam.CLASS({
           "firstName~SomeName",
           "ContainsIC(foam.core.auth.User.firstName, SomeName)",
           "String Test11: The name contains the value with ~ operator"
+        );
+        assertMatchesQuery(
+          "firstName MATCH (3,me)",
+          "SomeName",
+          true,
+          "String Test11c: MATCH finds a substring starting at a one-based position"
+        );
+        assertMatchesQuery(
+          "firstName MATCH (3,zz)",
+          "SomeName",
+          false,
+          "String Test11d: MATCH fails when the substring at the position does not match"
         );
         // JS Test12: The name exactly matches any of the listed values
         assertQuery(

--- a/src/foam/parse/test/SimpleQueryParserTest.js
+++ b/src/foam/parse/test/SimpleQueryParserTest.js
@@ -46,6 +46,8 @@ foam.CLASS({
       x.test(this.isValid("firstName CONTAINS SomeName", 'CONTAINS_IC(foam.core.auth.User.firstName, "SomeName")'), "String Test10: The name contains the value");
       x.test(this.isValid("firstName:SomeName", 'CONTAINS_IC(foam.core.auth.User.firstName, "SomeName")'), "String Test10: The name contains the value with : operator");
       x.test(this.isValid("firstName~SomeName", 'CONTAINS_IC(foam.core.auth.User.firstName, "SomeName")'), "String Test11: The name contains the value with ~ operator");
+      x.test(this.evaluate("firstName MATCH (3,me)", foam.core.auth.User.create({ firstName: "SomeName" })), "String Test11c: MATCH finds a substring starting at a one-based position");
+      x.test(! this.evaluate("firstName MATCH (3,zz)", foam.core.auth.User.create({ firstName: "SomeName" })), "String Test11d: MATCH fails when the substring at the position does not match");
       x.test(this.isValid("firstName IN (SomeName,AnotherName)", 'IN(foam.core.auth.User.firstName, ["SomeName", "AnotherName"])'), "String Test12: The name exactly matches any of the listed values");
       x.test(this.isValid('firstName NOT IN (SomeName,AnotherName)', 'NOT(IN(foam.core.auth.User.firstName, ["SomeName", "AnotherName"]))'), 'String Test13: The name does not exactly match any of the listed values');
       x.test(this.isValid('firstName IS EMPTY', 'NOT(HAS(foam.core.auth.User.firstName))'), 'String Test14: The name is empty');

--- a/src/pom.js
+++ b/src/pom.js
@@ -1426,6 +1426,7 @@ foam.POM({
     { name: "foam/lib/json/FObjectArrayParser" },
     { name: "foam/lib/json/MapParser" },
     { name: "foam/lib/json/IntParser" },
+    { name: "foam/lib/json/RegexParser" },
     { name: "foam/lib/json/UnknownReferenceParser" },
     { name: "foam/lib/json/Whitespace" },
     { name: "foam/lib/json/StringDoubleArrayParser" },


### PR DESCRIPTION
assume an obj has prop businessActivity it's value is "eee4ererewerwe" I want to query objects where the 4th char equals '4'

now we can with this PR.

aql search query is "businessActivity MATCH (4,4)"