### PR TITLE
DateUtil: add ISO-8601 formatIsoDate / formatIsoDateTime helpers

### DIFF
--- a/src/foam/util/DateUtil.js
+++ b/src/foam/util/DateUtil.js
@@ -418,8 +418,8 @@ foam.CLASS({
       name: 'formatIsoDate',
       args: 'java.util.Date date',
       type: 'String',
-      documentation: `ISO-8601 calendar date in UTC (e.g. "2016-01-01"). Use for
-        XSD xs:date fields whose REST peer expects the date-only form.`,
+      documentation: `ISO-8601 calendar date in UTC (e.g. "2016-01-01"). Use
+        when emitting a date without a time component.`,
       code: function(date) {
         if ( date == null ) return null;
         if ( typeof date === 'number' ) date = new Date(date);
@@ -434,8 +434,8 @@ foam.CLASS({
       args: 'java.util.Date date',
       type: 'String',
       documentation: `ISO-8601 instant in UTC with millisecond precision and
-        literal Z suffix (e.g. "2024-03-18T14:26:05.000Z"). Use for XSD
-        xs:dateTime fields whose REST peer expects the full timestamp.`,
+        literal Z suffix (e.g. "2024-03-18T14:26:05.000Z"). Use when
+        emitting a full timestamp.`,
       code: function(date) {
         if ( date == null ) return null;
         if ( typeof date === 'number' ) date = new Date(date);
@@ -450,8 +450,7 @@ foam.CLASS({
   javaCode: `
     // Thread-local ISO-8601 formatters in UTC. SimpleDateFormat is not
     // thread-safe; reusing instances per thread keeps formatIsoDate /
-    // formatIsoDateTime cheap on hot paths (per-property JSON serialization
-    // in XSD-generated REST clients).
+    // formatIsoDateTime cheap on hot paths.
     private static final ThreadLocal<SimpleDateFormat> ISO_DATE =
       ThreadLocal.withInitial(() -> {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");

--- a/src/foam/util/DateUtil.js
+++ b/src/foam/util/DateUtil.js
@@ -413,10 +413,59 @@ foam.CLASS({
 
         return showTimeFirst ? formattedTime + " " + formattedDate : formattedDate + " " + formattedTime;
       `
+    },
+    {
+      name: 'formatIsoDate',
+      args: 'java.util.Date date',
+      type: 'String',
+      documentation: `ISO-8601 calendar date in UTC (e.g. "2016-01-01"). Use for
+        XSD xs:date fields whose REST peer expects the date-only form.`,
+      code: function(date) {
+        if ( date == null ) return null;
+        if ( typeof date === 'number' ) date = new Date(date);
+        return date.toISOString().slice(0, 10);
+      },
+      javaCode: `
+        return date == null ? null : ISO_DATE.get().format(date);
+      `
+    },
+    {
+      name: 'formatIsoDateTime',
+      args: 'java.util.Date date',
+      type: 'String',
+      documentation: `ISO-8601 instant in UTC with millisecond precision and
+        literal Z suffix (e.g. "2024-03-18T14:26:05.000Z"). Use for XSD
+        xs:dateTime fields whose REST peer expects the full timestamp.`,
+      code: function(date) {
+        if ( date == null ) return null;
+        if ( typeof date === 'number' ) date = new Date(date);
+        return date.toISOString();
+      },
+      javaCode: `
+        return date == null ? null : ISO_DATE_TIME.get().format(date);
+      `
     }
   ],
 
   javaCode: `
+    // Thread-local ISO-8601 formatters in UTC. SimpleDateFormat is not
+    // thread-safe; reusing instances per thread keeps formatIsoDate /
+    // formatIsoDateTime cheap on hot paths (per-property JSON serialization
+    // in XSD-generated REST clients).
+    private static final ThreadLocal<SimpleDateFormat> ISO_DATE =
+      ThreadLocal.withInitial(() -> {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        return sdf;
+      });
+
+    private static final ThreadLocal<SimpleDateFormat> ISO_DATE_TIME =
+      ThreadLocal.withInitial(() -> {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        return sdf;
+      });
+
     /*
      * Java method overloads
      *


### PR DESCRIPTION
## Problem

JSONFObjectFormatter emits Date values as epoch-millisecond longs by default. REST peers that validate against XSD dateTime / date types reject that shape and expect ISO-8601 strings. xs:date and xs:dateTime want different wire shapes — calendar date `"2016-01-01"` vs full instant `"2024-03-18T14:26:05.000Z"` — and no shared helper exists in the framework, so every XSD-generated client that needs the ISO form ends up rolling its own SimpleDateFormat.

## Solution

Add two static methods to `foam.util.DateUtil`:

- `formatIsoDate(Date)` → `"yyyy-MM-dd"` in UTC (e.g. `"2016-01-01"`).
- `formatIsoDateTime(Date)` → `"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"` in UTC (e.g. `"2024-03-18T14:26:05.000Z"`).

Java path reuses thread-local `SimpleDateFormat` instances pinned to UTC — `SimpleDateFormat` is not thread-safe, so a per-thread instance keeps the formatters cheap on hot paths (per-property JSON serialization in XSD-generated REST clients). JS path delegates to `Date.toISOString()`. Both return `null` for `null` input so callers can compose with `if ( get_(obj) != null ) formatter.output(...)` style snippets without re-checking inside the helper.

## Changes

- Add `DateUtil.formatIsoDate(Date)` static method, JS via `toISOString().slice(0, 10)`, Java via thread-local `SimpleDateFormat("yyyy-MM-dd")` in UTC.
- Add `DateUtil.formatIsoDateTime(Date)` static method, JS via `toISOString()`, Java via thread-local `SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")` in UTC.
- Declare `ISO_DATE` and `ISO_DATE_TIME` `ThreadLocal<SimpleDateFormat>` fields in the class `javaCode` block.