### PR TITLE
Allow RemoteInstall mntHostname to accept explicit paths

### DIFF
--- a/tools/RemoteInstallTooling.js
+++ b/tools/RemoteInstallTooling.js
@@ -34,7 +34,7 @@ foam.POM({
     sshId: ['', 'ssh-id', 'SSH_ID', 'ssh id from .ssh/ to use for connection. Will default to that specified in .ssh/config when a matching host is found, otherwise to .ssh/id_rsa', '', arg => SSH_ID = arg],
     sshOpt: ['', 'ssh-opt', 'SSH_OPT', '', () => SSH_ID ? '-i ' + HOME_DIR + '/.ssh/' + SSH_ID : '', arg => SSH_OPT = arg],
     systemdRestart: ['', 'systemd-restart', 'SYSTEMD_RESTART', 'Execute systemd restart on succesful depoyment', true, function(arg) { SYSTEMD_RESTART = arg ? this.bool(arg) : true; }],
-    mntHostname: ['', 'mnt-hostname', 'MNT_HOSTNAME', 'Create a unique NFS mnt point using the $HOSTNAME. /mnt/APP_NAME/$HOSTNAME', true, function(arg) { MNT_HOSTNAME = arg ? this.bool(arg) : true; }]
+    mntHostname: ['', 'mnt-hostname', 'MNT_HOSTNAME', 'Create a unique NFS mnt point. true uses /mnt/APP_NAME/$HOSTNAME, false uses /mnt/APP_NAME, any other value is used as the mnt path.', true, arg => MNT_HOSTNAME = arg]
   },
 
   tasks: {

--- a/tools/deploy/bin/install.sh
+++ b/tools/deploy/bin/install.sh
@@ -52,7 +52,7 @@ function usage {
     info "  -T <path>         : Remote location of tarball"
     info "  -E <path>         : Remote directory tarball is extracted to, default to /tmp/tar_extract"
     info "  -N <app-name>     : Application name, also prefix of jar file"
-    info "  -Q <true | false> : Create a unique /mnt point for nfs using the hostname/ip. Defaults to true"
+    info "  -Q <true | false | path> : Persistent mnt path. true uses /mnt/name/HOSTNAME, false uses /mnt/name, path uses exact value. Defaults to true"
     info "  -R <true | false> : Issue systemd restart on succesful deployment, defaults to true"
     info "  -U user name      : Configure to run application under this user (and group)"
     info "  -Y user id        : Confiugre to run application under this user id (and group id)"
@@ -86,10 +86,13 @@ fi
 info "FOAM_ROOT [$FOAM_ROOT]"
 FOAM_HOME=${FOAM_ROOT}-${VERSION}
 MNT_HOME=/mnt/${APP_NAME}
-if [[ ${UNIQUE} = "true" ]]; then
+if [[ -z "${UNIQUE}" || ${UNIQUE} = "false" ]]; then
+    UNIQUE_HOME=${MNT_HOME}
+elif [[ ${UNIQUE} = "true" ]]; then
     UNIQUE_HOME=${MNT_HOME}/$HOSTNAME
 else
-    UNIQUE_HOME=${MNT_HOME}
+    UNIQUE_HOME=${UNIQUE%/}
+    MNT_HOME=$(dirname "${UNIQUE_HOME}")
 fi
 SHARED_HOME=${MNT_HOME}
 FILES_HOME=${MNT_HOME}/files


### PR DESCRIPTION
## Summary

- Extend `RemoteInstallTooling` so `--mnt-hostname` can accept either `true`, `false`, or an explicit mount path.
- Update the remote install script so:
  - `true` keeps the existing `/mnt/<app>/$HOSTNAME` behavior.
  - `false` uses `/mnt/<app>`.
  - any other value is treated as the exact persistent mount path.

## Why

Some deployments need a stable, named persistent mount path that is not derived from the machine hostname, e.g. `/mnt/bobSolutions/CA-FOAM3-T1` AND want to keep it with what it currently set on the machine.
