### PR TITLE
PT-FIXES:DOS-3605 fix(GroupBy): inner detach no longer kills outer scan

### DIFF
--- a/src/foam/mlang/sink/GroupBy.js
+++ b/src/foam/mlang/sink/GroupBy.js
@@ -122,7 +122,11 @@ return getGroupKeys();`
           this.groupKeys = undefined;
           this.groups[key] = group;
         }
-        group.put(obj, sub);
+        // Isolate the outer iteration's subscription from inner sinks.
+        // Inner sinks like LimitedSink call sub.detach() when their own
+        // limit is reached; that must not cancel the source-DAO scan,
+        // or subsequent groups silently disappear.
+        group.put(obj, { detach: function() {} });
         this.pub('propertyChange', 'groups');
       },
       javaCode:
@@ -133,7 +137,11 @@ return getGroupKeys();`
    getGroups().put(key, group);
    clearGroupKeys();
  }
- group.put(obj, sub);`
+ // Isolate the outer iteration's subscription from inner sinks.
+ // Inner sinks like LimitedSink call sub.detach() when their own
+ // limit is reached; that must not cancel the source-DAO scan,
+ // or subsequent groups silently disappear.
+ group.put(obj, new foam.lang.Detachable() { public void detach() {} });`
     },
 
     function reset() {


### PR DESCRIPTION
## Problem
`GROUP_BY(prop, LimitedSink(N, ...))` silently drops groups. Each group gets its own cloned `LimitedSink`, but every per-group sink shares the outer iteration's Detachable. When a group receives one more row than its limit, the inner sink calls `sub.detach()` and terminates the whole source-DAO scan, so every group that has not yet been seen disappears from the result. Top-level `groupLimit` masked the bug — it only manifests once two records collide on the same key, after which the scan dies on the second hit.

## Solution
In `GroupBy.putInGroup_` (JS and Java), pass a fresh no-op `Detachable` to the inner sink instead of the outer iteration's `sub`. Inner sinks still drive their own short-circuit logic against that no-op, so `LimitedSink` continues to ignore puts past its limit, but the source-DAO scan keeps running and the remaining groups arrive normally. `GroupBy.put` itself keeps using the real `sub` for its own `groupLimit` early-exit, so the top-level limit semantics is unchanged.