### PR TITLE
 fix(Unique): pass sub to delegate so downstream sinks can detach

### DIFF
--- a/src/foam/mlang/sink/Unique.js
+++ b/src/foam/mlang/sink/Unique.js
@@ -35,7 +35,7 @@ foam.CLASS({
         } else {
           if ( ! this.values.hasOwnProperty(value) ) {
             this.values[value] = obj;
-            this.delegate.put(obj);
+            this.delegate.put(obj, sub);
           }
         }
       },


### PR DESCRIPTION
## Problem
`Unique.js` JS path forwards each new object to its delegate without passing the subscription: `this.delegate.put(obj)`. The Java path already passes it (`Unique.java:46`), so a `LimitedSink` wrapped around the delegate detaches the source-DAO iteration when it reaches its limit on the server, but on the client the scan runs to the end even though no more rows can affect the result.

## Solution
Pass `sub` to the delegate's `put` call in the JS implementation so the two paths line up. No behaviour change for existing callers that don't rely on detach.