### PR TITLE
PT-Fixes Add warning if a property is declared in both properties + question

### DIFF
--- a/src/foam/u2/qa/QA.js
+++ b/src/foam/u2/qa/QA.js
@@ -202,6 +202,10 @@ foam.CLASS({
               choices: q.choices
             } } : {} )
           });
+        } else {
+          console.warn('[QACompiler] ' + pkg + '.' + name + ': question "' + q.name +
+            '" collides with a declared property of the same name — its choices and ' +
+            'generated view are dropped (the declared property wins).');
         }
       });
 


### PR DESCRIPTION
PT-Fixes Add warning if a property is declared in both properties + question, since in that case the question is skipped