### PR TITLE
Add LSP i18n diagnostics for hardcoded U2 add strings

### DIFF
--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -54,6 +54,11 @@ foam.CLASS({
       factory: function() { return {}; }
     },
     {
+      class: 'String',
+      name: 'uri_',
+      documentation: 'URI of the file currently being diagnosed; read by i18n validators for test/demo-file exemption.'
+    },
+    {
       class: 'FObjectProperty',
       of: 'foam.parse.lsp.CSSTokenResolver',
       name: 'cssTokenResolver'
@@ -77,6 +82,7 @@ foam.CLASS({
       if ( ! this.analyzer.isFoamFile(text) ) return [];
 
       var uri = opt_uri || '';
+      this.uri_ = uri;
       var models = this.cache.getModels(uri, text);
       var diagnostics = [];
       var prev = this.prevResults_[uri];
@@ -97,6 +103,10 @@ foam.CLASS({
           prev.modelKeys[modelKey] = modelDiags;
         }
       }
+
+      // Hardcoded display strings in .add() — scanned once over the whole file
+      // (not per model) so multi-class files locate each occurrence natively.
+      this.validateAddStrings_(text, diagnostics);
 
       // Parser-emitted diagnostics — single grammar pass covers all class-ref
       // and property-type positions (extends/requires/of/implements and
@@ -211,6 +221,312 @@ foam.CLASS({
 
       // Validate expression parameters
       this.validateExpressions_(m, text, diagnostics);
+
+      // i18n hardcoded .add() strings are scanned once per file in handle()
+      // (validateAddStrings_), not here — they need whole-file scoping.
+    },
+
+    function validateAddStrings_(text, diagnostics) {
+      /**
+       * WARNING when a hardcoded user-facing string literal is passed to .add()
+       * in a view's render code. Unlike declarative property/action labels (which
+       * foam/i18n/scripts.jrl auto-extracts by name), in-body .add('...') text is
+       * extracted by nothing and ships untranslated.
+       *
+       * Scans the raw file text directly (once per file, not per model) so every
+       * occurrence is located at its own native offset — no cross-class collision,
+       * and a per-line `i18n-ignore` only affects its own occurrence. Matches inside
+       * comments are skipped so commented-out .add() calls aren't flagged.
+       *
+       * Intentionally NOT matched: .start('tag') (structural, not display text)
+       * and .translate('...') (already on the translation-service path).
+       */
+      if ( this.isI18nExemptUri_(this.uri_) ) return;       // test/demo/mock files exempt
+
+      var skip = this.nonCodeRanges_(text);
+      var re = /\.add\(\s*(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
+      var match;
+      while ( ( match = re.exec(text) ) !== null ) {
+        var quote = match[1];
+        var content = match[2];
+        if ( quote === '`' && /\$\{/.test(content) ) continue;     // interpolated → dynamic
+        if ( ! this.isUserFacingText_(content) ) continue;
+        if ( this.offsetInRanges_(skip, match.index) ) continue;   // comment / Java / string block → skip
+        if ( this.isCollectionAddReceiver_(text, match.index) ) continue; // Set/Map .add(), not u2 display
+        var inner = match.index + match[0].indexOf(quote) + 1;       // past the opening quote
+        if ( this.lineHasI18nIgnore_(text, inner) ) continue;        // per-line suppression
+        this.addDiag_(diagnostics, text, inner, content.length, this.Diagnostic.WARNING,
+          'Hardcoded display string "' + content + '" — define it as a messages: entry ' +
+            '(in-body .add() text is not auto-extracted for i18n).',
+          'i18n-hardcoded-display-string');
+      }
+    },
+
+    function isCollectionAddReceiver_(text, dotOffset) {
+      /**
+       * True when the `.add(` at dotOffset is a Set/Map collection add rather than a
+       * u2 display add. Display adds are either chained off an element builder
+       * (`.start(...).add(...)` → preceded by `)`), on this/self, or on an element
+       * variable. A collection receiver is a bare identifier that is ALSO used with
+       * `.delete(`/`.has(` or assigned `new Set/Map` — Set/Map APIs u2 Elements lack.
+       * Content can't tell 'type' (display) from 'scheduled' (collection) — receiver can.
+       */
+      if ( text[dotOffset - 1] === ')' ) return false;     // chained off an element call → u2
+      var j = dotOffset - 1;
+      while ( j >= 0 && /[\w$]/.test(text[j]) ) j--;
+      var receiver = text.substring(j + 1, dotOffset);
+      if ( ! receiver || receiver === 'this' || receiver === 'self' ) return false;
+      var r = this.escapeRegex_(receiver);
+      if ( new RegExp('\\b' + r + '\\s*\\.\\s*(?:delete|has)\\s*\\(').test(text) ) return true;
+      if ( new RegExp('\\b' + r + '\\s*=\\s*new\\s+(?:Set|Map|WeakSet|WeakMap)\\b').test(text) ) return true;
+      return false;
+    },
+
+    function nonCodeRanges_(text) {
+      /**
+       * Single pass over `text` collecting [start,end) ranges of // line comments,
+       * /* block comments, AND string/template literals. The .add() scanner skips
+       * matches inside these so it ignores (a) commented-out code and (b) .add()
+       * calls embedded in non-JS string blocks — Java (`javaCode: '... list.add(..)'`),
+       * doc strings, backtick templates — flagging only real JS-code .add() calls.
+       * String state is tracked so a `//` inside a string (e.g. a URL) is not a comment.
+       */
+      var ranges = [];
+      var i = 0, n = text.length, str = null, strStart = -1;
+      while ( i < n ) {
+        var c = text[i];
+        if ( str ) {
+          if ( c === '\\' ) { i += 2; continue; }
+          if ( c === str ) { ranges.push([ strStart, i + 1 ]); str = null; }
+          i++; continue;
+        }
+        if ( c === '"' || c === "'" || c === '`' ) { str = c; strStart = i; i++; continue; }
+        if ( c === '/' && text[i + 1] === '/' ) {
+          var e = text.indexOf('\n', i); if ( e === -1 ) e = n;
+          ranges.push([ i, e ]); i = e; continue;
+        }
+        if ( c === '/' && text[i + 1] === '*' ) {
+          var e2 = text.indexOf('*/', i + 2); e2 = e2 === -1 ? n : e2 + 2;
+          ranges.push([ i, e2 ]); i = e2; continue;
+        }
+        i++;
+      }
+      return ranges;
+    },
+
+    function offsetInRanges_(ranges, offset) {
+      for ( var i = 0 ; i < ranges.length ; i++ ) {
+        if ( offset >= ranges[i][0] && offset < ranges[i][1] ) return true;
+      }
+      return false;
+    },
+
+    function isUserFacingText_(s) {
+      /**
+       * Conservative "looks like a word" test. Flags prose/words; skips all-caps
+       * codes, single chars, and pure symbol/digit strings. Shared by the label
+       * (HINT) and in-body .add() (WARNING) validators.
+       */
+      if ( ! s || typeof s !== 'string' ) return false;
+      if ( /^#?[0-9a-fA-F]{3,8}$/.test(s) ) return false;  // hex color ('#fff', 'aabbcc')
+      if ( /^[\d.]+(px|em|rem|%|vh|vw|vmin|vmax|pt|s|ms|deg|fr|ch|ex)$/i.test(s) ) return false; // CSS unit value
+      // programmatic identifier / key with no spaces — e.g. 'superuser.enable',
+      // 'foam.core.X' (dotted between word chars). Excludes permission/collection
+      // adds. Keeps prose ('Upload Complete') and ellipsis ('Processing...').
+      if ( ! /\s/.test(s) && /[A-Za-z0-9_$]\.[A-Za-z0-9_$]/.test(s) ) return false;
+      if ( ! /[a-z]/.test(s) ) return false;       // needs a lowercase letter → skips 'ID','API','Y','OK'
+      if ( ! /[A-Za-z]{2}/.test(s) ) return false; // needs 2+ consecutive letters → skips symbols/digits
+      return true;
+    },
+
+    function isI18nExemptUri_(uri) {
+      /**
+       * True for files where i18n diagnostics are noise: test/demo/mock sources.
+       * Framework and product views are NOT exempt.
+       */
+      if ( ! uri ) return false;
+      if ( /(?:^|\/)(?:test|tests|demos|mock|mocks)\//i.test(uri) ) return true;
+      if ( /Test\.js$/.test(uri) ) return true;
+      if ( /Mock[^\/]*\.js$/.test(uri) ) return true;
+      return false;
+    },
+
+    function lineHasI18nIgnore_(text, offset) {
+      /**
+       * True when the source line containing `offset` carries an `i18n-ignore`
+       * marker (e.g. a trailing `// i18n-ignore` comment) — per-line opt-out.
+       */
+      var start = text.lastIndexOf('\n', offset) + 1;
+      var end = text.indexOf('\n', offset);
+      if ( end === -1 ) end = text.length;
+      return text.substring(start, end).indexOf('i18n-ignore') !== -1;
+    },
+
+    function constantizeMessageName_(s) {
+      /** 'Upload Complete' -> 'UPLOAD_COMPLETE'; safe FOAM message constant. */
+      var up = String(s).toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+      if ( ! up ) up = 'MESSAGE';
+      if ( /^[0-9]/.test(up) ) up = 'MSG_' + up;
+      return up;
+    },
+
+    function findAddLiteral_(text, messageText) {
+      /** Locate `.add('messageText')` and return the {start,end} span of the
+       *  quoted literal (quotes included), or null. */
+      var re = new RegExp("\\.add\\(\\s*(['\"`])" + this.escapeRegex_(messageText) + "\\1");
+      var m = re.exec(text);
+      if ( ! m ) return null;
+      var quoteRel = m[0].indexOf(m[1]);          // opening quote within the match
+      var litStart = m.index + quoteRel;
+      var litEnd = litStart + 1 + messageText.length + 1;  // open + text + close
+      return { start: litStart, end: litEnd };
+    },
+
+    function literalSpanFromRange_(text, range) {
+      /** {start, end, content} of the quoted literal for the occurrence the diagnostic
+       *  range points at. The range covers the inner text (no quotes): the opening quote
+       *  is one char before range.start and the closing quote is at range.end. Reading
+       *  content straight from source (range as the source of truth) is robust to
+       *  embedded quotes — unlike re-deriving length from a (possibly message-truncated)
+       *  string. Returns null if the quotes don't line up. */
+      if ( ! range || ! range.start || ! range.end ) return null;
+      var innerStart = this.analyzer.positionToOffset(text, range.start);
+      var innerEnd   = this.analyzer.positionToOffset(text, range.end);
+      var open = innerStart - 1;
+      if ( open < 0 || innerEnd <= innerStart || innerEnd >= text.length ) return null;
+      var q = text[open];
+      if ( q !== "'" && q !== '"' && q !== '`' ) return null;   // not a quoted literal here
+      if ( text[innerEnd] !== q ) return null;                  // closing quote must match
+      return { start: open, end: innerEnd + 1, content: text.substring(innerStart, innerEnd) };
+    },
+
+    function buildAddExtractEdit(text, messageText, uri, opt_range) {
+      /**
+       * Build the "extract to messages: entry" WorkspaceEdit for a hardcoded
+       * .add('<messageText>') string: rewrite the usage to `this.<NAME>` and add
+       * a `{ name, message }` entry (into an existing messages: array, or a new
+       * one). Returns { changes: { [uri]: [edits] } } or null.
+       *
+       * opt_range (the triggering diagnostic's LSP range) pins the rewrite to the
+       * exact occurrence — without it, a repeated identical string would rewrite the
+       * first match. Falls back to the first .add() match only when no range is given.
+       *
+       * Scope safety: bail (null) unless there is exactly one top-level model and an
+       * unambiguous single insertion target. Multiple `foam.CLASS(`, inline `classes:`,
+       * or more than one `properties:`/`messages:` block → ambiguous → no autofix.
+       */
+      var classMatches = text.match(/foam\.CLASS\s*\(/g);
+      if ( ! classMatches || classMatches.length !== 1 ) return null;
+      // Ambiguous nesting → the "first" messages:/properties: may belong to an inner class.
+      if ( /\bclasses\s*:\s*\[/.test(text) ) return null;
+      if ( ( text.match(/\bproperties\s*:\s*\[/g) || [] ).length > 1 ) return null;
+      if ( ( text.match(/\bmessages\s*:\s*\[/g)   || [] ).length > 1 ) return null;
+
+      // With a range, read the literal (and its content) straight from source — the
+      // range is authoritative and handles embedded quotes; the passed messageText may
+      // be truncated by the caller's message-reparse. Without a range, fall back to the
+      // first .add() match of messageText.
+      var usage, content;
+      if ( opt_range ) {
+        usage = this.literalSpanFromRange_(text, opt_range);
+        if ( ! usage ) return null;
+        content = usage.content;
+      } else {
+        usage = this.findAddLiteral_(text, messageText);
+        if ( ! usage ) return null;
+        content = messageText;
+      }
+
+      var name = this.constantizeMessageName_(content);
+      var edits = [];
+
+      // Rewrite the usage: 'messageText' -> this.NAME
+      edits.push({
+        range: {
+          start: this.analyzer.offsetToPosition(text, usage.start),
+          end:   this.analyzer.offsetToPosition(text, usage.end)
+        },
+        newText: 'this.' + name
+      });
+
+      // Add the messages entry. Reuse the verbatim source literal (quotes + already-
+      // valid escaping) for the message: value — re-escaping the raw captured content
+      // would double-escape an existing `\'` and produce invalid JS.
+      var rawLiteral = text.substring(usage.start, usage.end);
+      var entry = "{ name: '" + name + "', message: " + rawLiteral + " }";
+      var msgArr = /messages\s*:\s*\[/.exec(text);
+      if ( msgArr ) {
+        var insAt = msgArr.index + msgArr[0].length;          // just after '['
+        var p = this.analyzer.offsetToPosition(text, insAt);
+        edits.push({ range: { start: p, end: p }, newText: '\n    ' + entry + ',' });
+      } else {
+        var ins = this.findNewMessagesInsertion_(text, entry);
+        if ( ! ins ) return null;
+        var p2 = this.analyzer.offsetToPosition(text, ins.offset);
+        edits.push({ range: { start: p2, end: p2 }, newText: ins.newText });
+      }
+
+      var changes = {};
+      changes[uri] = edits;
+      return { changes: changes };
+    },
+
+    function findNewMessagesInsertion_(text, entry) {
+      /**
+       * Pick where to insert a brand-new `messages: [...]` block. Preference:
+       *   1. Right before the FIRST top-level block — properties:/methods:/listeners:/
+       *      actions:. This sits after the declarative header (package/name/extends/
+       *      requires/imports) and before any body, so it never lands inside a method
+       *      body object literal.
+       *   2. Else after the last header key — requires/imports (arrays) or
+       *      package/name/extends (strings).
+       *   3. Else right after `foam.CLASS({`.
+       * Returns { offset, newText } for a zero-width insert, or null.
+       */
+      // 1. Before the first properties:/methods:/listeners:/actions: block.
+      // First match (not last) → the top-level block, never a body-nested key.
+      var pm = /(^|\n)([ \t]*)(?:properties|methods|listeners|actions)\s*:/.exec(text);
+      if ( pm ) {
+        var indent = pm[2];
+        var lineStart = pm.index + pm[1].length;   // start of that line's indent
+        return {
+          offset: lineStart,
+          newText: indent + 'messages: [\n' + indent + '  ' + entry + '\n' + indent + '],\n'
+        };
+      }
+
+      // 2. After the last header key
+      var endOff = -1, endIndent = '  ';
+      var strRe = /(^|\n)([ \t]*)(package|name|extends)\s*:\s*'[^']*'\s*,?/g, sm;
+      while ( ( sm = strRe.exec(text) ) !== null ) {
+        var e = sm.index + sm[0].length;
+        if ( e > endOff ) { endOff = e; endIndent = sm[2]; }
+      }
+      var arrKeys = ['requires', 'imports'];
+      for ( var k = 0 ; k < arrKeys.length ; k++ ) {
+        var am = new RegExp('(^|\\n)([ \\t]*)' + arrKeys[k] + '\\s*:\\s*\\[').exec(text);
+        if ( ! am ) continue;
+        var i = am.index + am[0].length - 1;       // at the '['
+        var depth = 0;
+        for ( ; i < text.length ; i++ ) {
+          if ( text[i] === '[' ) depth++;
+          else if ( text[i] === ']' ) { depth--; if ( depth === 0 ) { i++; break; } }
+        }
+        if ( text[i] === ',' ) i++;                // include trailing comma
+        if ( i > endOff ) { endOff = i; endIndent = am[2]; }
+      }
+      if ( endOff !== -1 ) {
+        return {
+          offset: endOff,
+          newText: '\n' + endIndent + 'messages: [\n' + endIndent + '  ' + entry + '\n' + endIndent + '],'
+        };
+      }
+
+      // 3. After foam.CLASS({
+      var clsOpen = /foam\.CLASS\s*\(\s*\{/.exec(text);
+      if ( ! clsOpen ) return null;
+      var o = clsOpen.index + clsOpen[0].length;
+      return { offset: o, newText: '\n  messages: [\n    ' + entry + '\n  ],' };
     },
 
     function validateCSS_(model, text, diagnostics) {
@@ -689,7 +1005,7 @@ foam.CLASS({
       return match.index + match[0].indexOf(value);
     },
 
-    function addDiag_(diagnostics, text, offset, length, severity, message) {
+    function addDiag_(diagnostics, text, offset, length, severity, message, opt_code) {
       var pos = this.analyzer.offsetToPosition(text, offset);
       diagnostics.push(this.Diagnostic.create({
         range: {
@@ -697,7 +1013,8 @@ foam.CLASS({
           end: { line: pos.line, character: pos.character + length }
         },
         severity: severity,
-        message: message
+        message: message,
+        code: opt_code
       }));
     }
   ]

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -414,6 +414,15 @@ foam.CLASS({
        * Scope safety: bail (null) unless there is exactly one top-level model and an
        * unambiguous single insertion target. Multiple `foam.CLASS(`, inline `classes:`,
        * or more than one `properties:`/`messages:` block → ambiguous → no autofix.
+       *
+       * Limitations:
+       * - Diagnostics can appear in multi-model files, but the extract code action is
+       *   intentionally disabled there; inserting `messages:` into the right model
+       *   requires model-boundary parsing, not whole-file regexes.
+       * - Inline inner `classes:` are skipped for the same reason: `messages:` or
+       *   `properties:` could belong to either the outer model or an inner class.
+       * - If the diagnostic range no longer lines up with the quoted literal, no edit is
+       *   returned rather than risking a rewrite at the wrong occurrence.
        */
       var classMatches = text.match(/foam\.CLASS\s*\(/g);
       if ( ! classMatches || classMatches.length !== 1 ) return null;

--- a/tools/lsp/handlers/WorkspaceAnalyzer.js
+++ b/tools/lsp/handlers/WorkspaceAnalyzer.js
@@ -81,10 +81,10 @@ foam.CLASS({
         var filePath = filePaths[i];
         try {
           var content = fs_.readFileSync(filePath, 'utf8');
-          var diagnostics = diag.handle(content);
+          var uri = 'file://' + filePath;
+          var diagnostics = diag.handle(content, uri);  // pass URI so test/demo i18n exemptions apply
 
           if ( diagnostics.length > 0 ) {
-            var uri = 'file://' + filePath;
             fileResults[uri] = diagnostics;
             filesWithIssues++;
 
@@ -94,8 +94,9 @@ foam.CLASS({
               else if ( sev === 2 ) warnings++;
               else infos++;
 
-              // Group by pattern — replace specific class/type names with *
-              var pattern = this.generalizeMessage(diagnostics[d].message);
+              // Group by pattern — coded diagnostics (e.g. i18n rules) collapse
+              // under their code; everything else generalizes class/type names to *
+              var pattern = this.patternFor(diagnostics[d]);
               var key = pattern + '|' + sev;
               if ( ! patternCounts[key] ) {
                 patternCounts[key] = { pattern: pattern, count: 0, severity: sev };
@@ -158,8 +159,8 @@ foam.CLASS({
         var filePath = unique[j];
         try {
           var content = fs_.readFileSync(filePath, 'utf8');
-          var diagnostics = diag.handle(content);
           var uri = 'file://' + filePath;
+          var diagnostics = diag.handle(content, uri);  // pass URI so test/demo i18n exemptions apply
           // ALWAYS include the file in results — empty arrays clear stale
           // diagnostics from a prior save.
           fileResults[uri] = diagnostics;
@@ -197,10 +198,21 @@ foam.CLASS({
       var absPath = path_.resolve(filePath);
       try {
         var content = fs_.readFileSync(absPath, 'utf8');
-        return this.diagnosticsHandler.handle(content);
+        return this.diagnosticsHandler.handle(content, 'file://' + absPath);  // URI → i18n exemptions apply
       } catch (e) {
         return null;
       }
+    },
+
+    function patternFor(diag) {
+      /**
+       * Grouping key for a diagnostic. Diagnostics that carry a stable `code`
+       * (e.g. the i18n rules) group under that code so the audit shows one row
+       * per rule instead of one row per distinct string. Uncoded diagnostics
+       * fall back to generalizeMessage (class/type names wildcarded).
+       */
+      if ( diag && diag.code ) return diag.code;
+      return this.generalizeMessage(diag.message);
     },
 
     function generalizeMessage(message) {

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -300,6 +300,23 @@ function start() {
         }
       }
 
+      // For hardcoded display strings, offer "extract to messages: entry"
+      if ( diag.code === 'i18n-hardcoded-display-string' ) {
+        var hsMatch = diag.message.match(/Hardcoded display string "([^"]+)"/);
+        if ( hsMatch ) {
+          var i18nEdit = diagnosticsHandler.buildAddExtractEdit(text, hsMatch[1], uri, diag.range);
+          if ( i18nEdit ) {
+            actions.push({
+              title: "Extract '" + hsMatch[1] + "' to a messages: entry",
+              kind: 'quickfix',
+              isPreferred: true,
+              diagnostics: [diag],
+              edit: i18nEdit
+            });
+          }
+        }
+      }
+
       // For wrong Java import packages, suggest correct ones
       var javaImportMappings = index.getJavaImportMappings();
       var wrongPkgMatch = diag.message.match(/Wrong Java package[^']*'([^']+)'/);

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -390,3 +390,295 @@ test(missing[0].message.indexOf('$primary400') === -1,
 
 // === HOVER ON ^selector IN CSS BLOCK ===
 
+// NOTE: declarative property/action `label:` strings are intentionally NOT flagged.
+// They are auto-extracted + translated by foam/i18n/scripts.jrl (keyed by the
+// property/action name, with the authored string as the default), so they are
+// already i18n-ready. Only imperative render text (.add('...'), below) is invisible
+// to that extraction and needs an explicit messages: entry.
+
+// === i18n in-body .add() WARNING tests (Step 2) ===
+section('DiagnosticsHandler i18n add() strings');
+
+function addStrDiags(src) {
+  return diagHandler.handle(src).filter(function(d) {
+    return d.code === 'i18n-hardcoded-display-string';
+  });
+}
+
+// .add('prose') in a method → one WARNING (severity 2)
+var addProse = "foam.CLASS({\n  package:'test', name:'AP',\n  methods:[ function render(){ this.add('Upload Complete'); } ]\n})";
+var apd = addStrDiags(addProse);
+test(apd.length === 1, 'Hardcoded .add() string flagged once');
+test(apd.length === 1 && apd[0].severity === 2, '.add() string diagnostic is WARNING severity (2)');
+
+// .add(dynamic expression) → zero
+var addDyn = "foam.CLASS({\n  package:'test', name:'AD',\n  methods:[ function render(){ this.add(this.data.name); } ]\n})";
+test(addStrDiags(addDyn).length === 0, '.add(dynamic expression) not flagged');
+
+// .addClass('container') → zero (not .add()
+var addClass = "foam.CLASS({\n  package:'test', name:'AC',\n  methods:[ function render(){ this.addClass('container'); } ]\n})";
+test(addStrDiags(addClass).length === 0, '.addClass() not flagged');
+
+// .start('span').add('Hello World') → one (only the .add text; .start tag ignored)
+var chained = "foam.CLASS({\n  package:'test', name:'CH',\n  methods:[ function render(){ this.start('span').add('Hello World').end(); } ]\n})";
+test(addStrDiags(chained).length === 1, "chained .start('span').add('Hello World') flags only the add() text");
+
+// template literal with interpolation → zero (dynamic)
+var interp = "foam.CLASS({\n  package:'test', name:'IN',\n  methods:[ function render(){ this.add(`Total ${this.n}`); } ]\n})";
+test(addStrDiags(interp).length === 0, '.add(`...${}...`) interpolated not flagged');
+
+// all-caps code → zero
+var addCode = "foam.CLASS({\n  package:'test', name:'ACd',\n  methods:[ function render(){ this.add('OK'); } ]\n})";
+test(addStrDiags(addCode).length === 0, ".add('OK') all-caps not flagged");
+
+// Real offender file: SmartUploadView has many in-body .add('...') strings
+var supPath = 'src/com/paytic/flow/fileupload/SmartUploadView.js';
+if ( fs.existsSync(supPath) ) {
+  var supText = fs.readFileSync(supPath, 'utf8');
+  var supDiags = diagHandler.handle(supText).filter(function(d) {
+    return d.code === 'i18n-hardcoded-display-string';
+  });
+  test(supDiags.length >= 3, 'SmartUploadView.js produces multiple i18n-hardcoded-display-string WARNINGs');
+} else {
+  test(true, 'SmartUploadView.js not present — real-file smoke skipped');
+}
+
+// === Step 3: noise control ===
+section('DiagnosticsHandler i18n noise control');
+
+function anyI18nDiags(src, uri) {
+  return diagHandler.handle(src, uri).filter(function(d) {
+    return d.code === 'i18n-hardcoded-display-string';
+  });
+}
+
+// CSS-ish values passed to .add() → not flagged (allowlist)
+var cssUnit = "foam.CLASS({\n  package:'test', name:'CU',\n  methods:[ function render(){ this.add('10px'); this.add('100%'); this.add('#fff'); } ]\n})";
+test(anyI18nDiags(cssUnit).length === 0, 'CSS units / hex values not flagged');
+
+// Inline // i18n-ignore on the same line suppresses
+var ignored = "foam.CLASS({\n  package:'test', name:'IG',\n  methods:[ function render(){ this.add('Real Text'); // i18n-ignore\n } ]\n})";
+test(anyI18nDiags(ignored).length === 0, 'Inline // i18n-ignore suppresses the diagnostic');
+
+// Same string WITHOUT the comment is still flagged (control)
+var notIgnored = "foam.CLASS({\n  package:'test', name:'NIG',\n  methods:[ function render(){ this.add('Real Text'); } ]\n})";
+test(anyI18nDiags(notIgnored).length === 1, 'Without i18n-ignore the string is still flagged');
+
+// Test/demo files are exempt (by uri)
+var exSrc = "foam.CLASS({\n  package:'test', name:'EX',\n  methods:[ function render(){ this.add('First Name'); } ]\n})";
+test(anyI18nDiags(exSrc, 'file:///app/src/foo/FooTest.js').length === 0, 'Test file (uri) is exempt');
+test(anyI18nDiags(exSrc, 'file:///app/src/foo/demos/Foo.js').length === 0, 'Demos file (uri) is exempt');
+test(anyI18nDiags(exSrc, 'file:///app/src/foo/Foo.js').length === 1, 'Non-test file still flagged (control)');
+
+// === Step 5: WorkspaceAnalyzer groups i18n diagnostics by code ===
+section('WorkspaceAnalyzer i18n grouping');
+var wsa = foam.parse.lsp.handlers.WorkspaceAnalyzer.create({ index: index });
+var p1 = wsa.patternFor({ code: 'i18n-hardcoded-display-string', message: 'Hardcoded display string "Upload Complete" — define it as a messages: entry.' });
+var p2 = wsa.patternFor({ code: 'i18n-hardcoded-display-string', message: 'Hardcoded display string "Processing..." — define it as a messages: entry.' });
+test(p1 === p2, 'Two different hardcoded strings collapse to one pattern (grouped by code)');
+test(p1 === 'i18n-hardcoded-display-string', 'i18n pattern key is the diagnostic code');
+var pu = wsa.patternFor({ message: "Unknown class in requires: 'foam.core.auth.User'" });
+test(pu.indexOf('*') !== -1, 'Non-coded diagnostics still grouped by generalizeMessage (wildcarded)');
+
+// === Regression: re-find must anchor to .add(, not match a same-text messages entry ===
+section('DiagnosticsHandler i18n re-find precision');
+
+// A messages entry and an .add() call share the exact same text. The WARNING must
+// point at the .add( occurrence, NOT the (correct) messages entry above it — which
+// is the case once "extract to messages" has already run on an identical string.
+var dupSrc = "foam.CLASS({\n  package:'t', name:'DUP',\n" +
+  "  messages:[ { name:'FORGOT_PASSWORD', message:'Forgot password?' } ],\n" +
+  "  methods:[ function render(){ this.add('Forgot password?'); } ]\n})";
+var dd = diagHandler.handle(dupSrc).filter(function(d){ return d.code === 'i18n-hardcoded-display-string'; });
+test(dd.length === 1, 're-find: exactly one WARNING when text duplicates a messages entry');
+var dOff = dd.length === 1 ? analyzer.positionToOffset(dupSrc, dd[0].range.start) : -1;
+var addInner = dupSrc.indexOf("this.add('Forgot password?')") + "this.add('".length;
+test(dOff === addInner, 're-find: WARNING lands on the .add() argument, not the messages entry');
+
+// === Comments + multi-class scoping (review P2/P3) ===
+section('DiagnosticsHandler i18n comments + multi-class');
+
+// P2: commented-out .add() must NOT be flagged (line comment)
+var lineCommented = "foam.CLASS({\n  package:'t', name:'CM',\n  methods:[ function render(){\n    // this.add('Commented Out Text');\n    this.add('Live Text');\n  } ]\n})";
+var cmd = addStrDiags(lineCommented);
+test(cmd.length === 1, 'P2: line-commented .add() not flagged; live one is');
+test(cmd.length === 1 && cmd[0].message.indexOf('Live Text') !== -1, 'P2: only the live .add() string is flagged');
+
+// P2: block-commented .add() must NOT be flagged
+var blockCommented = "foam.CLASS({\n  package:'t', name:'BC',\n  methods:[ function render(){ /* this.add('Block Comment Text'); */ this.add('Real One'); } ]\n})";
+var bcd = addStrDiags(blockCommented);
+test(bcd.length === 1 && bcd[0].message.indexOf('Real One') !== -1, 'P2: block-commented .add() not flagged');
+
+// P2: // inside a string is NOT treated as a comment
+var urlish = "foam.CLASS({\n  package:'t', name:'URL',\n  methods:[ function render(){ this.add('Visit Our Site'); } ]\n})";
+test(addStrDiags(urlish).length === 1, 'P2: control — non-commented .add() still flagged');
+
+// P3: earlier class's i18n-ignore must NOT suppress a later class's identical string
+var multiIgnore = "foam.CLASS({ package:'t', name:'A', methods:[ function render(){ this.add('Shared Phrase'); // i18n-ignore\n } ] })\n" +
+  "foam.CLASS({ package:'t', name:'B', methods:[ function render(){ this.add('Shared Phrase'); } ] })";
+var mid = addStrDiags(multiIgnore);
+test(mid.length === 1, 'P3: ignored earlier occurrence does not suppress the later one');
+test(mid.length === 1 && analyzer.positionToOffset(multiIgnore, mid[0].range.start) > multiIgnore.indexOf("name:'B'"), 'P3: surviving WARNING is the later (class B) occurrence');
+
+// P3: same string in two classes (neither ignored) → flagged in BOTH, at distinct offsets
+var multiBoth = "foam.CLASS({ package:'t', name:'A', methods:[ function render(){ this.add('Save Now'); } ] })\n" +
+  "foam.CLASS({ package:'t', name:'B', methods:[ function render(){ this.add('Save Now'); } ] })";
+var mbd = addStrDiags(multiBoth);
+test(mbd.length === 2, 'P3: same string in two classes flagged in both');
+test(mbd.length === 2 && analyzer.positionToOffset(multiBoth, mbd[0].range.start) !== analyzer.positionToOffset(multiBoth, mbd[1].range.start), 'P3: the two WARNINGs are at distinct offsets');
+
+// === Non-UI .add() must not be flagged (collection adds + Java blocks) ===
+section('DiagnosticsHandler i18n non-UI adds');
+
+// JS collection/permission add with a dotted key → not display text
+var permSrc = "foam.CLASS({\n  package:'t', name:'Perm',\n  methods:[ function init(){ this.permSet.add('superuser.enable'); } ]\n})";
+test(addStrDiags(permSrc).length === 0, 'dotted key add(superuser.enable) not flagged');
+
+// .add(...) inside a javaCode string block → not real JS render text
+var javaSrc = "foam.CLASS({\n  package:'t', name:'JavaUser',\n  methods:[ { name:'foo', javaCode: 'list.add(\"Metric Type\");' } ]\n})";
+test(addStrDiags(javaSrc).length === 0, '.add() inside a javaCode string not flagged');
+
+// .add(...) inside a backtick template (e.g. embedded code) → not flagged
+var tmplSrc = "foam.CLASS({\n  package:'t', name:'Tmpl',\n  properties:[ { name:'doc', value: `set.add('Some Backtick Text');` } ]\n})";
+test(addStrDiags(tmplSrc).length === 0, '.add() inside a backtick string not flagged');
+
+// Controls: real u2 display text still flagged, incl. ellipsis (dots but no identifier)
+test(addStrDiags("foam.CLASS({ package:'t', name:'U2a', methods:[ function render(){ this.add('Upload Complete'); } ] })").length === 1, 'control: real .add() display string still flagged');
+test(addStrDiags("foam.CLASS({ package:'t', name:'U2b', methods:[ function render(){ this.add('Processing...'); } ] })").length === 1, "control: ellipsis 'Processing...' still flagged");
+
+// === Step 4: extract-to-message code action edit ===
+section('DiagnosticsHandler i18n extract edit');
+
+// New messages array path
+var noMsgSrc = "foam.CLASS({\n  package:'test', name:'EX1',\n  methods:[ function render(){ this.add('Upload Complete'); } ]\n})";
+var e1 = diagHandler.buildAddExtractEdit(noMsgSrc, 'Upload Complete', 'file:///x.js');
+test(!! e1, 'buildAddExtractEdit returns an edit for a single-class file');
+var edits1 = e1 && e1.changes['file:///x.js'];
+test(!!edits1 && edits1.length === 2, 'edit has two text edits (insert message + rewrite usage)');
+test(!!edits1 && edits1.some(function(t){ return t.newText === 'this.UPLOAD_COMPLETE'; }), 'usage rewritten to this.UPLOAD_COMPLETE');
+test(!!edits1 && edits1.some(function(t){ return t.newText.indexOf("name: 'UPLOAD_COMPLETE'") !== -1 && t.newText.indexOf("message: 'Upload Complete'") !== -1; }), 'inserts a messages entry with constantized name + original text');
+test(!!edits1 && edits1.some(function(t){ return t.newText.indexOf('messages: [') !== -1; }), 'creates a new messages: array when none exists');
+
+// Existing messages array path — entry inserted, no new messages: key
+var withMsgSrc = "foam.CLASS({\n  package:'test', name:'EX2',\n  messages:[ { name:'FOO', message:'Foo' } ],\n  methods:[ function render(){ this.add('Upload Complete'); } ]\n})";
+var e2 = diagHandler.buildAddExtractEdit(withMsgSrc, 'Upload Complete', 'file:///y.js');
+var edits2 = e2 && e2.changes['file:///y.js'];
+test(!!edits2 && edits2.length === 2, 'existing-array path also produces two edits');
+test(!!edits2 && edits2.every(function(t){ return t.newText.indexOf('messages:') === -1; }), 'does not inject a second messages: key when one exists');
+
+// Multi-class file → null (avoid inserting into the wrong class)
+var multiSrc = "foam.CLASS({ package:'test', name:'A' })\nfoam.CLASS({ package:'test', name:'B', methods:[ function render(){ this.add('Upload Complete'); } ] })";
+test(diagHandler.buildAddExtractEdit(multiSrc, 'Upload Complete', 'file:///z.js') === null, 'multi-class file returns null (no autofix)');
+
+// Nested/inner class → ambiguous insertion scope → null (no autofix)
+var nestedClassesSrc = "foam.CLASS({\n  package:'t', name:'Outer',\n  classes:[ { name:'Inner', messages:[ { name:'X', message:'x' } ], properties:[ { name:'y' } ] } ],\n  methods:[ function render(){ this.add('Outer Text'); } ]\n})";
+test(diagHandler.buildAddExtractEdit(nestedClassesSrc, 'Outer Text', 'file:///n.js') === null, 'inner classes: present → ambiguous → no autofix');
+var twoPropSrc = "foam.CLASS({\n  package:'t', name:'TwoProp',\n  properties:[ { name:'a' } ],\n  sections:[ { name:'s' } ],\n  methods:[ function render(){ this.add('Some Text'); var v = { properties:[ {name:'b'} ] }; } ]\n})";
+test(diagHandler.buildAddExtractEdit(twoPropSrc, 'Some Text', 'file:///2p.js') === null, 'multiple properties: blocks → ambiguous → no autofix');
+
+// Insertion placement: messages lands right before properties:, after header keys
+function msgInsertOffset(edit, uri, src) {
+  var t = edit.changes[uri].filter(function(e){ return e.newText.indexOf("name: 'UPLOAD_COMPLETE'") !== -1; })[0];
+  return analyzer.positionToOffset(src, t.range.start);
+}
+var srcHP = "foam.CLASS({\n  package:'p',\n  name:'HP',\n  requires:['a.B'],\n  properties:[ { name:'x' } ],\n  methods:[ function render(){ this.add('Upload Complete'); } ]\n})";
+var eHP = diagHandler.buildAddExtractEdit(srcHP, 'Upload Complete', 'file:///hp.js');
+var offHP = msgInsertOffset(eHP, 'file:///hp.js', srcHP);
+test(offHP > srcHP.indexOf("requires:"), 'new messages inserted AFTER header keys (requires)');
+test(offHP <= srcHP.indexOf('properties:'), 'new messages inserted right BEFORE properties:');
+
+// No properties: inserted after the last header key, before methods
+var srcNP = "foam.CLASS({\n  package:'p',\n  name:'NP',\n  requires:['a.B'],\n  methods:[ function render(){ this.add('Upload Complete'); } ]\n})";
+var eNP = diagHandler.buildAddExtractEdit(srcNP, 'Upload Complete', 'file:///np.js');
+var offNP = msgInsertOffset(eNP, 'file:///np.js', srcNP);
+test(offNP > srcNP.indexOf("requires:['a.B']") , 'no-properties: messages inserted after requires array');
+test(offNP < srcNP.indexOf('methods:'), 'no-properties: messages inserted before methods:');
+
+// P3: extract must edit the occurrence at the diagnostic range, not the first match
+var twiceSrc = "foam.CLASS({\n  package:'t', name:'TWICE',\n  methods:[ function render(){ this.add('Repeat Me'); this.add('Repeat Me'); } ]\n})";
+var firstIdx2 = twiceSrc.indexOf("this.add('Repeat Me')");
+var secondIdx2 = twiceSrc.indexOf("this.add('Repeat Me')", firstIdx2 + 1);
+var secondInner = secondIdx2 + "this.add('".length;
+var secondRange = {
+  start: analyzer.offsetToPosition(twiceSrc, secondInner),
+  end:   analyzer.offsetToPosition(twiceSrc, secondInner + 'Repeat Me'.length)
+};
+var eTwice = diagHandler.buildAddExtractEdit(twiceSrc, 'Repeat Me', 'file:///tw.js', secondRange);
+var rwTwice = eTwice && eTwice.changes['file:///tw.js'].filter(function(t){ return t.newText === 'this.REPEAT_ME'; })[0];
+var rwOff = rwTwice ? analyzer.positionToOffset(twiceSrc, rwTwice.range.start) : -1;
+test(rwOff === secondInner - 1, 'P3: extract rewrites the occurrence at the diagnostic range (the 2nd), not the 1st');
+
+// === P2: WorkspaceAnalyzer threads the file URI (test/demo exemption) ===
+section('WorkspaceAnalyzer i18n URI exemption');
+var os = require('os');
+var tmpExempt = path.join(os.tmpdir(), 'WidgetTest.js');
+var tmpReal   = path.join(os.tmpdir(), 'Widget.js');
+fs.writeFileSync(tmpExempt, "foam.CLASS({ package:'t', name:'WidgetTest', methods:[ function render(){ this.add('Should Be Exempt'); } ] })");
+fs.writeFileSync(tmpReal,   "foam.CLASS({ package:'t', name:'Widget', methods:[ function render(){ this.add('Should Be Flagged'); } ] })");
+function i18nOf(arr){ return (arr || []).filter(function(d){ return d.code === 'i18n-hardcoded-display-string'; }); }
+test(i18nOf(wsa.analyzeSingleFile(tmpExempt)).length === 0, 'P2: analyzeSingleFile exempts *Test.js by URI');
+test(i18nOf(wsa.analyzeSingleFile(tmpReal)).length === 1, 'P2: analyzeSingleFile flags a non-exempt file (control)');
+test(i18nOf(wsa.analyzeFiles([tmpExempt]).fileResults['file://' + tmpExempt]).length === 0, 'P2: analyzeFiles exempts *Test.js by URI');
+fs.unlinkSync(tmpExempt);
+fs.unlinkSync(tmpReal);
+
+// === Review round 4: insertion scope, escaping, string-literal scanning ===
+section('DiagnosticsHandler i18n extract edit — robustness');
+
+// F1: no properties:, but a method body has a line-start `name:` object literal.
+// The messages: block must NOT be inserted inside the method/object.
+var bodyObjSrc = "foam.CLASS({\n  package:'p',\n  name:'BodyObj',\n  methods:[\n    function render(){\n      var cfg = {\n        name: 'inner'\n      };\n      this.add('Body Object Text');\n    }\n  ]\n})";
+var eBO = diagHandler.buildAddExtractEdit(bodyObjSrc, 'Body Object Text', 'file:///bo.js');
+var msgEditBO = eBO && eBO.changes['file:///bo.js'].filter(function(t){ return t.newText.indexOf("name: 'BODY_OBJECT_TEXT'") !== -1; })[0];
+var insBO = msgEditBO ? analyzer.positionToOffset(bodyObjSrc, msgEditBO.range.start) : -1;
+test(insBO !== -1 && insBO < bodyObjSrc.indexOf('methods:'), 'F1: messages inserted before methods:, not inside the body object');
+
+// F2: an escaped apostrophe must produce a valid message: literal (no double-escaping).
+var aposSrc = "foam.CLASS({\n  package:'p', name:'Apos',\n  methods:[ function render(){ this.add('Don\\'t save'); } ]\n})";
+var eA = diagHandler.buildAddExtractEdit(aposSrc, "Don\\'t save", 'file:///a.js');
+var msgEditA = eA && eA.changes['file:///a.js'].filter(function(t){ return t.newText.indexOf("name: 'DON_T_SAVE'") !== -1; })[0];
+test(!!msgEditA, 'F2: message entry generated for a string with an escaped apostrophe');
+test(!!msgEditA && msgEditA.newText.indexOf("message: 'Don\\'t save'") !== -1, 'F2: message: literal preserves the original valid escaping');
+test(!!msgEditA && msgEditA.newText.indexOf("Don\\\\'t") === -1, 'F2: no double-backslash escaping');
+
+// F3 (already fixed last round): .add() inside a string literal must not be flagged.
+var docStrSrc = "foam.CLASS({\n  package:'p', name:'Doc',\n  properties:[ { name:'x', documentation: \"see this.add('Upload Complete') in render\" } ],\n  methods:[ function render(){} ]\n})";
+test(addStrDiags(docStrSrc).length === 0, 'F3: .add() inside a documentation string literal is not flagged');
+
+// === Review round 5: single-word collection adds + double-quote literals ===
+section('DiagnosticsHandler i18n round 5');
+
+// P2: a Set/collection .add() (receiver paired with new Set + .delete) is not display text
+var collSrc = "foam.CLASS({\n  package:'t', name:'Coll',\n  methods:[ { name:'ps', code: function(){ const set = new Set(); set.add('scheduled'); set.delete('scheduled'); } } ]\n})";
+test(addStrDiags(collSrc).length === 0, "collection set.add('scheduled') (new Set + delete) not flagged");
+// control: a capitalized single word is display text → still flagged
+test(addStrDiags("foam.CLASS({ package:'t', name:'C2', methods:[ function render(){ this.add('Welcome'); } ] })").length === 1, 'control: capitalized single word still flagged');
+// control: a multi-word lowercase phrase is still display text → flagged
+test(addStrDiags("foam.CLASS({ package:'t', name:'C3', methods:[ function render(){ this.add('please wait'); } ] })").length === 1, 'control: multi-word lowercase phrase still flagged');
+
+// Medium: a display string containing double quotes must extract without corruption.
+var dqSrc = "foam.CLASS({\n  package:'t', name:'DQ',\n  methods:[ function render(){ this.add('Say \"Hi\"'); } ]\n})";
+var dqDiags = diagHandler.handle(dqSrc).filter(function(d){ return d.code === 'i18n-hardcoded-display-string'; });
+test(dqDiags.length === 1, 'double-quote-containing display string flagged once');
+// Simulate the server passing a message-truncated text ('Say ') BUT the real diag range.
+var eDQ = dqDiags.length === 1 ? diagHandler.buildAddExtractEdit(dqSrc, 'Say ', 'file:///dq.js', dqDiags[0].range) : null;
+var rwDQ = eDQ && eDQ.changes['file:///dq.js'].filter(function(t){ return t.newText.indexOf('this.') === 0; })[0];
+var rwStr = rwDQ ? dqSrc.substring(analyzer.positionToOffset(dqSrc, rwDQ.range.start), analyzer.positionToOffset(dqSrc, rwDQ.range.end)) : '';
+test(rwStr === "'Say \"Hi\"'", 'Medium: rewrite span covers the full literal incl. embedded double quotes');
+var msgDQ = eDQ && eDQ.changes['file:///dq.js'].filter(function(t){ return t.newText.indexOf('message:') !== -1; })[0];
+test(!!msgDQ && msgDQ.newText.indexOf("message: 'Say \"Hi\"'") !== -1, 'Medium: message entry uses the full source literal');
+
+// === Review round 6: lowercase display copy must NOT be suppressed ===
+section('DiagnosticsHandler i18n round 6');
+
+// Real cases: chained .add() of lowercase UI copy (from:, to:, type) — must be flagged.
+var lcChain = "foam.CLASS({\n  package:'t', name:'LC',\n  methods:[ function render(){ return this.E().start('strong').add('from:').end().start('td').add('type').end(); } ]\n})";
+test(addStrDiags(lcChain).length === 2, "lowercase chained display copy ('from:', 'type') is flagged");
+
+// Lowercase display on this.add (view receiver) — still flagged.
+test(addStrDiags("foam.CLASS({ package:'t', name:'LC2', methods:[ function render(){ this.add('please'); } ] })").length === 1, "lowercase display on this.add('please') flagged");
+
+// Lowercase add on an element var receiver (not a collection) — flagged.
+test(addStrDiags("foam.CLASS({ package:'t', name:'LC3', methods:[ function render(){ var row = this.E(); row.add('total'); } ] })").length === 1, "lowercase .add('total') on an element var flagged");
+
+


### PR DESCRIPTION
## Summary

Adds FOAM LSP diagnostics for hardcoded display strings passed to U2 `.add(...)`, with quick-fix support to extract the string into a `messages:` entry.

## Capabilities

- Warns on untranslated in-body display strings such as `this.add('Upload Complete')`.
- Skips test/demo/mock files, comments, Java/string blocks, dynamic/interpolated values, and collection-style `.add(...)` calls.
- Handles multi-class files without misplaced diagnostics.
- Supports `i18n-ignore` per line.
- Adds a code action to rewrite `.add('Text')` to `this.TEXT` and insert a matching `messages:` entry when safe.
- Groups workspace i18n findings by diagnostic code.

## Validation

- `node tools/tests/testFoamLSP.js`
- Result: `846 passed, 0 failed`

## Code Actions (limited support)

Limitations:
- Diagnostics can appear in multi-model files, but the extract code action is
  intentionally disabled there; inserting `messages:` into the right model
  requires model-boundary parsing, not whole-file regexes.
- Inline inner `classes:` are skipped for the same reason: `messages:` or
  `properties:` could belong to either the outer model or an inner class.
- If the diagnostic range no longer lines up with the quoted literal, no edit is
  returned rather than risking a rewrite at the wrong occurrence.

1. Code Action Available
<img width="546" height="126" alt="Screenshot 2026-05-31 at 3 33 34 PM" src="https://github.com/user-attachments/assets/513e940e-d517-464a-b91e-dd730b03a235" />

2. Result of code action
<img width="806" height="71" alt="Screenshot 2026-05-31 at 3 34 04 PM" src="https://github.com/user-attachments/assets/f47c5fe0-ebfe-40df-9da8-447e68bcd124" />
