### PR TITLE
Changed checkbox label to be the label rather than the help text

### DIFF
--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -2059,7 +2059,7 @@ foam.CLASS({
       expression: function(label, checkboxLabelFormatter) {
         return {
           class: 'foam.u2.CheckBox',
-          label: this.label,
+          label: this.placeholder,
           labelFormatter: checkboxLabelFormatter
         };
       }

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -2059,7 +2059,7 @@ foam.CLASS({
       expression: function(label, checkboxLabelFormatter) {
         return {
           class: 'foam.u2.CheckBox',
-          label: this.help,
+          label: this.label,
           labelFormatter: checkboxLabelFormatter
         };
       }


### PR DESCRIPTION
I don't think it makes sense for checkboxes (and other boolean views) to use the help text as a label because we end up getting these really long labels and duplicate text on-screen when you open the help text pop-up.

<img width="347" height="433" alt="image" src="https://github.com/user-attachments/assets/1e944946-9897-49b0-87cb-49e18808f772" />

It makes more sense to use the label property instead (which looks a little silly in this screenshot)

<img width="336" height="67" alt="image" src="https://github.com/user-attachments/assets/ab6541a4-b64d-432d-8ca0-420d043bda08" />

Also, if you don't provide help text but you do provide a label it looks like this:

<img width="132" height="57" alt="image" src="https://github.com/user-attachments/assets/c96e23f2-d138-4438-8cb4-27e2e80763ba" />

Which is unintuitive

Help text should stay in the help text pop-up, labels should behave how you'd expect.