### PR TITLE
CSpec non lazy order

### DIFF
--- a/src/foam/core/boot/Boot.java
+++ b/src/foam/core/boot/Boot.java
@@ -203,7 +203,7 @@ public class Boot {
 
     Agency agency = (Agency) root_.get("threadPool");
     serviceDAO_.where(EQ(CSpec.LAZY, false))
-      .orderBy(CSpec.PRIORITY)
+      .orderBy(CSpec.LAZY_ORDER)
       .select(new AbstractSink() {
       @Override
       public void put(Object obj, Detachable sub) {

--- a/src/foam/core/boot/Boot.java
+++ b/src/foam/core/boot/Boot.java
@@ -202,7 +202,9 @@ public class Boot {
     }
 
     Agency agency = (Agency) root_.get("threadPool");
-    serviceDAO_.where(EQ(CSpec.LAZY, false)).select(new AbstractSink() {
+    serviceDAO_.where(EQ(CSpec.LAZY, false))
+      .orderBy(CSpec.PRIORITY)
+      .select(new AbstractSink() {
       @Override
       public void put(Object obj, Detachable sub) {
         CSpec sp = (CSpec) obj;

--- a/src/foam/core/boot/CSpec.js
+++ b/src/foam/core/boot/CSpec.js
@@ -131,9 +131,9 @@ foam.CLASS({
     },
     {
       class: 'Int',
-      name: 'priority',
+      name: 'lazyOrder',
       tableWidth: 65,
-      documentation: 'Order non-lazy DAO invocation from low (0) to high.  Essential DAOs such as users, grants, ... should be priority 0 with larger DAOs which take minutes to load should be a higher priority value'
+      documentation: 'Order non-lazy DAO invocation from low (0) to high.  Essential DAOs such as users, grants, ... should be low order, 0, with larger DAOs which take minutes to load should be a higher order value'
     },
     {
       class: 'Boolean',

--- a/src/foam/core/boot/CSpec.js
+++ b/src/foam/core/boot/CSpec.js
@@ -130,6 +130,12 @@ foam.CLASS({
       value: true
     },
     {
+      class: 'Int',
+      name: 'priority',
+      tableWidth: 65,
+      documentation: 'Order non-lazy DAO invocation from low (0) to high.  Essential DAOs such as users, grants, ... should be priority 0 with larger DAOs which take minutes to load should be a higher priority value'
+    },
+    {
       class: 'Boolean',
       name: 'serve',
       tableWidth: 72,


### PR DESCRIPTION
Add Cspec.lazyOrder to order loading of non-lazy DAOs.
Order from low (0) to high.
Essential DAOs such as users, groups, should be order 0 to load first
making the system accessible, with larger DAOs which make take minutes
to load, given a higher order.