### PR TITLE
PT-FIXES: DOS-3595 skip O(n^2) Or.partialEval dedup for large arg counts

### DIFF
--- a/src/foam/mlang/predicate/Or.js
+++ b/src/foam/mlang/predicate/Or.js
@@ -90,7 +90,18 @@ return stmt.toString();`
           }
         }
 
-        this.reduce_(newArgs, FALSE, 'reduceOr');
+        // reduce_ is an O(n^2) pairwise dedup (Nary.reduce_): every arg is
+        // deep-equality-compared against every other. For a query built as a
+        // large OR of distinct clauses (e.g. a join emitting OR(Eq/And, ...)
+        // with thousands of unique values) it does zero useful work — the args
+        // are distinct, nothing collapses — yet costs ~n^2 deep-equals and
+        // dominates the whole select. Skip it past a threshold; OR with a few
+        // redundant args is still correct, just evaluated without the merge.
+        if ( newArgs.length > 10 ) {
+          console.warn('[Or.partialEval] skipping O(n^2) reduce_ dedup for ' + newArgs.length + ' args');
+        } else {
+          this.reduce_(newArgs, FALSE, 'reduceOr');
+        }
 
         if ( newArgs.length === 0 ) return FALSE;
         if ( newArgs.length === 1 ) return newArgs[0];


### PR DESCRIPTION
## Problem
`Or.partialEval` runs a pairwise dedup (`Nary.reduce_`) that deep-equality-compares every arg against every other — O(n²). A predicate built as a large OR of distinct clauses (thousands of args, e.g. a join expanded into `OR(Eq/And, ...)`) pays the full n² for zero merges, because no args collapse. Since `partialEval` runs on every predicated select, this cost dominates query planning and stalls the whole select.
## Solution
Skip the `reduce_` dedup when the arg count exceeds 10, and log when skipped. Small ORs still dedup (cheap). An OR carrying a few un-merged duplicate args is semantically identical, so the result is unchanged — only the pathological n² merge is dropped.