### PR TITLE
PT-FIXES:DOS-3707 Remove ofOverride from DAOControllerConfig

### DIFF
--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -64,32 +64,9 @@ foam.CLASS({
       view: { class: 'foam.u2.view.JSONTextView' }
     },
     {
-      class: 'Class',
-      name: 'ofOverride',
-      documentation: `Optional explicit model for typing the table when the bound
-        DAO is abstract or polymorphic — e.g. a relationship whose rows are a
-        concrete subclass. When set, the bound DAO is wrapped in a ProxyDAO of this
-        model so the table columns resolve against it instead of the DAO's abstract
-        'of'. No effect when unset.`,
-      postSet: function() {
-        // Reactive: when ofOverride resolves after the DAO was bound (e.g. derived
-        // from the first loaded row), re-apply the dao adapt so it retypes. Guard on
-        // an explicitly-set dao so daoKey-based configs keep their expression.
-        if ( this.hasOwnProperty('dao') ) this.dao = this.dao;
-      }
-    },
-    {
       class: 'foam.dao.DAOProperty',
       name: 'dao',
       hidden: true,
-      adapt: function(_, dao) {
-        // Retype an abstract/polymorphic DAO to a concrete model when ofOverride is
-        // set, so the table's columns resolve against the concrete model.
-        if ( this.ofOverride && dao && dao.of !== this.ofOverride ) {
-          return foam.dao.ProxyDAO.create({ of: this.ofOverride, delegate: dao });
-        }
-        return dao;
-      },
       expression: function(daoKey, predicate) {
         var dao = this.__context__[daoKey];
         if ( ! dao ) {
@@ -128,7 +105,7 @@ foam.CLASS({
     {
       class: 'Class',
       name: 'of',
-      expression: function(ofOverride, dao$of) { return ofOverride || dao$of; }
+      expression: function(dao$of) { return dao$of; }
     },
     {
       class: 'String',


### PR DESCRIPTION
## Problem
DAOControllerConfig gained an `ofOverride` field to retype an abstract or polymorphic bound DAO to a concrete model so the table's columns resolve against it. ProxyDAO already retypes a DAO, and `of` derives from the bound DAO's `of`, so the field duplicated existing capability.
## Solution
Revert the `ofOverride` field. `of` resolves from the bound DAO again. A caller that needs a concrete type wraps the DAO in a ProxyDAO of that model before binding it.