### PR TITLE
Seed QA2 OUTPUT_NAMES from a model-level outputNames

### DIFF
--- a/src/foam/u2/qa/QA.js
+++ b/src/foam/u2/qa/QA.js
@@ -172,7 +172,10 @@ foam.CLASS({
     // =========================================================================
 
     function buildClass_(pkg, name, properties, questions, outcomes, model) {
-      let outputNames   = [];
+      // Seed from an explicit model-level outputNames so a questionnaire with no
+      // outcomes[] can still declare which (already-declared) properties are outputs
+      // the wizard's OUTCOME step renders. Outcome keys are appended below.
+      let outputNames   = ( model.outputNames || [] ).slice();
       let inputNames    = [];
       let props         = [];
       let existingNames = {};


### PR DESCRIPTION
## Problem
The QA2 compiler inferred OUTPUT_NAMES only from the keys of the outcomes rows. A questionnaire that drives its wizard by remaining questions instead of outcome narrowing leaves outcomes empty, so OUTPUT_NAMES came out empty and the wizard's OUTCOME step rendered no result fields.
## Solution
Seed OUTPUT_NAMES from an optional model-level outputNames, then append outcome keys as before. A questionnaire with no outcomes can now declare which already-declared properties are outputs for the OUTCOME step. Backward compatible: with no outputNames the list still derives from outcomes.