### PR TITLE
PT-FIXES: 3740 Add outcomeView extension point to QAWizardView

### DIFF
--- a/src/foam/u2/qa/QAWizardView.js
+++ b/src/foam/u2/qa/QAWizardView.js
@@ -246,6 +246,8 @@ foam.CLASS({
       this.start().addClass(this.myClass('header'))
         .start('span').addClass(this.myClass('candidate-count'))
           .add(this.slot(function(phase, candidatesCount, totalOutcomes) {
+            // Custom outcomeView owns the end step — suppress the framework label too.
+            if ( phase == 'OUTCOME' && self.outcomeView ) return null;
             return phase.labelFormatter(candidatesCount, totalOutcomes);
           }))
         .end()
@@ -439,6 +441,8 @@ foam.ENUM({
       name: 'OUTCOME',
       labelFormatter: function() { return this.MATCH_FOUND; },
       headingFormatter: function(self) {
+        // A custom outcomeView owns the whole end step — no framework heading.
+        if ( self.outcomeView ) return '';
         return self.candidatesCount ? this.ALL_DONE : this.NO_MATCH_FOUND;
       },
       subHeadingFormatter: function(self) {

--- a/src/foam/u2/qa/QAWizardView.js
+++ b/src/foam/u2/qa/QAWizardView.js
@@ -135,6 +135,14 @@ foam.CLASS({
       name: 'onComplete',
       documentation: 'Optional callback invoked with (data) when the wizard finishes'
     },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'outcomeView',
+      documentation: `View for the OUTCOME step. Receives the questionnaire as data. When
+        unset, the default TabularSectionView of the OUTPUT_NAMES properties is rendered.
+        A questionnaire that computes its outcome asynchronously can supply a view that
+        shows a loading state and renders the result reactively.`
+    },
     'valueSub_',
     'validSub_'
   ],
@@ -263,22 +271,27 @@ foam.CLASS({
                 .addClass('p')
                 .add(self.NO_CANDIDATES)
               .end();
-            var outputProps = self.getOutputProperties_();
-            this.startContext({ controllerMode: foam.u2.ControllerMode.VIEW })
-            .tag({
-              class: 'foam.u2.detail.VerticalDetailView',
-              of: self.data.cls_,
-              data$: self.data$,
-              sections: [
-                {
-                  name: 'info_output_',
-                  title: '',
-                  view: { class: 'foam.u2.detail.TabularSectionView' },
-                  properties: outputProps.map(p => p.name),
-                }
-              ]
-            })
-            .endContext();
+            this.startContext({ controllerMode: foam.u2.ControllerMode.VIEW });
+            if ( self.outcomeView ) {
+              // Caller-supplied end-step view (e.g. async/loading or richer rendering).
+              this.tag(self.outcomeView, { data$: self.data$ });
+            } else {
+              var outputProps = self.getOutputProperties_();
+              this.tag({
+                class: 'foam.u2.detail.VerticalDetailView',
+                of: self.data.cls_,
+                data$: self.data$,
+                sections: [
+                  {
+                    name: 'info_output_',
+                    title: '',
+                    view: { class: 'foam.u2.detail.TabularSectionView' },
+                    properties: outputProps.map(p => p.name),
+                  }
+                ]
+              });
+            }
+            this.endContext();
           } else if ( phase == 'PICK' ) {
             var candidates = self.data.getCandidates();
             var ranked     = self.data.rankOutcomes(candidates);


### PR DESCRIPTION
## Problem
QAWizardView hardcoded its OUTCOME step to a TabularSectionView of the OUTPUT_NAMES properties. A questionnaire could not supply its own end-step view, so an outcome computed asynchronously had no way to show a loading state or a custom rendering.
## Solution
Add an outcomeView ViewSpec to QAWizardView, defaulting to the existing TabularSectionView render. When set, the OUTCOME step tags the supplied view with the questionnaire as data. Backward compatible: unset keeps the current behavior.