### PR TITLE
Support ssl/https connections to untrusted certificates.

### DIFF
--- a/src/foam/box/socket/UnsafeSslContextFactory.js
+++ b/src/foam/box/socket/UnsafeSslContextFactory.js
@@ -1,0 +1,49 @@
+/**
+* @license
+* Copyright 2021 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  package: 'foam.box.socket',
+  name: 'UnsafeSslContextFactory',
+  extends: 'foam.box.socket.SslContextFactory',
+  documentation: 'create SSL context which trusts all certification requests',
+
+  javaImports: [
+    'java.security.cert.X509Certificate',
+    'java.security.*',
+    'javax.net.ssl.*'
+  ],
+
+  methods: [
+    {
+      name: 'getSSLContext',
+      javaType: 'SSLContext',
+      javaCode: `
+        SSLContext sslContext = null;
+        try {
+          sslContext = SSLContext.getInstance(getProtocol());
+
+          TrustManager[] trustAll = new TrustManager[] {
+            new X509TrustManager() {
+              public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+              public void checkClientTrusted(X509Certificate[] c, String a) {}
+              public void checkServerTrusted(X509Certificate[] c, String a) {
+                getLogger().debug("UnsafeSSLContext", "checkServerTrusted", a);
+              }
+            }
+          };
+          sslContext.init(null, trustAll, null);
+        } catch ( NoSuchAlgorithmException e ) {
+          getLogger().error(e);
+          throw new RuntimeException(e);
+        } catch ( KeyManagementException e ) {
+          getLogger().error(e);
+          throw new RuntimeException(e);
+        }
+        return sslContext;
+      `
+    }
+  ]
+});

--- a/src/foam/box/socket/services.jrl
+++ b/src/foam/box/socket/services.jrl
@@ -25,3 +25,13 @@ p({
     "class": "foam.box.socket.SslContextFactory"
   }
 })
+
+p({
+  "class": "foam.core.boot.CSpec",
+  "name": "unsafeSslContextFactory",
+  "description": "ssl context factory for creating ssl socket, without certificate verification",
+  "lazy":false,
+  "service": {
+    "class": "foam.box.socket.UnsafeSslContextFactory"
+  }
+})

--- a/src/foam/core/auth/Credential.js
+++ b/src/foam/core/auth/Credential.js
@@ -85,6 +85,11 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'useMock'
+    },
+    {
+      class: 'Boolean',
+      name: 'unsafe',
+      documentation: 'Trust unverified certificates and hostnames'
     }
   ],
 

--- a/src/pom.js
+++ b/src/pom.js
@@ -514,6 +514,7 @@ foam.POM({
     { name: "foam/box/socket/SocketConnectionBoxManager",             flags: "js|java" },
     { name: "foam/box/socket/SocketServer",                           flags: "js|java" },
     { name: "foam/box/socket/SslContextFactory",                      flags: "js|java" },
+    { name: "foam/box/socket/UnsafeSslContextFactory",                flags: "js|java" },
     { name: "foam/dao/BaseClientDAO",                                 flags: "js|java" },
     { name: "foam/dao/BaseNotificationClientDAO",                     flags: "js|java" },
     { name: "foam/dao/MergeBox",                                      flags: "js" },


### PR DESCRIPTION
Credentials - unsafe - instructs the credential user to allow configuration which can bypass certificate verification.
UnsafeSslContextFactory - provides an SSLContext for Https clients which will skip certificate verification.
