### PR TITLE
DOS-3738 PT-Fixees QA multi-select answers with value 0

### DIFF
--- a/src/foam/u2/qa/QA.js
+++ b/src/foam/u2/qa/QA.js
@@ -303,7 +303,10 @@ foam.CLASS({
           function isTermConsistent(term) {
             var val = this[term.property];
 
-            // Unanswered question — term is still possible
+            // Unanswered question — term is still possible. Arrays are used by
+            // multi-select questions; handle them before loose numeric checks so
+            // ['0'] is not coerced to 0 and treated as unanswered.
+            if ( Array.isArray(val) ) return val.length === 0;
             if ( val == 0 || val === '' || val === undefined || val === null ) return true;
 
             // Evaluate the mlang term against this object
@@ -311,7 +314,11 @@ foam.CLASS({
           },
 
           function isQuestionAnswered(q) {
-            return this[q.name] !== '' && this[q.name] != 0 && this[q.name] != undefined;
+            var val = this[q.name];
+            // Multi-select questions store answers as arrays. Any non-empty
+            // array means the user selected at least one option, including ['0'].
+            if ( Array.isArray(val) ) return val.length > 0;
+            return val !== '' && val != 0 && val != undefined;
           },
 
           /**


### PR DESCRIPTION
### Fix QA multi-select answer detection for `0` values. 

In the Questionnaire - when we have a view which can accept multiple-answers. 
And it just happens to be the case (which it did happen) that one of the option answer is `0`, the QA treats it as unanswered coz the previous loose comparison treated `['0']` as equal to `0`, so QA considered the question unanswered and blocked progression.

e.g. of code which was not working
```js
choices: [
  ['C', 'Canada'],
  ['D', 'National'],
  ['0', 'Some other third answer']
]
```

 Now array answers are handled explicitly:
 - empty array = unanswered
 - non-empty array = answered