### PR TITLE
PT-FIXES: DOS-3558: key File by GUID, store content digest separately

### DIFF
--- a/src/foam/core/blob/FileService.java
+++ b/src/foam/core/blob/FileService.java
@@ -63,7 +63,7 @@ public class FileService
 
       if ( SafetyUtil.isEmpty(file.getDataString()) ){
         BlobService store = (BlobService) x.get("blobStore");
-        blob = store.find(file.getId());
+        blob = store.find(file.getDigest());
       } else {
         //Replace @version@ with actual foam version
         if ( "text/html".equals(file.getMimeType()) ) {

--- a/src/foam/core/fs/File.js
+++ b/src/foam/core/fs/File.js
@@ -84,6 +84,22 @@ foam.CLASS({
     },
     {
       class: 'String',
+      name: 'digest',
+      createVisibility: 'HIDDEN',
+      updateVisibility: 'HIDDEN',
+      readVisibility: 'RO',
+      documentation: `Blob store key (sha256 of the file content). Falls back to id for
+        legacy records created before digest was split out of id.`,
+      javaGetter: `
+        if ( digestIsSet_ ) return digest_;
+        return getId();
+      `,
+      getter: function() {
+        return this.instance_.digest || this.id;
+      }
+    },
+    {
+      class: 'String',
       name: 'filename',
       documentation: 'Filename'
     },
@@ -326,7 +342,7 @@ foam.CLASS({
         return ((InputStreamBlob)blob).getInputStream();
       } else {
         BlobService blobStore = (BlobService) x.get("blobStore");
-        blob = blobStore.find(getId());
+        blob = blobStore.find(getDigest());
         if ( blob != null ) {
           try {
             return new java.io.FileInputStream(((FileBlob) blob).getFile());

--- a/src/foam/core/fs/FileDataDAO.js
+++ b/src/foam/core/fs/FileDataDAO.js
@@ -98,7 +98,7 @@ foam.CLASS({
         // save to filesystem
         BlobService blobStore = (BlobService) x.get("blobStore");
         IdentifiedBlob result = (IdentifiedBlob) blobStore.put(blob);
-        file.setId(result.getId());
+        file.setDigest(result.getId());
         file.clearData();
         return getDelegate().put_(x, file);
       } catch (Exception e) {

--- a/src/foam/core/notification/email/SMTPAgent.js
+++ b/src/foam/core/notification/email/SMTPAgent.js
@@ -347,7 +347,7 @@ foam.CLASS({
                 Blob blob = (Blob) file.getData();
                 InputStream stream = null;
                 if ( blob instanceof  IdentifiedBlob || blob == null ) {
-                  String id = blob == null ? file.getId(): ((IdentifiedBlob) blob).getId();
+                  String id = blob == null ? file.getDigest(): ((IdentifiedBlob) blob).getId();
                   BlobService blobStore = (BlobService) getX().get("blobStore");
                   FileBlob temp = (FileBlob) blobStore.find(id);
                   var os = new ByteArrayOutputStream();


### PR DESCRIPTION
## Problem
FileDataDAO replaced File.id with the stored blob's content hash. Identical content collapsed into a single record, so re-uploading the same bytes hit that record's update path and failed authorization, surfacing to the caller as "Failed to save file". The first upload of any content succeeded; every later upload of the same content failed.
## Solution
Keep the GUID id and store the content hash in a new digest field. Each upload becomes its own record, while the blob stays content-addressed on disk. Reads resolve blobs by digest and fall back to id for records created before the split, so no journal migration is needed.
## Changes
- Add a `digest` field to File for the blob key; its getter falls back to `id` so legacy records keep resolving.
- Store the content hash in `digest` on save instead of overwriting `id`, leaving `id` a GUID.
- Resolve blobs by `digest` in the file-serving and email-attachment paths.