### PR TITLE
feat(lsp): comment/doc suppression, relationship hover, instantiation value resolution

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -143,6 +143,12 @@ cd <project> && node foam3/tools/tests/testFoamLSP.js
 2. Use `P.sug()` for completions, `P.sym()` for rule references
 3. Dynamic parsers built from registry in `buildDynamicParsers_()`
 
+### Grammar-harvested positions (single-parse `P.msg` records)
+`FoamClassGrammar` emits position-tagged `P.msg` records harvested by the `apply` hook in one parse. Beyond axiom positions (`collectAxiomPositions`):
+- `collectRanges(text)` → `{comment, documentation}` spans (`P.msg({kind:'comment'|'documentation'})`). Drives comment/doc suppression in `HoverHandler` (no hover inside) and `SemanticTokenHandler` (no non-comment tokens inside).
+- `collectInstantiations(text)` → grouped `X.create({…})` / `.tag(this.X,{…})` calls with receiver class + key/value spans (`instCall`/`instCreateReceiver`/`instTagClass`/`instKey`/`instValue` kinds). The receiver chain uses `P.not` negative lookahead so only real create/tag calls match — generic `foo.bar(...)` emits nothing. Drives enum value completion (`MemberCompletionHandler`) and value diagnostics (`DiagnosticsHandler`).
+- `FoamIndex.getRelationships(classId)` (relationship hover, #5091) and `FoamIndex.getPropertyInfo(classId, prop)` (enum/primitive value resolution, #5093) back the index-side lookups.
+
 ## Metrics
 - ~3800 lines of LSP code
 - 123 automated tests

--- a/tools/lsp/CursorAnalyzer.js
+++ b/tools/lsp/CursorAnalyzer.js
@@ -71,6 +71,36 @@ foam.CLASS({
       return word;
     },
 
+    function getEnclosingStringContent(text, position) {
+      /**
+       * If the cursor sits inside a quoted string literal on its line, return
+       * the string's content (between the quotes); otherwise null. Used to
+       * stop a word inside a label like 'Reset Password' from resolving to a
+       * type/class — only a string whose WHOLE content is a reference should.
+       */
+      var lines = text.split('\n');
+      var line = lines[position.line] || '';
+      var ch = position.character;
+      var quotes = "'\"`";
+      var i = 0;
+      while ( i < line.length ) {
+        if ( quotes.indexOf(line[i]) !== -1 ) {
+          var q = line[i];
+          var start = i + 1;
+          var j = start;
+          while ( j < line.length && line[j] !== q ) {
+            if ( line[j] === '\\' ) j++;
+            j++;
+          }
+          if ( ch > start - 1 && ch <= j ) return line.substring(start, j);
+          i = j + 1;
+        } else {
+          i++;
+        }
+      }
+      return null;
+    },
+
     function getSegmentAtPosition(text, position) {
       /**
        * Get just the single identifier segment under the cursor (stops at dots).

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -1168,6 +1168,11 @@ foam.CLASS({
           lineComment, blockComment, P.sym('instantiationCall'), P.notChars('{}')
         ), null, 0)), P.literal('}')),
 
+        balancedBrackets: P.seq(P.literal('['), P.str(P.repeat(P.alt(
+          P.sym('balancedBrackets'), P.sym('balancedBraces'), P.sym('balancedParens'),
+          stringLiteral, backtickString, lineComment, blockComment, P.notChars('[]')
+        ), null, 0)), P.literal(']')),
+
         // === INSTANTIATION RULES (F3) ===
         instCreateCall: P.msg(P.seq(
           P.msg(instReceiverChain, { kind: 'instCreateReceiver' }),
@@ -1176,8 +1181,12 @@ foam.CLASS({
           wsc, P.optional(P.literal(')'))
         ), { kind: 'instCall' }),
 
+        // .tag is anchored on the `.tag(` literal itself — NOT on a receiver.
+        // In real fluent u2 code .tag chains off a method call
+        // (`.addClass(...).tag(this.X, {...})`), so the token before `.tag` is
+        // `)`, not an identifier. The view class is the FIRST argument, which
+        // instTagClass captures; whatever precedes `.tag` is irrelevant.
         instTagCall: P.msg(P.seq(
-          instReceiverChain,
           P.literal('.tag'), wsc, P.literal('('), wsc,
           P.msg(dottedId, { kind: 'instTagClass' }),
           wsc, P.literal(','), wsc,
@@ -1193,8 +1202,19 @@ foam.CLASS({
 
         instEntry: P.alt(
           P.seq(P.msg(identifier, { kind: 'instKey' }), wsc, P.literal(':'), wsc,
-            P.msg(anyValue, { kind: 'instValue' })),
-          P.sym('genericEntry'))
+            P.msg(P.sym('instValueExpr'), { kind: 'instValue' })),
+          P.sym('genericEntry')),
+
+        // A property value: a primary token plus any call/index/member trailers,
+        // so call expressions (this.slot(...)), slots (this.x$), nested objects
+        // and arrays parse as ONE value instead of stopping at `this.slot` and
+        // desyncing the rest of the object literal.
+        instValueExpr: P.seq(
+          P.alt(stringLiteral, number, booleanLiteral, P.sym('functionBody'),
+            P.sym('object'), P.sym('array'), dottedId),
+          P.repeat0(P.alt(P.sym('balancedParens'), P.sym('balancedBrackets'),
+            P.seq(P.literal('.'), dottedId)))
+        )
       };
     }
   ]

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -83,7 +83,8 @@ foam.CLASS({
       var map = {
         message:     {}, value:    {}, property: {}, method:  {},
         pomFileName: {}, classRef: {}, comment:  {}, documentation: {},
-        instCall: {}, instCreateReceiver: {}, instTagClass: {}, instKey: {}, instValue: {}
+        instCall: {}, instCreateReceiver: {}, instTagClass: {}, instClassRef: {},
+        instKey: {}, instValue: {}
       };
       // Kinds that allow multiple occurrences per name. Single-occurrence
       // kinds (message, value, property, method, pomFileName) keep their
@@ -92,7 +93,7 @@ foam.CLASS({
       // so collect every position.
       var MULTI = { classRef: true, comment: true, documentation: true,
         instCall: true, instCreateReceiver: true, instTagClass: true,
-        instKey: true, instValue: true };
+        instClassRef: true, instKey: true, instValue: true };
 
       var apply = function(p, grammar) {
         var startPos = this.pos;
@@ -176,7 +177,8 @@ foam.CLASS({
         return out;
       }
       var calls = recs('instCall'), creators = recs('instCreateReceiver'),
-          tags = recs('instTagClass'), keys = recs('instKey'), vals = recs('instValue');
+          tags = recs('instTagClass'), classRefs = recs('instClassRef'),
+          keys = recs('instKey'), vals = recs('instValue');
       function within(r, span) { return r.startPos >= span.startPos && r.endPos <= span.endPos; }
       function innermost(r) {
         var best = null;
@@ -200,8 +202,9 @@ foam.CLASS({
       for ( var c = 0 ; c < calls.length ; c++ ) {
         var span = calls[c];
         var tag = firstIn(tags, span);
+        var classRef = firstIn(classRefs, span);   // { class: 'X', ... } form
         var creator = firstIn(creators, span);
-        var classText = tag ? tag.text : ( creator ? creator.text : null );
+        var classText = tag ? tag.text : ( classRef ? classRef.text : ( creator ? creator.text : null ) );
         if ( ! classText ) continue;
         if ( classText.indexOf('this.') === 0 ) classText = classText.substring(5);
         // keys/values that belong to THIS call (innermost containing call)
@@ -222,7 +225,7 @@ foam.CLASS({
             valuePos: val ? { startPos: val.startPos, endPos: val.endPos } : null
           });
         }
-        out.push({ classText: classText, isTag: !! tag,
+        out.push({ classText: classText, isTag: !! ( tag || classRef ),
           callSpan: { startPos: span.startPos, endPos: span.endPos }, entries: entries });
       }
       return out;
@@ -1164,7 +1167,7 @@ foam.CLASS({
         ), null, 0)), P.literal(')')),
 
         balancedBraces: P.seq(P.literal('{'), P.str(P.repeat(P.alt(
-          P.sym('balancedBraces'), stringLiteral, backtickString,
+          P.sym('instClassObject'), P.sym('balancedBraces'), stringLiteral, backtickString,
           lineComment, blockComment, P.sym('instantiationCall'), P.notChars('{}')
         ), null, 0)), P.literal('}')),
 
@@ -1193,6 +1196,22 @@ foam.CLASS({
           wsc, P.literal(','), wsc,
           P.sym('instObject'),
           wsc, P.optional(P.literal(')'))
+        ), { kind: 'instCall' }),
+
+        // Inline ViewSpec object: `{ class: 'X', prop: ... }` — the class is
+        // named by the `class:` key (required first), siblings are X's props.
+        // Only reached inside code (balancedBraces); property/axiom specs in
+        // `properties:`/`actions:`/etc. arrays are parsed by their own object
+        // rules and never hit this, so `{ class: 'String', name: 'x' }` defs
+        // are untouched.
+        instClassObject: P.msg(P.seq(
+          P.literal('{'), wsc,
+          P.literal('class'), wsc, P.literal(':'), wsc,
+          quotedAny(P.msg(P.str(P.repeat(P.alt(alphaNum, P.chars('._')), null, 1)),
+            { kind: 'instClassRef' })),
+          P.repeat0(P.seq(comma, P.sym('instEntry'))),
+          P.optional(comma),
+          wsc, P.optional(P.literal('}'))
         ), { kind: 'instCall' }),
 
         instantiationCall: P.alt(P.sym('instCreateCall'), P.sym('instArgCall')),

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -1181,20 +1181,21 @@ foam.CLASS({
           wsc, P.optional(P.literal(')'))
         ), { kind: 'instCall' }),
 
-        // .tag is anchored on the `.tag(` literal itself — NOT on a receiver.
-        // In real fluent u2 code .tag chains off a method call
-        // (`.addClass(...).tag(this.X, {...})`), so the token before `.tag` is
-        // `)`, not an identifier. The view class is the FIRST argument, which
-        // instTagClass captures; whatever precedes `.tag` is irrelevant.
-        instTagCall: P.msg(P.seq(
-          P.literal('.tag'), wsc, P.literal('('), wsc,
+        // Generic argument-call form: ANY call that passes a class reference
+        // immediately followed by an object literal — `.tag(this.X, {...})`,
+        // `.add(this.X, {...})`, `helper(this.X, {...})`, `[this.X, {...}]`,
+        // etc. The class is the arg before the object; the method name is
+        // irrelevant, so the LSP works it out without per-helper knowledge.
+        // Anchored on `classRef, {` adjacency. Non-class refs are dropped later
+        // by resolution (classExists), so matching broadly is safe.
+        instArgCall: P.msg(P.seq(
           P.msg(dottedId, { kind: 'instTagClass' }),
           wsc, P.literal(','), wsc,
-          repeatList(P.alt(P.sym('instObject'), anyValue)),
+          P.sym('instObject'),
           wsc, P.optional(P.literal(')'))
         ), { kind: 'instCall' }),
 
-        instantiationCall: P.alt(P.sym('instCreateCall'), P.sym('instTagCall')),
+        instantiationCall: P.alt(P.sym('instCreateCall'), P.sym('instArgCall')),
 
         instObject: P.seq(P.literal('{'), wsc,
           repeatList(P.sym('instEntry')),

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -82,14 +82,17 @@ foam.CLASS({
       var self = this;
       var map = {
         message:     {}, value:    {}, property: {}, method:  {},
-        pomFileName: {}, classRef: {}
+        pomFileName: {}, classRef: {}, comment:  {}, documentation: {},
+        instCall: {}, instCreateReceiver: {}, instTagClass: {}, instKey: {}, instValue: {}
       };
       // Kinds that allow multiple occurrences per name. Single-occurrence
       // kinds (message, value, property, method, pomFileName) keep their
       // first sighting only — a model defines each name once. Class
       // references DO repeat (requires + extends + ofs + raw strings + …),
       // so collect every position.
-      var MULTI = { classRef: true };
+      var MULTI = { classRef: true, comment: true, documentation: true,
+        instCall: true, instCreateReceiver: true, instTagClass: true,
+        instKey: true, instValue: true };
 
       var apply = function(p, grammar) {
         var startPos = this.pos;
@@ -129,6 +132,100 @@ foam.CLASS({
 
       this.axiomCache_ = { text: text, map: map };
       return map;
+    },
+
+    function collectRanges(text) {
+      /** Comment + documentation-value spans, harvested from the grammar's
+       *  P.msg(comment)/P.msg(documentation) emissions in a single parse.
+       *  Dedupes by startPos (wsc is retried at the same offset during
+       *  backtracking, so a comment can be recorded more than once). */
+      var map = this.collectAxiomPositions(text);
+      function flatten(byName) {
+        var out = [], seen = {};
+        for ( var name in byName ) {
+          var arr = byName[name];
+          if ( ! Array.isArray(arr) ) arr = [arr];
+          for ( var i = 0 ; i < arr.length ; i++ ) {
+            var rec = arr[i];
+            if ( seen[rec.startPos] ) continue;
+            seen[rec.startPos] = true;
+            out.push({ startPos: rec.startPos, endPos: rec.endPos });
+          }
+        }
+        return out;
+      }
+      return { comment: flatten(map.comment), documentation: flatten(map.documentation) };
+    },
+
+    function collectInstantiations(text) {
+      /** Groups instKey/instValue under each instCall (by innermost span) and
+       *  resolves the view class from instCreateReceiver (the receiver) or
+       *  instTagClass (the .tag first arg). Grammar-driven — no regex.
+       *  Returns [{ classText, isTag, callSpan, entries:[{ key, keyPos,
+       *  valueText, valuePos }] }]. */
+      var map = this.collectAxiomPositions(text);
+      function recs(kind) {
+        var byName = map[kind] || {}, out = [];
+        for ( var n in byName ) {
+          var a = byName[n];
+          if ( ! Array.isArray(a) ) a = [a];
+          for ( var i = 0 ; i < a.length ; i++ ) {
+            out.push({ text: n, startPos: a[i].startPos, endPos: a[i].endPos });
+          }
+        }
+        return out;
+      }
+      var calls = recs('instCall'), creators = recs('instCreateReceiver'),
+          tags = recs('instTagClass'), keys = recs('instKey'), vals = recs('instValue');
+      function within(r, span) { return r.startPos >= span.startPos && r.endPos <= span.endPos; }
+      function innermost(r) {
+        var best = null;
+        for ( var c = 0 ; c < calls.length ; c++ ) {
+          if ( within(r, calls[c]) ) {
+            if ( ! best || ( calls[c].endPos - calls[c].startPos ) < ( best.endPos - best.startPos ) ) {
+              best = calls[c];
+            }
+          }
+        }
+        return best;
+      }
+      function firstIn(list, span) {
+        var best = null;
+        for ( var i = 0 ; i < list.length ; i++ ) {
+          if ( within(list[i], span) && ( ! best || list[i].startPos < best.startPos ) ) best = list[i];
+        }
+        return best;
+      }
+      var out = [];
+      for ( var c = 0 ; c < calls.length ; c++ ) {
+        var span = calls[c];
+        var tag = firstIn(tags, span);
+        var creator = firstIn(creators, span);
+        var classText = tag ? tag.text : ( creator ? creator.text : null );
+        if ( ! classText ) continue;
+        if ( classText.indexOf('this.') === 0 ) classText = classText.substring(5);
+        // keys/values that belong to THIS call (innermost containing call)
+        var kIn = keys.filter(function(k) { var ic = innermost(k); return ic && ic.startPos === span.startPos; })
+                      .sort(function(a, b) { return a.startPos - b.startPos; });
+        var vIn = vals.filter(function(v) { var ic = innermost(v); return ic && ic.startPos === span.startPos; })
+                      .sort(function(a, b) { return a.startPos - b.startPos; });
+        var entries = [];
+        for ( var i = 0 ; i < kIn.length ; i++ ) {
+          var val = null;
+          for ( var j = 0 ; j < vIn.length ; j++ ) {
+            if ( vIn[j].startPos > kIn[i].startPos ) { val = vIn[j]; break; }
+          }
+          entries.push({
+            key: kIn[i].text,
+            keyPos: { startPos: kIn[i].startPos, endPos: kIn[i].endPos },
+            valueText: val ? val.text : null,
+            valuePos: val ? { startPos: val.startPos, endPos: val.endPos } : null
+          });
+        }
+        out.push({ classText: classText, isTag: !! tag,
+          callSpan: { startPos: span.startPos, endPos: span.endPos }, entries: entries });
+      }
+      return out;
     },
 
     function findAxiomPosition(text, kind, name) {
@@ -336,9 +433,9 @@ foam.CLASS({
 
       // Whitespace primitives. `ws` is whitespace-only; `wsc` is the
       // whitespace + comments form used between grammar tokens.
-      var lineComment = P.seq(P.literal('//'), P.str(P.repeat(P.notChars('\n\r'), null, 0)),
-        P.alt(P.literal('\r\n'), P.literal('\n'), P.literal('\r')));
-      var blockComment = P.seq(P.literal('/*'), P.str(P.until(P.literal('*/'))));
+      var lineComment = P.msg(P.seq(P.literal('//'), P.str(P.repeat(P.notChars('\n\r'), null, 0)),
+        P.alt(P.literal('\r\n'), P.literal('\n'), P.literal('\r'))), { kind: 'comment' });
+      var blockComment = P.msg(P.seq(P.literal('/*'), P.str(P.until(P.literal('*/')))), { kind: 'comment' });
       var wsChar = P.chars(' \t\n\r');
       var ws  = P.repeat0(wsChar);
       var wsc = P.repeat0(P.alt(wsChar, lineComment, blockComment));
@@ -365,6 +462,18 @@ foam.CLASS({
       var dottedIdentChars = P.alt(alphaNum, P.chars('_.$'));
       var identifier = P.str(P.repeat(identChars, null, 1));
       var dottedId   = P.str(P.repeat(dottedIdentChars, null, 1));
+
+      // === INSTANTIATION (F3) ===
+      // Receiver chain for `X.create(` / `el.tag(`: (this.)? seg (.seg)*
+      // that STOPS before the trailing `.create(` / `.tag(`. Negative
+      // lookahead (P.not) keeps the rule from matching generic calls.
+      var instMethodAhead = P.seq(P.alt(P.literal('create'), P.literal('tag')), wsc, P.literal('('));
+      var classSeg = P.str(P.repeat(identChars, null, 1));
+      var instReceiverChain = P.str(P.seq(
+        P.optional(P.seq(P.literal('this'), P.literal('.'))),
+        classSeg,
+        P.repeat0(P.seq(P.literal('.'), P.seq(P.not(instMethodAhead), classSeg)))
+      ));
 
       // Identifier-as-msg helper. The grammar has many `name: ` slots
       // that must emit a position-tagged msg for downstream handlers
@@ -702,7 +811,8 @@ foam.CLASS({
           wsc, P.literal(':'), wsc,
           quoted(P.sym('classRef'))
         ),
-        documentationEntry: P.seq(key('documentation', topHint('documentation')), wsc, P.literal(':'), wsc, stringLiteral),
+        documentationEntry: P.seq(key('documentation', topHint('documentation')), wsc, P.literal(':'), wsc,
+          P.msg(stringLiteral, { kind: 'documentation' })),
         abstractEntry: P.seq(key('abstract', topHint('abstract')), wsc, P.literal(':'), wsc, booleanLiteral),
         flagsEntry: P.seq(key('flags', topHint('flags')), wsc, P.literal(':'), wsc, P.sym('array')),
         // actions/listeners/sections — array-of-object axioms. Each gets a
@@ -965,7 +1075,7 @@ foam.CLASS({
             wsc, P.literal(':'), wsc, quoted(P.sym('classRef'))),
           P.seq(P.sug(P.literal('documentation'), foam.parse.Suggestion.create({
             text: 'documentation', category: 'key' })),
-            wsc, P.literal(':'), wsc, stringLiteral),
+            wsc, P.literal(':'), wsc, P.msg(stringLiteral, { kind: 'documentation' })),
           P.seq(P.sug(P.literal('hidden'), foam.parse.Suggestion.create({
             text: 'hidden', category: 'key' })),
             wsc, P.literal(':'), wsc, booleanLiteral),
@@ -1055,8 +1165,36 @@ foam.CLASS({
 
         balancedBraces: P.seq(P.literal('{'), P.str(P.repeat(P.alt(
           P.sym('balancedBraces'), stringLiteral, backtickString,
-          lineComment, blockComment, P.notChars('{}')
-        ), null, 0)), P.literal('}'))
+          lineComment, blockComment, P.sym('instantiationCall'), P.notChars('{}')
+        ), null, 0)), P.literal('}')),
+
+        // === INSTANTIATION RULES (F3) ===
+        instCreateCall: P.msg(P.seq(
+          P.msg(instReceiverChain, { kind: 'instCreateReceiver' }),
+          P.literal('.create'), wsc, P.literal('('), wsc,
+          repeatList(P.alt(P.sym('instObject'), anyValue)),
+          wsc, P.optional(P.literal(')'))
+        ), { kind: 'instCall' }),
+
+        instTagCall: P.msg(P.seq(
+          instReceiverChain,
+          P.literal('.tag'), wsc, P.literal('('), wsc,
+          P.msg(dottedId, { kind: 'instTagClass' }),
+          wsc, P.literal(','), wsc,
+          repeatList(P.alt(P.sym('instObject'), anyValue)),
+          wsc, P.optional(P.literal(')'))
+        ), { kind: 'instCall' }),
+
+        instantiationCall: P.alt(P.sym('instCreateCall'), P.sym('instTagCall')),
+
+        instObject: P.seq(P.literal('{'), wsc,
+          repeatList(P.sym('instEntry')),
+          wsc, P.optional(P.literal('}'))),
+
+        instEntry: P.alt(
+          P.seq(P.msg(identifier, { kind: 'instKey' }), wsc, P.literal(':'), wsc,
+            P.msg(anyValue, { kind: 'instValue' })),
+          P.sym('genericEntry'))
       };
     }
   ]

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -621,6 +621,62 @@ foam.CLASS({
       });
     },
 
+    function getRelationships(classId) {
+      /** Relationships (foam.dao.Relationship) this class participates in.
+       *  A Relationship installs itself as an axiom on BOTH its source and
+       *  target classes (Relationship.js:235,280), so getAxiomsByClass finds
+       *  every one. Returns [{ dir: 'out'|'in', name, other, card }]. */
+      var cls = this.getClass(classId);
+      if ( ! cls || ! foam.dao.Relationship ) return [];
+      var rels = cls.getAxiomsByClass(foam.dao.Relationship);
+      var out = [];
+      for ( var i = 0 ; i < rels.length ; i++ ) {
+        var r = rels[i];
+        var card = r.cardinality || '1:*';
+        if ( r.sourceModel === classId ) {
+          out.push({ dir: 'out', name: r.forwardName, other: r.targetModel, card: card });
+        }
+        if ( r.targetModel === classId && ! r.oneWay ) {
+          out.push({ dir: 'in', name: r.inverseName, other: r.sourceModel, card: card });
+        }
+      }
+      return out;
+    },
+
+    function getPropertyInfo(classId, propName) {
+      /** General property resolver for value validation/completion. Returns
+       *  { found, propClassName, isEnum, enumId, enumValues, primitiveKind }.
+       *  primitiveKind ∈ {'int','float','boolean', null}. Enum detection is
+       *  independent of the property's class name: a property whose `of`
+       *  resolves to a class with VALUES is treated as an enum. */
+      var info = { found: false, propClassName: null, isEnum: false,
+                   enumId: null, enumValues: [], primitiveKind: null };
+      var cls = this.getClass(classId);
+      if ( ! cls ) return info;
+      var prop = cls.getAxiomByName(propName);
+      if ( ! prop || ! foam.lang.Property.isInstance(prop) ) return info;
+      info.found = true;
+      info.propClassName = ( prop.cls_ && prop.cls_.model_ ) ? prop.cls_.model_.name : null;
+
+      var ofId = prop.of && ( prop.of.id || prop.of );
+      if ( ofId ) {
+        var vals = this.getEnumValues(ofId);
+        if ( vals && vals.length > 0 ) {
+          info.isEnum = true;
+          info.enumId = ofId;
+          info.enumValues = vals;
+        }
+      }
+      if ( ! info.isEnum ) {
+        switch ( info.propClassName ) {
+          case 'Int': case 'Long':   info.primitiveKind = 'int';     break;
+          case 'Float': case 'Double': info.primitiveKind = 'float'; break;
+          case 'Boolean':            info.primitiveKind = 'boolean'; break;
+        }
+      }
+      return info;
+    },
+
     function getClassDoc(classId) {
       /** Build markdown hover content for a class. */
       var cls = this.getClass(classId);

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -113,6 +113,10 @@ foam.CLASS({
       // class: '…'). Positions come straight from parser offsets, no regex.
       this.collectGrammarDiagnostics_(text, diagnostics);
 
+      // Enum / primitive literal values inside X.create({})/.tag(this.X,{}).
+      // Whole-file scan (like validateAddStrings_); detection via the grammar.
+      this.validateInstantiations_(text, diagnostics);
+
       this.prevResults_[uri] = { text: text, modelKeys: prev ? prev.modelKeys : {} };
       return this.toLSPDiagnostics_(diagnostics);
     },
@@ -159,6 +163,57 @@ foam.CLASS({
             var classId = this.cache.getClassId(model);
             this.addDiag_(diagnostics, text, r.startPos, matched.length, 2,
               "Property '" + matched + "' does not exist on " + classId);
+          }
+        }
+      }
+    },
+
+    function validateInstantiations_(text, diagnostics) {
+      /** Validate enum/primitive LITERAL values in X.create({})/.tag(this.X,{}).
+       *  Detection is grammar-driven (collectInstantiations). Comments never
+       *  reach here — the grammar's lineComment arm consumes them before the
+       *  instantiationCall arm. Expressions/slots/identifiers are skipped;
+       *  only quoted strings, numbers, and true/false are checked. */
+      var insts = this.grammar.collectInstantiations(text);
+      for ( var i = 0 ; i < insts.length ; i++ ) {
+        var inst = insts[i];
+        var line = this.analyzer.offsetToPosition(text, inst.callSpan.startPos).line;
+        var classId = this.cache.resolveShortName(this.uri_ || '', text, inst.classText, line) || inst.classText;
+        if ( ! this.index.classExists(classId) ) continue;
+
+        for ( var e = 0 ; e < inst.entries.length ; e++ ) {
+          var entry = inst.entries[e];
+          if ( ! entry.valueText || ! entry.valuePos ) continue;
+          var v = entry.valueText;
+          var c0 = v.charAt(0);
+          var isStr  = c0 === "'" || c0 === '"';
+          var isNum  = c0 === '-' || ( c0 >= '0' && c0 <= '9' );
+          var isBool = v === 'true' || v === 'false';
+          if ( ! isStr && ! isNum && ! isBool ) continue;   // literals only
+
+          var info = this.index.getPropertyInfo(classId, entry.key);
+          if ( ! info.found ) continue;
+          var off = entry.valuePos.startPos;
+          var len = entry.valuePos.endPos - entry.valuePos.startPos;
+
+          if ( info.isEnum ) {
+            if ( ! isStr ) continue;
+            var inner = v.slice(1, -1);
+            var names = info.enumValues.map(function(x) { return x.name; });
+            if ( names.indexOf(inner) === -1 ) {
+              this.addDiag_(diagnostics, text, off, len, 2,
+                "'" + inner + "' is not a valid " + info.enumId + " value. Expected: " + names.join(', '));
+            }
+          } else if ( info.primitiveKind === 'int' || info.primitiveKind === 'float' ) {
+            if ( isStr ) {
+              this.addDiag_(diagnostics, text, off, len, 2,
+                "'" + entry.key + "' expects a numeric value, got a string literal");
+            }
+          } else if ( info.primitiveKind === 'boolean' ) {
+            if ( isStr || isNum ) {
+              this.addDiag_(diagnostics, text, off, len, 2,
+                "'" + entry.key + "' expects a boolean (true/false)");
+            }
           }
         }
       }

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -199,6 +199,7 @@ foam.CLASS({
           if ( info.isEnum ) {
             if ( ! isStr ) continue;
             var inner = v.slice(1, -1);
+            if ( inner === '' ) continue;   // empty = unfilled/mid-edit, not an error
             var names = info.enumValues.map(function(x) { return x.name; });
             if ( names.indexOf(inner) === -1 ) {
               this.addDiag_(diagnostics, text, off, len, 2,

--- a/tools/lsp/handlers/HoverHandler.js
+++ b/tools/lsp/handlers/HoverHandler.js
@@ -81,6 +81,12 @@ foam.CLASS({
         }
       }
 
+      // Inside a string literal, only the WHOLE string may be a reference. A
+      // sub-word of a label like 'Reset Password' must not resolve to a type
+      // (e.g. foam.lang.Password) — that is data, not a code reference.
+      var strContent = this.analyzer.getEnclosingStringContent(text, position);
+      if ( strContent !== null && word !== strContent.trim() ) return null;
+
       // Hovering a class's own `name:` value shows that class (info +
       // relationships) — same result as hovering a reference to it elsewhere.
       // Gated on the `name:` line + a match against the model's own name so a
@@ -697,17 +703,26 @@ foam.CLASS({
         }
       }
 
-      // 6. Relationships — to / from this class (foam.dao.Relationship axioms).
+      // 6. Relationships — to / from this class (foam.dao.Relationship axioms),
+      //    grouped by direction. The model name and cardinality go in backticks
+      //    so `*:*` renders literally instead of being eaten as markdown italics.
       var rels = this.index.getRelationships ? this.index.getRelationships(classId) : [];
       if ( rels && rels.length > 0 ) {
+        var outs = rels.filter(function(x) { return x.dir === 'out'; });
+        var ins  = rels.filter(function(x) { return x.dir === 'in'; });
         md += '\n**Relationships**\n\n';
-        for ( var r = 0 ; r < rels.length ; r++ ) {
-          var rel = rels[r];
-          var otherShort = rel.other ? rel.other.split('.').pop() : '?';
-          if ( rel.dir === 'out' ) {
-            md += '- → `' + rel.name + '`: ' + otherShort + ' (' + rel.card + ')\n';
-          } else {
-            md += '- ← `' + rel.name + '`: ' + otherShort + '\n';
+        if ( outs.length > 0 ) {
+          md += '*Outgoing*\n';
+          for ( var o = 0 ; o < outs.length ; o++ ) {
+            var oShort = outs[o].other ? outs[o].other.split('.').pop() : '?';
+            md += '- `' + outs[o].name + '` → `' + oShort + '` `' + outs[o].card + '`\n';
+          }
+        }
+        if ( ins.length > 0 ) {
+          md += ( outs.length > 0 ? '\n' : '' ) + '*Incoming*\n';
+          for ( var n = 0 ; n < ins.length ; n++ ) {
+            var iShort = ins[n].other ? ins[n].other.split('.').pop() : '?';
+            md += '- `' + ins[n].name + '` ← `' + iShort + '`\n';
           }
         }
       }

--- a/tools/lsp/handlers/HoverHandler.js
+++ b/tools/lsp/handlers/HoverHandler.js
@@ -81,6 +81,20 @@ foam.CLASS({
         }
       }
 
+      // Hovering a class's own `name:` value shows that class (info +
+      // relationships) — same result as hovering a reference to it elsewhere.
+      // Gated on the `name:` line + a match against the model's own name so a
+      // property or variable sharing the name never false-triggers.
+      var selfLine = ( text.split('\n')[position.line] || '' );
+      if ( /^\s*name\s*:/.test(selfLine) ) {
+        var selfModel = this.cache.getModelAt(opt_uri || '', text, position.line);
+        var selfSeg = this.analyzer.getSegmentAtPosition(text, position);
+        if ( selfModel && selfSeg && selfSeg === selfModel.name ) {
+          var selfHover = this.buildClassHover(this.cache.getClassId(selfModel));
+          if ( selfHover ) return selfHover;
+        }
+      }
+
       // Axiom key hover: cursor on `requires:`, `properties:`, `messages:`,
       // `sections:`, `searchColumns:`, etc. — show the description from
       // AxiomCatalog (single source of truth shared with the grammar).

--- a/tools/lsp/handlers/HoverHandler.js
+++ b/tools/lsp/handlers/HoverHandler.js
@@ -68,6 +68,19 @@ foam.CLASS({
       var word = this.analyzer.getDottedWordAtPosition(text, position);
       if ( ! word ) return null;
 
+      // F1: suppress hover inside comments and documentation values. Detection
+      // is grammar-driven via collectRanges (no regex). The documentation KEY
+      // sits before its value span, so axiom-key hover is unaffected.
+      var grammar = this.index.getGrammar && this.index.getGrammar();
+      if ( grammar && grammar.collectRanges ) {
+        var hoverOffset = this.analyzer.positionToOffset(text, position);
+        var ncRanges = grammar.collectRanges(text);
+        if ( this.offsetInRanges_(hoverOffset, ncRanges.comment) ||
+             this.offsetInRanges_(hoverOffset, ncRanges.documentation) ) {
+          return null;
+        }
+      }
+
       // Axiom key hover: cursor on `requires:`, `properties:`, `messages:`,
       // `sections:`, `searchColumns:`, etc. — show the description from
       // AxiomCatalog (single source of truth shared with the grammar).
@@ -205,6 +218,14 @@ foam.CLASS({
       if ( ! model ) return null;
       var requiresMap = this.cache.buildRequiresMap(model);
       return requiresMap[shortName] || null;
+    },
+
+    function offsetInRanges_(off, ranges) {
+      /** True when `off` falls inside any [startPos, endPos) span. */
+      for ( var i = 0 ; i < ranges.length ; i++ ) {
+        if ( off >= ranges[i].startPos && off < ranges[i].endPos ) return true;
+      }
+      return false;
     },
 
     function axiomKeyHover_(text, position) {
@@ -659,6 +680,21 @@ foam.CLASS({
           var group = inherited[g];
           var visibleProps = this.filterUserFacing_(group.properties);
           md += '- `' + group.className + '` — ' + visibleProps.length + ' properties\n';
+        }
+      }
+
+      // 6. Relationships — to / from this class (foam.dao.Relationship axioms).
+      var rels = this.index.getRelationships ? this.index.getRelationships(classId) : [];
+      if ( rels && rels.length > 0 ) {
+        md += '\n**Relationships**\n\n';
+        for ( var r = 0 ; r < rels.length ; r++ ) {
+          var rel = rels[r];
+          var otherShort = rel.other ? rel.other.split('.').pop() : '?';
+          if ( rel.dir === 'out' ) {
+            md += '- → `' + rel.name + '`: ' + otherShort + ' (' + rel.card + ')\n';
+          } else {
+            md += '- ← `' + rel.name + '`: ' + otherShort + '\n';
+          }
         }
       }
 

--- a/tools/lsp/handlers/MemberCompletionHandler.js
+++ b/tools/lsp/handlers/MemberCompletionHandler.js
@@ -51,6 +51,11 @@ foam.CLASS({
       var line = lines[position.line] || '';
       var prefix = line.substring(0, position.character);
 
+      // Value-mode (F3): cursor on an enum-typed property value inside
+      // X.create({…}) / .tag(this.X, {…}). Grammar-driven detection.
+      var instItems = this.instantiationValueItems_(text, position, opt_uri);
+      if ( instItems ) return instItems;
+
       // Detect context: foam.X. ▊ or foam.X.Y. ▊ where foam.X is a LIB
       var libMatch = prefix.match(/(foam(?:\.\w+)+)\.\w*$/);
       if ( libMatch ) {
@@ -203,6 +208,51 @@ foam.CLASS({
       var fullId = this.cache.resolveShortName(opt_uri, text, shortName, position ? position.line : 0);
       if ( ! fullId ) return { isIncomplete: false, items: [] };
       return this.getClassPropertyItems(fullId);
+    },
+
+    function instantiationValueItems_(text, position, opt_uri) {
+      /** Enum value completion for a property value inside an instantiation.
+       *  Returns null unless the cursor is on (or just after) an enum-typed
+       *  property's value. */
+      var grammar = this.index.getGrammar && this.index.getGrammar();
+      if ( ! grammar || ! grammar.collectInstantiations ) return null;
+      var off = this.analyzer.positionToOffset(text, position);
+
+      // end-of-line offset (bounds an unclosed/absent value to its own line)
+      var lineEnd = text.indexOf('\n', off);
+      if ( lineEnd === -1 ) lineEnd = text.length;
+
+      var insts = grammar.collectInstantiations(text);
+      var best = null;  // { inst, entry }
+      for ( var i = 0 ; i < insts.length ; i++ ) {
+        var inst = insts[i];
+        for ( var e = 0 ; e < inst.entries.length ; e++ ) {
+          var entry = inst.entries[e];
+          if ( off <= entry.keyPos.endPos ) continue;   // cursor not past this key's colon
+          var regionEnd = entry.valuePos ? entry.valuePos.endPos + 1 : lineEnd;
+          if ( off > regionEnd ) continue;
+          if ( ! best || entry.keyPos.startPos > best.entry.keyPos.startPos ) best = { inst: inst, entry: entry };
+        }
+      }
+      if ( ! best ) return null;
+
+      var classId = this.cache.resolveShortName(opt_uri, text, best.inst.classText, position.line) || best.inst.classText;
+      if ( ! this.index.classExists(classId) ) return null;
+      var info = this.index.getPropertyInfo(classId, best.entry.key);
+      if ( ! info.found || ! info.isEnum ) return null;
+
+      var items = [];
+      for ( var v = 0 ; v < info.enumValues.length ; v++ ) {
+        var val = info.enumValues[v];
+        items.push({
+          label: val.name,
+          kind: 13,  // EnumMember
+          detail: info.enumId + '.' + val.name + ( val.label ? ' — ' + val.label : '' ),
+          documentation: val.label || '',
+          sortText: '!0_' + ( '0000' + val.ordinal ).slice(-4)
+        });
+      }
+      return { isIncomplete: false, items: items };
     },
 
     function getLibMemberItems_(dottedPrefix) {

--- a/tools/lsp/handlers/SemanticTokenHandler.js
+++ b/tools/lsp/handlers/SemanticTokenHandler.js
@@ -65,6 +65,11 @@ foam.CLASS({
         this.collectCSSTokens_(text, models[i], tokens);
       }
 
+      // F1: drop non-comment tokens that fall inside comment / documentation
+      // spans. Comment-as-comment coloring (token type 5) is preserved. Spans
+      // come from the grammar (no regex).
+      tokens = this.filterNonCodeTokens_(text, tokens);
+
       // Sort by position (line, then character)
       tokens.sort(function(a, b) {
         return a.line !== b.line ? a.line - b.line : a.char - b.char;
@@ -698,6 +703,30 @@ foam.CLASS({
         prevChar = t.char;
       }
       return { data: data };
+    },
+
+    function filterNonCodeTokens_(text, tokens) {
+      /** Remove non-comment tokens (type !== 5) whose offset lands in a
+       *  comment or documentation-value span. Grammar-driven detection. */
+      var grammar = this.index.getGrammar && this.index.getGrammar();
+      if ( ! grammar || ! grammar.collectRanges ) return tokens;
+      var ranges = grammar.collectRanges(text);
+      var spans = ranges.comment.concat(ranges.documentation);
+      if ( spans.length === 0 ) return tokens;
+      var lineOffsets = [0];
+      for ( var i = 0 ; i < text.length ; i++ ) if ( text[i] === '\n' ) lineOffsets.push(i + 1);
+      var out = [];
+      for ( var t = 0 ; t < tokens.length ; t++ ) {
+        var tok = tokens[t];
+        if ( tok.type === 5 ) { out.push(tok); continue; }   // keep comment tokens
+        var off = ( lineOffsets[tok.line] || 0 ) + tok.char;
+        var inSpan = false;
+        for ( var s = 0 ; s < spans.length ; s++ ) {
+          if ( off >= spans[s].startPos && off < spans[s].endPos ) { inSpan = true; break; }
+        }
+        if ( ! inSpan ) out.push(tok);
+      }
+      return out;
     }
   ]
 });

--- a/tools/lsp/handlers/WorkspaceAnalyzer.js
+++ b/tools/lsp/handlers/WorkspaceAnalyzer.js
@@ -31,105 +31,139 @@ foam.CLASS({
   ],
 
   methods: [
+    function collectFilePaths_() {
+      /** Unique file paths in the index that match active flags. */
+      var idx = this.index;
+      if ( ! idx.fileIndex_ ) idx.buildFileIndex();
+      var fileIndex = idx.fileIndex_;
+      var seen = {};
+      var paths = [];
+      for ( var classId in fileIndex ) {
+        var entry = fileIndex[classId];
+        var fp = entry.path || entry; // handle both {path,flags} and legacy string
+        if ( seen[fp] ) continue;
+        if ( entry.flags && entry.flags.length > 0 ) {
+          var active = entry.flags.some(function(flag) { return foam.flags[flag] === true; });
+          if ( ! active ) continue;
+        }
+        seen[fp] = true;
+        paths.push(fp);
+      }
+      return paths;
+    },
+
+    function newAcc_() {
+      /** Fresh accumulator for a scan (shared by sync + async drivers). */
+      return { filesScanned: 0, filesWithIssues: 0, warnings: 0, errors: 0,
+               infos: 0, fileResults: {}, patternCounts: {}, slowest: [] };
+    },
+
+    function scanFileInto_(filePath, acc) {
+      /** Diagnose one file, fold its results into `acc`, track parse time. */
+      var fs_ = require('fs');
+      try {
+        var content = fs_.readFileSync(filePath, 'utf8');
+        var uri = 'file://' + filePath;
+        var t0 = process.hrtime.bigint();
+        var diagnostics = this.diagnosticsHandler.handle(content, uri);
+        var ms = Number(process.hrtime.bigint() - t0) / 1e6;
+        if ( acc.slowest.length < 10 || ms > acc.slowest[acc.slowest.length - 1].ms ) {
+          acc.slowest.push({ path: filePath, ms: ms });
+          acc.slowest.sort(function(a, b) { return b.ms - a.ms; });
+          if ( acc.slowest.length > 10 ) acc.slowest.pop();
+        }
+        if ( diagnostics.length > 0 ) {
+          acc.fileResults[uri] = diagnostics;
+          acc.filesWithIssues++;
+          for ( var d = 0 ; d < diagnostics.length ; d++ ) {
+            var sev = diagnostics[d].severity;
+            if ( sev === 1 ) acc.errors++;
+            else if ( sev === 2 ) acc.warnings++;
+            else acc.infos++;
+            var pattern = this.patternFor(diagnostics[d]);
+            var key = pattern + '|' + sev;
+            if ( ! acc.patternCounts[key] ) {
+              acc.patternCounts[key] = { pattern: pattern, count: 0, severity: sev };
+            }
+            acc.patternCounts[key].count++;
+          }
+        }
+      } catch (e) {
+        // File read or parse error — skip silently
+      }
+      acc.filesScanned++;
+    },
+
+    function finalizeAcc_(acc, totalMs) {
+      /** Build the result object; log timing + slowest files when timed. */
+      if ( totalMs !== undefined ) {
+        console.error('[LSP] ⏱ workspace analysis ' + totalMs.toFixed(0) + 'ms over ' +
+          acc.filesScanned + ' files (' + (totalMs / Math.max(acc.filesScanned, 1)).toFixed(1) + 'ms/file avg)');
+        for ( var sI = 0 ; sI < Math.min(acc.slowest.length, 5) ; sI++ ) {
+          console.error('[LSP] ⏱   slowest: ' + acc.slowest[sI].ms.toFixed(0) + 'ms  ' + acc.slowest[sI].path);
+        }
+      }
+      var patterns = [];
+      for ( var key in acc.patternCounts ) patterns.push(acc.patternCounts[key]);
+      patterns.sort(function(a, b) { return b.count - a.count; });
+      return {
+        filesScanned:    acc.filesScanned,
+        filesWithIssues: acc.filesWithIssues,
+        warnings:        acc.warnings,
+        errors:          acc.errors,
+        infos:           acc.infos,
+        patterns:        patterns,
+        fileResults:     acc.fileResults
+      };
+    },
+
     function analyze(progressCallback) {
       /**
-       * Scans all files in the index, runs diagnostics on each,
-       * and returns aggregated results with pattern grouping.
+       * Scans all files in the index synchronously, runs diagnostics on each,
+       * and returns aggregated results with pattern grouping. Blocks the event
+       * loop for the whole scan — prefer analyzeAsync for the startup scan.
        *
        * @param progressCallback - optional function({ filesScanned, total })
        * @returns { filesScanned, filesWithIssues, warnings, errors, infos, patterns, fileResults }
        */
-      var fs_   = require('fs');
-      var idx   = this.index;
-      var diag  = this.diagnosticsHandler;
-
-      if ( ! idx.fileIndex_ ) idx.buildFileIndex();
-
-      // Collect unique file paths that match active flags.
-      // Files with flags like 'test' or 'swift' are skipped unless
-      // those flags are currently active.
-      var fileIndex = idx.fileIndex_;
-      var seenPaths = {};
-      var filePaths = [];
-      for ( var classId in fileIndex ) {
-        var entry = fileIndex[classId];
-        var fp = entry.path || entry; // handle both new {path,flags} and legacy string format
-        if ( seenPaths[fp] ) continue;
-
-        // Check if file's flags match active flags
-        if ( entry.flags && entry.flags.length > 0 ) {
-          var hasActiveFlag = entry.flags.some(function(flag) {
-            return foam.flags[flag] === true;
-          });
-          if ( ! hasActiveFlag ) continue;
-        }
-
-        seenPaths[fp] = true;
-        filePaths.push(fp);
-      }
-
-      var total          = filePaths.length;
-      var filesScanned   = 0;
-      var filesWithIssues = 0;
-      var warnings       = 0;
-      var errors         = 0;
-      var infos          = 0;
-      var fileResults    = {};
-      var patternCounts  = {};
-
-      for ( var i = 0 ; i < filePaths.length ; i++ ) {
-        var filePath = filePaths[i];
-        try {
-          var content = fs_.readFileSync(filePath, 'utf8');
-          var uri = 'file://' + filePath;
-          var diagnostics = diag.handle(content, uri);  // pass URI so test/demo i18n exemptions apply
-
-          if ( diagnostics.length > 0 ) {
-            fileResults[uri] = diagnostics;
-            filesWithIssues++;
-
-            for ( var d = 0 ; d < diagnostics.length ; d++ ) {
-              var sev = diagnostics[d].severity;
-              if ( sev === 1 ) errors++;
-              else if ( sev === 2 ) warnings++;
-              else infos++;
-
-              // Group by pattern — coded diagnostics (e.g. i18n rules) collapse
-              // under their code; everything else generalizes class/type names to *
-              var pattern = this.patternFor(diagnostics[d]);
-              var key = pattern + '|' + sev;
-              if ( ! patternCounts[key] ) {
-                patternCounts[key] = { pattern: pattern, count: 0, severity: sev };
-              }
-              patternCounts[key].count++;
-            }
-          }
-        } catch (e) {
-          // File read or parse error — skip silently
-        }
-
-        filesScanned++;
-        if ( progressCallback && filesScanned % 50 === 0 ) {
-          progressCallback({ filesScanned: filesScanned, total: total });
+      var paths = this.collectFilePaths_();
+      var total = paths.length;
+      var acc = this.newAcc_();
+      var start = process.hrtime.bigint();
+      for ( var i = 0 ; i < paths.length ; i++ ) {
+        this.scanFileInto_(paths[i], acc);
+        if ( progressCallback && acc.filesScanned % 50 === 0 ) {
+          progressCallback({ filesScanned: acc.filesScanned, total: total });
         }
       }
+      return this.finalizeAcc_(acc, Number(process.hrtime.bigint() - start) / 1e6);
+    },
 
-      // Convert pattern map to sorted array
-      var patterns = [];
-      for ( var key in patternCounts ) {
-        patterns.push(patternCounts[key]);
+    function analyzeAsync(progressCallback, done) {
+      /**
+       * Non-blocking workspace scan. Processes files in chunks and yields to
+       * the event loop (setImmediate) between chunks, so the server keeps
+       * answering hover / completion / diagnostic requests while the scan runs.
+       * Calls done(results) — same shape as analyze() — when finished.
+       */
+      var self = this;
+      var paths = this.collectFilePaths_();
+      var total = paths.length;
+      var acc = this.newAcc_();
+      var start = process.hrtime.bigint();
+      var CHUNK = 25;
+      var i = 0;
+      function step() {
+        var end = Math.min(i + CHUNK, paths.length);
+        for ( ; i < end ; i++ ) self.scanFileInto_(paths[i], acc);
+        if ( progressCallback ) progressCallback({ filesScanned: acc.filesScanned, total: total });
+        if ( i < paths.length ) {
+          setImmediate(step);   // yield: queued requests get serviced between chunks
+        } else {
+          done(self.finalizeAcc_(acc, Number(process.hrtime.bigint() - start) / 1e6));
+        }
       }
-      patterns.sort(function(a, b) { return b.count - a.count; });
-
-      return {
-        filesScanned:   filesScanned,
-        filesWithIssues: filesWithIssues,
-        warnings:       warnings,
-        errors:         errors,
-        infos:          infos,
-        patterns:       patterns,
-        fileResults:    fileResults
-      };
+      step();
     },
 
     function analyzeFiles(filePaths) {

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -324,11 +324,11 @@ function start() {
             typeHierarchyProvider: true,
             implementationProvider: true,
             typeDefinitionProvider: true,
-            callHierarchyProvider: true,
-            diagnosticProvider: {
-              interFileDependencies: false,
-              workspaceDiagnostics:  false
-            }
+            callHierarchyProvider: true
+            // No diagnosticProvider (pull): diagnostics are PUSHED via
+            // publishDiagnostics on open/change and from the workspace scan.
+            // Advertising pull here too made clients render every diagnostic
+            // twice (push copy + pull copy).
           },
           experimental: {
             workspaceAnalyzer: true

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -276,11 +276,19 @@ function start() {
 
   // === Message Dispatch ===
 
+  // Per-request timing. Logs `[LSP] ⏱ <method> <ms>ms` for any request/
+  // notification whose handler runs at least LSP_TIMING_MIN_MS. Override the
+  // threshold with env LSP_TIMING_MS (set to 0 to log every message).
+  var LSP_TIMING_MIN_MS = process.env.LSP_TIMING_MS !== undefined ?
+    Number(process.env.LSP_TIMING_MS) : 5;
+
   function handleMessage(msg) {
     var method = msg.method;
     var params = msg.params;
     var id     = msg.id;
 
+    var timerStart = process.hrtime.bigint();
+    try {
     switch ( method ) {
       case 'initialize':
         respond(id, {
@@ -496,26 +504,29 @@ function start() {
         break;
 
       case 'foam/analyzeWorkspace':
+        // Non-blocking: analyzeAsync yields between chunks so hover/completion/
+        // diagnostics keep responding while the workspace scan runs.
         try {
-          var results = workspaceAnalyzer.analyze(function(progress) {
+          workspaceAnalyzer.analyzeAsync(function(progress) {
             notify('foam/analyzeProgress', progress);
-          });
-          // Push diagnostics to Problems panel via standard LSP protocol
-          for ( var uri in results.fileResults ) {
-            notify('textDocument/publishDiagnostics', {
-              uri: uri,
-              diagnostics: results.fileResults[uri]
+          }, function(results) {
+            // Push diagnostics to Problems panel via standard LSP protocol
+            for ( var uri in results.fileResults ) {
+              notify('textDocument/publishDiagnostics', {
+                uri: uri,
+                diagnostics: results.fileResults[uri]
+              });
+            }
+            // Also return results for sidebar tree view
+            respond(id, {
+              filesScanned:    results.filesScanned,
+              filesWithIssues: results.filesWithIssues,
+              warnings:        results.warnings,
+              errors:          results.errors,
+              infos:           results.infos,
+              patterns:        results.patterns,
+              fileResults:     results.fileResults
             });
-          }
-          // Also return results for sidebar tree view
-          respond(id, {
-            filesScanned:    results.filesScanned,
-            filesWithIssues: results.filesWithIssues,
-            warnings:        results.warnings,
-            errors:          results.errors,
-            infos:           results.infos,
-            patterns:        results.patterns,
-            fileResults:     results.fileResults
           });
         } catch (e) {
           console.error('[LSP] analyzeWorkspace error:', e.message);
@@ -740,6 +751,12 @@ function start() {
         if ( id !== undefined ) {
           respondError(id, -32601, 'Method not found: ' + method);
         }
+    }
+    } finally {
+      var elapsedMs = Number(process.hrtime.bigint() - timerStart) / 1e6;
+      if ( method && elapsedMs >= LSP_TIMING_MIN_MS ) {
+        console.error('[LSP] ⏱ ' + method + ' ' + elapsedMs.toFixed(1) + 'ms');
+      }
     }
   }
 

--- a/tools/tests/lsp/completion.js
+++ b/tools/tests/lsp/completion.js
@@ -723,6 +723,17 @@ test(innerPositions.method && innerPositions.method.m2,
 test(innerPositions.property && innerPositions.property.tail,
   'property "tail" after a methods block with rich inner objects still emits');
 
+// === COMPLETION — ENUM VALUE IN INSTANTIATION (F3) ===
+section('Completion — enum value in instantiation (F3)');
+var compText = "foam.CLASS({\n  requires: ['foam.core.app.Health'],\n" +
+  "  methods: [ function f() { this.Health.create({ status: '' }); } ]\n})";
+function posOf(t, o) { var l = 0, c = 0; for ( var i = 0 ; i < o ; i++ ) { if ( t[i] === '\n' ) { l++; c = 0; } else c++; } return { line: l, character: c }; }
+var off = compText.indexOf("status: '") + "status: '".length;  // cursor inside the empty quotes
+var compRes = memberHandler.handle(compText, posOf(compText, off));
+test(compRes && compRes.items.length > 0, 'enum value completion returns items');
+test(compRes.items.some(function(it) { return it.label === 'UP'; }), 'offers HealthStatus value UP');
+test(compRes.items.some(function(it) { return it.label === 'DOWN'; }), 'offers HealthStatus value DOWN');
+
 // === SUMMARY ===
 
 

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -681,4 +681,23 @@ test(addStrDiags("foam.CLASS({ package:'t', name:'LC2', methods:[ function rende
 // Lowercase add on an element var receiver (not a collection) — flagged.
 test(addStrDiags("foam.CLASS({ package:'t', name:'LC3', methods:[ function render(){ var row = this.E(); row.add('total'); } ] })").length === 1, "lowercase .add('total') on an element var flagged");
 
+section('Diagnostics — instantiation enum / primitive values (F3)');
+var badSrc = "foam.CLASS({\n  requires: ['foam.core.app.Health'],\n  methods: [ function f() {\n" +
+  "    this.Health.create({ status: 'BOGUS', port: 'abc', appName: 'ok' });\n  } ]\n})";
+var badMsgs = diagHandler.handle(badSrc, '').map(function(d) { return d.message || ''; });
+function has(arr, sub) { return arr.some(function(m) { return m.indexOf(sub) !== -1; }); }
+test(has(badMsgs, "not a valid foam.core.app.HealthStatus"), 'bad enum value is flagged');
+test(has(badMsgs, "expects a numeric"), 'string assigned to Int port is flagged');
+
+var okSrc = "foam.CLASS({\n  requires: ['foam.core.app.Health'],\n  methods: [ function f() {\n" +
+  "    this.Health.create({ status: 'UP', appName: 'svc' });\n  } ]\n})";
+var okMsgs = diagHandler.handle(okSrc, '').map(function(d) { return d.message || ''; });
+test(! has(okMsgs, 'HealthStatus'), 'valid enum value is not flagged');
+
+var exprSrc = "foam.CLASS({\n  requires: ['foam.core.app.Health'],\n  methods: [ function f() {\n" +
+  "    this.Health.create({ status: this.x, port: someVar });\n  } ]\n})";
+var exprMsgs = diagHandler.handle(exprSrc, '').map(function(d) { return d.message || ''; });
+test(! has(exprMsgs, 'HealthStatus') && ! has(exprMsgs, 'numeric'),
+  'expression values are not flagged (literals only)');
+
 

--- a/tools/tests/lsp/editorFeatures.js
+++ b/tools/tests/lsp/editorFeatures.js
@@ -12,6 +12,7 @@
 var h = require('./_harness');
 var test = h.test, section = h.section;
 var index = h.index, cache = h.cache, cssTokenResolver = h.cssTokenResolver;
+var semanticHandler = h.semanticHandler;
 
 // === FoldingRangeHandler ===
 
@@ -116,3 +117,26 @@ var emptyIndex = foam.parse.lsp.FoamIndex.create();
 var emptyHandler = foam.parse.lsp.handlers.WorkspaceSymbolHandler.create({ index: emptyIndex });
 var none = emptyHandler.handle('Anything');
 test(Array.isArray(none), 'WorkspaceSymbol: empty index returns empty array');
+
+
+// === Semantic tokens — none inside comments / docs (F1) ===
+
+section('Semantic tokens — none inside comments / docs (F1)');
+var stText = "foam.CLASS({\n" +                                  // line 0
+  "  requires: ['foam.parse.Suggestion'],\n" +                    // line 1
+  "  documentation: 'this.Suggestion note',\n" +                  // line 2
+  "  methods: [\n" +                                              // line 3
+  "    function f() {\n" +                                        // line 4
+  "      // this.Suggestion in comment\n" +                       // line 5
+  "      return this.Suggestion;\n" +                             // line 6
+  "    }\n  ]\n})";                                               // lines 7-9
+var st = semanticHandler.handle(stText, '');
+function tokenLines(data) {
+  var lines = [], line = 0;
+  for ( var i = 0 ; i < data.length ; i += 5 ) { line += data[i]; lines.push(line); }
+  return lines;
+}
+var lns = tokenLines(st.data);
+test(lns.indexOf(2) === -1, 'no semantic token on the documentation line (2)');
+test(lns.indexOf(5) === -1, 'no semantic token on the comment line (5)');
+test(lns.indexOf(6) !== -1, 'the real this.Suggestion on line 6 is still tokenized');

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -246,5 +246,35 @@ for ( var rIdx = 0 ; rIdx < allIds.length ; rIdx++ ) {
 test(relCount >= 1,
   'Unified indexing: RELATIONSHIP classes are indexed (got ' + relCount + ')');
 
+section('FoamIndex — getRelationships (#5091)');
+if ( index.classExists('foam.core.demo.relationship.Course') ) {
+  var courseRels = index.getRelationships('foam.core.demo.relationship.Course');
+  test(courseRels.length >= 1, 'Course participates in at least one relationship');
+  var profRel = courseRels.find(function(r) { return r.name === 'professor'; });
+  test(profRel && profRel.dir === 'in' && profRel.other === 'foam.core.demo.relationship.Professor',
+    'Course has incoming professor from Professor');
+  var profOut = index.getRelationships('foam.core.demo.relationship.Professor')
+    .find(function(r) { return r.name === 'courses'; });
+  test(profOut && profOut.dir === 'out' && profOut.other === 'foam.core.demo.relationship.Course',
+    'Professor has outgoing courses to Course');
+} else {
+  test(Array.isArray(index.getRelationships('foam.lang.FObject')),
+    'getRelationships returns an array (demo relationship classes not loaded — fixture skipped)');
+}
+
+section('FoamIndex — getPropertyInfo (F3 resolver)');
+var statusInfo = index.getPropertyInfo('foam.core.app.Health', 'status');
+test(statusInfo.found, 'Health.status resolves');
+test(statusInfo.isEnum && statusInfo.enumId === 'foam.core.app.HealthStatus',
+  'Health.status is an Enum of HealthStatus');
+test(statusInfo.enumValues.some(function(v) { return v.name === 'UP'; }),
+  'HealthStatus values include UP');
+var portInfo = index.getPropertyInfo('foam.core.app.Health', 'port');
+test(portInfo.found && portInfo.primitiveKind === 'int', 'Health.port is an int primitive');
+var nameInfo = index.getPropertyInfo('foam.core.app.Health', 'hostname');
+test(nameInfo.found && ! nameInfo.isEnum && nameInfo.primitiveKind === null,
+  'Health.hostname is a plain String (no enum, no numeric/boolean kind)');
+test(! index.getPropertyInfo('foam.core.app.Health', 'nope').found, 'unknown prop is not found');
+
 // === MESSAGE + CONSTANT REFERENCES ===
 

--- a/tools/tests/lsp/grammar.js
+++ b/tools/tests/lsp/grammar.js
@@ -735,3 +735,18 @@ test(addForm.length === 1, '.add(classRef, {...}) is detected');
 var noClass = grammar.collectInstantiations(
   "foam.CLASS({ methods: [ function f() { foo.bar({ a: 1 }); } ] })");
 test(noClass.length === 0, 'object-only call (no class arg) is not detected');
+
+section('Grammar — inline ViewSpec { class: X, ... } detection (F3)');
+var vsAdd = grammar.collectInstantiations(
+  "foam.CLASS({ methods: [ function f() { this.add({ class: 'com.paytic.ui.MetricCard', variant: 'WARN' }); } ] })");
+test(vsAdd.length === 1 && vsAdd[0].classText === 'com.paytic.ui.MetricCard',
+  '{ class: X, ... } in code is detected with the class from the class: key');
+var vsEntry = vsAdd.length === 1 && vsAdd[0].entries.find(function(e){ return e.key === 'variant'; });
+test(vsEntry && vsEntry.valueText.indexOf('WARN') !== -1, 'sibling props captured (class: key excluded)');
+// CRITICAL guard: a property DEFINITION is NOT a ViewSpec instantiation.
+var propDef = grammar.collectInstantiations(
+  "foam.CLASS({ properties: [ { class: 'String', name: 'x', documentation: 'd' } ] })");
+test(propDef.length === 0, "property definition { class: 'String', name: 'x' } is NOT treated as an instantiation");
+var plainObj = grammar.collectInstantiations(
+  "foam.CLASS({ methods: [ function f() { var o = { a: 1, b: 2 }; } ] })");
+test(plainObj.length === 0, 'plain object with no class: key is not an instantiation');

--- a/tools/tests/lsp/grammar.js
+++ b/tools/tests/lsp/grammar.js
@@ -674,3 +674,35 @@ test(/foam.*function\.macro/.test(zedHi.replace(/\s+/g, ' ')) ||
 
 // === Migration coverage: buildLocationAtProperty uses the grammar path ===
 
+section('Grammar — collectRanges comments + documentation (F1)');
+var crText = "foam.CLASS({\n" +
+  "  documentation: 'Hello World',\n" +
+  "  // a line comment FObject\n" +
+  "  methods: [ function f() { /* block FObject */ return 1; } ]\n" +
+  "})";
+var ranges = grammar.collectRanges(crText);
+test(ranges.comment.length >= 2, 'collectRanges finds the line + block comments');
+test(ranges.documentation.length >= 1, 'collectRanges finds the documentation value');
+var docSpan = ranges.documentation[0];
+test(crText.substring(docSpan.startPos, docSpan.endPos).indexOf('Hello World') !== -1,
+  'documentation span covers the value text');
+
+section('Grammar — collectInstantiations (F3)');
+var ciCreate = "foam.CLASS({ methods: [ function f() { " +
+  "var x = this.Health.create({ status: 'UP', port: 8080 }); } ] })";
+var insts = grammar.collectInstantiations(ciCreate);
+test(insts.length >= 1, 'collectInstantiations finds the create call');
+var call = insts.find(function(c) { return ! c.isTag; });
+test(call && call.classText === 'Health', 'create receiver resolved to Health (this. stripped)');
+var statusEntry = call && call.entries.find(function(e) { return e.key === 'status'; });
+test(statusEntry && statusEntry.valueText.indexOf('UP') !== -1, 'status entry value captured');
+
+var ciTag = "foam.CLASS({ methods: [ function f() { " +
+  "this.tag(this.Health, { status: 'DOWN' }); } ] })";
+var tagCall = grammar.collectInstantiations(ciTag).find(function(c) { return c.isTag; });
+test(tagCall && tagCall.classText === 'Health', 'tag first-arg class resolved to Health');
+
+var generic = "foam.CLASS({ methods: [ function f() { foo.bar({ a: 1 }); this.doThing(x); } ] })";
+test(grammar.collectInstantiations(generic).length === 0,
+  'generic calls produce no instantiation records (negative lookahead works)');
+

--- a/tools/tests/lsp/grammar.js
+++ b/tools/tests/lsp/grammar.js
@@ -706,3 +706,17 @@ var generic = "foam.CLASS({ methods: [ function f() { foo.bar({ a: 1 }); this.do
 test(grammar.collectInstantiations(generic).length === 0,
   'generic calls produce no instantiation records (negative lookahead works)');
 
+
+section('Grammar — chained .tag + call-expression values (F3 regression)');
+// .tag chained off a method call (receiver before .tag is ')') with a slot
+// value and a function-call value — must still detect every call + entry.
+var chainSrc = "foam.CLASS({ methods: [ function f() {" +
+  " this.start().addClass('m')" +
+  "  .tag(this.MetricCard, { value$: this.totalCount$, variant: 'CRITICAL' })" +
+  "  .tag(this.MetricCard, { subText$: this.slot(function(n){ return n + ''; }, this.x$), variant: 'WARN' })" +
+  " .end(); } ] })";
+var chainInsts = grammar.collectInstantiations(chainSrc);
+test(chainInsts.length === 2, 'both chained .tag calls detected (got ' + chainInsts.length + ')');
+var second = chainInsts[1];
+var vEntry = second && second.entries.find(function(e){ return e.key === 'variant'; });
+test(vEntry && vEntry.valueText.indexOf('WARN') !== -1, 'variant captured past a function-call value without desync');

--- a/tools/tests/lsp/grammar.js
+++ b/tools/tests/lsp/grammar.js
@@ -720,3 +720,18 @@ test(chainInsts.length === 2, 'both chained .tag calls detected (got ' + chainIn
 var second = chainInsts[1];
 var vEntry = second && second.entries.find(function(e){ return e.key === 'variant'; });
 test(vEntry && vEntry.valueText.indexOf('WARN') !== -1, 'variant captured past a function-call value without desync');
+
+section('Grammar — generic classRef + object detection (F3, not .tag-specific)');
+// Any call passing a class ref followed by an object literal is detected,
+// regardless of the method name.
+var genHelper = grammar.collectInstantiations(
+  "foam.CLASS({ methods: [ function f() { renderCard(this.MetricCard, { variant: 'WARN' }); } ] })");
+test(genHelper.length === 1 && genHelper[0].classText === 'MetricCard',
+  'arbitrary helper(classRef, {...}) is detected (not just .tag)');
+var addForm = grammar.collectInstantiations(
+  "foam.CLASS({ methods: [ function f() { this.add(this.MetricCard, { variant: 'X' }); } ] })");
+test(addForm.length === 1, '.add(classRef, {...}) is detected');
+// An object literal with no sibling class ref is NOT an instantiation.
+var noClass = grammar.collectInstantiations(
+  "foam.CLASS({ methods: [ function f() { foo.bar({ a: 1 }); } ] })");
+test(noClass.length === 0, 'object-only call (no class arg) is not detected');

--- a/tools/tests/lsp/hover.js
+++ b/tools/tests/lsp/hover.js
@@ -332,3 +332,24 @@ var ownHover = hoverHandler.handle(ownNameText, { line: 2, character: 12 });
 test(ownHover != null, 'hovering the class own name value shows class info');
 test(ownHover && ownHover.contents.value.indexOf('foam.parse.Suggestion') !== -1,
   'own-name hover shows the full class id');
+
+section('Hover — string-literal sub-word does not resolve (label vs reference)');
+// 'Reset Password' is a label; 'Password' is a property type but only a sub-word
+var labelText = "foam.CLASS({\n  package: 'x',\n  name: 'Y',\n  methods: [ function f(e) { e.add('Reset Password'); } ]\n})";
+var pwOff = labelText.indexOf('Reset Password') + 'Reset '.length + 2; // inside 'Password'
+function posOfH(t, o) { var l = 0, c = 0; for ( var i = 0 ; i < o ; i++ ) { if ( t[i] === '\n' ) { l++; c = 0; } else c++; } return { line: l, character: c }; }
+var labelHover = hoverHandler.handle(labelText, posOfH(labelText, pwOff));
+test(labelHover == null, "no hover on a sub-word ('Password') of a label string");
+// control: a class id that IS the whole string still hovers
+var idStrText = "foam.CLASS({\n  requires: ['foam.parse.Suggestion']\n})";
+var idStrHover = hoverHandler.handle(idStrText, { line: 1, character: 20 });
+test(idStrHover != null, 'whole-string class reference still hovers');
+
+section('Hover — relationship cardinality renders literally');
+if ( index.classExists('foam.core.auth.Group') ) {
+  var grpSrc = "foam.CLASS({\n  requires: ['foam.core.auth.Group']\n})";
+  var grpHover = hoverHandler.handle(grpSrc, { line: 1, character: 30 });
+  var grpText = ( grpHover && grpHover.contents && grpHover.contents.value ) || '';
+  test(grpText.indexOf('*:*') !== -1 || grpText.indexOf('1:*') !== -1,
+    'cardinality (*:* or 1:*) appears verbatim in relationship hover');
+}

--- a/tools/tests/lsp/hover.js
+++ b/tools/tests/lsp/hover.js
@@ -324,3 +324,11 @@ test(cmtHover == null, 'no hover inside a line comment');
 
 // === GRAMMAR-DRIVEN AXIOM POSITIONS ===
 
+
+section('Hover — class own name value shows class info');
+var ownNameText = "foam.CLASS({\n  package: 'foam.parse',\n  name: 'Suggestion'\n})";
+// line 2: "  name: 'Suggestion'" — 'Suggestion' value begins at char 9
+var ownHover = hoverHandler.handle(ownNameText, { line: 2, character: 12 });
+test(ownHover != null, 'hovering the class own name value shows class info');
+test(ownHover && ownHover.contents.value.indexOf('foam.parse.Suggestion') !== -1,
+  'own-name hover shows the full class id');

--- a/tools/tests/lsp/hover.js
+++ b/tools/tests/lsp/hover.js
@@ -296,5 +296,31 @@ scopeCases.forEach(function(c) {
     label + ' hover mentions "' + needle + '" (got: ' + got.slice(0, 90) + ')');
 });
 
+section('Hover — relationships section (#5091)');
+if ( index.classExists('foam.core.demo.relationship.Professor') ) {
+  var relSrc = "foam.CLASS({\n  requires: ['foam.core.demo.relationship.Professor']\n})";
+  // char 40 lands inside the class id string on line 1
+  var relHover = hoverHandler.handle(relSrc, { line: 1, character: 40 });
+  var relText = ( relHover && relHover.contents && relHover.contents.value ) || '';
+  test(relText.indexOf('Relationship') !== -1, 'Professor hover shows a Relationships section');
+  test(relText.indexOf('courses') !== -1, 'Professor hover lists the forward relationship courses');
+} else {
+  test(true, 'demo relationship classes not loaded — relationship hover fixture skipped');
+}
+
+section('Hover — suppressed in comments + documentation (F1)');
+var docText = "foam.CLASS({\n  documentation: 'see FObject for details'\n})";
+// line 1: "  documentation: 'see FObject..." — 'FObject' begins at char 22
+var docHover = hoverHandler.handle(docText, { line: 1, character: 24 });
+test(docHover == null, 'no hover inside a documentation value');
+// the documentation KEY itself still hovers (char 5 is inside 'documentation')
+var keyHover = hoverHandler.handle(docText, { line: 1, character: 5 });
+test(keyHover != null, 'documentation key still hovers');
+var cmtText = "foam.CLASS({\n  methods: [\n    function f() {\n" +
+  "      // uses FObject here\n      return 1;\n    }\n  ]\n})";
+// line 3: "      // uses FObject here" — 'FObject' begins at char 14
+var cmtHover = hoverHandler.handle(cmtText, { line: 3, character: 16 });
+test(cmtHover == null, 'no hover inside a line comment');
+
 // === GRAMMAR-DRIVEN AXIOM POSITIONS ===
 


### PR DESCRIPTION
## Problem
The LSP highlighted and showed hover popups for identifiers inside comments and documentation strings, treating prose words as class references. Class hover gave no view of a class's relationships, and property values passed to a class on construction were never checked against the target property type.
## Solution
Drive all three from the grammar emitting positioned `P.msg` records in the existing single parse, plus two index lookups. The grammar tags comment and documentation spans and recognizes `X.create({…})` / `.tag(this.X, {…})` calls (receiver chain guarded by `P.not` negative lookahead so generic calls never match); handlers consume the harvested positions and the new index resolvers.
## Changes
- Add `FoamClassGrammar.collectRanges` (comment + documentation spans) and `collectInstantiations` (create/tag calls with receiver class and key/value spans).
- Add `FoamIndex.getRelationships` (walks `foam.dao.Relationship` axioms on both ends) and `getPropertyInfo` (enum/primitive property resolver).
- Suppress hover and non-comment semantic tokens inside comment and documentation spans.
- Show an Outgoing/Incoming relationship section in class hover, with direction and cardinality.
- Autocomplete enum value names and warn on invalid enum or primitive literal values in create/tag calls (literals only; expressions skipped).
- Extend the LSP test suite from 946 to 978 passing assertions, including a negative test that generic calls produce no instantiation records.