### PR TITLE
feat(lsp): find-references finds this.Short usages in method bodies

### DIFF
--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -84,7 +84,7 @@ foam.CLASS({
         message:     {}, value:    {}, property: {}, method:  {},
         pomFileName: {}, classRef: {}, comment:  {}, documentation: {},
         instCall: {}, instCreateReceiver: {}, instTagClass: {}, instClassRef: {},
-        instKey: {}, instValue: {}
+        instKey: {}, instValue: {}, memberRef: {}
       };
       // Kinds that allow multiple occurrences per name. Single-occurrence
       // kinds (message, value, property, method, pomFileName) keep their
@@ -93,7 +93,7 @@ foam.CLASS({
       // so collect every position.
       var MULTI = { classRef: true, comment: true, documentation: true,
         instCall: true, instCreateReceiver: true, instTagClass: true,
-        instClassRef: true, instKey: true, instValue: true };
+        instClassRef: true, instKey: true, instValue: true, memberRef: true };
 
       var apply = function(p, grammar) {
         var startPos = this.pos;
@@ -1168,8 +1168,21 @@ foam.CLASS({
 
         balancedBraces: P.seq(P.literal('{'), P.str(P.repeat(P.alt(
           P.sym('instClassObject'), P.sym('balancedBraces'), stringLiteral, backtickString,
-          lineComment, blockComment, P.sym('instantiationCall'), P.notChars('{}')
+          lineComment, blockComment, P.sym('instantiationCall'), P.sym('thisMemberRef'),
+          P.notChars('{}')
         ), null, 0)), P.literal('}')),
+
+        // `this.Ident` / `self.Ident` member access inside code — the FOAM
+        // idiom for using a required class (or property/method) in render,
+        // init, listeners. Emits the full `this.Ident` span; ReferencesHandler
+        // maps the trailing identifier to a class via requires. Runs after
+        // instantiationCall so `this.X.create(...)` / `.tag(this.X, ...)` are
+        // claimed by their own rules first.
+        thisMemberRef: P.msg(P.seq(
+          P.alt(P.literal('this'), P.literal('self')),
+          P.literal('.'),
+          P.str(P.repeat(identChars, null, 1))
+        ), { kind: 'memberRef' }),
 
         balancedBrackets: P.seq(P.literal('['), P.str(P.repeat(P.alt(
           P.sym('balancedBrackets'), P.sym('balancedBraces'), P.sym('balancedParens'),

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -374,12 +374,17 @@ foam.CLASS({
       var isQualified = word.indexOf('.') !== -1;
       if ( isQualified && this.index.classExists(word) ) return word;
 
+      // Cursor on a `this.Short` / `self.Short` usage — resolve the short name
+      // via requires so references work FROM a usage site, not just the decl.
+      var bare = word.replace(/^(?:this|self)\./, '');
+
       var model = this.cache.getModelAt(opt_uri || '', text, position.line);
       if ( model ) {
         var selfId = this.cache.getClassId(model);
-        if ( selfId && ( model.name === word || selfId === word ) ) return selfId;
+        if ( selfId && ( model.name === word || selfId === word || model.name === bare ) ) return selfId;
         var map = this.cache.buildRequiresMap(model);
         if ( map[word] && this.index.classExists(map[word]) ) return map[word];
+        if ( map[bare] && this.index.classExists(map[bare]) ) return map[bare];
       }
 
       var propTypes = this.index.getPropertyTypes();
@@ -485,6 +490,36 @@ foam.CLASS({
           if ( out.length >= 200 ) break;
         }
       }
+
+      // === D. Grammar-emitted usage positions (no regex) ===
+      // Code usages the grammar tags: `this.Short` / `self.Short` member access
+      // (render, init, listeners, const access) via `memberRef`, plus the class
+      // positions inside .create() / .tag() / { class: } instantiations. Each
+      // is mapped to the target through this class's requires short names or a
+      // full-id match. The bare scan in C can't see `.`-preceded usages.
+      try {
+        var g2 = typeof this.index.getGrammar === 'function' ? this.index.getGrammar() : null;
+        if ( g2 ) {
+          var shortSet = {};
+          for ( var s2 = 0 ; s2 < shortNames.length ; s2++ ) shortSet[shortNames[s2]] = true;
+          var pm = g2.collectAxiomPositions(content);
+          var self2 = this;
+          ['memberRef', 'instCreateReceiver', 'instTagClass', 'instClassRef'].forEach(function(kind) {
+            var bucket = ( pm && pm[kind] ) || {};
+            for ( var nm in bucket ) {
+              var stripped = nm.replace(/^(?:this|self)\./, '');
+              var isMatch = shortSet[stripped] || nm === targetClassId || stripped === targetClassId;
+              if ( ! isMatch ) continue;
+              var recs = Array.isArray(bucket[nm]) ? bucket[nm] : [bucket[nm]];
+              for ( var r2 = 0 ; r2 < recs.length && out.length < 200 ; r2++ ) {
+                // point at the short-name segment, not the `this.` prefix
+                var off = recs[r2].startPos + ( nm.length - stripped.length );
+                push(off, stripped.length);
+              }
+            }
+          });
+        }
+      } catch (e) {}
 
       return out.length > 0 ? out : fallback;
     },

--- a/tools/tests/lsp/grammar.js
+++ b/tools/tests/lsp/grammar.js
@@ -750,3 +750,14 @@ test(propDef.length === 0, "property definition { class: 'String', name: 'x' } i
 var plainObj = grammar.collectInstantiations(
   "foam.CLASS({ methods: [ function f() { var o = { a: 1, b: 2 }; } ] })");
 test(plainObj.length === 0, 'plain object with no class: key is not an instantiation');
+
+section('Grammar — this.Short member usages emit memberRef (references)');
+var memSrc = "foam.CLASS({ methods: [ function render() {" +
+  " this.add(this.MetricCard); this.tag(this.MetricCard, { a: 1 }); var x = this.Other.create({}); } ] })";
+var memMap = grammar.collectAxiomPositions(memSrc);
+test(!! (memMap.memberRef && memMap.memberRef['this.MetricCard']),
+  'bare this.MetricCard (render add) emits a memberRef');
+test(!! (memMap.instTagClass && memMap.instTagClass['this.MetricCard']),
+  '.tag(this.MetricCard, {...}) still emits instTagClass');
+test(!! (memMap.instCreateReceiver && memMap.instCreateReceiver['this.Other']),
+  'this.Other.create({}) still emits instCreateReceiver');


### PR DESCRIPTION
find-references now includes this.Short / self.Short usages in render, init, listeners and .tag/.create receivers, not just requires and subclasses. The grammar emits a memberRef position for every this.Ident and references maps it (plus the instantiation class positions) to the target via requires. Grammar-driven, no new regex.