### PR TITLE
DOS-3640: Add a "Mark All as Read" button to the Notifications menu

### DIFF
--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -27,7 +27,7 @@ foam.CLASS({
   properties: [
     {
       class: 'Boolean',
-      name: 'readTabIsOpen'
+      name: 'readTabIsOpen',
     }
   ],
 
@@ -68,6 +68,12 @@ foam.CLASS({
         if ( result && result.array && result.array.length > 0 ) {
           // Check if the first record is read or not
           this.readTabIsOpen = result.array[0].read;
+        }
+
+        // If there are no notifications
+        if ( result && result.array && result.array.length == 0 ) {
+          // Hide the button
+          this.readTabIsOpen = true;
         }
       }
     }

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -11,10 +11,6 @@ foam.CLASS({
 
   documentation: 'An extension of GroupingDAOList that adds additional actions for Notifications.',
 
-  implements: [
-    'foam.mlang.Expressions'
-  ],
-
   imports: [
     'stack',
     'myNotificationDAO',

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -28,7 +28,7 @@ foam.CLASS({
   ],
 
   exports: [
-    'notificationDAO'
+    'myNotificationDAO'
   ],
 
   properties: [

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -20,10 +20,6 @@ foam.CLASS({
     'foam.core.notification.Notification',
   ],
 
-  exports: [
-    'myNotificationDAO'
-  ],
-
   properties: [
     {
       class: 'Boolean',

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -65,13 +65,13 @@ foam.CLASS({
 
         // Get the first record
         var result = await dao.limit(1).select();
-        if ( result && result.array && result.array.length > 0 ) {
+        if ( result?.array?.length > 0 ) {
           // Check if the first record is read or not
           this.readTabIsOpen = result.array[0].read;
         }
 
         // If there are no notifications
-        if ( result && result.array && result.array.length == 0 ) {
+        if ( result?.array?.length == 0 ) {
           // Hide the button
           this.readTabIsOpen = true;
         }

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -19,7 +19,6 @@ foam.CLASS({
 
   requires: [
     'foam.core.notification.Notification',
-    'foam.dao.ArraySink',
     'foam.u2.memento.WindowHashMemento'
   ],
 

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -67,6 +67,7 @@ foam.CLASS({
       }
       // Call refresh() everytime the memento's usedStr updates
       this.onDetach(top.usedStr$.sub(refresh));
+      this.SUPER();
     },
 
     // Render the action at the top of the page

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'NotificationGroupingDAOList',
   extends: 'foam.u2.GroupingDAOList',
 
-  documentation: 'An extension of GroupingDAOList that adds additional actions for Notifications.',
+  documentation: 'An extension of GroupingDAOList that adds a MARK_ALL_AS_READ action',
 
   imports: [
     'stack',
@@ -28,12 +28,8 @@ foam.CLASS({
 
   properties: [
     {
-      class: 'String',
-      name: 'query_',
-      // Pre-set the value because the query property is only set after the user
-      // clicks a tab for the first time BUT the 'Unread' tab will be the first
-      // tab the user sees, so the button should be visible immediately.
-      value: 'Unread'
+      class: 'Boolean',
+      name: 'readTabIsOpen'
     }
   ],
 
@@ -44,29 +40,12 @@ foam.CLASS({
   `,
 
   methods: [
-    // Walk the memento hierarchy to find the WindowHashMemento
-    function topMemento_() {
-      var m = this.memento_;
-      while ( ! this.WindowHashMemento.isInstance(m) && m.parent ) m = m.parent;
-      return m;
-    },
-
-    // Init the memento-related things we need
-    function init() {
-      var self = this, top = this.topMemento_();
-      function refresh() {
-        // Check the memento's usedStr for the query parameter
-        var hit = /[?&]query=([^&]*)/.exec(top.usedStr || '');
-        // Return the value from the query parameter
-        self.query_ = hit ? decodeURIComponent(hit[1]) : '';
-      }
-      // Call refresh() everytime the memento's usedStr updates
-      this.onDetach(top.usedStr$.sub(refresh));
-      this.SUPER();
-    },
-
-    // Render the action at the top of the page
     function render() {
+      // Subscribe to dao changes
+      this.data$proxy.sub('on', this.onDAOUpdate);
+      this.onDAOUpdate();
+
+      // Render the action at the top of the page
       this.onDetach(this.stack.setTrailingContainer(
         this.E()
           .startContext({data: this})
@@ -77,12 +56,31 @@ foam.CLASS({
     }
   ],
 
+    listeners: [
+    {
+      name: 'onDAOUpdate',
+      isFramed: true,
+      code: async function() {
+        // Look for the dao (this will have only the current tab's records)
+        var dao = this.data;
+        if ( ! dao ) return;
+
+        // Get the first record
+        var result = await dao.limit(1).select();
+        if ( result && result.array && result.array.length > 0 ) {
+          // Check if the first record is read or not
+          this.readTabIsOpen = result.array[0].read;
+        }
+      }
+    }
+  ],
+
   actions: [
     {
       name: 'markAllAsRead',
-      isAvailable: function(query_) {
+      isAvailable: function(readTabIsOpen) {
         // Only show the button when we're on the 'Unread' tab
-        return query_ === 'Unread';
+        return ! readTabIsOpen;
       },
       code: async function(X) {
         try {

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.notification',
+  name: 'NotificationGroupingDAOList',
+  extends: 'foam.u2.GroupingDAOList',
+
+  documentation: 'An extension of GroupingDAOList that adds additional actions for Notifications.',
+
+  implements: [
+    'foam.mlang.Expressions'
+  ],
+
+  imports: [
+    'stack',
+    'myNotificationDAO',
+    'subject',
+    'group'
+  ],
+
+  requires: [
+    'foam.core.notification.Notification',
+    'foam.dao.ArraySink'
+  ],
+
+  exports: [
+    'notificationDAO'
+  ],
+
+  css: `
+    ^button {
+      margin-left: auto;
+    }
+  `,
+
+  methods: [
+    function render() {
+      this.onDetach(this.stack.setTrailingContainer(
+        this.E()
+          .startContext({data: this})
+            .tag(this.MARK_ALL_AS_READ).addClass(this.myClass('button'))
+          .endContext()
+      ));
+      this.SUPER();
+    }
+  ],
+
+  actions: [
+    {
+      name: 'markAllAsRead',
+      code: function(X) {
+        //this.myNotificationDAO
+      }
+    }
+  ]
+});

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -18,17 +18,28 @@ foam.CLASS({
   imports: [
     'stack',
     'myNotificationDAO',
-    'subject',
-    'group'
+    'memento_'
   ],
 
   requires: [
     'foam.core.notification.Notification',
-    'foam.dao.ArraySink'
+    'foam.dao.ArraySink',
+    'foam.u2.memento.WindowHashMemento'
   ],
 
   exports: [
     'notificationDAO'
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'query_',
+      // Pre-set the value because the query property is only set after the user
+      // clicks a tab for the first time BUT the 'Unread' tab will be the first
+      // tab the user sees, so the button should be visible immediately.
+      value: 'Unread'
+    }
   ],
 
   css: `
@@ -38,6 +49,27 @@ foam.CLASS({
   `,
 
   methods: [
+    // Walk the memento hierarchy to find the WindowHashMemento
+    function topMemento_() {
+      var m = this.memento_;
+      while ( ! this.WindowHashMemento.isInstance(m) && m.parent ) m = m.parent;
+      return m;
+    },
+
+    // Init the memento-related things we need
+    function init() {
+      var self = this, top = this.topMemento_();
+      function refresh() {
+        // Check the memento's usedStr for the query parameter
+        var hit = /[?&]query=([^&]*)/.exec(top.usedStr || '');
+        // Return the value from the query parameter
+        self.query_ = hit ? decodeURIComponent(hit[1]) : '';
+      }
+      // Call refresh() everytime the memento's usedStr updates
+      this.onDetach(top.usedStr$.sub(refresh));
+    },
+
+    // Render the action at the top of the page
     function render() {
       this.onDetach(this.stack.setTrailingContainer(
         this.E()
@@ -52,8 +84,24 @@ foam.CLASS({
   actions: [
     {
       name: 'markAllAsRead',
-      code: function(X) {
-        //this.myNotificationDAO
+      isAvailable: function(query_) {
+        // Only show the button when we're on the 'Unread' tab
+        return query_ === 'Unread';
+      },
+      code: async function(X) {
+        try {
+          // Clone the unread notifications in myNotificationDAO
+          var unreadNotifs = await this.myNotificationDAO.where(this.EQ(this.Notification.READ, false)).select();
+
+          // Update the read property for all of 'em
+          for ( var notif of unreadNotifs.array ) {
+            var clone = notif.clone();
+            clone.read = true;
+            await this.myNotificationDAO.put(clone);
+          }
+        } catch (e) {
+          console.log(e);
+        }
       }
     }
   ]

--- a/src/foam/core/notification/NotificationGroupingDAOList.js
+++ b/src/foam/core/notification/NotificationGroupingDAOList.js
@@ -14,12 +14,10 @@ foam.CLASS({
   imports: [
     'stack',
     'myNotificationDAO',
-    'memento_'
   ],
 
   requires: [
     'foam.core.notification.Notification',
-    'foam.u2.memento.WindowHashMemento'
   ],
 
   exports: [

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -531,7 +531,8 @@ foam.POM({
     { name: "benchmark/F3FileJournalBenchmark",                       flags: "js&test|java&test" },
     { name: "benchmark/JSONFormatterBenchmark",                       flags: "js&test|java&test" },
     { name: "benchmark/F3JournalReplayBenchmark",                     flags: "js&test|java&test" },
-    { name: "benchmark/FileJournalBenchmark",                         flags: "js&test|java&test" }
+    { name: "benchmark/FileJournalBenchmark",                         flags: "js&test|java&test" },
+    { name: "notification/NotificationGroupingDAOList",               flags: "web" }
   ],
 
   javaFiles: [

--- a/src/menus.jrl
+++ b/src/menus.jrl
@@ -211,7 +211,7 @@ p({
       "deletePredicate":{"class":"foam.mlang.predicate.False"},
       "hideQueryBar": true,
       "summaryView":{
-        "class":"foam.u2.GroupingDAOList",
+        "class":"foam.core.notification.NotificationGroupingDAOList",
         "showEmptyMessage": true,
         "order":{
           "class": "foam.mlang.order.Desc",


### PR DESCRIPTION
- Created an extension of GroupingDAOList that is specific to notifications and includes a "mark all as read" action
- Modified Notifications menu entry in the menus.jrl file to use the new NotificationsGroupingDAOList

**UPDATE: Removed memento nonsense and replaced it with onDAOUpdate listener**

(I had to extend GroupingDAOList rather than a DAOControllerConfig because DAOControlelrConfigs render their actions as part of the query bar which is hidden on the Notifications menu.)

I also elected NOT to include a "Mark All as Unread" button because that is WAY too much power for anyone to have.

[DOS Link](https://payticconnect.atlassian.net/browse/DOS-3640?atlOrigin=eyJpIjoiMDFlNTc4MWU4MGZmNDAwNDlhMTRkOTM3YmI1OWVkOTIiLCJwIjoiaiJ9)