### PR TITLE
Z Garbage Collector - optionally specify generational option based on java version

### DIFF
--- a/tools/deploy/etc/shrc.local
+++ b/tools/deploy/etc/shrc.local
@@ -41,6 +41,9 @@ if [ -z "`echo "${JAVA_OPTS}" | grep "Xmx"`" ]; then
   JAVA_OPTS="${JAVA_OPTS} -Xmx4096m"
 fi
 
+# Calculate major java version, print $1$2 will append the minor version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F '.' '{sub("^$", "0", $2); print $1}')
+
 # memory - stack
 #if [ -z "`echo "${JAVA_OPTS}" | grep "Xss"`" ]; then
 #  JAVA_OPTS="${JAVA_OPTS} -Xss1m"
@@ -95,7 +98,12 @@ fi
 ##### Garbage Collection
 # Java <21 The default G1 garbage collector, presently gives the best performance
 # Java 21 onward, Generational Z garbage collector is most performant
-JAVA_OPTS="${JAVA_OPTS} -XX:+UseZGC -XX:+ZGenerational"
+JAVA_OPTS="${JAVA_OPTS} -XX:+UseZGC"
+# Java 24 onward, Generational option is the default for ZGC and some
+# JDKs fail rather than warn if the flag is still present.
+if [ "${JAVA_VERSION}" -lt "24" ]; then
+    JAVA_OPTS="${JAVA_OPTS} -XX:+ZGenerational"
+fi
 
 JAVA_OPTS="${JAVA_OPTS} -XX:+UseStringDeduplication"
 # -XX:StringTableSize - explicit adjustment had negative impact.


### PR DESCRIPTION
Z Garbage Collector - optionally specify generational option based on java version.

Generational is default after java 21, and some JVMs from java 24 onward fail startup rather than warn if the generational flag is specified. 
Now test for java version and set when version is less than 24.

Tested against Java 21 and Java 25. 