### PR TITLE
PT-FIXES: DOS-3558: derive File id from owner, filename, and content digest

### DIFF
--- a/src/foam/core/blob/FileService.java
+++ b/src/foam/core/blob/FileService.java
@@ -63,7 +63,7 @@ public class FileService
 
       if ( SafetyUtil.isEmpty(file.getDataString()) ){
         BlobService store = (BlobService) x.get("blobStore");
-        blob = store.find(file.getId());
+        blob = store.find(file.getDigest());
       } else {
         //Replace @version@ with actual foam version
         if ( "text/html".equals(file.getMimeType()) ) {

--- a/src/foam/core/fs/File.js
+++ b/src/foam/core/fs/File.js
@@ -84,6 +84,22 @@ foam.CLASS({
     },
     {
       class: 'String',
+      name: 'digest',
+      createVisibility: 'HIDDEN',
+      updateVisibility: 'HIDDEN',
+      readVisibility: 'RO',
+      documentation: `Blob store key (sha256 of the file content). Falls back to id for
+        legacy records created before digest was split out of id.`,
+      javaGetter: `
+        if ( digestIsSet_ ) return digest_;
+        return getId();
+      `,
+      getter: function() {
+        return this.instance_.digest || this.id;
+      }
+    },
+    {
+      class: 'String',
       name: 'filename',
       documentation: 'Filename'
     },
@@ -326,7 +342,7 @@ foam.CLASS({
         return ((InputStreamBlob)blob).getInputStream();
       } else {
         BlobService blobStore = (BlobService) x.get("blobStore");
-        blob = blobStore.find(getId());
+        blob = blobStore.find(getDigest());
         if ( blob != null ) {
           try {
             return new java.io.FileInputStream(((FileBlob) blob).getFile());

--- a/src/foam/core/fs/FileDataDAO.js
+++ b/src/foam/core/fs/FileDataDAO.js
@@ -98,7 +98,7 @@ foam.CLASS({
         // save to filesystem
         BlobService blobStore = (BlobService) x.get("blobStore");
         IdentifiedBlob result = (IdentifiedBlob) blobStore.put(blob);
-        file.setId(result.getId());
+        file.setDigest(result.getId());
         file.clearData();
         return getDelegate().put_(x, file);
       } catch (Exception e) {

--- a/src/foam/core/fs/FileDataDAO.js
+++ b/src/foam/core/fs/FileDataDAO.js
@@ -11,10 +11,15 @@ foam.CLASS({
 
   javaImports: [
     'foam.blob.*',
+    'foam.core.auth.Subject',
+    'foam.core.auth.User',
     'foam.dao.ArraySink',
     'foam.dao.DAO',
     'foam.dao.Sink',
     'foam.util.SafetyUtil',
+    'foam.util.SecurityUtil',
+    'java.nio.charset.StandardCharsets',
+    'java.security.MessageDigest',
     'static foam.mlang.MLang.AND',
     'static foam.mlang.MLang.EQ',
   ],
@@ -33,6 +38,16 @@ foam.CLASS({
       name: 'put_',
       javaCode: `
       File file = (File) obj;
+
+      // Stamp owner from the authenticated subject when missing. owner is part of
+      // the file id below, so an empty owner would let two users' identical uploads
+      // collide on the same id and fail the update authorization.
+      if ( file.getOwner() == 0 ) {
+        Subject subject = (Subject) x.get("subject");
+        User user = subject == null ? null : subject.getUser();
+        if ( user != null ) file.setOwner(user.getId());
+      }
+
       DAO fileTypeDAO = (DAO) x.get("fileTypeDAO");
       FileType fileType;
       String type = "";
@@ -99,6 +114,15 @@ foam.CLASS({
         BlobService blobStore = (BlobService) x.get("blobStore");
         IdentifiedBlob result = (IdentifiedBlob) blobStore.put(blob);
         file.setDigest(result.getId());
+
+        // Derive the file id from owner + filename + content digest so identical
+        // content from different users (or different filenames) lands on distinct
+        // records, while the same user re-uploading the same file stays idempotent.
+        // Blobs remain keyed by digest alone, so content dedup is preserved.
+        String idSeed = file.getOwner() + "/" + file.getFilename() + "/" + result.getId();
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        file.setId(SecurityUtil.ByteArrayToHexString(md.digest(idSeed.getBytes(StandardCharsets.UTF_8))));
+
         file.clearData();
         return getDelegate().put_(x, file);
       } catch (Exception e) {

--- a/src/foam/core/notification/email/SMTPAgent.js
+++ b/src/foam/core/notification/email/SMTPAgent.js
@@ -347,7 +347,7 @@ foam.CLASS({
                 Blob blob = (Blob) file.getData();
                 InputStream stream = null;
                 if ( blob instanceof  IdentifiedBlob || blob == null ) {
-                  String id = blob == null ? file.getId(): ((IdentifiedBlob) blob).getId();
+                  String id = blob == null ? file.getDigest(): ((IdentifiedBlob) blob).getId();
                   BlobService blobStore = (BlobService) getX().get("blobStore");
                   FileBlob temp = (FileBlob) blobStore.find(id);
                   var os = new ByteArrayOutputStream();


### PR DESCRIPTION
Uploading the same file as two different users failed to save.

- The file id was the content hash, so identical content from two users produced the same id.

- The second upload landed on the first user's record via the immutable update path and failed authorization, since the owner did not match.

Fix:

- Stamp the file owner from the request subject when it is unset.

- Key the id on owner, filename, and content digest, so each owner/filename/content is its own record and a re-upload by the same user stays idempotent.

Blobs stay keyed by the content digest alone, so identical bytes are still stored once.

Stacked on file-dedup-guid-id (needs the digest field).