### PR TITLE
PT-FIXES:DOS-3791 Add one-time single-file → PartitionedDAO migrator

### DIFF
--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -86,7 +86,11 @@ public class PartitionedDAO
     String journalName = getDirName() + "_" + part;
 
     // TODO: directory creation would be better done by JDAO itself
-    Storage storage = (Storage) getX().get(Storage.class);
+    // Create the directory in the WRITABLE FileSystemStorage where JDAO writes the
+    // journal, not the Storage.class read storage — the two differ when
+    // resource.journals.dir is set (read journals come from a resource/jar), so
+    // mkdirs on Storage.class would target the wrong root and the write would fail.
+    Storage storage = (Storage) getX().get(foam.core.fs.FileSystemStorage.class);
     File    parent  = storage.get(journalName).getParentFile();
     if ( parent != null && ! parent.isDirectory() && ! parent.mkdirs() ) {
       throw new RuntimeException("Failed to create directory " + parent);

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -67,10 +67,46 @@ public class SingleToPartitionMigrator {
   }
 
   public boolean validate(X x, PartitionedDAO target, Map<String,Long> expected) {
-    throw new UnsupportedOperationException("not implemented");
+    for ( Map.Entry<String,Long> e : expected.entrySet() ) {
+      Count c = (Count) target.getDelegate(e.getKey()).select(COUNT());
+      if ( c.getValue() != e.getValue() ) {
+        Loggers.logger(x, this).warning(
+          "Partition validation mismatch for", e.getKey(),
+          "expected", e.getValue(), "got", c.getValue());
+        return false;
+      }
+    }
+    return true;
   }
 
   public void run(X x, String legacyJournalName, PartitionedDAO target) {
-    throw new UnsupportedOperationException("not implemented");
+    Storage storage = (Storage) x.get(Storage.class);
+    if ( ! needsMigration(storage, legacyJournalName) ) {
+      Loggers.logger(x, this).info("No legacy journal to migrate:", legacyJournalName);
+      return;
+    }
+
+    DAO source = new JDAO(x, target.getOf(), legacyJournalName);
+    long srcCount = ((Count) source.select(COUNT())).getValue();
+
+    Map<String,Long> counts = migrate(x, source, target);
+    long migrated = 0L;
+    for ( Long v : counts.values() ) migrated += v;
+
+    if ( migrated != srcCount ) {
+      Loggers.logger(x, this).warning(
+        "Migration count mismatch; NOT archiving.",
+        "source", srcCount, "migrated", migrated);
+      return;
+    }
+
+    if ( ! validate(x, target, counts) ) {
+      Loggers.logger(x, this).warning("Partition validation failed; NOT archiving.");
+      return;
+    }
+
+    archive(storage, legacyJournalName);
+    Loggers.logger(x, this).info(
+      "Migration complete and archived:", legacyJournalName, "records", srcCount);
   }
 }

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -84,7 +84,12 @@ public class SingleToPartitionMigrator {
   }
 
   public void run(X x, String legacyJournalName, PartitionedDAO target) {
-    Storage storage = (Storage) x.get(Storage.class);
+    // Use the WRITABLE FileSystemStorage (JOURNAL_HOME), not Storage.class — the
+    // latter is a read-only ResourceStorage when -Dresource.journals.dir is set
+    // (dev/most deploys), which can't detect or rename the runtime journal.
+    // The source read (new JDAO below) still pulls .0 from resources transparently,
+    // so any records shipped in the repo .0 are imported on the first migration.
+    Storage storage = (Storage) x.get(foam.core.fs.FileSystemStorage.class);
     if ( ! needsMigration(storage, legacyJournalName) ) {
       Loggers.logger(x, this).info("No legacy journal to migrate:", legacyJournalName);
       return;

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core.partition;
+
+import foam.core.fs.Storage;
+import foam.core.logger.Loggers;
+import foam.dao.AbstractSink;
+import foam.dao.DAO;
+import foam.dao.java.JDAO;
+import foam.lang.FObject;
+import foam.lang.X;
+import foam.mlang.sink.Count;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+
+import static foam.mlang.MLang.COUNT;
+
+/**
+ * One-time migrator: copies a single-file DAO journal into a PartitionedDAO's
+ * per-partition journals, validates by count, then archives the legacy journal
+ * by rename. Generic — no knowledge of any specific model.
+ */
+public class SingleToPartitionMigrator {
+
+  public Map<String,Long> migrate(X x, DAO source, PartitionedDAO target) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  public boolean needsMigration(Storage storage, String journalName) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  public void archive(Storage storage, String journalName) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  public boolean validate(X x, PartitionedDAO target, Map<String,Long> expected) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  public void run(X x, String legacyJournalName, PartitionedDAO target) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+}

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -30,7 +30,17 @@ import static foam.mlang.MLang.COUNT;
 public class SingleToPartitionMigrator {
 
   public Map<String,Long> migrate(X x, DAO source, PartitionedDAO target) {
-    throw new UnsupportedOperationException("not implemented");
+    final Map<String,Long> counts = new HashMap<>();
+    source.select(new AbstractSink() {
+      public void put(Object obj, foam.lang.Detachable sub) {
+        FObject record = (FObject) obj;
+        target.put_(x, record);
+        String part = target.getPartition(record);
+        counts.merge(part, 1L, Long::sum);
+      }
+    });
+    Loggers.logger(x, this).info("Migrated partitions:", counts.toString());
+    return counts;
   }
 
   public boolean needsMigration(Storage storage, String journalName) {

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -44,11 +44,26 @@ public class SingleToPartitionMigrator {
   }
 
   public boolean needsMigration(Storage storage, String journalName) {
-    throw new UnsupportedOperationException("not implemented");
+    File runtime = storage.get(journalName);
+    File repo    = storage.get(journalName + ".0");
+    return ( runtime != null && runtime.exists() )
+        || ( repo != null && repo.exists() );
   }
 
   public void archive(Storage storage, String journalName) {
-    throw new UnsupportedOperationException("not implemented");
+    moveIfExists(storage, journalName,        journalName + ".migrated");
+    moveIfExists(storage, journalName + ".0", journalName + ".0.migrated");
+  }
+
+  private void moveIfExists(Storage storage, String from, String to) {
+    File src = storage.get(from);
+    if ( src == null || ! src.exists() ) return;
+    File dst = storage.get(to);
+    try {
+      Files.move(src.toPath(), dst.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    } catch ( java.io.IOException e ) {
+      throw new RuntimeException("Failed to archive journal " + from + " -> " + to, e);
+    }
   }
 
   public boolean validate(X x, PartitionedDAO target, Map<String,Long> expected) {

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -62,6 +62,10 @@ public class SingleToPartitionMigrator {
   private void moveIfExists(Storage storage, String from, String to) {
     File src = storage.get(from);
     if ( src == null || ! src.exists() ) return;
+    // Never archive a directory — when partitions are nested under a dir named
+    // like the legacy journal, that dir shares the journal's base name; only
+    // journal files should be renamed to .migrated.
+    if ( src.isDirectory() ) return;
     File dst = storage.get(to);
     try {
       Files.move(src.toPath(), dst.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/src/foam/core/partition/SingleToPartitionMigrator.java
+++ b/src/foam/core/partition/SingleToPartitionMigrator.java
@@ -34,8 +34,12 @@ public class SingleToPartitionMigrator {
     source.select(new AbstractSink() {
       public void put(Object obj, foam.lang.Detachable sub) {
         FObject record = (FObject) obj;
-        target.put_(x, record);
+        // Route explicitly by the partition property rather than target.put_(),
+        // which derives the partition from getID()/identityExpr — that path
+        // mis-routes a Long-id model to the "null" partition unless the caller
+        // passes Constant(null). Explicit routing is correct for any caller.
         String part = target.getPartition(record);
+        target.getDelegate(part).put_(x, record);
         counts.merge(part, 1L, Long::sum);
       }
     });

--- a/src/foam/core/partition/pom.js
+++ b/src/foam/core/partition/pom.js
@@ -1,11 +1,16 @@
 foam.POM({
   name: "partition",
 
+  projects: [
+    { name: 'test/pom', flags: 'test' }
+  ],
+
   files: [
     { name: "AbstractPartitionedDAO",   flags: "java" }
   ],
 
   javaFiles: [
-    { name: "PartitionedDAO" }
+    { name: "PartitionedDAO" },
+    { name: "SingleToPartitionMigrator" }
   ]
 });

--- a/src/foam/core/partition/test/PartitionTestRecord.js
+++ b/src/foam/core/partition/test/PartitionTestRecord.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'PartitionTestRecord',
+
+  documentation: 'Minimal model for testing SingleToPartitionMigrator. Partitions on `bucket`.',
+
+  properties: [
+    { class: 'Long',   name: 'id' },
+    { class: 'Int',    name: 'bucket' },
+    { class: 'String', name: 'data' }
+  ]
+});

--- a/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
+++ b/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
@@ -31,6 +31,7 @@ foam.CLASS({
       name: 'runTest',
       javaCode: `
         testMigrateRoutesByBucket(x);
+        testNeedsMigrationAndArchive(x);
       `
     },
     {
@@ -111,6 +112,37 @@ foam.CLASS({
         Count c2 = (Count) target.getDelegate("2").select(COUNT());
         test( c1.getValue() == 3, "Bucket 1 journal has 3 rows, got " + c1.getValue() );
         test( c2.getValue() == 2, "Bucket 2 journal has 2 rows, got " + c2.getValue() );
+      `
+    },
+    {
+      name: 'testNeedsMigrationAndArchive',
+      args: 'X x',
+      type: 'Void',
+      javaCode: `
+        X tx = newStorageContext(x);
+        Storage storage = (Storage) tx.get(Storage.class);
+        SingleToPartitionMigrator m = new SingleToPartitionMigrator();
+        String name = "archiveSrc_" + System.nanoTime();
+
+        test( ! m.needsMigration(storage, name),
+          "needsMigration false when no legacy journal present" );
+
+        DAO d = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), name);
+        seedRec(tx, d, 1L, 7);
+        test( m.needsMigration(storage, name),
+          "needsMigration true once legacy journal exists" );
+
+        m.archive(storage, name);
+        test( ! m.needsMigration(storage, name),
+          "needsMigration false after archive (renamed to .migrated)" );
+        test( storage.get(name + ".migrated").exists(),
+          "archived runtime journal exists as .migrated" );
+
+        DAO d2 = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), name);
+        seedRec(tx, d2, 2L, 7);
+        m.archive(storage, name);
+        test( storage.get(name + ".migrated").exists(),
+          "re-archive overwrites prior .migrated without error" );
       `
     }
   ]

--- a/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
+++ b/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
@@ -34,6 +34,7 @@ foam.CLASS({
         testNeedsMigrationAndArchive(x);
         testRunEndToEndAndIdempotent(x);
         testRunUsesWritableStorageNotResourceStorage(x);
+        testArchiveSkipsDirectory(x);
       `
     },
     {
@@ -222,6 +223,35 @@ foam.CLASS({
         m.archive(storage, name);
         test( storage.get(name + ".migrated").exists(),
           "re-archive overwrites prior .migrated without error" );
+      `
+    },
+    {
+      name: 'testArchiveSkipsDirectory',
+      args: 'X x',
+      type: 'Void',
+      documentation: 'archive must rename journal files but never a directory that shares the journal base name (the nested-partition dir case).',
+      javaCode: `
+        X tx = newStorageContext(x);
+        Storage storage = (Storage) tx.get(Storage.class);
+        String name = "dirGuard_" + System.nanoTime();
+
+        // A directory named like the journal (stands in for the nested partition dir).
+        File dir = storage.get(name);
+        dir.mkdirs();
+        test( dir.isDirectory(), "precondition: <name> is a directory" );
+
+        // A real repo journal file <name>.0.
+        DAO d = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), name + ".0");
+        seedRec(tx, d, 1L, 5);
+
+        new SingleToPartitionMigrator().archive(storage, name);
+
+        test( storage.get(name).isDirectory(),
+          "archive left the directory in place (did not rename it)" );
+        test( ! storage.get(name + ".migrated").exists(),
+          "archive did NOT create <name>.migrated from the directory" );
+        test( storage.get(name + ".0.migrated").exists(),
+          "archive renamed the repo journal file <name>.0 to .0.migrated" );
       `
     }
   ]

--- a/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
+++ b/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
@@ -82,13 +82,20 @@ foam.CLASS({
         X tx = newStorageContext(x);
         String src = "ptestSource_" + System.nanoTime();
 
-        DAO writeDAO = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), src);
-        seedRec(tx, writeDAO, 1L, 1);
-        seedRec(tx, writeDAO, 2L, 1);
-        seedRec(tx, writeDAO, 3L, 1);
-        seedRec(tx, writeDAO, 4L, 2);
-        seedRec(tx, writeDAO, 5L, 2);
+        // Seed the REPO journal (.0) — bucket 1: ids 1,2 ; bucket 2: id 4.
+        // Writing via a JDAO whose filename is "<src>.0" lands records in the file <src>.0,
+        // which a JDAO opened on "<src>" later replays as its read-only repo journal.
+        DAO repoDAO = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), src + ".0");
+        seedRec(tx, repoDAO, 1L, 1);
+        seedRec(tx, repoDAO, 2L, 1);
+        seedRec(tx, repoDAO, 4L, 2);
 
+        // Seed the RUNTIME journal "<src>" — bucket 1: id 3 ; bucket 2: id 5.
+        DAO runtimeDAO = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), src);
+        seedRec(tx, runtimeDAO, 3L, 1);
+        seedRec(tx, runtimeDAO, 5L, 2);
+
+        // A fresh JDAO on "<src>" replays BOTH <src>.0 (repo) and <src> (runtime) — the union.
         DAO source = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), src);
         PartitionedDAO target = newPartitioned(tx);
 
@@ -96,9 +103,9 @@ foam.CLASS({
 
         test( counts.size() == 2, "Two partitions written, got " + counts.size() );
         test( counts.get("1") != null && counts.get("1") == 3L,
-          "Bucket 1 has 3 records, got " + counts.get("1") );
+          "Bucket 1 has 3 records (2 from .0 + 1 runtime), got " + counts.get("1") );
         test( counts.get("2") != null && counts.get("2") == 2L,
-          "Bucket 2 has 2 records, got " + counts.get("2") );
+          "Bucket 2 has 2 records (1 from .0 + 1 runtime), got " + counts.get("2") );
 
         Count c1 = (Count) target.getDelegate("1").select(COUNT());
         Count c2 = (Count) target.getDelegate("2").select(COUNT());

--- a/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
+++ b/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
@@ -33,6 +33,7 @@ foam.CLASS({
         testMigrateRoutesByBucket(x);
         testNeedsMigrationAndArchive(x);
         testRunEndToEndAndIdempotent(x);
+        testRunUsesWritableStorageNotResourceStorage(x);
       `
     },
     {
@@ -160,6 +161,36 @@ foam.CLASS({
           "Re-migrating same ids upserts (still 2 rows), got " + p1redeploy.getValue() );
         test( storage.get(legacy + ".0.migrated").exists(),
           "redeploy .0 journal archived to .0.migrated" );
+      `
+    },
+    {
+      name: 'testRunUsesWritableStorageNotResourceStorage',
+      args: 'X x',
+      type: 'Void',
+      documentation: 'In production Storage.class is a read-only ResourceStorage; detect/archive must use the writable FileSystemStorage.class. Puts DIFFERENT storages under the two keys to prove run() archives in the writable one.',
+      javaCode: `
+        String wdir = System.getProperty("java.io.tmpdir") + File.separator + "wmig_" + System.nanoTime();
+        String rdir = System.getProperty("java.io.tmpdir") + File.separator + "rmig_" + System.nanoTime();
+        new File(wdir).mkdirs();
+        new File(rdir).mkdirs();
+        FileSystemStorage writable = new FileSystemStorage(wdir);
+        FileSystemStorage readOnly = new FileSystemStorage(rdir);
+        X tx = x.put(Storage.class, readOnly).put(FileSystemStorage.class, writable);
+
+        String legacy = "splitSrc_" + System.nanoTime();
+        DAO writeDAO = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), legacy);
+        seedRec(tx, writeDAO, 20L, 1);
+        seedRec(tx, writeDAO, 21L, 1);
+
+        PartitionedDAO target = newPartitioned(tx);
+        new SingleToPartitionMigrator().run(tx, legacy, target);
+
+        test( writable.get(legacy + ".migrated").exists(),
+          "run archived the legacy journal in the WRITABLE storage" );
+        test( ! readOnly.get(legacy + ".migrated").exists(),
+          "run did NOT touch the read-only storage" );
+        Count p1 = (Count) target.getDelegate("1").select(COUNT());
+        test( p1.getValue() == 2, "Bucket 1 partition has 2 rows, got " + p1.getValue() );
       `
     },
     {

--- a/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
+++ b/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'SingleToPartitionMigratorTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'Tests SingleToPartitionMigrator: routing, counts, archive, idempotent re-run.',
+
+  javaImports: [
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.partition.PartitionedDAO',
+    'foam.core.partition.SingleToPartitionMigrator',
+    'foam.dao.DAO',
+    'foam.dao.java.JDAO',
+    'foam.lang.X',
+    'foam.mlang.Constant',
+    'foam.mlang.sink.Count',
+    'java.io.File',
+    'java.util.Map',
+    'static foam.mlang.MLang.COUNT'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        testMigrateRoutesByBucket(x);
+      `
+    },
+    {
+      name: 'newStorageContext',
+      args: 'X x',
+      type: 'X',
+      documentation: 'Sub-context with a temp-dir FileSystemStorage so journals are isolated.',
+      javaCode: `
+        String dir = System.getProperty("java.io.tmpdir") + File.separator
+          + "partmig_" + System.nanoTime();
+        new File(dir).mkdirs();
+        FileSystemStorage fs = new FileSystemStorage(dir);
+        return x.put(Storage.class, fs).put(FileSystemStorage.class, fs);
+      `
+    },
+    {
+      name: 'seedRec',
+      args: 'X x, DAO dao, long id, int bucket',
+      type: 'Void',
+      javaCode: `
+        PartitionTestRecord r = new PartitionTestRecord();
+        r.setId(id);
+        r.setBucket(bucket);
+        r.setData("d" + id);
+        dao.put(r);
+      `
+    },
+    {
+      name: 'newPartitioned',
+      args: 'X x',
+      type: 'PartitionedDAO',
+      javaCode: `
+        // Use Constant(null) as identityExpr so put_ routes via getPartition(obj)
+        // (the default IdentityExpr returns a Long which cannot be cast to String).
+        return new PartitionedDAO(
+          x,
+          PartitionTestRecord.getOwnClassInfo(),
+          "ptest",
+          new Constant(null),
+          PartitionTestRecord.BUCKET);
+      `
+    },
+    {
+      name: 'testMigrateRoutesByBucket',
+      args: 'X x',
+      type: 'Void',
+      javaThrows: ['Throwable'],
+      javaCode: `
+        X tx = newStorageContext(x);
+        String src = "ptestSource_" + System.nanoTime();
+
+        DAO writeDAO = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), src);
+        seedRec(tx, writeDAO, 1L, 1);
+        seedRec(tx, writeDAO, 2L, 1);
+        seedRec(tx, writeDAO, 3L, 1);
+        seedRec(tx, writeDAO, 4L, 2);
+        seedRec(tx, writeDAO, 5L, 2);
+
+        DAO source = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), src);
+        PartitionedDAO target = newPartitioned(tx);
+
+        Map<String,Long> counts = new SingleToPartitionMigrator().migrate(tx, source, target);
+
+        test( counts.size() == 2, "Two partitions written, got " + counts.size() );
+        test( counts.get("1") != null && counts.get("1") == 3L,
+          "Bucket 1 has 3 records, got " + counts.get("1") );
+        test( counts.get("2") != null && counts.get("2") == 2L,
+          "Bucket 2 has 2 records, got " + counts.get("2") );
+
+        Count c1 = (Count) target.getDelegate("1").select(COUNT());
+        Count c2 = (Count) target.getDelegate("2").select(COUNT());
+        test( c1.getValue() == 3, "Bucket 1 journal has 3 rows, got " + c1.getValue() );
+        test( c2.getValue() == 2, "Bucket 2 journal has 2 rows, got " + c2.getValue() );
+      `
+    }
+  ]
+});

--- a/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
+++ b/src/foam/core/partition/test/SingleToPartitionMigratorTest.js
@@ -32,6 +32,7 @@ foam.CLASS({
       javaCode: `
         testMigrateRoutesByBucket(x);
         testNeedsMigrationAndArchive(x);
+        testRunEndToEndAndIdempotent(x);
       `
     },
     {
@@ -112,6 +113,53 @@ foam.CLASS({
         Count c2 = (Count) target.getDelegate("2").select(COUNT());
         test( c1.getValue() == 3, "Bucket 1 journal has 3 rows, got " + c1.getValue() );
         test( c2.getValue() == 2, "Bucket 2 journal has 2 rows, got " + c2.getValue() );
+      `
+    },
+    {
+      name: 'testRunEndToEndAndIdempotent',
+      args: 'X x',
+      type: 'Void',
+      javaCode: `
+        X tx = newStorageContext(x);
+        Storage storage = (Storage) tx.get(Storage.class);
+        String legacy = "legacySrc_" + System.nanoTime();
+
+        // Seed legacy single-file journal: bucket 1 x2, bucket 3 x1.
+        DAO writeDAO = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), legacy);
+        seedRec(tx, writeDAO, 10L, 1);
+        seedRec(tx, writeDAO, 11L, 1);
+        seedRec(tx, writeDAO, 12L, 3);
+
+        SingleToPartitionMigrator m = new SingleToPartitionMigrator();
+        PartitionedDAO target = newPartitioned(tx);
+
+        m.run(tx, legacy, target);
+
+        test( storage.get(legacy + ".migrated").exists(),
+          "run archived the legacy journal after success" );
+        Count p1 = (Count) target.getDelegate("1").select(COUNT());
+        Count p3 = (Count) target.getDelegate("3").select(COUNT());
+        test( p1.getValue() == 2, "Bucket 1 partition has 2 rows, got " + p1.getValue() );
+        test( p3.getValue() == 1, "Bucket 3 partition has 1 row, got " + p3.getValue() );
+
+        // Idempotent re-run: legacy archived -> no-op, no double-write.
+        m.run(tx, legacy, target);
+        Count p1again = (Count) target.getDelegate("1").select(COUNT());
+        test( p1again.getValue() == 2,
+          "Re-run does not duplicate (still 2 rows), got " + p1again.getValue() );
+
+        // Simulate redeploy: legacy .0 reappears with the SAME records.
+        DAO repoWrite = new JDAO(tx, PartitionTestRecord.getOwnClassInfo(), legacy + ".0");
+        seedRec(tx, repoWrite, 10L, 1);
+        seedRec(tx, repoWrite, 11L, 1);
+        seedRec(tx, repoWrite, 12L, 3);
+
+        m.run(tx, legacy, target);
+        Count p1redeploy = (Count) target.getDelegate("1").select(COUNT());
+        test( p1redeploy.getValue() == 2,
+          "Re-migrating same ids upserts (still 2 rows), got " + p1redeploy.getValue() );
+        test( storage.get(legacy + ".0.migrated").exists(),
+          "redeploy .0 journal archived to .0.migrated" );
       `
     },
     {

--- a/src/foam/core/partition/test/pom.js
+++ b/src/foam/core/partition/test/pom.js
@@ -1,0 +1,8 @@
+foam.POM({
+  name: 'partition-test',
+
+  files: [
+    { name: 'PartitionTestRecord',           flags: 'js&test|java&test' },
+    { name: 'SingleToPartitionMigratorTest', flags: 'js&test|java&test' }
+  ]
+});

--- a/src/foam/core/partition/test/tests.jrl
+++ b/src/foam/core/partition/test/tests.jrl
@@ -1,0 +1,1 @@
+p({"class":"foam.core.partition.test.SingleToPartitionMigratorTest","id":"SingleToPartitionMigratorTest"})

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -36,7 +36,8 @@ foam.POM({
     { name: "ai/pom" },
     { name: "bench/pom",                               flags: "test" },
     { name: "test/pom",                                flags: "test" },
-    { name: "theme/pom" }
+    { name: "theme/pom" },
+    { name: "partition/pom",                           flags: "partition" },
   ],
   files: [
     { name: "client/ClientBuilder",                                                       flags: "js" },


### PR DESCRIPTION
Adds a one-time migrator that moves records from a single-file journal-backed DAO into a PartitionedDAO's per-partition journals, behind the off-by-default `partition` build flag.

- **Migrate** — streams every record from a source DAO and routes each to its partition via the partition property, returning per-partition counts.

- **Validate** — re-counts each partition against the source; a count mismatch aborts before any archival.

- **Archive** — renames the legacy journal (runtime and `.0`) to `.migrated` so it stops loading on the next boot; the rename doubles as the "already migrated" marker.

- **Resource-aware + idempotent** — reads the source through a transient JDAO, so repo (`.0`) and resource-packaged journals are imported on the first run; archival uses the writable FileSystemStorage, and re-running upserts by id rather than duplicating.

Gate-included the partition pom behind the `partition` flag (off by default), so standard builds are unaffected.

Covered by a server test: `.0`+runtime merge, per-partition routing, count validation, archive-by-rename, idempotent re-run, and writable-vs-read-only storage resolution.