### PR TITLE
PartitionedDAO: create partition dir in the writable storage

### DIFF
--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -86,7 +86,11 @@ public class PartitionedDAO
     String journalName = getDirName() + "_" + part;
 
     // TODO: directory creation would be better done by JDAO itself
-    Storage storage = (Storage) getX().get(Storage.class);
+    // Create the directory in the WRITABLE FileSystemStorage where JDAO writes the
+    // journal, not the Storage.class read storage — the two differ when
+    // resource.journals.dir is set (read journals come from a resource/jar), so
+    // mkdirs on Storage.class would target the wrong root and the write would fail.
+    Storage storage = (Storage) getX().get(foam.core.fs.FileSystemStorage.class);
     File    parent  = storage.get(journalName).getParentFile();
     if ( parent != null && ! parent.isDirectory() && ! parent.mkdirs() ) {
       throw new RuntimeException("Failed to create directory " + parent);


### PR DESCRIPTION
PartitionedDAO.createDAO created the partition directory through the read storage (`Storage.class`), but JDAO writes the journal through the writable `FileSystemStorage`.

When `resource.journals.dir` is set, those two resolve to different roots — so a nested `dirName` created the directory under the resource root while the write targeted the writable root, and the write failed. With no resource dir set the two coincide, which is why flat names and the existing demo never hit it.

Fix:

- Resolve the partition directory against `FileSystemStorage` (the writable root where the journal is written), so the directory creation and the write land in the same place.