### PR TITLE
PT-FIXES:DOS-3854 Fix CurrencyCode/CountryCode columns rendering blank in tables

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -1460,8 +1460,14 @@ foam.CLASS({
     },
     {
       name: 'adapt',
-      value: function(_, n) {
+      value: function(_, n, prop) {
         if ( foam.lang.Currency.isInstance(n) ) return n.id;
+        // RefSummary projection shape { id, summary } — cache summary, return id
+        // (mirrors Reference.adapt so CurrencyCode table columns render in projections)
+        if ( n && ! foam.lang.FObject.isInstance(n) && typeof n === 'object' && n.id !== undefined ) {
+          if ( n.summary != undefined ) this[`${(prop || this).name}$summary_`] = n.summary;
+          return n.id;
+        }
         return n;
       }
     },
@@ -1566,8 +1572,14 @@ foam.CLASS({
     },
     {
       name: 'adapt',
-      value: function(_, n) {
+      value: function(_, n, prop) {
         if ( foam.core.auth.Country.isInstance(n) ) return n.code || n.id;
+        // RefSummary projection shape { id, summary } — cache summary, return id
+        // (mirrors Reference.adapt so CountryCode table columns render in projections)
+        if ( n && ! foam.lang.FObject.isInstance(n) && typeof n === 'object' && n.id !== undefined ) {
+          if ( n.summary != undefined ) this[`${(prop || this).name}$summary_`] = n.summary;
+          return n.id;
+        }
         if ( ! foam.String.isInstance(n) ) return n;
 
         let v = n.trim();


### PR DESCRIPTION
RefSummary table projections set a reference property to a `{ id, summary }` map, so the client renders the summary without a per-row DAO lookup.

`Reference.adapt` unwraps that shape (stores the id, caches the summary into `$summary_`), but `CurrencyCode` and `CountryCode` override `adapt` and were never updated, so they keep the raw map and never cache the summary. Their table columns render blank.

Fix:

- Add the `{ id, summary }` unwrap to `CurrencyCode.adapt` and `CountryCode.adapt`, mirroring `Reference.adapt` (cache summary, return id).

- Direct id/string and `Currency`/`Country` instance assignment stay unchanged.

DOS-3288 fixed the generic `Ref.js` sync path but left these two subclasses.