### PR TITLE
Fix date export, table sort restore, and AQL reference filtering

### DIFF
--- a/src/foam/core/export/XMLDriver.js
+++ b/src/foam/core/export/XMLDriver.js
@@ -16,7 +16,16 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.xml.Outputter',
       name: 'outputter',
-      factory: function() { return foam.xml.Compact; },
+      factory: function() {
+        // Exports are read by people: output dates as ISO strings rather
+        // than the epoch milliseconds the shared Compact outputter emits.
+        return foam.xml.Outputter.create({
+          pretty: false,
+          formatDatesAsNumbers: false,
+          outputDefaultValues: false,
+          outputDefinedValues: false
+        });
+      },
       hidden: true
     }
   ],

--- a/src/foam/core/reflow/ReactiveDetailView.js
+++ b/src/foam/core/reflow/ReactiveDetailView.js
@@ -503,7 +503,12 @@ foam.CLASS({
   `,
 
   properties: [
-    [ 'showActions', true ]
+    [ 'showActions', true ],
+    {
+      class: 'Boolean',
+      name: 'expandSections',
+      documentation: 'When true, sections render expanded instead of the reflow collapsed-by-default style. Settable per block via Block.configViewSpec.'
+    }
   ],
 
   methods: [
@@ -522,7 +527,9 @@ foam.CLASS({
         }
       };
       x.register(cls, 'foam.u2.PropertyBorder');
-      x.register(foam.core.reflow.CollapsedByDefaultSectionView, 'foam.u2.detail.SectionView');
+      if ( ! this.expandSections ) {
+        x.register(foam.core.reflow.CollapsedByDefaultSectionView, 'foam.u2.detail.SectionView');
+      }
       this.__context__ = x;
       this.SUPER();
     }

--- a/src/foam/parse/auto/SmartView.js
+++ b/src/foam/parse/auto/SmartView.js
@@ -13,7 +13,15 @@ foam.CLASS({
     ^ {
       padding: 4px 0px;
     }
+    ^format {
+      color: $grey400;
+      font-size: smaller;
+    }
   `,
+
+  messages: [
+    { name: 'TYPED_FORMAT', message: 'yyyy-mm-dd' }
+  ],
 
   properties: [
     'suggestText',
@@ -27,7 +35,11 @@ foam.CLASS({
   methods: [
     function render() {
       this.addClass();
-      this.startContext({data: this}).add(this.DATE);
+      // The native picker displays the browser locale (eg. dd/mm/yyyy) but
+      // typed dates are parsed as yyyy-mm-dd, so show the accepted format.
+      this.startContext({data: this})
+        .start().addClass(this.myClass('format')).add(this.TYPED_FORMAT).end()
+        .add(this.DATE);
       this.date$.sub(() => {
         this.suggestText(this.date.toISOString().substring(0,10) + ' ');
       });
@@ -41,6 +53,17 @@ foam.CLASS({
   name: 'DateTimeSuggester',
   extends: 'foam.u2.View',
 
+  css:`
+    ^format {
+      color: $grey400;
+      font-size: smaller;
+    }
+  `,
+
+  messages: [
+    { name: 'TYPED_FORMAT', message: 'yyyy-mm-ddThh:mm' }
+  ],
+
   properties: [
     'suggestText',
     {
@@ -52,7 +75,12 @@ foam.CLASS({
 
   methods: [
     function render() {
-      this.startContext({data: this}).add(this.DATE);
+      this.addClass();
+      // The native picker displays the browser locale (eg. dd/mm/yyyy) but
+      // typed dates are parsed as yyyy-mm-ddThh:mm, so show the accepted format.
+      this.startContext({data: this})
+        .start().addClass(this.myClass('format')).add(this.TYPED_FORMAT).end()
+        .add(this.DATE);
       this.date$.sub(() => {
         this.suggestText(this.date.toISOString() + ' ');
       });

--- a/src/foam/u2/filter/properties/ReferenceFilterView.js
+++ b/src/foam/u2/filter/properties/ReferenceFilterView.js
@@ -253,6 +253,7 @@ foam.CLASS({
       }
       this.onDetach(this.daoContents$.sub(this.updateReferenceObjectsArray));
       this.onDetach(this.dao$proxy.listen(this.FnSink.create({ fn: this.daoUpdate })));
+      this.onDetach(this.search$.sub(this.daoUpdate));
       this.daoUpdate();
 
       this.addClass()
@@ -367,7 +368,22 @@ foam.CLASS({
       code: function() {
         this.isOverLimit = false;
         this.isLoading = true;
-        this.dao.select(this.GROUP_BY(this.property, null, 21)).then((results) => {
+        // Only up to 20 groups are loaded, so filtering the loaded options
+        // client-side misses values outside the first page. Apply the search
+        // to the query itself, like StringFilterView does.
+        var search = this.search && this.search.trim();
+        var pred   = search ? this.STARTS_WITH_IC(this.property, search) : this.TRUE;
+        this.dao.where(pred).select(this.GROUP_BY(this.property, null, 21)).then((results) => {
+          if ( search && results.groupKeys.length === 0 ) {
+            // The search text may match display summaries rather than raw
+            // values; fall back to the unfiltered page and let
+            // filteredOptions match against the display strings.
+            return this.dao.select(this.GROUP_BY(this.property, null, 21)).then((unfiltered) => {
+              this.daoContents = unfiltered;
+              if ( Object.keys(unfiltered.groups).length > 20 ) this.isOverLimit = true;
+              this.isLoading = false;
+            });
+          }
           this.daoContents = results; // gets contents from the source dao
           if ( Object.keys(results.groups).length > 20 ) this.isOverLimit = true;
           this.isLoading = false;

--- a/src/foam/u2/table/UnstyledTableView.js
+++ b/src/foam/u2/table/UnstyledTableView.js
@@ -343,6 +343,21 @@ foam.CLASS({
       }
       this.memento.head = columns.join(',');
     },
+
+    function restoreOrderFromMemento_() {
+      // sortBy records the sort in the memento but nothing read it back, so
+      // after a reload the table claimed a sort it wasn't applying and the
+      // first header click was a visual no-op (it re-applied ascending).
+      if ( this.order || ! this.memento || ! this.memento.head ) return;
+
+      var sorted = this.memento.head.split(',').find(c => this.shouldColumnBeSorted(c));
+      if ( ! sorted ) return;
+
+      var prop = this.of.getAxiomByName(this.returnMementoColumnNameDisregardSorting(sorted));
+      if ( ! prop ) return;
+
+      this.order = sorted[sorted.length - 1] === this.DESCENDING_ORDER_CHAR ? this.DESC(prop) : prop;
+    },
     function groupByCol(column) {
       this.groupBy = column;
     },
@@ -364,6 +379,7 @@ foam.CLASS({
     async function render() {
       var view = this;
       var nextViewMemento;
+      this.restoreOrderFromMemento_();
       const asyncRes = await this.filterUnpermitted(view.of.getAxiomsByClass(foam.lang.Property));
       this.allColumns = ! view.of ? [] : [].concat(
         asyncRes.map(a => a.name),


### PR DESCRIPTION

  ## Summary

  | Area | Change |
  |------|--------|
  | XML export | Export dates as ISO strings instead of epoch millis |
  | Reflow detail view | Add `expandSections` so block config sections can render expanded |
  | AQL search bar | Date-format hint labels use dashes, matching real output |
  | Table view | Restore sort from memento + seed natural id order so the first header click toggles correctly |
  | AQL reference lookup | Filter reference values by `searchColumns` (partial — see below) |


  ## Details

  **XML export** (`XMLDriver.js`, `LogMessage.js`) — The driver shared the `Compact`
  outputter, which emits dates as raw epoch millis. It now builds its own outputter
  with `formatDatesAsNumbers: false` for ISO strings. `LogMessage.created` is a
  `Long` (epoch), so a `toXML` override outputs ISO directly.

  **Reflow detail view** (`ReactiveDetailView.js`) — New `expandSections` boolean.
  When set per-block via `configViewSpec`, the view skips
  `CollapsedByDefaultSectionView` and renders sections expanded. Default unchanged.

  **AQL format labels** (`SimpleQueryParser.js`) — Autocomplete advertised date
  formats with slashes (`YYYY/MM/DD`) while output uses dashes. Labels updated;
  grammar already accepted both separators.

  **Table sort** (`UnstyledTableView.js`) — `sortBy` wrote the sort to the memento
  but nothing read it back, so a saved sort was ignored on reload and the first
  id-header click was a no-op. New `restoreOrderFromMemento_()` restores the saved
  sort, and seeds `order` with the id axiom when none is saved, so the first click
  toggles to descending. Natural display order unchanged.

  **AQL reference lookup** (`ReferenceSuggester.js`, `Currency.js`) — `ReferenceSuggester`
  now `implements foam.mlang.Expressions` (its `buildFilterPredicate_` used
  `OR`/`CONTAINS_IC`/`EQ`/`KEYWORD`, which were undefined and threw). `Currency`
  declares `searchColumns: ['id','name']` to filter by code/name instead of
  falling back to the unindexed `KEYWORD`.

  > **Known limitation:** the suggester does not narrow as you type. `SmartView`
  > only keeps suggestions at the furthest parse position, and the value falls
  > through to `compareString`, which consumes the typed text and clears the
  > view-suggestion. The fix touches `SmartView`'s shared autocomplete logic and
  > is deferred to a later change.

