### PR TITLE
LSP: name-addressed navigation, accurate positions, and Java symbol resolution

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -14,7 +14,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 | File | Purpose | Key Functions |
 |---|---|---|
 | `FileModelCache.js` | Eval-intercept model extraction + caching | `getModels()`, `getModelAt()`, `parseFileModels()` |
-| `FoamIndex.js` | Query layer over FOAM registry | `getAllClassIds()`, `getProperties()`, `getFilePath()`, `buildFileIndex()` |
+| `FoamIndex.js` | Query layer over FOAM registry | `getAllClassIds()`, `getProperties()`, `getFilePath()`, `getClassLine()`, `getSymbolPosition()`, `resolveSymbol()`, `buildFileIndex()` |
 | `FoamClassGrammar.js` | Grammar parser for completion `sug()` only | Skip-and-match pattern, dynamic `sug()` from registry |
 | `CursorAnalyzer.js` | Shared text/position utilities + regex fallback | `offsetToPosition()`, `resolveClassId()`, `parseRequires()`, `findCreateContext()` |
 | `TypeTracker.js` | Variable type resolution from `.create()` assignments | `getVariableTypes()` |

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -59,18 +59,18 @@ foam.CLASS({
     function collectAxiomPositions(text) {
       /**
        * Single-parse axiom-position index driven by the grammar itself.
-       * The `messageNameValue` / `enumValueName` / (future) propertyName /
-       * methodName rules are wrapped in `P.msg({kind: '...'})`. On successful
-       * match their msg is emitted with the parser's start/end position —
-       * exactly the info callers need to go-to-definition or build hover
-       * targets.
+       * The `messageNameValue` / `enumValueName` / `propertyNameValue` /
+       * `methodNameValue` rules are wrapped in `P.msg({kind: '...'})`. On
+       * successful match their msg is emitted with the parser's start/end
+       * position — exactly the info callers need to go-to-definition or build
+       * hover targets.
        *
        * Returns:
        *   {
        *     message:  { NAME: { line, col, startPos, endPos } },
        *     value:    { NAME: { … } },
-       *     property: { name: { … } },       // future
-       *     method:   { name: { … } }        // future
+       *     property: { name: { … } },
+       *     method:   { name: { … } }
        *   }
        *
        * Cached by text identity on the grammar instance.

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -95,6 +95,23 @@ foam.CLASS({
         instCall: true, instCreateReceiver: true, instTagClass: true,
         instClassRef: true, instKey: true, instValue: true, memberRef: true };
 
+      // Line-start offsets, computed once (O(n)), so each msg match resolves
+      // line/col by binary search (O(log n)). Scanning text from offset 0 per
+      // match would be O(startPos) — quadratic over a file with many matches,
+      // and matches dominate the workspace usage scan.
+      var lineStarts = [ 0 ];
+      for ( var ls = 0 ; ls < text.length ; ls++ ) {
+        if ( text.charCodeAt(ls) === 10 ) lineStarts.push(ls + 1);
+      }
+      var posToLineCol = function(pos) {
+        var lo = 0, hi = lineStarts.length - 1;
+        while ( lo < hi ) {
+          var mid = ( lo + hi + 1 ) >> 1;
+          if ( lineStarts[mid] <= pos ) lo = mid; else hi = mid - 1;
+        }
+        return { line: lo, col: pos - lineStarts[lo] };
+      };
+
       var apply = function(p, grammar) {
         var startPos = this.pos;
         var result = p.parse(this, grammar);
@@ -104,12 +121,9 @@ foam.CLASS({
             var endPos = result.pos;
             var name = text.substring(startPos, endPos);
             if ( name ) {
-              var line = 0, col = 0;
-              for ( var i = 0 ; i < startPos ; i++ ) {
-                if ( text.charCodeAt(i) === 10 ) { line++; col = 0; } else col++;
-              }
+              var lc = posToLineCol(startPos);
               var rec = {
-                line: line, col: col,
+                line: lc.line, col: lc.col,
                 startPos: startPos, endPos: endPos
               };
               if ( MULTI[m.kind] ) {

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -1575,7 +1575,11 @@ foam.CLASS({
       this.stringUsageIndex_   = null;
       this.memberUsageIndex_   = null;
       this.viewSpecUsageIndex_ = null;
-      this.filePosCache_       = null;
+      // filePosCache_ is deliberately NOT dropped here: collectAxiomPositions
+      // output is a pure function of file text, and each entry carries the
+      // file's mtime, so the guard in getFilePosMap_ re-parses only files that
+      // actually changed. Dropping it would force a full-workspace reparse on
+      // the next usage/symbol query after every save.
       // FoamClassGrammar bakes class ids into its parser at build time —
       // adding or removing a class invalidates the alt() list, so drop the
       // cached instance too.
@@ -1681,15 +1685,14 @@ foam.CLASS({
         else fileless.push(ids[i]);
       }
 
-      var grammar = this.getGrammar();
-      var fs_     = require('fs');
       for ( var filePath in fileToClasses ) {
         var classIds = fileToClasses[filePath];
-        var content;
-        try { content = fs_.readFileSync(filePath, 'utf8'); } catch ( e ) { continue; }
-        if ( content.length > 2 * 1024 * 1024 ) continue;
-        var posMap;
-        try { posMap = grammar.collectAxiomPositions(content); } catch ( e ) { continue; }
+        // mtime-cached parse, shared with getSymbolPosition and reused across
+        // rebuilds. collectAxiomPositions output depends only on file text (the
+        // harvested kinds match broadly and are narrowed later by resolution),
+        // so the cache survives invalidateSymbolIndex_ — without it, the first
+        // usage query after any save reparses the whole workspace (~3000 files).
+        var posMap = this.getFilePosMap_(filePath);
         if ( ! posMap ) continue;
         var shortMap = requiresShortMap(classIds);
         var sourceId = classIds[0];

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -31,6 +31,10 @@ foam.CLASS({
     {
       name: 'grammar_',
       documentation: 'Cached FoamClassGrammar instance. Building one walks every class id and builds N parser alternatives — share it across handlers.'
+    },
+    {
+      name: 'filePosCache_',
+      documentation: 'filePath → grammar.collectAxiomPositions(content) map. Lazy, per-file; lets getSymbolPosition resolve a member line with one parse per file. Dropped on reindex via invalidateSymbolIndex_.'
     }
   ],
 
@@ -811,6 +815,7 @@ foam.CLASS({
           var ownId = m.package ? m.package + '.' + m.name : m.name;
           if ( ownId ) this.fileIndex_[ownId] = {
             path:         filePath,
+            line:         m.sourceLine_ || 0,
             flags:        fileFlags,
             pomFile:      pomFile,
             pomEntryName: pomEntryName
@@ -818,6 +823,7 @@ foam.CLASS({
           if ( m.refines && ! this.fileIndex_[m.refines] ) {
             this.fileIndex_[m.refines] = {
               path:         filePath,
+              line:         m.sourceLine_ || 0,
               flags:        fileFlags,
               pomFile:      pomFile,
               pomEntryName: pomEntryName
@@ -1025,6 +1031,206 @@ foam.CLASS({
       if ( ! this.fileIndex_ ) this.buildFileIndex();
       var entry = this.fileIndex_[classId];
       return entry ? entry.path : null;
+    },
+
+    function getClassLine(classId) {
+      /** 0-based line of a class's foam.CLASS/ENUM/INTERFACE call, captured
+       *  from FileModelCache sourceLine_ at index-build time. 0 if unknown. */
+      if ( ! this.fileIndex_ ) this.buildFileIndex();
+      var entry = this.fileIndex_[classId];
+      return entry ? ( entry.line || 0 ) : 0;
+    },
+
+    function getFilePosMap_(filePath) {
+      /**
+       * filePath → grammar.collectAxiomPositions(content), cached per file.
+       * One grammar parse yields accurate positions for every axiom (property,
+       * method, value, classRef, ...). Reused by getSymbolPosition so resolving
+       * many members of one class costs a single parse.
+       *
+       * Cache entries carry the file's mtime: an entry is reused only while the
+       * file is unchanged on disk. invalidateSymbolIndex_ drops the cache on
+       * save/reindex, but the mtime guard also catches external edits (git
+       * checkout, other tools) that never trigger a reindex — important when an
+       * agent traces a repo changing underneath it.
+       */
+      if ( ! filePath ) return null;
+      if ( ! this.filePosCache_ ) this.filePosCache_ = {};
+
+      var fs_ = require('fs');
+      var mtime;
+      try { mtime = fs_.statSync(filePath).mtimeMs; }
+      catch ( e ) { return null; }
+
+      var entry = this.filePosCache_[filePath];
+      if ( entry && entry.mtimeMs === mtime ) return entry.posMap;
+
+      var map = null;
+      try {
+        var content = fs_.readFileSync(filePath, 'utf8');
+        if ( content.length <= 2 * 1024 * 1024 ) {
+          map = this.getGrammar().collectAxiomPositions(content);
+        }
+      } catch ( e ) {}
+      this.filePosCache_[filePath] = { mtimeMs: mtime, posMap: map };
+      return map;
+    },
+
+    function getSymbolPosition(classId, memberName, kind) {
+      /**
+       * { uri, line, character } for a class or one of its members. Member
+       * lines come from the grammar position map (single parse per file);
+       * the class line comes from getClassLine. Always returns a valid object
+       * so handlers never special-case null — falls back to the class line.
+       */
+      var filePath = this.getFilePath(classId);
+      var uri      = filePath ? 'file://' + filePath : '';
+      var line     = this.getClassLine(classId);
+      var character = 0;
+
+      if ( memberName && filePath ) {
+        var posMap = this.getFilePosMap_(filePath);
+        var rec = null;
+        if ( posMap ) {
+          // 7=Property, 6=Method, 22=EnumMember, 24=Action/Listener (method-ish).
+          var bucket =
+            kind === 7  ? posMap.property :
+            kind === 22 ? posMap.value    :
+            posMap.method;
+          rec = bucket && bucket[memberName];
+          // 24 (Action/Listener) is not msg-tagged; fall back to method bucket.
+          if ( ! rec && kind === 24 && posMap.method ) rec = posMap.method[memberName];
+        }
+        if ( rec ) {
+          line = rec.line; character = rec.col || 0;
+        } else if ( kind === 6 ) {
+          // Method absent from the .js model — resolve to its Java impl.
+          var jp = this.getJavaMemberPosition_(classId, memberName);
+          if ( jp ) return jp;
+        }
+      }
+      return { uri: uri, line: line, character: character };
+    },
+
+    function getJavaMemberPosition_(classId, memberName) {
+      /**
+       * { uri, line, character } of a method implemented in a sibling .java
+       * (no JS axiom), or null. Walks the inheritance chain so an inherited
+       * Java method resolves to the declaring class's .java. Grammar-based
+       * via JavaParser (scanJavaFile_); lines are 0-based.
+       */
+      var chain = this.getInheritanceChain(classId);
+      for ( var c = 0 ; c < chain.length ; c++ ) {
+        var entry  = this.fileIndex_ && this.fileIndex_[chain[c]];
+        var jsPath = entry && ( typeof entry === 'string' ? entry : entry.path );
+        if ( ! jsPath || ! jsPath.endsWith('.js') ) continue;
+        var methods = this.scanJavaFile_(chain[c]);
+        for ( var i = 0 ; i < methods.length ; i++ ) {
+          if ( methods[i].name === memberName ) {
+            return {
+              uri:       'file://' + jsPath.slice(0, -3) + '.java',
+              line:      methods[i].line || 0,
+              character: 0
+            };
+          }
+        }
+      }
+      return null;
+    },
+
+    function resolveSymbol(name) {
+      /**
+       * Name-addressed lookup for coding agents. Accepts:
+       *   - a full class id            ("foam.u2.DetailView")
+       *   - a short class name         ("DetailView")
+       *   - Class.member               ("DetailView.data", "DAO.find")
+       *   - FullId.member              ("foam.u2.DetailView.data")
+       * Returns { classId, memberName?, uri, line, character, kind } or null.
+       */
+      if ( ! name ) return null;
+
+      var classId = null, memberName = null;
+
+      if ( this.classExists(name) ) {
+        classId = name;
+      } else {
+        var dot = name.lastIndexOf('.');
+        if ( dot > 0 ) {
+          var left  = name.substring(0, dot);
+          var right = name.substring(dot + 1);
+          if ( this.classExists(left) ) {
+            classId = left; memberName = right;
+          } else if ( left.indexOf('.') === -1 ) {
+            var lc = this.findClassByShortName_(left);
+            if ( lc ) { classId = lc; memberName = right; }
+          }
+        }
+        if ( ! classId && name.indexOf('.') === -1 ) {
+          classId = this.findClassByShortName_(name);
+        }
+      }
+      if ( ! classId ) return null;
+
+      var kind;
+      if ( memberName ) {
+        kind = this.memberKind_(classId, memberName);
+        if ( ! kind ) return null;
+      } else {
+        kind = this.isInterface(classId) ? 11 :
+          ( this.getClass(classId) && this.getClass(classId).VALUES ) ? 10 : 5;
+      }
+
+      var pos = this.getSymbolPosition(classId, memberName, kind);
+      return {
+        classId:    classId,
+        memberName: memberName || undefined,
+        uri:        pos.uri,
+        line:       pos.line,
+        character:  pos.character,
+        kind:       kind
+      };
+    },
+
+    function findClassByShortName_(shortName) {
+      /** Resolve a short class name to a full id via the symbol index — an
+       *  exact, class-kind (Class/Interface/Enum) name match. Null if none or
+       *  ambiguous-but-no-exact. */
+      var hits = this.searchSymbols(shortName, { limit: 50 });
+      for ( var i = 0 ; i < hits.length ; i++ ) {
+        var h = hits[i];
+        if ( h.name === shortName && ( h.kind === 5 || h.kind === 11 || h.kind === 10 ) ) {
+          return h.classId;
+        }
+      }
+      return null;
+    },
+
+    function memberKind_(classId, memberName) {
+      /** LSP SymbolKind for a class member, or null if the class has no such
+       *  property/method/action/listener/enum-value. */
+      var cls = this.getClass(classId);
+      if ( ! cls ) return null;
+      try {
+        var props = cls.getAxiomsByClass(foam.lang.Property);
+        for ( var i = 0 ; i < props.length ; i++ ) if ( props[i].name === memberName ) return 7;
+        var methods = cls.getAxiomsByClass(foam.lang.Method);
+        for ( var i = 0 ; i < methods.length ; i++ ) if ( methods[i].name === memberName ) return 6;
+        if ( foam.lang.Action ) {
+          var actions = cls.getAxiomsByClass(foam.lang.Action);
+          for ( var i = 0 ; i < actions.length ; i++ ) if ( actions[i].name === memberName ) return 24;
+        }
+        if ( foam.lang.Listener ) {
+          var listeners = cls.getAxiomsByClass(foam.lang.Listener);
+          for ( var i = 0 ; i < listeners.length ; i++ ) if ( listeners[i].name === memberName ) return 24;
+        }
+        if ( cls.VALUES ) {
+          for ( var i = 0 ; i < cls.VALUES.length ; i++ ) if ( cls.VALUES[i].name === memberName ) return 22;
+        }
+      } catch ( e ) {}
+      // Java-only methods: implemented in the sibling .java, no JS axiom.
+      var jms = this.getJavaMethods(classId);
+      for ( var k = 0 ; k < jms.length ; k++ ) if ( jms[k].name === memberName ) return 6;
+      return null;
     },
 
     function getFileFlags(classId) {
@@ -1369,6 +1575,7 @@ foam.CLASS({
       this.stringUsageIndex_   = null;
       this.memberUsageIndex_   = null;
       this.viewSpecUsageIndex_ = null;
+      this.filePosCache_       = null;
       // FoamClassGrammar bakes class ids into its parser at build time —
       // adding or removing a class invalidates the alt() list, so drop the
       // cached instance too.

--- a/tools/lsp/editors/mcp/README.md
+++ b/tools/lsp/editors/mcp/README.md
@@ -33,13 +33,24 @@ first tool call in a given session pays that cost.
 
 ## Tools
 
+Navigation tools are **name-addressable**: pass `symbol` (a class id like
+`foam.u2.DetailView`, a short class name like `DetailView`, or `Class.member`
+like `foam.u2.DetailView.data`) instead of `uri` + `line` + `character`. This lets an
+agent trace by name without first opening the file to count columns. Results
+come back as compact `path:line:character` text (paths project-relative,
+positions 0-based) rather than raw LSP JSON.
+
 | Tool | Arguments | Returns |
 |---|---|---|
-| `foam_hover` | `uri`, `line`, `character` (0-based) | Class docs, property types, method signatures, short-name resolution |
-| `foam_definition` | `uri`, `line`, `character` | Source location for classes in `extends:`, `requires:`, `of:`, property types |
-| `foam_references` | `uri`, `line`, `character` | Subclasses of a class, implementors of an interface |
-| `foam_document_symbols` | `uri` | Outline of a file (classes, properties, methods, actions) |
-| `foam_workspace_symbols` | `query` | All FOAM classes matching a name substring |
+| `foam_hover` | `symbol` \| `uri`+`line`+`character` | Class docs, property types, method signatures, short-name resolution |
+| `foam_definition` | `symbol` \| `uri`+`line`+`character` | Source location for classes in `extends:`, `requires:`, `of:`, property types |
+| `foam_references` | `symbol` \| `uri`+`line`+`character` | Subclasses, interface implementors, and JS/Java/string usages |
+| `foam_implementation` | `symbol` \| `uri`+`line`+`character` | Concrete implementors of an interface (or direct subclasses) |
+| `foam_type_definition` | `symbol` \| `uri`+`line`+`character` | For a property usage, the property's type class |
+| `foam_type_hierarchy` | `symbol` \| position, `direction` (`subtypes`/`supertypes`/`both`) | Supertypes (extends chain) and/or subtypes (subclasses + implementors) |
+| `foam_call_hierarchy` | `symbol` \| position, `direction` (`incoming`/`outgoing`/`both`) | Method callers and/or callees |
+| `foam_document_symbols` | `uri` | Outline of a file (classes, properties, methods, actions) with lines |
+| `foam_workspace_symbols` | `query` | Ranked class/property/method matches (capped at 60; narrow to see more) |
 | `foam_diagnostics` | `uri` (optional) | Unknown classes, bad `foam.nanos.*` imports, CSS-token violations, invalid getters/setters in javaCode |
 | `foam_code_actions` | `uri`, `line` (optional) | Quick fixes with ready-to-apply edits: extract hardcoded strings to `messages:` (i18n), raw color → `$token`, wrong Java package, did-you-mean class suggestions |
 

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -11,10 +11,18 @@
 // (`foam3/tools/lsp-start.js`) as a child, and speaks LSP (Content-
 // Length-framed JSON-RPC) to it.
 //
+// Tool results are shaped into compact `path:line:character` text rather
+// than raw LSP JSON, and navigation tools accept a `symbol` name in place
+// of a cursor position — both so AI agents can trace through FOAM code
+// efficiently. All positions are 0-based (LSP convention).
+//
 // Environment:
 //   FOAM_PROJECT_ROOT  — absolute path to the FOAM project root (the dir
 //                        containing pom.js and the foam3/ submodule).
 //                        Falls back to process.cwd() if unset.
+//
+// Requiring this file (e.g. from tests) loads the pure helpers + schemas
+// WITHOUT spawning the LSP; the server only boots when run directly.
 
 'use strict';
 
@@ -42,8 +50,227 @@ function normalizeUri(raw, projectRoot) {
 }
 
 function uriToPath(uri) {
+  if ( ! uri ) return uri;
   if ( uri.startsWith('file://') ) return decodeURIComponent(uri.slice(7));
   return uri;
+}
+
+// Project-relative path for compact output. Falls back to the absolute path
+// when the file lives outside the project root.
+function relPath(uri, projectRoot) {
+  var p = uriToPath(uri);
+  if ( ! p ) return '';
+  if ( projectRoot && p.indexOf(projectRoot) === 0 ) {
+    var rel = p.slice(projectRoot.length);
+    return rel.replace(/^\/+/, '');
+  }
+  return p;
+}
+
+// --- LSP SymbolKind names (compact output) -------------------------------
+
+const KIND_NAMES = {
+  5: 'class', 6: 'method', 7: 'property', 8: 'field', 9: 'constructor',
+  10: 'enum', 11: 'interface', 12: 'function', 13: 'variable',
+  22: 'enum-value', 24: 'action'
+};
+function kindName(kind) { return KIND_NAMES[kind] || ('kind' + kind); }
+
+const SEVERITY_NAMES = { 1: 'error', 2: 'warn', 3: 'info', 4: 'hint' };
+function severityName(sev) { return SEVERITY_NAMES[sev] || 'info'; }
+
+// --- Output shapers: raw LSP result -> compact agent-friendly text --------
+
+function posOf(range) {
+  var s = ( range && range.start ) || { line: 0, character: 0 };
+  return s.line + ':' + s.character;
+}
+
+function shapeLocations(res, projectRoot) {
+  var arr = ! res ? [] : ( Array.isArray(res) ? res : [ res ] );
+  if ( arr.length === 0 ) return 'No results.';
+  return arr.map(function(loc) {
+    return relPath(loc.uri, projectRoot) + ':' + posOf(loc.range);
+  }).join('\n');
+}
+
+function shapeHover(res) {
+  if ( res && res.contents ) {
+    if ( typeof res.contents === 'string' ) return res.contents;
+    if ( res.contents.value ) return res.contents.value;
+  }
+  return 'No hover information.';
+}
+
+function shapeDocumentSymbols(res, projectRoot) {
+  if ( ! Array.isArray(res) || res.length === 0 ) return 'No symbols.';
+  var lines = [];
+  function walk(sym, depth) {
+    var indent = '  '.repeat(depth);
+    var line = ( sym.range && sym.range.start ) ? sym.range.start.line : 0;
+    lines.push(indent + sym.name + ' [' + kindName(sym.kind) + '] @' + line);
+    if ( Array.isArray(sym.children) ) {
+      for ( var i = 0 ; i < sym.children.length ; i++ ) walk(sym.children[i], depth + 1);
+    }
+  }
+  for ( var i = 0 ; i < res.length ; i++ ) walk(res[i], 0);
+  return lines.join('\n');
+}
+
+function shapeWorkspaceSymbols(res, projectRoot, cap) {
+  if ( ! Array.isArray(res) || res.length === 0 ) return 'No matching symbols.';
+  cap = cap || 60;
+  var shown = res.slice(0, cap);
+  var lines = shown.map(function(s) {
+    var loc  = s.location || {};
+    var line = ( loc.range && loc.range.start ) ? loc.range.start.line : 0;
+    var name = s.containerName ? ( s.containerName + '.' + s.name ) : s.name;
+    return name + ' [' + kindName(s.kind) + '] ' + relPath(loc.uri, projectRoot) + ':' + line;
+  });
+  if ( res.length > cap ) {
+    lines.push('… ' + ( res.length - cap ) + ' more — narrow the query for the rest.');
+  }
+  return lines.join('\n');
+}
+
+function shapeDiagnostics(res, projectRoot, uri) {
+  // A single-file request returns Diagnostic[]; a whole-workspace request
+  // returns { uri: Diagnostic[] }.
+  function fmt(rel, d) {
+    var line = ( d.range && d.range.start ) ? d.range.start.line : 0;
+    var col  = ( d.range && d.range.start ) ? d.range.start.character : 0;
+    var code = d.code ? ( ' ' + d.code ) : '';
+    return rel + ':' + line + ':' + col + ' [' + severityName(d.severity) + code + '] ' + d.message;
+  }
+  if ( Array.isArray(res) ) {
+    if ( res.length === 0 ) return 'No diagnostics.';
+    var rel = relPath(uri, projectRoot);
+    return res.map(function(d) { return fmt(rel, d); }).join('\n');
+  }
+  if ( res && typeof res === 'object' ) {
+    var lines = [];
+    for ( var u in res ) {
+      var r = relPath(u, projectRoot);
+      var ds = res[u] || [];
+      for ( var i = 0 ; i < ds.length ; i++ ) lines.push(fmt(r, ds[i]));
+    }
+    return lines.length ? lines.join('\n') : 'No diagnostics.';
+  }
+  return 'No diagnostics.';
+}
+
+function shapeItems(items, projectRoot) {
+  // items: TypeHierarchyItem[] / CallHierarchyItem[] (name + uri + range).
+  if ( ! Array.isArray(items) || items.length === 0 ) return null;
+  return items.map(function(it) {
+    return it.name + ' (' + ( it.detail || '' ) + ') — ' +
+      relPath(it.uri, projectRoot) + ':' + posOf(it.range);
+  });
+}
+
+function shapeCodeActions(res) {
+  if ( ! Array.isArray(res) || res.length === 0 ) return 'No code actions.';
+  return res.map(function(a, i) {
+    var title = a.title || ( a.command && a.command.title ) || ( 'action ' + i );
+    return '- ' + title;
+  }).join('\n');
+}
+
+// --- MCP tool schemas -----------------------------------------------------
+
+function toolSchemas() {
+  // Every navigation tool accepts EITHER a `symbol` name OR a cursor position
+  // (uri + line + character). Positions are 0-based.
+  const target = {
+    symbol:    { type: 'string',  description: "Name-addressed target: a class id (\"foam.u2.DetailView\"), a short class name (\"DetailView\"), or Class.member (\"foam.u2.DetailView.data\", \"foam.dao.DAO.find\"). Use this instead of uri+line+character to navigate by name." },
+    uri:       { type: 'string',  description: 'Absolute path, project-relative path, or file:// URI (used with line+character)' },
+    line:      { type: 'integer', description: '0-based line number' },
+    character: { type: 'integer', description: '0-based column' }
+  };
+  return [
+    {
+      name:        'foam_hover',
+      description: 'FOAM-aware hover for a class or member. Returns class docs, property types, method signatures, and short-name resolution from the live FOAM registry. Address by symbol name or cursor position.',
+      inputSchema: { type: 'object', properties: target }
+    },
+    {
+      name:        'foam_definition',
+      description: 'Go-to-definition for a FOAM class, property type, or require reference. Address by symbol name or cursor position. Returns path:line:character.',
+      inputSchema: { type: 'object', properties: target }
+    },
+    {
+      name:        'foam_references',
+      description: 'Find references to a FOAM class: subclasses, interface implementors, and JS/Java/string usages across the workspace. Address by symbol name or cursor position. Returns path:line:character per usage.',
+      inputSchema: { type: 'object', properties: target }
+    },
+    {
+      name:        'foam_implementation',
+      description: 'Concrete implementors of a FOAM interface (or direct subclasses of a class). Address by symbol name or cursor position.',
+      inputSchema: { type: 'object', properties: target }
+    },
+    {
+      name:        'foam_type_definition',
+      description: 'For a property usage, jump to the property type class (e.g. a CurrencyCode property → foam.lang.CurrencyCode). Address by symbol name or cursor position.',
+      inputSchema: { type: 'object', properties: target }
+    },
+    {
+      name:        'foam_type_hierarchy',
+      description: 'Inheritance tree for a FOAM class/interface: supertypes (extends chain) and/or subtypes (subclasses + implementors). Address by symbol name or cursor position.',
+      inputSchema: {
+        type: 'object',
+        properties: Object.assign({}, target, {
+          direction: { type: 'string', enum: ['subtypes','supertypes','both'], description: 'Which way to walk the hierarchy (default both)' }
+        })
+      }
+    },
+    {
+      name:        'foam_call_hierarchy',
+      description: 'Call hierarchy for a FOAM method: incoming callers and/or outgoing callees. Address by symbol name (Class.method) or cursor position.',
+      inputSchema: {
+        type: 'object',
+        properties: Object.assign({}, target, {
+          direction: { type: 'string', enum: ['incoming','outgoing','both'], description: 'incoming = who calls this, outgoing = what this calls (default both)' }
+        })
+      }
+    },
+    {
+      name:        'foam_document_symbols',
+      description: 'Outline of a FOAM file: classes, properties, methods, actions, with line numbers. Good for quickly understanding a model.',
+      inputSchema: {
+        type: 'object', required: ['uri'], properties: { uri: target.uri }
+      }
+    },
+    {
+      name:        'foam_workspace_symbols',
+      description: 'Search all FOAM classes, properties, and methods across the workspace by name (substring match). Returns up to 60 ranked hits as name [kind] path:line; narrow the query if truncated.',
+      inputSchema: {
+        type:     'object',
+        required: ['query'],
+        properties: {
+          query: { type: 'string', description: 'Class/member name or substring, e.g. "DetailView" or "DAO"' }
+        }
+      }
+    },
+    {
+      name:        'foam_diagnostics',
+      description: 'FOAM-aware diagnostics for a file or the whole workspace: unknown class references, wrong foam.nanos.* imports, CSS-token violations, invalid getters/setters in javaCode blocks.',
+      inputSchema: {
+        type: 'object', properties: { uri: target.uri }
+      }
+    },
+    {
+      name:        'foam_code_actions',
+      description: 'Quick fixes for FOAM diagnostics in a file: extract hardcoded display strings to messages: entries (i18n), replace raw colors with $css-tokens, correct wrong Java import packages, did-you-mean class suggestions. Optionally scope to one 0-based line.',
+      inputSchema: {
+        type:     'object',
+        required: ['uri'],
+        properties: {
+          uri:  target.uri,
+          line: { type: 'integer', description: 'Optional 0-based line — only return actions for diagnostics touching this line' }
+        }
+      }
+    }
+  ];
 }
 
 // --- FOAM LSP client ------------------------------------------------------
@@ -189,7 +416,9 @@ class FoamLSPClient {
     await this.whenReady();
     if ( this.openedUris.has(uri) ) return;
     const fsPath = uriToPath(uri);
-    const text   = fs.readFileSync(fsPath, 'utf8');
+    let text;
+    try { text = fs.readFileSync(fsPath, 'utf8'); }
+    catch (e) { throw new Error('file not found: ' + fsPath); }
     this._notify('textDocument/didOpen', {
       textDocument: {
         uri:        uri,
@@ -218,111 +447,122 @@ class FoamLSPClient {
   }
 }
 
-// --- MCP tool schemas -----------------------------------------------------
+// --- Position resolution --------------------------------------------------
 
-function toolSchemas() {
-  const pos = {
-    uri: {
-      type:        'string',
-      description: 'Absolute path, project-relative path, or file:// URI'
-    },
-    line:      { type: 'integer', description: '0-based line number' },
-    character: { type: 'integer', description: '0-based column' }
+// Returns { uri, line, character } for cursor-position addressing. Name
+// addressing is handled server-side by foam/byName (see navRaw/hierarchyRaw),
+// so this only ever sees an explicit uri + line + character.
+function resolvePos(projectRoot, args) {
+  if ( ! args.uri ) throw new Error('provide either "symbol" or "uri"+"line"+"character"');
+  // line/character default to 0 when omitted with a uri (start of file).
+  return {
+    uri:       normalizeUri(args.uri, projectRoot),
+    line:      args.line | 0,
+    character: args.character | 0
   };
-  return [
-    {
-      name:        'foam_hover',
-      description: 'FOAM-aware hover at a cursor position. Returns class docs, property types, method signatures, and short-name resolution from the live FOAM registry.',
-      inputSchema: {
-        type: 'object', required: ['uri','line','character'], properties: pos
-      }
-    },
-    {
-      name:        'foam_definition',
-      description: 'Go-to-definition for FOAM classes, property types, or require references at a cursor position.',
-      inputSchema: {
-        type: 'object', required: ['uri','line','character'], properties: pos
-      }
-    },
-    {
-      name:        'foam_references',
-      description: 'Find FOAM references: subclasses of a class or implementors of an interface at a cursor position.',
-      inputSchema: {
-        type: 'object', required: ['uri','line','character'], properties: pos
-      }
-    },
-    {
-      name:        'foam_document_symbols',
-      description: 'Outline of a FOAM file: classes, properties, methods, actions. Good for quickly understanding a model.',
-      inputSchema: {
-        type: 'object', required: ['uri'], properties: { uri: pos.uri }
-      }
-    },
-    {
-      name:        'foam_workspace_symbols',
-      description: 'Search all FOAM classes across the workspace by name (substring match against the full class id).',
-      inputSchema: {
-        type:     'object',
-        required: ['query'],
-        properties: {
-          query: { type: 'string', description: 'Class name or substring, e.g. "MCIFee" or "Fee"' }
-        }
-      }
-    },
-    {
-      name:        'foam_diagnostics',
-      description: 'FOAM-aware diagnostics for a file or the whole workspace: unknown class references, wrong foam.nanos.* imports, CSS-token violations, invalid getters/setters in javaCode blocks.',
-      inputSchema: {
-        type: 'object', properties: { uri: pos.uri }
-      }
-    },
-    {
-      name:        'foam_code_actions',
-      description: 'Quick fixes for FOAM diagnostics in a file: extract hardcoded display strings to messages: entries (i18n), replace raw colors with $css-tokens, correct wrong Java import packages, did-you-mean class suggestions. Returns LSP code actions with ready-to-apply workspace edits. Optionally scope to one 0-based line.',
-      inputSchema: {
-        type:     'object',
-        required: ['uri'],
-        properties: {
-          uri:  pos.uri,
-          line: { type: 'integer', description: 'Optional 0-based line — only return actions for diagnostics touching this line' }
-        }
-      }
-    }
-  ];
+}
+
+// Raw result for a single-request nav op: foam/byName (by class id) when
+// addressed by `symbol`, else the cursor-position LSP request. `extraParams`
+// merges into the position request (e.g. references' includeDeclaration).
+// Symbol mode and position mode return the same LSP shape, so callers run one
+// shaper over either.
+async function navRaw(lsp, projectRoot, args, op, lspMethod, extraParams) {
+  if ( args.symbol ) {
+    const r = await lsp.request('foam/byName', { name: args.symbol, op: op });
+    if ( r === null ) throw new Error('could not resolve symbol: ' + args.symbol);
+    return r;
+  }
+  const t = resolvePos(projectRoot, args);
+  await lsp.ensureOpen(t.uri);
+  const params = Object.assign({
+    textDocument: { uri: t.uri },
+    position:     { line: t.line, character: t.character }
+  }, extraParams || {});
+  return lsp.request(lspMethod, params);
+}
+
+// Two-list hierarchy result. kind 'type' → { a: supertypes, b: subtypes };
+// kind 'call' → { a: incoming-callers, b: outgoing-callees }. Symbol mode goes
+// through foam/byName (by class id); position mode does the LSP prepare +
+// sub-calls. Returns null when the position can't be prepared.
+async function hierarchyRaw(lsp, projectRoot, args, kind) {
+  if ( args.symbol ) {
+    const r = await lsp.request('foam/byName',
+      { name: args.symbol, op: kind === 'type' ? 'typeHierarchy' : 'callHierarchy' });
+    if ( r === null ) throw new Error('could not resolve symbol: ' + args.symbol);
+    if ( kind === 'type' ) return { a: r.supertypes || [], b: r.subtypes || [] };
+    return { a: ( r.incoming || [] ).map(function(c) { return c.from; }),
+             b: ( r.outgoing || [] ).map(function(c) { return c.to; }) };
+  }
+  const t = resolvePos(projectRoot, args);
+  await lsp.ensureOpen(t.uri);
+  const prepMethod = kind === 'type' ? 'textDocument/prepareTypeHierarchy' : 'textDocument/prepareCallHierarchy';
+  const prep = await lsp.request(prepMethod, {
+    textDocument: { uri: t.uri }, position: { line: t.line, character: t.character }
+  });
+  const item = Array.isArray(prep) ? prep[0] : prep;
+  if ( ! item ) return null;
+  if ( kind === 'type' ) {
+    return {
+      a: await lsp.request('typeHierarchy/supertypes', { item: item }),
+      b: await lsp.request('typeHierarchy/subtypes', { item: item })
+    };
+  }
+  const inc = await lsp.request('callHierarchy/incomingCalls', { item: item });
+  const og  = await lsp.request('callHierarchy/outgoingCalls', { item: item });
+  return { a: ( inc || [] ).map(function(c) { return c.from; }),
+           b: ( og || [] ).map(function(c) { return c.to; }) };
 }
 
 // --- Tool dispatch --------------------------------------------------------
 
+// Returns a compact text string for the MCP text content block.
 async function callTool(lsp, projectRoot, name, args) {
   args = args || {};
   switch ( name ) {
-    case 'foam_hover': {
-      const uri = normalizeUri(args.uri, projectRoot);
-      await lsp.ensureOpen(uri);
-      const res = await lsp.request('textDocument/hover', {
-        textDocument: { uri: uri },
-        position:     { line: args.line | 0, character: args.character | 0 }
-      });
-      return res || { contents: null };
+    case 'foam_hover':
+      return shapeHover(await navRaw(lsp, projectRoot, args, 'hover', 'textDocument/hover'));
+    case 'foam_definition':
+      return shapeLocations(await navRaw(lsp, projectRoot, args, 'definition', 'textDocument/definition'), projectRoot);
+    case 'foam_references':
+      return shapeLocations(await navRaw(lsp, projectRoot, args, 'references', 'textDocument/references',
+        { context: { includeDeclaration: false } }), projectRoot);
+    case 'foam_implementation':
+      return shapeLocations(await navRaw(lsp, projectRoot, args, 'implementation', 'textDocument/implementation'), projectRoot);
+    case 'foam_type_definition':
+      // Symbol mode resolves the symbol's own definition; position mode jumps
+      // to the property type at the cursor.
+      return shapeLocations(await navRaw(lsp, projectRoot, args, 'definition', 'textDocument/typeDefinition'), projectRoot);
+    case 'foam_type_hierarchy': {
+      const hr = await hierarchyRaw(lsp, projectRoot, args, 'type');
+      if ( ! hr ) return 'No type hierarchy at this target.';
+      const dir = args.direction || 'both';
+      const out = [];
+      if ( dir === 'supertypes' || dir === 'both' ) {
+        const lines = shapeItems(hr.a, projectRoot);
+        out.push('Supertypes:\n' + ( lines ? lines.join('\n') : '  (none)' ));
+      }
+      if ( dir === 'subtypes' || dir === 'both' ) {
+        const lines = shapeItems(hr.b, projectRoot);
+        out.push('Subtypes:\n' + ( lines ? lines.join('\n') : '  (none)' ));
+      }
+      return out.join('\n\n');
     }
-    case 'foam_definition': {
-      const uri = normalizeUri(args.uri, projectRoot);
-      await lsp.ensureOpen(uri);
-      const res = await lsp.request('textDocument/definition', {
-        textDocument: { uri: uri },
-        position:     { line: args.line | 0, character: args.character | 0 }
-      });
-      return res || [];
-    }
-    case 'foam_references': {
-      const uri = normalizeUri(args.uri, projectRoot);
-      await lsp.ensureOpen(uri);
-      const res = await lsp.request('textDocument/references', {
-        textDocument: { uri: uri },
-        position:     { line: args.line | 0, character: args.character | 0 },
-        context:      { includeDeclaration: false }
-      });
-      return res || [];
+    case 'foam_call_hierarchy': {
+      const hr = await hierarchyRaw(lsp, projectRoot, args, 'call');
+      if ( ! hr ) return 'No call hierarchy at this target (point at a method).';
+      const dir = args.direction || 'both';
+      const out = [];
+      if ( dir === 'incoming' || dir === 'both' ) {
+        const lines = shapeItems(hr.a, projectRoot);
+        out.push('Incoming (callers):\n' + ( lines ? lines.join('\n') : '  (none)' ));
+      }
+      if ( dir === 'outgoing' || dir === 'both' ) {
+        const lines = shapeItems(hr.b, projectRoot);
+        out.push('Outgoing (callees):\n' + ( lines ? lines.join('\n') : '  (none)' ));
+      }
+      return out.join('\n\n');
     }
     case 'foam_document_symbols': {
       const uri = normalizeUri(args.uri, projectRoot);
@@ -330,17 +570,16 @@ async function callTool(lsp, projectRoot, name, args) {
       const res = await lsp.request('textDocument/documentSymbol', {
         textDocument: { uri: uri }
       });
-      return res || [];
+      return shapeDocumentSymbols(res, projectRoot);
     }
     case 'foam_workspace_symbols': {
-      const res = await lsp.request('workspace/symbol', {
-        query: String(args.query || '')
-      });
-      return res || [];
+      const res = await lsp.request('workspace/symbol', { query: String(args.query || '') });
+      return shapeWorkspaceSymbols(res, projectRoot, 60);
     }
     case 'foam_diagnostics': {
       const uri = args.uri ? normalizeUri(args.uri, projectRoot) : null;
-      return await lsp.getDiagnostics(uri);
+      const res = await lsp.getDiagnostics(uri);
+      return shapeDiagnostics(res, projectRoot, uri);
     }
     case 'foam_code_actions': {
       const uri   = normalizeUri(args.uri, projectRoot);
@@ -352,13 +591,13 @@ async function callTool(lsp, projectRoot, name, args) {
             d.range.start.line <= (args.line | 0) &&
             (args.line | 0) <= d.range.end.line;
         });
-      if ( scoped.length === 0 ) return [];
+      if ( scoped.length === 0 ) return 'No code actions.';
       const res = await lsp.request('textDocument/codeAction', {
         textDocument: { uri: uri },
         range:        scoped[0].range,
         context:      { diagnostics: scoped }
       });
-      return res || [];
+      return shapeCodeActions(res);
     }
     default:
       throw new Error('Unknown tool: ' + name);
@@ -375,11 +614,11 @@ function mcpResult(id, result) { sendMCP({ jsonrpc: '2.0', id: id, result: resul
 function mcpError(id, code, message) {
   sendMCP({ jsonrpc: '2.0', id: id, error: { code: code, message: message } });
 }
-function toolContent(obj) {
-  return { content: [{ type: 'text', text: JSON.stringify(obj, null, 2) }] };
+function toolContent(text) {
+  return { content: [{ type: 'text', text: typeof text === 'string' ? text : JSON.stringify(text, null, 2) }] };
 }
 
-(async function main() {
+function main() {
   const projectRoot = process.env.FOAM_PROJECT_ROOT || process.cwd();
   log('project root:', projectRoot);
 
@@ -410,7 +649,7 @@ function toolContent(obj) {
         mcpResult(id, {
           protocolVersion: '2024-11-05',
           capabilities:    { tools: {} },
-          serverInfo:      { name: 'foam-lsp', version: '0.1.0' }
+          serverInfo:      { name: 'foam-lsp', version: '0.2.0' }
         });
         return;
       }
@@ -444,4 +683,15 @@ function toolContent(obj) {
     if ( lsp.child && ! lsp.child.killed ) lsp.child.kill();
     process.exit(0);
   });
-})();
+}
+
+// --- exports (for tests) + entrypoint guard ------------------------------
+
+module.exports = {
+  normalizeUri, uriToPath, relPath, kindName, severityName,
+  shapeLocations, shapeHover, shapeDocumentSymbols, shapeWorkspaceSymbols,
+  shapeDiagnostics, shapeItems, shapeCodeActions,
+  toolSchemas, resolvePos, callTool, FoamLSPClient
+};
+
+if ( require.main === module ) main();

--- a/tools/lsp/editors/vscode/package.json
+++ b/tools/lsp/editors/vscode/package.json
@@ -23,6 +23,11 @@
           "type": "string",
           "default": "./build.sh",
           "description": "Path to build.sh relative to workspace root"
+        },
+        "foam.nodePath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the Node binary that launches the language server. Leave empty to use the Node bundled with VS Code — this avoids 'spawn node ENOENT' when VS Code is launched from the GUI without a shell PATH (e.g. Node installed via nvm)."
         }
       }
     },

--- a/tools/lsp/editors/vscode/src/extension.ts
+++ b/tools/lsp/editors/vscode/src/extension.ts
@@ -136,10 +136,17 @@ function startServer(
   treeProvider: FoamTreeProvider,
   onRunnerReady: (runner: FoamAnalysisRunner) => void
 ) {
+  // GUI-launched VS Code does not inherit the shell PATH, so a bare `node`
+  // command fails with ENOENT when Node lives under nvm or homebrew. Default to
+  // the Node binary bundled with VS Code (run via ELECTRON_RUN_AS_NODE); honour
+  // an explicit foam.nodePath override when the user sets one.
+  const configuredNode = (workspace.getConfiguration('foam').get<string>('nodePath') || '').trim();
+  const env = { ...process.env };
+  if ( ! configuredNode ) env.ELECTRON_RUN_AS_NODE = '1';
   const serverOptions: ServerOptions = {
-    command: 'node',
+    command: configuredNode || process.execPath,
     args: [lspScript, pomPath],
-    options: { cwd }
+    options: { cwd, env }
   };
 
   const clientOptions: LanguageClientOptions = {

--- a/tools/lsp/handlers/CallHierarchyHandler.js
+++ b/tools/lsp/handlers/CallHierarchyHandler.js
@@ -148,12 +148,15 @@ foam.CLASS({
     function itemFor_(classId, memberName) {
       var filePath = this.index.getFilePath(classId);
       var uri      = filePath ? 'file://' + filePath : 'file:///' + classId.replace(/\./g, '/');
+      var pos      = filePath ? this.index.getSymbolPosition(classId, memberName, this.SYMBOL_KIND_METHOD)
+                              : { line: 0, character: 0 };
+      var range    = { start: { line: pos.line, character: pos.character }, end: { line: pos.line, character: pos.character } };
       return {
         name:           memberName,
         kind:           this.SYMBOL_KIND_METHOD,
         uri:            uri,
-        range:          { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-        selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        range:          range,
+        selectionRange: range,
         detail:         classId,
         data:           { classId: classId, memberName: memberName }
       };

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -418,12 +418,59 @@ foam.CLASS({
       return text.substring(start, end).indexOf('i18n-ignore') !== -1;
     },
 
-    function constantizeMessageName_(s) {
-      /** 'Upload Complete' -> 'UPLOAD_COMPLETE'; safe FOAM message constant. */
+    function constantizeMessageName_(s, opt_taken) {
+      /** 'Upload Complete' -> 'UPLOAD_COMPLETE_MSG'; safe, unique FOAM message
+       *  constant. The _MSG suffix keeps the generated constant out of the
+       *  property/action namespace — a 'fileName' property already installs a
+       *  FILE_NAME constant, so extracting the label 'File Name' to a bare
+       *  FILE_NAME would clash. opt_taken is the set of names already defined on
+       *  the model; on any remaining clash a numeric suffix is appended until
+       *  free (FILE_NAME_MSG, FILE_NAME_MSG2, ...). */
       var up = String(s).toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
       if ( ! up ) up = 'MESSAGE';
-      if ( /^[0-9]/.test(up) ) up = 'MSG_' + up;
-      return up;
+      if ( /^[0-9]/.test(up) ) up = 'M_' + up;     // an identifier can't start with a digit
+      var base = up + '_MSG';
+      if ( ! opt_taken ) return base;
+      var name = base, n = 2;
+      while ( opt_taken[name] ) name = base + (n++);
+      return name;
+    },
+
+    function collectAxiomConstants_(text, uri) {
+      /** Names already defined as constant-style members on the file's single
+       *  model, so an extracted message name can dodge them. Holds the CONSTANT
+       *  form of every own + inherited property and action (FOAM installs a
+       *  FILE_NAME constant for a 'fileName' property) plus existing message /
+       *  constant names (already constant-cased). */
+      var taken = {};
+      var models = this.cache.getModels(uri || '', text);
+      if ( ! models || ! models.length ) return taken;
+      var model = models[0];
+      var nameOf   = function(x) { return typeof x === 'string' ? x : ( x && x.name ); };
+      var addConst = function(nm) { if ( nm ) taken[foam.String.constantize(nm)] = true; };
+      var addRaw   = function(nm) { if ( nm ) taken[nm] = true; };
+
+      var props = model.properties || [];
+      for ( var i = 0 ; i < props.length ; i++ ) addConst(nameOf(props[i]));
+      var acts = model.actions || [];
+      for ( var i = 0 ; i < acts.length ; i++ ) addConst(nameOf(acts[i]));
+      var msgs = model.messages || [];
+      for ( var i = 0 ; i < msgs.length ; i++ ) addRaw(nameOf(msgs[i]));
+
+      var consts = model.constants;
+      if ( Array.isArray(consts) ) {
+        for ( var i = 0 ; i < consts.length ; i++ ) addRaw(nameOf(consts[i]));
+      } else if ( consts && typeof consts === 'object' ) {
+        for ( var k in consts ) if ( Object.prototype.hasOwnProperty.call(consts, k) ) addRaw(k);
+      }
+
+      // Inherited properties — best effort; getProperties returns [] when the
+      // class isn't registered (incomplete file mid-edit).
+      var inherited = this.index.getProperties(this.cache.getClassId(model));
+      if ( inherited ) {
+        for ( var i = 0 ; i < inherited.length ; i++ ) addConst(inherited[i].name);
+      }
+      return taken;
     },
 
     function findAddLiteral_(text, messageText) {
@@ -502,7 +549,7 @@ foam.CLASS({
         content = messageText;
       }
 
-      var name = this.constantizeMessageName_(content);
+      var name = this.constantizeMessageName_(content, this.collectAxiomConstants_(text, uri));
       var edits = [];
 
       // Rewrite the usage: 'messageText' -> this.NAME

--- a/tools/lsp/handlers/ImplementationHandler.js
+++ b/tools/lsp/handlers/ImplementationHandler.js
@@ -42,9 +42,10 @@ foam.CLASS({
       for ( var i = 0 ; i < targets.length ; i++ ) {
         var filePath = this.index.getFilePath(targets[i]);
         if ( ! filePath ) continue;
+        var line = this.index.getClassLine(targets[i]);
         locations.push({
           uri: 'file://' + filePath,
-          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
+          range: { start: { line: line, character: 0 }, end: { line: line, character: 0 } }
         });
       }
       return locations;

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -57,6 +57,16 @@ foam.CLASS({
       var classId = this.resolveClassAtCursor_(text, position, word, opt_uri);
       if ( ! classId ) return [];
 
+      return this.referencesForClassId(classId);
+    },
+
+    function referencesForClassId(classId) {
+      /**
+       * Reference locations for a resolved class id — the by-id core shared by
+       * the cursor-driven handle() and name-addressed lookups (foam/byName).
+       * Unions subclasses, implementors, requirers, of-users, and the JS/Java/
+       * string/view-spec usage indexes.
+       */
       // Collect referencing class IDs from every angle. Dedup — a class may
       // both extend and require the target (rare, but keep it honest).
       var seen = {};

--- a/tools/lsp/handlers/TypeHierarchyHandler.js
+++ b/tools/lsp/handlers/TypeHierarchyHandler.js
@@ -77,12 +77,14 @@ foam.CLASS({
       var filePath = this.index.getFilePath(classId);
       if ( ! filePath ) return null;
       var isInterface = this.index.isInterface(classId);
+      var line = this.index.getClassLine(classId);
+      var range = { start: { line: line, character: 0 }, end: { line: line, character: 0 } };
       return {
         name:           classId.split('.').pop(),
         kind:           isInterface ? this.SYMBOL_KIND_INTERFACE : this.SYMBOL_KIND_CLASS,
         uri:            'file://' + filePath,
-        range:          { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-        selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        range:          range,
+        selectionRange: range,
         detail:         classId,
         data:           { classId: classId }
       };

--- a/tools/lsp/handlers/WorkspaceSymbolHandler.js
+++ b/tools/lsp/handlers/WorkspaceSymbolHandler.js
@@ -27,12 +27,22 @@ foam.CLASS({
       var out   = [];
       for ( var i = 0 ; i < hits.length ; i++ ) {
         var h = hits[i];
+        // Class-level hits (Class/Interface/Enum) sit at the foam.CLASS call;
+        // member hits resolve to their axiom line via the grammar position map
+        // (one parse per file, cached in FoamIndex.getFilePosMap_).
+        var line = 0, character = 0;
+        if ( h.kind === 5 || h.kind === 11 || h.kind === 10 ) {
+          line = this.index.getClassLine(h.classId);
+        } else {
+          var pos = this.index.getSymbolPosition(h.classId, h.name, h.kind);
+          line = pos.line; character = pos.character;
+        }
         out.push({
           name:          h.name,
           kind:          h.kind,
           location: {
             uri:   'file://' + h.filePath,
-            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
+            range: { start: { line: line, character: character }, end: { line: line, character: character } }
           },
           containerName: h.containerName
         });

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -103,6 +103,85 @@ function start() {
     send({ jsonrpc: '2.0', method: method, params: params });
   }
 
+  function byNameResult(info, op) {
+    // Name-addressed lookup by resolved class id (not cursor position) — the
+    // engine behind foam/byName. info = { classId, memberName?, uri, line,
+    // character, kind }. Returns the same shapes the cursor-driven LSP methods
+    // return, so the MCP reuses one set of shapers for both addressing modes.
+    var classId = info.classId;
+    switch ( op ) {
+      case 'definition':
+        return [ {
+          uri:   info.uri,
+          range: { start: { line: info.line, character: info.character },
+                   end:   { line: info.line, character: info.character } }
+        } ];
+      case 'hover': {
+        // buildMethodHover_ returns a raw markdown string (wrap it);
+        // buildClassHover already returns a { contents: {...} } hover (pass
+        // it through). Don't double-wrap.
+        if ( info.memberName && info.kind === 6 ) {
+          var cls = index.getClass(classId);
+          var methodAxiom = null;
+          if ( cls ) {
+            try {
+              var ms = cls.getAxiomsByClass(foam.lang.Method);
+              for ( var i = 0 ; i < ms.length ; i++ ) {
+                if ( ms[i].name === info.memberName ) { methodAxiom = ms[i]; break; }
+              }
+            } catch (e) {}
+          }
+          if ( methodAxiom ) {
+            var mmd = hoverHandler.buildMethodHover_(methodAxiom, classId);
+            return mmd ? { contents: { kind: 'markdown', value: mmd } } : null;
+          }
+          // Java-only method (no FOAM axiom): hover from its parsed signature.
+          var jms = index.getJavaMethods(classId);
+          for ( var ji = 0 ; ji < jms.length ; ji++ ) {
+            if ( jms[ji].name === info.memberName ) {
+              var jv = '```java\n' + ( jms[ji].sig || jms[ji].name ) + '\n```';
+              if ( jms[ji].doc ) jv += '\n\n' + jms[ji].doc;
+              return { contents: { kind: 'markdown', value: jv } };
+            }
+          }
+        }
+        return hoverHandler.buildClassHover(classId);
+      }
+      case 'references':
+        return referencesHandler.referencesForClassId(classId);
+      case 'implementation': {
+        var targets = index.isInterface(classId) ?
+          index.getImplementors(classId) : index.getSubclasses(classId);
+        var locs = [];
+        for ( var i = 0 ; i < targets.length ; i++ ) {
+          var fp = index.getFilePath(targets[i]);
+          if ( ! fp ) continue;
+          var ln = index.getClassLine(targets[i]);
+          locs.push({ uri: 'file://' + fp,
+            range: { start: { line: ln, character: 0 }, end: { line: ln, character: 0 } } });
+        }
+        return locs;
+      }
+      case 'typeHierarchy': {
+        var item = typeHierarchyHandler.itemFor_(classId);
+        return {
+          supertypes: item ? typeHierarchyHandler.supertypes(item) : [],
+          subtypes:   item ? typeHierarchyHandler.subtypes(item)   : []
+        };
+      }
+      case 'callHierarchy': {
+        if ( ! info.memberName ) return { incoming: [], outgoing: [] };
+        var chItem = callHierarchyHandler.itemFor_(classId, info.memberName);
+        return {
+          incoming: callHierarchyHandler.incomingCalls(chItem),
+          outgoing: callHierarchyHandler.outgoingCalls(chItem)
+        };
+      }
+      default:
+        return null;
+    }
+  }
+
   function isFoamFile(text) {
     return foam.parse.lsp.CursorAnalyzer.FOAM_CALL_REGEX.test(text);
   }
@@ -531,6 +610,21 @@ function start() {
         } catch (e) {
           console.error('[LSP] analyzeWorkspace error:', e.message);
           respondError(id, -32603, e.message);
+        }
+        break;
+
+      case 'foam/byName':
+        // Custom request: name-addressed navigation by class id. params:
+        // { name, op } where op ∈ definition|hover|references|implementation|
+        // typeHierarchy|callHierarchy. Returns the same shapes as the
+        // cursor-driven LSP methods so MCP reuses its shapers. null if the
+        // name can't be resolved.
+        try {
+          var bnInfo = index.resolveSymbol(params && params.name);
+          respond(id, bnInfo ? byNameResult(bnInfo, params && params.op) : null);
+        } catch (e) {
+          console.error('[LSP] foam/byName error:', e.message);
+          respond(id, null);
         }
         break;
 

--- a/tools/tests/lsp/callHierarchy.js
+++ b/tools/tests/lsp/callHierarchy.js
@@ -88,3 +88,22 @@ test(outgoing.some(function(c) { return c.to.name === 'methodB'; }),
   'outgoingCalls: methodA calls methodB');
 test(! outgoing.some(function(c) { return c.to.name === 'methodA'; }),
   'outgoingCalls: self-recursion excluded');
+
+
+// === Real method positions (itemFor_ via grammar position map) ===
+
+section('CallHierarchy — real method positions');
+var realCls = index.getClass('foam.core.controller.ApplicationController');
+if ( realCls && index.getFilePath('foam.core.controller.ApplicationController') ) {
+  var realMethods = realCls.getOwnAxiomsByClass(foam.lang.Method);
+  var named = realMethods.filter(function(m) { return typeof m.name === 'string' && m.name; });
+  if ( named.length ) {
+    var mItem = ch.itemFor_('foam.core.controller.ApplicationController', named[0].name);
+    test(mItem.range.start.line > 0,
+      'itemFor_: real method ' + named[0].name + ' has a non-zero line (@' + mItem.range.start.line + ')');
+  } else {
+    test(true, 'method position test skipped (no named own methods)');
+  }
+} else {
+  test(true, 'method position test skipped (ApplicationController not in file index)');
+}

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -555,8 +555,8 @@ var e1 = diagHandler.buildAddExtractEdit(noMsgSrc, 'Upload Complete', 'file:///x
 test(!! e1, 'buildAddExtractEdit returns an edit for a single-class file');
 var edits1 = e1 && e1.changes['file:///x.js'];
 test(!!edits1 && edits1.length === 2, 'edit has two text edits (insert message + rewrite usage)');
-test(!!edits1 && edits1.some(function(t){ return t.newText === 'this.UPLOAD_COMPLETE'; }), 'usage rewritten to this.UPLOAD_COMPLETE');
-test(!!edits1 && edits1.some(function(t){ return t.newText.indexOf("name: 'UPLOAD_COMPLETE'") !== -1 && t.newText.indexOf("message: 'Upload Complete'") !== -1; }), 'inserts a messages entry with constantized name + original text');
+test(!!edits1 && edits1.some(function(t){ return t.newText === 'this.UPLOAD_COMPLETE_MSG'; }), 'usage rewritten to this.UPLOAD_COMPLETE_MSG');
+test(!!edits1 && edits1.some(function(t){ return t.newText.indexOf("name: 'UPLOAD_COMPLETE_MSG'") !== -1 && t.newText.indexOf("message: 'Upload Complete'") !== -1; }), 'inserts a messages entry with _MSG-suffixed name + original text');
 test(!!edits1 && edits1.some(function(t){ return t.newText.indexOf('messages: [') !== -1; }), 'creates a new messages: array when none exists');
 
 // Existing messages array path — entry inserted, no new messages: key
@@ -578,7 +578,7 @@ test(diagHandler.buildAddExtractEdit(twoPropSrc, 'Some Text', 'file:///2p.js') =
 
 // Insertion placement: messages lands right before properties:, after header keys
 function msgInsertOffset(edit, uri, src) {
-  var t = edit.changes[uri].filter(function(e){ return e.newText.indexOf("name: 'UPLOAD_COMPLETE'") !== -1; })[0];
+  var t = edit.changes[uri].filter(function(e){ return e.newText.indexOf("name: 'UPLOAD_COMPLETE_MSG'") !== -1; })[0];
   return analyzer.positionToOffset(src, t.range.start);
 }
 var srcHP = "foam.CLASS({\n  package:'p',\n  name:'HP',\n  requires:['a.B'],\n  properties:[ { name:'x' } ],\n  methods:[ function render(){ this.add('Upload Complete'); } ]\n})";
@@ -604,9 +604,26 @@ var secondRange = {
   end:   analyzer.offsetToPosition(twiceSrc, secondInner + 'Repeat Me'.length)
 };
 var eTwice = diagHandler.buildAddExtractEdit(twiceSrc, 'Repeat Me', 'file:///tw.js', secondRange);
-var rwTwice = eTwice && eTwice.changes['file:///tw.js'].filter(function(t){ return t.newText === 'this.REPEAT_ME'; })[0];
+var rwTwice = eTwice && eTwice.changes['file:///tw.js'].filter(function(t){ return t.newText === 'this.REPEAT_ME_MSG'; })[0];
 var rwOff = rwTwice ? analyzer.positionToOffset(twiceSrc, rwTwice.range.start) : -1;
 test(rwOff === secondInner - 1, 'P3: extract rewrites the occurrence at the diagnostic range (the 2nd), not the 1st');
+
+// === _MSG suffix + axiom-collision uniqueness ===
+section('DiagnosticsHandler i18n message-name uniqueness');
+
+// A 'fileName' property installs a FILE_NAME constant; extracting the label
+// 'File Name' must NOT reuse FILE_NAME — the _MSG suffix keeps them apart.
+var collideSrc = "foam.CLASS({\n  package:'t', name:'TextSaveView',\n  properties:[ { name:'fileName' } ],\n  methods:[ function render(){ this.add('File Name'); } ]\n})";
+var eCollide = diagHandler.buildAddExtractEdit(collideSrc, 'File Name', 'file:///c.js');
+var editsC = eCollide && eCollide.changes['file:///c.js'];
+test(!!editsC && editsC.some(function(t){ return t.newText === 'this.FILE_NAME_MSG'; }), 'property constant FILE_NAME does not block the _MSG name; usage -> this.FILE_NAME_MSG');
+test(!!editsC && editsC.every(function(t){ return t.newText.indexOf("name: 'FILE_NAME'") === -1 || t.newText.indexOf("name: 'FILE_NAME_MSG'") !== -1; }), 'extracted message is named FILE_NAME_MSG, not FILE_NAME');
+
+// An existing FOO_MSG message forces a numeric suffix on a second 'Foo'.
+var dupMsgSrc = "foam.CLASS({\n  package:'t', name:'DUP',\n  messages:[ { name:'FOO_MSG', message:'x' } ],\n  methods:[ function render(){ this.add('Foo'); } ]\n})";
+var eDup = diagHandler.buildAddExtractEdit(dupMsgSrc, 'Foo', 'file:///d.js');
+var editsD = eDup && eDup.changes['file:///d.js'];
+test(!!editsD && editsD.some(function(t){ return t.newText === 'this.FOO_MSG2'; }), 'taken FOO_MSG -> numeric suffix FOO_MSG2');
 
 // === P2: WorkspaceAnalyzer threads the file URI (test/demo exemption) ===
 section('WorkspaceAnalyzer i18n URI exemption');
@@ -629,14 +646,14 @@ section('DiagnosticsHandler i18n extract edit — robustness');
 // The messages: block must NOT be inserted inside the method/object.
 var bodyObjSrc = "foam.CLASS({\n  package:'p',\n  name:'BodyObj',\n  methods:[\n    function render(){\n      var cfg = {\n        name: 'inner'\n      };\n      this.add('Body Object Text');\n    }\n  ]\n})";
 var eBO = diagHandler.buildAddExtractEdit(bodyObjSrc, 'Body Object Text', 'file:///bo.js');
-var msgEditBO = eBO && eBO.changes['file:///bo.js'].filter(function(t){ return t.newText.indexOf("name: 'BODY_OBJECT_TEXT'") !== -1; })[0];
+var msgEditBO = eBO && eBO.changes['file:///bo.js'].filter(function(t){ return t.newText.indexOf("name: 'BODY_OBJECT_TEXT_MSG'") !== -1; })[0];
 var insBO = msgEditBO ? analyzer.positionToOffset(bodyObjSrc, msgEditBO.range.start) : -1;
 test(insBO !== -1 && insBO < bodyObjSrc.indexOf('methods:'), 'F1: messages inserted before methods:, not inside the body object');
 
 // F2: an escaped apostrophe must produce a valid message: literal (no double-escaping).
 var aposSrc = "foam.CLASS({\n  package:'p', name:'Apos',\n  methods:[ function render(){ this.add('Don\\'t save'); } ]\n})";
 var eA = diagHandler.buildAddExtractEdit(aposSrc, "Don\\'t save", 'file:///a.js');
-var msgEditA = eA && eA.changes['file:///a.js'].filter(function(t){ return t.newText.indexOf("name: 'DON_T_SAVE'") !== -1; })[0];
+var msgEditA = eA && eA.changes['file:///a.js'].filter(function(t){ return t.newText.indexOf("name: 'DON_T_SAVE_MSG'") !== -1; })[0];
 test(!!msgEditA, 'F2: message entry generated for a string with an escaped apostrophe');
 test(!!msgEditA && msgEditA.newText.indexOf("message: 'Don\\'t save'") !== -1, 'F2: message: literal preserves the original valid escaping');
 test(!!msgEditA && msgEditA.newText.indexOf("Don\\\\'t") === -1, 'F2: no double-backslash escaping');

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -294,3 +294,64 @@ if ( index.classExists('foam.u2.view.ReferenceArrayView') && index.classExists('
   test(vsUsers.every(function(u) { return u.sourceClassId && u.axiomName; }),
     'getViewSpecUsers: entries carry sourceClassId + axiomName');
 }
+
+// === POSITIONS + NAME RESOLUTION (tracing) ===
+
+section('FoamIndex — getClassLine / getSymbolPosition / resolveSymbol');
+var POS_CLASS = 'foam.core.controller.ApplicationController';
+if ( index.classExists(POS_CLASS) && index.getFilePath(POS_CLASS) ) {
+  var clsLine = index.getClassLine(POS_CLASS);
+  test(clsLine > 0, 'getClassLine: ApplicationController has a non-zero class line (' + clsLine + ')');
+
+  var rs = index.resolveSymbol(POS_CLASS);
+  test(rs && rs.classId === POS_CLASS && rs.kind === 5,
+    'resolveSymbol: full class id resolves to a class');
+  test(rs && rs.uri.indexOf('file://') === 0 && rs.line === clsLine,
+    'resolveSymbol: class uri is file:// and line matches getClassLine');
+
+  var rsShort = index.resolveSymbol('ApplicationController');
+  test(rsShort && rsShort.classId === POS_CLASS,
+    'resolveSymbol: short class name resolves to full id');
+
+  var acCls = index.getClass(POS_CLASS);
+  var ownProps = acCls.getOwnAxiomsByClass(foam.lang.Property);
+  if ( ownProps.length ) {
+    var pName = ownProps[0].name;
+    var rsMember = index.resolveSymbol(POS_CLASS + '.' + pName);
+    test(rsMember && rsMember.classId === POS_CLASS && rsMember.memberName === pName && rsMember.kind === 7,
+      'resolveSymbol: Class.property resolves with property kind (' + pName + ')');
+    var sp = index.getSymbolPosition(POS_CLASS, pName, 7);
+    test(sp && sp.uri.indexOf('file://') === 0 && sp.line > 0,
+      'getSymbolPosition: returns a file:// uri and a non-zero line (@' + (sp && sp.line) + ')');
+  }
+
+  test(index.resolveSymbol('no.such.Class.member') === null,
+    'resolveSymbol: unknown name returns null');
+} else {
+  test(true, 'position/resolveSymbol tests skipped (ApplicationController not in file index)');
+}
+
+// === JAVA-IMPLEMENTED SYMBOL RESOLUTION ===
+// Methods that live only in a sibling .java (no JS axiom) must still resolve —
+// definition/hover should land on the .java file, not fall back to the .js.
+
+section('FoamIndex — Java-only method resolution');
+var JAVA_CLASS = 'foam.lang.FObject';
+if ( index.classExists(JAVA_CLASS) && index.getFilePath(JAVA_CLASS) ) {
+  var javaMethods = index.getJavaMethods(JAVA_CLASS);
+  if ( javaMethods.length ) {
+    var jName = javaMethods[0].name;
+    var jKind = index.memberKind_(JAVA_CLASS, jName);
+    test(jKind === 6,
+      'memberKind_: a Java-only method resolves as a method (' + jName + ')');
+    var rsJava = index.resolveSymbol(JAVA_CLASS + '.' + jName);
+    test(rsJava && rsJava.classId === JAVA_CLASS && rsJava.memberName === jName && rsJava.kind === 6,
+      'resolveSymbol: Class.javaMethod resolves to the class + method kind');
+    test(rsJava && rsJava.uri.endsWith('.java'),
+      'resolveSymbol: a Java-only method resolves to a .java uri (' + ( rsJava && rsJava.uri.split('/').pop() ) + ')');
+  } else {
+    test(true, 'Java-only method tests skipped (no Java-only methods scanned for FObject)');
+  }
+} else {
+  test(true, 'Java-only method tests skipped (FObject not in file index)');
+}

--- a/tools/tests/lsp/mcp.js
+++ b/tools/tests/lsp/mcp.js
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Unit tests for the FOAM LSP MCP server's pure translation layer
+// (foam3/tools/lsp/editors/mcp/server.js): URI helpers, output shapers,
+// tool schemas, and argument routing. These exercise the agent-facing
+// surface WITHOUT spawning the LSP child — requiring the server module only
+// loads its helpers because main() is guarded by `require.main === module`.
+
+var h = require('./_harness');
+var test = h.test, section = h.section;
+
+var mcp = require('../../lsp/editors/mcp/server');
+var ROOT = '/proj';
+
+section('MCP — URI helpers');
+
+test(mcp.normalizeUri('src/Foo.js', ROOT) === 'file:///proj/src/Foo.js',
+  'normalizeUri: project-relative path → file:// under root');
+test(mcp.normalizeUri('/abs/Foo.js', ROOT) === 'file:///abs/Foo.js',
+  'normalizeUri: absolute path → file://');
+test(mcp.normalizeUri('file:///x/Foo.js', ROOT) === 'file:///x/Foo.js',
+  'normalizeUri: existing file:// passes through');
+test(mcp.uriToPath('file:///proj/src/Foo.js') === '/proj/src/Foo.js',
+  'uriToPath: strips file:// scheme');
+test(mcp.relPath('file:///proj/src/Foo.js', ROOT) === 'src/Foo.js',
+  'relPath: project-relative output');
+test(mcp.relPath('file:///other/Bar.js', ROOT) === '/other/Bar.js',
+  'relPath: outside root → absolute path');
+
+section('MCP — kind/severity names');
+
+test(mcp.kindName(5) === 'class' && mcp.kindName(7) === 'property' && mcp.kindName(6) === 'method',
+  'kindName: maps common SymbolKinds');
+test(mcp.severityName(1) === 'error' && mcp.severityName(2) === 'warn',
+  'severityName: maps diagnostic severities');
+
+section('MCP — output shapers');
+
+var locs = [
+  { uri: 'file:///proj/a/X.js', range: { start: { line: 10, character: 2 } } },
+  { uri: 'file:///proj/b/Y.js', range: { start: { line: 0,  character: 0 } } }
+];
+test(mcp.shapeLocations(locs, ROOT) === 'a/X.js:10:2\nb/Y.js:0:0',
+  'shapeLocations: array → path:line:character lines');
+test(mcp.shapeLocations(locs[0], ROOT) === 'a/X.js:10:2',
+  'shapeLocations: single Location accepted');
+test(mcp.shapeLocations([], ROOT) === 'No results.',
+  'shapeLocations: empty → No results.');
+
+test(mcp.shapeHover({ contents: { kind: 'markdown', value: 'HELLO' } }) === 'HELLO',
+  'shapeHover: returns markdown value');
+test(mcp.shapeHover({ contents: null }) === 'No hover information.',
+  'shapeHover: null contents → message');
+
+var docSyms = [
+  { name: 'com.x.Foo', kind: 5, range: { start: { line: 17 } }, children: [
+    { name: 'bar', kind: 7, range: { start: { line: 20 } } },
+    { name: 'baz', kind: 6, range: { start: { line: 30 } } }
+  ] }
+];
+var docOut = mcp.shapeDocumentSymbols(docSyms, ROOT);
+test(docOut.indexOf('com.x.Foo [class] @17') === 0, 'shapeDocumentSymbols: class line');
+test(docOut.indexOf('  bar [property] @20') !== -1, 'shapeDocumentSymbols: indented child property');
+test(docOut.indexOf('  baz [method] @30') !== -1, 'shapeDocumentSymbols: indented child method');
+
+var wsHits = [
+  { name: 'data', kind: 7, containerName: 'foam.u2.DetailView',
+    location: { uri: 'file:///proj/src/DetailView.js', range: { start: { line: 17 } } } }
+];
+test(mcp.shapeWorkspaceSymbols(wsHits, ROOT, 60) === 'foam.u2.DetailView.data [property] src/DetailView.js:17',
+  'shapeWorkspaceSymbols: container.name [kind] path:line');
+var many = [];
+for ( var i = 0 ; i < 70 ; i++ ) {
+  many.push({ name: 'C' + i, kind: 5, containerName: 'p.C' + i,
+    location: { uri: 'file:///proj/C' + i + '.js', range: { start: { line: i } } } });
+}
+var manyOut = mcp.shapeWorkspaceSymbols(many, ROOT, 60);
+test(manyOut.split('\n').length === 61 && manyOut.indexOf('10 more') !== -1,
+  'shapeWorkspaceSymbols: caps at 60 and appends a truncation note');
+
+var fileDiags = [
+  { range: { start: { line: 5, character: 4 } }, severity: 2, code: 'i18n', message: 'Hardcoded string' }
+];
+test(mcp.shapeDiagnostics(fileDiags, ROOT, 'file:///proj/src/Z.js') === 'src/Z.js:5:4 [warn i18n] Hardcoded string',
+  'shapeDiagnostics: single-file array form');
+var wsDiags = { 'file:///proj/A.js': [ { range: { start: { line: 1, character: 0 } }, severity: 1, message: 'boom' } ] };
+test(mcp.shapeDiagnostics(wsDiags, ROOT) === 'A.js:1:0 [error] boom',
+  'shapeDiagnostics: whole-workspace map form');
+test(mcp.shapeDiagnostics([], ROOT, 'file:///proj/A.js') === 'No diagnostics.',
+  'shapeDiagnostics: empty array → message');
+
+var items = [ { name: 'Sub', detail: 'com.x.Sub', uri: 'file:///proj/Sub.js', range: { start: { line: 9, character: 0 } } } ];
+test(mcp.shapeItems(items, ROOT)[0] === 'Sub (com.x.Sub) — Sub.js:9:0',
+  'shapeItems: name (detail) — path:line:character');
+test(mcp.shapeItems([], ROOT) === null, 'shapeItems: empty → null');
+
+section('MCP — tool schemas');
+
+var tools = mcp.toolSchemas();
+var names = tools.map(function(t) { return t.name; });
+test(tools.length === 11, 'toolSchemas: 11 tools — 7 original + 4 trace (got ' + tools.length + ')');
+['foam_implementation','foam_type_definition','foam_type_hierarchy','foam_call_hierarchy'].forEach(function(n) {
+  test(names.indexOf(n) !== -1, 'toolSchemas: includes new trace tool ' + n);
+});
+var hover = tools.find(function(t) { return t.name === 'foam_hover'; });
+test(hover && hover.inputSchema.properties.symbol && hover.inputSchema.properties.uri,
+  'toolSchemas: nav tools accept both symbol and uri (name-addressing)');
+var ws = tools.find(function(t) { return t.name === 'foam_workspace_symbols'; });
+test(ws && ws.inputSchema.required.indexOf('query') !== -1,
+  'toolSchemas: workspace_symbols still requires query');
+
+section('MCP — resolvePos (cursor-position addressing)');
+
+// Name addressing is handled server-side by foam/byName; resolvePos only ever
+// sees an explicit uri + line + character and resolves it synchronously.
+var pos = mcp.resolvePos(ROOT, { uri: 'src/DetailView.js', line: 3, character: 5 });
+test(pos && pos.uri.indexOf('file://') === 0 && pos.uri.endsWith('/src/DetailView.js'),
+  'resolvePos: project-relative uri is normalized to file://');
+test(pos && pos.line === 3 && pos.character === 5,
+  'resolvePos: line/character pass through');
+
+var threw = false;
+try { mcp.resolvePos(ROOT, {}); } catch ( e ) { threw = true; }
+test(threw, 'resolvePos: throws when neither symbol nor uri is provided');

--- a/tools/tests/lsp/typeHierarchy.js
+++ b/tools/tests/lsp/typeHierarchy.js
@@ -104,3 +104,46 @@ var propText = 'foam.CLASS({\n  package: ' + h.Q + 'x' + h.Q + ',\n  name: ' + h
 var tdef2 = tdefHandler.handle(propText, { line: 4, character: 32 }, 'file:///prop');
 test(tdef2 === null || (tdef2.uri && tdef2.uri.indexOf('file://') === 0),
   'typeDefinition on a property name returns null or a file:// location');
+
+
+// === Real positions (no more hardcoded line:0) ===
+
+section('TypeHierarchy/Implementation — real positions');
+var posItem = tyHandler.itemFor_('foam.core.controller.ApplicationController');
+if ( posItem ) {
+  test(posItem.range.start.line > 0,
+    'itemFor_ range carries a non-zero class line (' + posItem.range.start.line + ')');
+  test(posItem.range.start.line === posItem.selectionRange.start.line,
+    'itemFor_ range and selectionRange agree');
+} else {
+  test(true, 'itemFor_ position test skipped (ApplicationController not in file index)');
+}
+
+
+// === Name-addressing by-id cores (the foam/byName engine) ===
+// These are the class-id-driven paths the MCP uses for symbol-addressed
+// hover/references/implementation/typeHierarchy — independent of cursor
+// position, which is what makes "trace by name" work.
+
+section('Name-addressing by-id cores');
+
+var refHandler = foam.parse.lsp.handlers.ReferencesHandler.create({ index: index });
+var fobjRefs = refHandler.referencesForClassId('foam.lang.FObject');
+test(Array.isArray(fobjRefs) && fobjRefs.length > 0,
+  'referencesForClassId(FObject) returns usages by class id (' + fobjRefs.length + ')');
+
+// Use a class the harness has fully realized (getClass non-null), not just
+// registered — buildClassHover walks the model so it needs the loaded class.
+var BYID_CLASS = 'foam.core.controller.ApplicationController';
+if ( index.getClass(BYID_CLASS) ) {
+  // buildClassHover returns an LSP hover { contents: { kind, value } }.
+  var byIdHover = h.hoverHandler.buildClassHover(BYID_CLASS);
+  test(byIdHover && byIdHover.contents && typeof byIdHover.contents.value === 'string' &&
+    byIdHover.contents.value.indexOf(BYID_CLASS) !== -1,
+    'buildClassHover returns a hover naming the class (name-addressed hover core)');
+  var byIdItem = tyHandler.itemFor_(BYID_CLASS);
+  test(byIdItem && byIdItem.range.start.line > 0,
+    'itemFor_ carries a real class line for name-addressed typeHierarchy');
+} else {
+  test(true, 'buildClassHover/itemFor_ name-address test skipped (class not loaded)');
+}

--- a/tools/tests/testFoamLSP.js
+++ b/tools/tests/testFoamLSP.js
@@ -29,27 +29,34 @@ if ( require.main === module ) {
   }, 90000).unref();
 }
 
+// Category files, "building blocks first" so a grammar failure surfaces before
+// the handlers that depend on it. usageIndex (~79s) and navigation (~47s) do
+// full-workspace scans and dominate the run; pass a category list to skip them
+// while iterating on one area:
+//   node foam3/tools/tests/testFoamLSP.js                  # all
+//   node foam3/tools/tests/testFoamLSP.js diagnostics      # just diagnostics
+//   node foam3/tools/tests/testFoamLSP.js hover,completion # comma- or space-separated
+var CATEGORIES = [
+  'foamIndex', 'grammar', 'utilities', 'completion', 'hover', 'diagnostics',
+  'navigation', 'java', 'jrl', 'editorFeatures', 'typeHierarchy', 'usageIndex',
+  'callHierarchy', 'pomValidation', 'pomNavigation', 'mcp'
+];
+
+// Resolve the category list BEFORE booting the harness so an unknown name fails
+// instantly instead of after the ~2s pmake boot.
+var requested = process.argv.slice(2).join(',').split(',').map(function(s){ return s.trim(); }).filter(Boolean);
+var unknown   = requested.filter(function(c){ return CATEGORIES.indexOf(c) === -1; });
+if ( unknown.length ) {
+  console.error('Unknown categor' + (unknown.length > 1 ? 'ies' : 'y') + ': ' + unknown.join(', '));
+  console.error('Available: ' + CATEGORIES.join(', '));
+  process.exit(2);
+}
+var toRun = requested.length ? CATEGORIES.filter(function(c){ return requested.indexOf(c) !== -1; }) : CATEGORIES;
+
 var h = require('./lsp/_harness');
 
-// Each require() runs its category's tests against the shared harness. Order
-// is roughly "building blocks first" so a failure in the grammar surfaces
-// before the downstream handlers that depend on it.
-require('./lsp/foamIndex');
-require('./lsp/grammar');
-require('./lsp/utilities');
-require('./lsp/completion');
-require('./lsp/hover');
-require('./lsp/diagnostics');
-require('./lsp/navigation');
-require('./lsp/java');
-require('./lsp/jrl');
-require('./lsp/editorFeatures');
-require('./lsp/typeHierarchy');
-require('./lsp/usageIndex');
-require('./lsp/callHierarchy');
-require('./lsp/pomValidation');
-require('./lsp/pomNavigation');
-require('./lsp/mcp');
+// Each require() runs its category's tests against the shared harness.
+toRun.forEach(function(c){ require('./lsp/' + c); });
 
 h.section('SUMMARY');
 console.error(h.counters.passes + ' passed, ' + h.counters.failures + ' failed');

--- a/tools/tests/testFoamLSP.js
+++ b/tools/tests/testFoamLSP.js
@@ -49,6 +49,7 @@ require('./lsp/usageIndex');
 require('./lsp/callHierarchy');
 require('./lsp/pomValidation');
 require('./lsp/pomNavigation');
+require('./lsp/mcp');
 
 h.section('SUMMARY');
 console.error(h.counters.passes + ' passed, ' + h.counters.failures + ' failed');


### PR DESCRIPTION
Makes the LSP and its MCP bridge navigable by name with real source positions, so an agent or editor can trace a class without first knowing a cursor coordinate. Stacked on more-lsp-fixes.

- **Resolve by name** — pass a class id, short name, or Class.member instead of uri+line+character; a server-side foam/byName engine dispatches definition, references, hover, implementation, and the hierarchies off the resolved class.

- **Real positions** — workspace symbols, implementation, and the type/call hierarchies return the actual source line (grammar-harvested via collectAxiomPositions, mtime-cached per file) instead of 0.

- **Java symbols** — a method that lives only in a sibling .java resolves to that file with a signature hover, instead of falling back to the .js or nothing.

- **More trace tools over MCP** — implementation, type-definition, type-hierarchy, and call-hierarchy, with compact path:line output and name-or-position addressing.

- **Bounded workspace search** — symbol queries cap and compact their output so a broad query stays within an agent's token budget instead of returning thousands of raw locations.

Covered by the LSP test suite: positions non-zero, name resolution including Java, and the MCP shapers and routing.