### PR TITLE
PT-FIXES:DOS-3598 OrSchedule view: choose each delegate's schedule type

### DIFF
--- a/src/foam/core/cron/OrSchedule.js
+++ b/src/foam/core/cron/OrSchedule.js
@@ -30,6 +30,10 @@ foam.CLASS({
         return {
           class: 'foam.u2.view.FObjectArrayView',
           of: 'foam.core.cron.Schedule',
+          valueView: {
+            class: 'foam.u2.view.FObjectView',
+            of: 'foam.core.cron.Schedule'
+          },
           defaultNewItem: foam.core.cron.IntervalSchedule.create({
             start: "2019-10-14",
             duration: foam.core.cron.TimeHMS.create({


### PR DESCRIPTION
The OrSchedule editor locked every delegate row to IntervalSchedule.

The row view fell back to an FObjectView with no `of`, so it inferred the concrete class from the row data and the class chooser only saw IntervalSchedule. No way to add a Time-of-day, Cron, or other Schedule delegate.

Fix:

- Pass `of: foam.core.cron.Schedule` to the delegate row's FObjectView, so each row shows the same strategy-backed type chooser the top-level Schedule picker uses.

Delegates can now mix types in one OrSchedule.