### PR TITLE
PT-FIXES:DOS-3895 fix(reflow): stop flow-load infinite loop on slow loads

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1857,16 +1857,16 @@ foam.CLASS({
 
     function generateScript() {
       this.value.script = this.generateScriptString();
-      // console.log('******************** script', this.value.script);
     },
 
     function maybeRegenScript() {
-//      if ( this.feedback_ ) return;
+      // Save/restore feedback_ so we never clear a guard onScriptChange owns mid-load.
+      var prev = this.feedback_;
       this.feedback_ = true;
       try {
         this.generateScript();
       } finally {
-        this.feedback_ = false;
+        this.feedback_ = prev;
       }
     },
 
@@ -2142,6 +2142,8 @@ foam.CLASS({
       isMerged: true,
       delay: 500,
       code: function() {
+        // Skip regen during load: serializing a half-built flow clobbers the real script.
+        if ( this.isLoading_ ) return;
         this.maybeRegenScript();
         this.saveScriptToLocalStorage();
       }


### PR DESCRIPTION
A recent change re-writes value.script after a flow finishes loading (the canonical-restore that fixes undo/redo). But value.script's listener IS the loader (onScriptChange), so that write re-runs the load.

The feedback_ flag is meant to block that re-entry. On a slow load the mid-load auto-save (maybeRegenScript) cleared feedback_ too early, so the restore write slipped through, re-entered the loader, and looped forever.

Fix:

- skip the auto-save/regen while a load is running (isLoading_)

- save/restore feedback_ instead of force-clearing it, so the guard survives the whole load