### PR TITLE
DOS-969 fix(column-picker): drop hidden axioms from nested sub-columns

### DIFF
--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -823,7 +823,7 @@ foam.CLASS({
         if ( ! this.of || ! this.of.getAxiomByName )
           return [];
         if ( prop && prop.of && prop.cls_ && ( foam.lang.FObjectProperty.isInstance(prop) || ( foam.lang.Reference.isInstance(prop) && prop.showSubColumns ) ) )
-          return prop.of.getAxiomsByClass(foam.lang.Property).map(p => { if ( ! foam.dao.DAOProperty.isInstance(p) )  return [p.name, this.columnHandler.returnAxiomHeader(p)] }).filter(e => e != undefined);
+          return prop.of.getAxiomsByClass(foam.lang.Property).map(p => { if ( ! foam.dao.DAOProperty.isInstance(p) && ! p.hidden )  return [p.name, this.columnHandler.returnAxiomHeader(p)] }).filter(e => e != undefined);
         return [];
       }
     },


### PR DESCRIPTION
The column-config dropdown lists a nested column's sub-properties by walking every Property axiom of the nested model and filtering only DAOProperty.

It never filtered hidden, so framework-internal hidden axioms (reactions_ and friends) showed up as selectable sub-columns under any FObject or Reference column. The top-level column list already drops axiom.hidden; the nested enumeration didn't match it.

Fix:

- skip hidden axioms in the subProperties enumeration, same as the top-level list