### PR TITLE
DOS-969 fix(column-picker): scope search to matching sub-columns

### DIFF
--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -920,14 +920,22 @@ foam.CLASS({
       this.showOnSearch = selfMatch || !! parentMatched;
       if ( this.hasSubProperties && this.level < 2 ) {
         this.expanded = false;
-        if ( this.subColumnSelectConfig.length == 0 )
-          this.subColumnSelectConfig = this.returnSubColumnSelectConfig(this.subProperties, this.level, this.expanded, true);
-        for ( var  i = 0 ; i < this.subColumnSelectConfig.length ; i++ ) {
-          if ( this.subColumnSelectConfig[i].updateOnSearch(query, selfMatch || parentMatched) ) {
+        // Snapshot the children locally: subColumnSelectConfig is an expression
+        // keyed on `expanded`, so toggling this.expanded inside the loop would
+        // regenerate fresh child objects (default showOnSearch=true) and discard
+        // the per-child results computed here.
+        var subs = this.subColumnSelectConfig.length == 0
+          ? this.returnSubColumnSelectConfig(this.subProperties, this.level, true, true)
+          : this.subColumnSelectConfig;
+        for ( var  i = 0 ; i < subs.length ; i++ ) {
+          if ( subs[i].updateOnSearch(query, selfMatch || parentMatched) ) {
             this.expanded = true;
             this.showOnSearch = true;
           }
         }
+        // Reassign after expanded is settled so the rendered children are the
+        // same instances we just scored, overriding any expression recompute.
+        this.subColumnSelectConfig = subs;
       }
       return this.showOnSearch;
     },

--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -912,17 +912,18 @@ foam.CLASS({
       }
       return [this.rootProperty[0]];
     },
-    function updateOnSearch(query) {
+    function updateOnSearch(query, parentMatched) {
       this.showOnSearch = false;
       this.expanded = false;
       if ( query.length == 0 ) { this.showOnSearch = true; this.expanded = false; return this.showOnSearch; }
-      this.showOnSearch = foam.Array.isInstance(this.rootProperty) ? this.rootProperty[1].toLowerCase().includes(query) : this.rootProperty.name.toLowerCase().includes(query);
+      var selfMatch = foam.Array.isInstance(this.rootProperty) ? this.rootProperty[1].toLowerCase().includes(query) : this.rootProperty.name.toLowerCase().includes(query);
+      this.showOnSearch = selfMatch || !! parentMatched;
       if ( this.hasSubProperties && this.level < 2 ) {
         this.expanded = false;
         if ( this.subColumnSelectConfig.length == 0 )
           this.subColumnSelectConfig = this.returnSubColumnSelectConfig(this.subProperties, this.level, this.expanded, true);
         for ( var  i = 0 ; i < this.subColumnSelectConfig.length ; i++ ) {
-          if ( this.subColumnSelectConfig[i].updateOnSearch(query) ) {
+          if ( this.subColumnSelectConfig[i].updateOnSearch(query, selfMatch || parentMatched) ) {
             this.expanded = true;
             this.showOnSearch = true;
           }


### PR DESCRIPTION
Noticed two issues searching in the column-config dropdown:

- A query matching a parent column hid all of its sub-columns. Each node matched only against its own header and never inherited a match from its parent, so searching a parent name surfaced the parent with nothing under it.

- A query matching a sub-column left every non-matching sibling visible. subColumnSelectConfig is an expression keyed on expanded, and setting expanded inside the match loop regenerated the child objects with their default showOnSearch=true — discarding the per-child results already computed. Every sibling ahead of the matching one stayed shown.

Fix:

- cascade a matched node's result to its descendants, so a parent match expands and shows its children

- snapshot the children into a local before scoring and reassign once after expanded settles, so the rendered instances are the ones just scored