### PR TITLE
FObject copy from verbose - comment out debug log

### DIFF
--- a/src/foam/lang/FObject.java
+++ b/src/foam/lang/FObject.java
@@ -310,7 +310,7 @@ public interface FObject
           }
         }
       } catch (ClassCastException ignore) {
-        StdoutLogger.instance().debug("FObject.copyFrom", p.getName(), p, p2, obj, ignore.getMessage());
+        // StdoutLogger.instance().debug("FObject.copyFrom", p.getName(), p, p2, obj, ignore.getMessage());
       }
     }
     return this;


### PR DESCRIPTION
FObject copy from verbose - comment out debug log - too verbose, and potentially exposes PII.  Enable during development. 