### PR TITLE
On service invocation record initialization and replay status and info

### DIFF
--- a/src/foam/core/boot/Boot.java
+++ b/src/foam/core/boot/Boot.java
@@ -79,6 +79,11 @@ public class Boot {
     var subContexts = new HashSet<String>();
     for ( int i = 0 ; i < l.size() ; i++ ) {
       CSpec sp = (CSpec) l.get(i);
+      sp = (CSpec) sp.fclone();
+      sp.setX(root_);
+      sp.setCSpecDAO(mdao);
+      sp = (CSpec) mdao.put_(root_, sp);
+
       if ( ! sp.getEnabled() ) {
         logger.info("Disabled", sp.getName());
         continue;
@@ -121,14 +126,6 @@ public class Boot {
         root_.putFactory(sp.getName(), factory);
     }
 
-    serviceDAO_.listen(new AbstractSink() {
-      @Override
-      public void put(Object obj, Detachable sub) {
-        CSpec sp = (CSpec) obj;
-        factories_.get(sp.getName()).invalidate(sp);
-      }
-    }, null);
-
     new ShutdownHook(root_, factories_);
 
     // Use an XFactory so that the root context can contain itself.
@@ -167,7 +164,7 @@ public class Boot {
     // Export the ServiceDAO
     ((ProxyDAO) root_.get("cSpecDAO")).setDelegate(
       new foam.core.auth.AuthorizationDAO.Builder(getX())
-        .setDelegate(serviceDAO_)
+        .setDelegate(mdao)
         .setAuthorizer(new foam.core.auth.AuthorizableAuthorizer("service"))
         .build());
 
@@ -209,18 +206,32 @@ public class Boot {
       public void put(Object obj, Detachable sub) {
         CSpec sp = (CSpec) obj;
         if ( agency == null ) {
-          logger.info("Invoking Service", sp.getName());
+          // logger.info("Invoking Service", cs.getName());
+          sp.updateStatus("Invoking");
           root_.get(sp.getName());
         } else {
           agency.submit(root_, new ContextAgent() {
               public void execute(X x) {
-                logger.info("Invoking Service", sp.getName());
+                // logger.info("Invoking Service", sp.getName());
+                sp.updateStatus("Invoking");
                 x.get(sp.getName());
               }
             }, sp.getName());
         }
       }
     });
+
+    // setup last to reduce invalidation during startup updateStatus calls.
+    serviceDAO_.listen(new AbstractSink() {
+      @Override
+      public void put(Object obj, Detachable sub) {
+        CSpec sp = (CSpec) obj;
+        if ( SafetyUtil.isEmpty(sp.getThreadName()) ||
+             ! sp.getThreadName().equals(Thread.currentThread().getName()) ) {
+          factories_.get(sp.getName()).invalidate(sp);
+        }
+      }
+    }, null);
   }
 
   protected List perfectList(List src) {

--- a/src/foam/core/boot/Boot.java
+++ b/src/foam/core/boot/Boot.java
@@ -206,13 +206,11 @@ public class Boot {
       public void put(Object obj, Detachable sub) {
         CSpec sp = (CSpec) obj;
         if ( agency == null ) {
-          // logger.info("Invoking Service", cs.getName());
           sp.updateStatus("Invoking");
           root_.get(sp.getName());
         } else {
           agency.submit(root_, new ContextAgent() {
               public void execute(X x) {
-                // logger.info("Invoking Service", sp.getName());
                 sp.updateStatus("Invoking");
                 x.get(sp.getName());
               }

--- a/src/foam/core/boot/Boot.java
+++ b/src/foam/core/boot/Boot.java
@@ -164,7 +164,7 @@ public class Boot {
     // Export the ServiceDAO
     ((ProxyDAO) root_.get("cSpecDAO")).setDelegate(
       new foam.core.auth.AuthorizationDAO.Builder(getX())
-        .setDelegate(mdao)
+        .setDelegate(serviceDAO_)
         .setAuthorizer(new foam.core.auth.AuthorizableAuthorizer("service"))
         .build());
 

--- a/src/foam/core/boot/CSpec.js
+++ b/src/foam/core/boot/CSpec.js
@@ -266,7 +266,12 @@ foam.CLASS({
     {
       class: 'String',
       name: 'message',
-      storageTransient: true
+      storageTransient: true,
+      view: {
+        class: 'foam.u2.view.ModeAltView',
+        writeView: { class: 'foam.u2.tag.TextArea', rows: 12, cols: 140 },
+        readView:  { class: 'foam.u2.view.PreView' }
+      },
     },
     {
       class: 'foam.dao.DAOProperty',
@@ -451,12 +456,9 @@ foam.CLASS({
               cs = (CSpec) cs.fclone();
               CSpecStatus oldStatus = cs.getStatus();
               cs.setStatus(status);
-
-              // REVIEW: on transition to READY, leave last message
-              // to retain possible replay info - best effort for now.
-              if ( status != CSpecStatus.READY )
-                cs.setMessage(msgSb.toString());
-
+              if ( ! SafetyUtil.isEmpty(cs.getMessage()) )
+                cs.setMessage(cs.getMessage() + "\\n");
+              cs.setMessage(cs.getMessage() + msgSb.toString());
               cs.setThreadName(Thread.currentThread().getName());
               if ( cs.getStatus() == CSpecStatus.INITIAL )
                 cs.setStatus(CSpecStatus.INITIALIZING);

--- a/src/foam/core/boot/CSpec.js
+++ b/src/foam/core/boot/CSpec.js
@@ -15,9 +15,9 @@ foam.CLASS({
 
   constants: [
     {
-      name: 'NSPEC_CTX_KEY',
+      name: 'CSPEC_CTX_KEY',
       type: 'String',
-      value: 'NSPEC_CTX_KEY',
+      value: 'CSPEC_CTX_KEY',
       documentation: 'Constant for addressing the CSpec through the context'
     }
   ],
@@ -35,15 +35,15 @@ foam.CLASS({
   ],
 
   javaImports: [
-    'java.io.IOException',
-    'java.io.PrintStream',
-
-    'foam.lang.X',
     'foam.core.auth.AuthService',
     'foam.core.auth.AuthorizationException',
     'foam.core.script.BeanShellExecutor',
     'foam.core.script.JShellExecutor',
-    'foam.core.script.Language'
+    'foam.core.script.Language',
+    'foam.lang.X',
+    'foam.util.SafetyUtil',
+    'java.io.IOException',
+    'java.io.PrintStream'
   ],
 
   axioms: [
@@ -95,7 +95,23 @@ foam.CLASS({
 
   ids: [ 'name' ],
 
-  tableColumns: [ 'name', 'lazy', 'serve', 'authenticate', /*'serviceClass',*/ 'configure' ],
+  tableColumns: [
+    'name',
+    'lazy',
+    'serve',
+    'authenticate',
+    /*'serviceClass',*/
+    'configure',
+    'status',
+    'message'
+  ],
+
+  searchColumns: [
+    'lazy',
+    'serve',
+    'authenticate',
+    'status'
+  ],
 
   properties: [
     {
@@ -240,6 +256,31 @@ foam.CLASS({
       transient: true,
       javaGetter: 'return getName();',
       getter: function() { return this.name; }
+    },
+    {
+      class: 'Enum',
+      of: 'foam.core.boot.CSpecStatus',
+      name: 'status',
+      storageTransient: true
+    },
+    {
+      class: 'String',
+      name: 'message',
+      storageTransient: true
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'cSpecDAO',
+      storageTransient: true,
+      hidden: true,
+      visibility: 'HIDDEN'
+    },
+    {
+      class: 'String',
+      name: 'threadName',
+      storageTransient: true,
+      hidden: true,
+      visibility: 'HIDDEN'
     }
     // TODO: permissions, parent
   ],
@@ -352,6 +393,81 @@ foam.CLASS({
           ((foam.core.logger.Logger) x.get("logger")).debug("AuthorizableAuthorizer", "Permission denied.", permission);
           throw new AuthorizationException("Permission denied: Cannot delete this CSpec.");
         }
+      `
+    },
+    {
+      name: 'updateStatus',
+      args: 'Object... vargs',
+      javaCode: `
+        foam.core.logger.Logger logger = foam.core.logger.StdoutLogger.instance();
+        Throwable t = null;
+        CSpecStatus status = null;
+        StringBuilder sb = new StringBuilder();
+        StringBuilder msgSb = new StringBuilder();
+        for ( Object o : vargs ) {
+          if ( o == null )
+            continue;
+          if ( o instanceof CSpecStatus )
+            status = (CSpecStatus) o;
+          else if ( o instanceof Throwable )
+            t = (Throwable) o;
+          else {
+            if ( sb.length() == 0 ) {
+              // Existing log output format
+              sb.append(o.toString());
+              sb.append(" Service,");
+              sb.append(getName());
+            } else {
+              sb.append(",");
+              sb.append(o.toString());
+              if ( msgSb.length() > 0 )
+                msgSb.append(",");
+              msgSb.append(o.toString());
+            }
+          }
+        }
+        if ( t != null ) {
+          if ( sb.length() > 0)
+            sb.append(",");
+          sb.append(t.getMessage());
+          if ( msgSb.length() > 0)
+            msgSb.append(",");
+          msgSb.append(t.getMessage());
+          status = CSpecStatus.ERROR;
+        }
+
+        if ( ! "cSpecDAO".equals(getId()) &&
+             ! "logger".equals(getId()) &&
+             ! "PM".equals(getId()) ) {
+          X x = getX();
+          foam.dao.DAO cSpecDAO = getCSpecDAO();
+          if ( cSpecDAO == null ) {
+            logger.debug("CSPec.updateStatus,cSpecDAO not found,cSpec", getId());
+          } else {
+            CSpec cs = (CSpec) cSpecDAO.find_(x, getId());
+            if ( cs == null ) {
+              logger.debug("CSPec.updateStatus,CSpec not found", getId());
+            } else {
+              cs = (CSpec) cs.fclone();
+              CSpecStatus oldStatus = cs.getStatus();
+              cs.setStatus(status);
+
+              // REVIEW: on transition to READY, leave last message
+              // to retain possible replay info - best effort for now.
+              if ( status != CSpecStatus.READY )
+                cs.setMessage(msgSb.toString());
+
+              cs.setThreadName(Thread.currentThread().getName());
+              if ( cs.getStatus() == CSpecStatus.INITIAL )
+                cs.setStatus(CSpecStatus.INITIALIZING);
+              cs = (CSpec) cSpecDAO.put_(x, cs);
+            }
+          }
+        }
+        if ( t == null )
+          logger.info(sb.toString());
+        else
+          logger.error(sb.toString(), t);
       `
     }
   ],

--- a/src/foam/core/boot/CSpecFactory.java
+++ b/src/foam/core/boot/CSpecFactory.java
@@ -148,10 +148,8 @@ public class CSpecFactory
           ns = null;
         }
       }
-      // logger.info("Initialized Service", spec_.getName(), ns_ != null ? ns_.getClass().getSimpleName() : "null");
       spec_.updateStatus(CSpecStatus.READY, "Initialized", (ns_ != null && ! ( ns_ instanceof ProxyDAO)) ? ns_.getClass().getSimpleName() : null);
     } catch (Throwable t) {
-      // logger.error("Error Initializing Service", spec_.getName(), t);
       spec_.updateStatus("Initializing", t);
     }
   }
@@ -183,7 +181,6 @@ public class CSpecFactory
     if ( logger == null ) {
       logger = StdoutLogger.instance();
     }
-    // logger.warning("Invalidating Service", spec.getName());
     spec.updateStatus("Invalidating");
     if ( ! SafetyUtil.equals(spec.getService(), spec_.getService())
       || ! SafetyUtil.equals(spec.getServiceClass(), spec_.getServiceClass())
@@ -191,14 +188,11 @@ public class CSpecFactory
     ) {
       if ( ns_ instanceof COREService ) {
         spec_ = spec;
-        // logger.warning("Reloading Service", spec_.getName());
         spec_.updateStatus(CSpecStatus.INITIALIZING, "Reloading");
         try {
           ((COREService) ns_).reload();
-          // logger.info("Reloaded Service", spec_.getName());
           spec_.updateStatus(CSpecStatus.READY, "Reloaded");
         } catch (Throwable t) {
-          // logger.error("Reloading Service", spec_.getName(), t.getMessage(), t);
           spec_.updateStatus("Reloading", t.getMessage(), t);
         }
       } else if ( ns_ instanceof DAO ) {
@@ -210,14 +204,12 @@ public class CSpecFactory
           ((ProxyDAO) ns_).setDelegate(null);
         } else {
           // Clustered MDAOs are not reloadable as replay is handled by medusa.
-          // logger.info("Invalidation of Clustered MDAOs not supported", spec_.getName());
           spec_.updateStatus("Reloading", "Invalidation of Clustered MDAOs not supported");
         }
       } else {
         ns_ = null;
         spec_ = spec;
         if ( ! spec_.getLazy() ) {
-          // logger.info("Invalidate create non-Lazy Service", spec_.getName());
           spec_.updateStatus("Invalidate", "create non-lazy Service");
           create(x_);
         }

--- a/src/foam/core/boot/CSpecFactory.java
+++ b/src/foam/core/boot/CSpecFactory.java
@@ -74,15 +74,20 @@ public class CSpecFactory
     }
 
     try {
-      logger.info("Creating Service", spec_.getName());
-      var service = spec_.createService(nx.put(CSpec.class, spec_).put("logger", logger), null);
+      // logger.info("Creating Service", spec_.getName());
+      spec_.updateStatus("Creating");
+      var service = spec_.createService(nx.put(CSpec.class, spec_).put("logger", logger).put(CSpec.CSPEC_CTX_KEY, spec_), null);
       if (service == null) {
-        throw new RuntimeException("createService returned null");
+        RuntimeException t = new RuntimeException("createService returned null");
+        spec_.updateStatus("Creating", "returned null", t);
+        throw t;
       }
       setCoreService(service);
-      logger.info("Created Service", spec_.getName());
+      // logger.info("Created Service", spec_.getName());
+      spec_.updateStatus("Created");
     } catch (Throwable t) {
-      logger.error("Error Creating Service", spec_.getName(), t);
+      // logger.error("Error Creating Service", spec_.getName(), t);
+      spec_.updateStatus("Creating", t);
     } finally {
       pm.log(nx);
       creatingThread_ = null;
@@ -116,17 +121,20 @@ public class CSpecFactory
                ! spec_.getLazy() /* already in agency */ ||
                spec_.getName().toLowerCase().contains("pool") ||
                spec_.getClass().getName().toLowerCase().contains("agency") ) {
-            logger.info("Starting Service", spec_.getName(), ns.getClass().getName());
+            // logger.info("Starting Service", spec_.getName(), ns.getClass().getName());
+            spec_.updateStatus("Starting", ns.getClass().getName());
             ((COREService) ns).start();
           } else {
             final COREService cs = (COREService) ns;
             agency.submit(nx, new ContextAgent() {
               public void execute(X x) {
                 StdoutLogger.instance().info("Starting Service", spec_.getName(), cs.getClass().getName());
+                spec_.updateStatus("Starting", cs.getClass().getName());
                 try {
                   cs.start();
                 } catch (Throwable t) {
                   StdoutLogger.instance().error("Error Starting Service", spec_.getName(), t);
+                  spec_.updateStatus("Starting", cs.getClass().getName(), t);
                 }
               }
             }, spec_.getName());
@@ -140,9 +148,11 @@ public class CSpecFactory
           ns = null;
         }
       }
-      logger.info("Initialized Service", spec_.getName(), ns_ != null ? ns_.getClass().getSimpleName() : "null");
+      // logger.info("Initialized Service", spec_.getName(), ns_ != null ? ns_.getClass().getSimpleName() : "null");
+      spec_.updateStatus(CSpecStatus.READY, "Initialized", ns_ != null ? ns_.getClass().getSimpleName() : "");
     } catch (Throwable t) {
-      logger.error("Error Initializing Service", spec_.getName(), t);
+      // logger.error("Error Initializing Service", spec_.getName(), t);
+      spec_.updateStatus("Initializing", t);
     }
   }
 
@@ -173,19 +183,23 @@ public class CSpecFactory
     if ( logger == null ) {
       logger = StdoutLogger.instance();
     }
-    logger.warning("Invalidating Service", spec.getName());
+    // logger.warning("Invalidating Service", spec.getName());
+    spec.updateStatus("Invalidating");
     if ( ! SafetyUtil.equals(spec.getService(), spec_.getService())
       || ! SafetyUtil.equals(spec.getServiceClass(), spec_.getServiceClass())
       || ! SafetyUtil.equals(spec.getServiceScript(), spec_.getServiceScript())
     ) {
       if ( ns_ instanceof COREService ) {
         spec_ = spec;
-        logger.warning("Reloading Service", spec_.getName());
+        // logger.warning("Reloading Service", spec_.getName());
+        spec_.updateStatus(CSpecStatus.INITIALIZING, "Reloading");
         try {
           ((COREService) ns_).reload();
-          logger.info("Reloaded Service", spec_.getName());
+          // logger.info("Reloaded Service", spec_.getName());
+          spec_.updateStatus(CSpecStatus.READY, "Reloaded");
         } catch (Throwable t) {
-          logger.error("Reloading Service", spec_.getName(), t.getMessage(), t);
+          // logger.error("Reloading Service", spec_.getName(), t.getMessage(), t);
+          spec_.updateStatus("Reloading", t.getMessage(), t);
         }
       } else if ( ns_ instanceof DAO ) {
         boolean cluster = "true".equals(System.getProperty("CLUSTER", "false"));
@@ -196,13 +210,15 @@ public class CSpecFactory
           ((ProxyDAO) ns_).setDelegate(null);
         } else {
           // Clustered MDAOs are not reloadable as replay is handled by medusa.
-          logger.info("Invalidation of Clustered MDAOs not supported", spec_.getName());
+          // logger.info("Invalidation of Clustered MDAOs not supported", spec_.getName());
+          spec_.updateStatus("Reloading", "Invalidation of Clustered MDAOs not supported");
         }
       } else {
         ns_ = null;
         spec_ = spec;
         if ( ! spec_.getLazy() ) {
-          logger.info("Invalidate create non-Lazy Service", spec_.getName());
+          // logger.info("Invalidate create non-Lazy Service", spec_.getName());
+          spec_.updateStatus("Invalidate", "create non-lazy Service");
           create(x_);
         }
       }

--- a/src/foam/core/boot/CSpecFactory.java
+++ b/src/foam/core/boot/CSpecFactory.java
@@ -149,7 +149,7 @@ public class CSpecFactory
         }
       }
       // logger.info("Initialized Service", spec_.getName(), ns_ != null ? ns_.getClass().getSimpleName() : "null");
-      spec_.updateStatus(CSpecStatus.READY, "Initialized", ns_ != null ? ns_.getClass().getSimpleName() : "");
+      spec_.updateStatus(CSpecStatus.READY, "Initialized", (ns_ != null && ! ( ns_ instanceof ProxyDAO)) ? ns_.getClass().getSimpleName() : null);
     } catch (Throwable t) {
       // logger.error("Error Initializing Service", spec_.getName(), t);
       spec_.updateStatus("Initializing", t);

--- a/src/foam/core/boot/CSpecStatus.js
+++ b/src/foam/core/boot/CSpecStatus.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.core.boot',
+  name: 'CSpecStatus',
+
+  values: [
+    {
+      name: 'INITIAL',
+      label: 'Initial',
+      color: '$textSecondary',
+      background: '$backgroundSecondary',
+      borderColor: '$textSecondary',
+    },
+    {
+      name: 'INITIALIZING',
+      label: 'Initializing',
+      color: '$yellow700',
+      background: '$yellow100',
+      borderColor: '$yellow700'
+    },
+    {
+      name: 'REPLAYING',
+      label: 'Replaying',
+      color: '$blue500',
+      background: '$blue50',
+      borderColor: '$blue500'
+    },
+    {
+      name: 'READY',
+      label: 'Ready',
+      color: '$green600',
+      background: '$green50',
+      borderColor: '$green600'
+    },
+    {
+      name: 'ERROR',
+      label: 'Error',
+      color: '$red600',
+      background: '$red50',
+      borderColor: '$red600'
+    }
+  ]
+});

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -120,6 +120,7 @@ foam.POM({
     { name: "benchmark/AuthorizerBenchmark",                                              flags: "js&test|java&test" },
     { name: "boot/CSpec",                                                                 flags: "js|java" },
     { name: "boot/CSpecAware",                                                            flags: "js|java" },
+    { name: "boot/CSpecStatus",                                                           flags: "js|java" },
     // { name: "boot/CSpecCitationView",                                                     flags: "js" },
     { name: "boot/DataManagement",                                                        flags: "web" },
     { name: "boot/DAOCSpecMenu",                                                          flags: "js|java" },

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -187,7 +187,7 @@ foam.CLASS({
             }
             // hook for NDiff-related stuff downstream
             // code in JDAO.js is looking for cSpecName set in a subX
-            delegate = getJournalDelegate(getX().put(foam.core.boot.CSpec.NSPEC_CTX_KEY, getCSpec()), delegate);
+            delegate = getJournalDelegate(getX().put(foam.core.boot.CSpec.CSPEC_CTX_KEY, getCSpec()), delegate);
           }
         }
 

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -15,9 +15,11 @@ foam.CLASS({
   ],
 
   javaImports: [
+    'foam.core.boot.CSpec',
+    'foam.core.boot.CSpecStatus',
+    'foam.core.pm.PM',
     'foam.lang.FObject',
     'foam.lib.json.JSONParser',
-    'foam.core.pm.PM',
     'foam.util.concurrent.AbstractAssembly',
     'foam.util.concurrent.AssemblyLine',
     'foam.util.SafetyUtil',
@@ -62,7 +64,11 @@ foam.CLASS({
 
         String lastVersion = "";
 
-        getLogger().info("Replay starting");
+        CSpec cspec = (CSpec)getX().get(CSpec.CSPEC_CTX_KEY);
+        if ( cspec != null )
+          cspec.updateStatus(CSpecStatus.REPLAYING, "Replay", "start", getFilename());
+        else
+          getLogger().info("Replay starting");
 
         // Pre-compute the parser X context once per replay. When the target
         // ClassInfo has no backing Java class (getObjClass() is null), thread
@@ -85,6 +91,7 @@ foam.CLASS({
           new foam.util.concurrent.SyncAssemblyLine() :
           new foam.util.concurrent.BatchingAssemblyLine(new foam.util.concurrent.SimpleAsyncAssemblyLine(x, "replay")) ;
 
+        boolean threw = false;
         try ( BufferedReader reader = getReader() ) {
           if ( reader == null ) {
             return;
@@ -142,7 +149,11 @@ foam.CLASS({
                   long pass = passCount.incrementAndGet();
                   // Provide some feedback on long running replays
                   if ( pass % 100000 == 0 ) {
-                    getLogger().info("Replay progress", "processed", pass, "in", Duration.ofMillis(pm.getTime()));
+                    String msg = String.format("progress,%1$s,processed,%2$d,in,%3$s", getFilename(), pass, Duration.ofMillis(pm.getTime()));
+                    if ( cspec != null )
+                      cspec.updateStatus(CSpecStatus.REPLAYING, "Replay", msg);
+                    else
+                      getLogger().info("Replay", msg);
                     if ( Thread.currentThread().isInterrupted() ) {
                       getLogger().info("Replay interrupted");
                       return;
@@ -156,18 +167,30 @@ foam.CLASS({
               getLogger().error("Error replaying journal", dao.getOf().getId(), entry, t);
             }
           }
+
         } catch ( Throwable t) {
-          getLogger().error("Failed to read journal", dao.getOf().getId(), t);
+          threw = true;
+          if ( cspec != null )
+            cspec.updateStatus(CSpecStatus.REPLAYING, "Replay", getFilename(), "Failed to read journal", dao.getOf().getId(), t);
+          else
+            getLogger().error("Failed to read journal", dao.getOf().getId(), t);
         } finally {
-          setLastReplayVersion(lastVersion);
-          setPassCount(passCount.get());
-          setFailCount(failCount.get());
           assemblyLine.shutdown();
           pm.log(x);
-          if ( getFailCount() == 0 ) {
-            getLogger().info("Replay complete", "processed", passCount.get(), "of", failCount.get()+passCount.get(), "in", Duration.ofMillis(pm.getTime()));
-          } else {
-            getLogger().warning("Replay complete", "processed", passCount.get(), "of", failCount.get()+passCount.get(), "in", Duration.ofMillis(pm.getTime()));
+          setLastReplayVersion(lastVersion);
+          if ( threw )
+            return;
+          setPassCount(passCount.get());
+          setFailCount(failCount.get());
+          String msg = String.format("complete,%1$s,processed,%2$d,of,%3$d,in,%4$s", getFilename(), passCount.get(), failCount.get()+passCount.get(), Duration.ofMillis(pm.getTime()));
+          if ( cspec != null )
+            cspec.updateStatus(CSpecStatus.REPLAYING, "Replay", msg);
+          else {
+            if ( getFailCount() == 0 ) {
+              getLogger().info("Replay", msg);
+            } else {
+              getLogger().warning("Replay", msg);
+            }
           }
         }
       `

--- a/src/foam/dao/java/JDAO.js
+++ b/src/foam/dao/java/JDAO.js
@@ -141,7 +141,7 @@ In this current implementation setDelegate must be called last.`,
 
             // if CSpec present in X then go through NDiff
             // (set up in EasyDAO's decorator chain)
-            CSpec nspec = (CSpec)getX().get(CSpec.NSPEC_CTX_KEY);
+            CSpec nspec = (CSpec)getX().get(CSpec.CSPEC_CTX_KEY);
 
             String cSpecName = getFilename();
 


### PR DESCRIPTION
Add CSpecStatus to track service state; INITIALIZATION during service setup and REPLAYING during replay.
Service.message records activity during init or replay, such as the replay statistics on completion.
When initialization and replay are complete, status becomes READY. Intented for both human inspection, and programatic check on DAO readiness.

<img width="1467" height="98" alt="Screenshot 2026-06-26 at 9 04 26 AM" src="https://github.com/user-attachments/assets/69269050-47ec-4077-91ed-1d5bb27077f6" />

<img width="489" height="224" alt="Screenshot 2026-06-26 at 9 03 52 AM" src="https://github.com/user-attachments/assets/2d1e363d-5518-4a19-9616-61f3a8cfd98a" />

<img width="1170" height="130" alt="Screenshot 2026-06-26 at 8 28 34 AM" src="https://github.com/user-attachments/assets/ed674ca6-b99f-42a0-95c7-ef88a2a8e91c" />
