### PR TITLE
PT-FIXES:DOS-3982 Add resolveKeyStore to KeyStoreAware for vaulted keystores

### DIFF
--- a/src/foam/box/socket/SslContextFactory.js
+++ b/src/foam/box/socket/SslContextFactory.js
@@ -167,14 +167,18 @@ foam.CLASS({
       javaCode: `
         KeyStore keyStore = null;
         try {
-          InputStream is = getStorage().getInputStream(storePath);
-          if ( is == null ) {
-            throw new IOException("Failed opening inputstream "+storePath);
-          }
+          if ( ! foam.util.SafetyUtil.isEmpty(getVault()) ) {
+            keyStore = resolveKeyStore(getX(), storePath, getStoreType(), storePass);
+          } else {
+            InputStream is = getStorage().getInputStream(storePath);
+            if ( is == null ) {
+              throw new IOException("Failed opening inputstream "+storePath);
+            }
 
-          keyStore = KeyStore.getInstance(getStoreType());
-          keyStore.load(is, storePass == null ? null : storePass.toCharArray());
-          is.close();
+            keyStore = KeyStore.getInstance(getStoreType());
+            keyStore.load(is, storePass == null ? null : storePass.toCharArray());
+            is.close();
+          }
         } catch ( KeyStoreException e ) {
           getLogger().error(e);
           throw new RuntimeException(e);
@@ -188,6 +192,9 @@ foam.CLASS({
           getLogger().error(e);
           throw new RuntimeException(e);
         } catch ( IOException e ) {
+          getLogger().error(e);
+          throw new RuntimeException(e);
+        } catch ( Exception e ) {
           getLogger().error(e);
           throw new RuntimeException(e);
         }

--- a/src/foam/core/security/KeyStoreAware.js
+++ b/src/foam/core/security/KeyStoreAware.js
@@ -122,17 +122,21 @@ foam.INTERFACE({
       args: 'Context x, String keyStoreAlias, String storeType, String passphrase',
       javaThrows: ['Exception'],
       documentation: `
-        Materializes a KeyStore from a vault-stored, base64-encoded keystore
-        binary. The value at keyStoreAlias is fetched via resolveSecret, base64
-        decoded, and loaded as a KeyStore of the given type using passphrase
-        (already resolved by the caller). Only call when a vault is configured.
+        Materializes a KeyStore from a base64-encoded keystore binary. The value
+        at keyStoreAlias is resolved via resolveSecret — from the vault when one
+        is configured, otherwise the literal value — then base64-decoded and
+        loaded as a KeyStore of storeType using passphrase (already resolved by
+        the caller). The resolved value must be a base64-encoded keystore; a
+        plain, non-base64 value will fail to decode.
       `,
       javaCode: `
     String b64 = resolveSecret(x, keyStoreAlias);
     if ( foam.util.SafetyUtil.isEmpty(b64) ) {
       throw new RuntimeException("Empty keystore secret for alias: " + keyStoreAlias);
     }
-    byte[] der = java.util.Base64.getDecoder().decode(b64);
+    // MIME decoder tolerates line-wrapped base64 (openssl base64, GNU base64 without -w0);
+    // truly corrupt bytes still fail loudly at KeyStore.load below.
+    byte[] der = java.util.Base64.getMimeDecoder().decode(b64);
     java.security.KeyStore ks = java.security.KeyStore.getInstance(storeType);
     ks.load(new java.io.ByteArrayInputStream(der),
             passphrase == null ? null : passphrase.toCharArray());

--- a/src/foam/core/security/KeyStoreAware.js
+++ b/src/foam/core/security/KeyStoreAware.js
@@ -115,6 +115,29 @@ foam.INTERFACE({
     }
     return secretId;
 `
+    },
+    {
+      name: 'resolveKeyStore',
+      type: 'java.security.KeyStore',
+      args: 'Context x, String keyStoreAlias, String storeType, String passphrase',
+      javaThrows: ['Exception'],
+      documentation: `
+        Materializes a KeyStore from a vault-stored, base64-encoded keystore
+        binary. The value at keyStoreAlias is fetched via resolveSecret, base64
+        decoded, and loaded as a KeyStore of the given type using passphrase
+        (already resolved by the caller). Only call when a vault is configured.
+      `,
+      javaCode: `
+    String b64 = resolveSecret(x, keyStoreAlias);
+    if ( foam.util.SafetyUtil.isEmpty(b64) ) {
+      throw new RuntimeException("Empty keystore secret for alias: " + keyStoreAlias);
+    }
+    byte[] der = java.util.Base64.getDecoder().decode(b64);
+    java.security.KeyStore ks = java.security.KeyStore.getInstance(storeType);
+    ks.load(new java.io.ByteArrayInputStream(der),
+            passphrase == null ? null : passphrase.toCharArray());
+    return ks;
+`
     }
   ]
 });


### PR DESCRIPTION
Adds a vault path for keystore binaries alongside the existing string-secret resolution, so a PKCS12/JKS keystore can be materialized from a vault instead of read from disk.

- **`resolveKeyStore(x, alias, type, passphrase)`** — new default method on `KeyStoreAware`, peer to `resolveSecret`: fetches a base64-encoded keystore from the configured vault, decodes it, and loads an in-memory `KeyStore`. The stored value is a base64 string, so it works for any `KeyStoreManager` backend.

- **`SslContextFactory.getKeystore`** — when a vault is configured, materializes the key and trust stores from the vault; with no vault set, the existing file-load path is unchanged.

Opt-in per object: with no vault configured, behavior is identical to before.