### PR TITLE
PT-FIXES:DOS-4048 Apply getOuterDAO in the JS client delegateFactory

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -1284,9 +1284,6 @@ dao loading, which improves overall startup time.`,
         });
       }
 
-      // Apply user-specific outer decorators (mirrors the Java delegate
-      // factory). On the client this is where program-aware DAOs get wrapped
-      // in ProgramAwareDAO so they scope and purge on program switch.
       return this.getOuterDAO(dao);
     },
 

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -1042,6 +1042,9 @@ dao loading, which improves overall startup time.`,
           name: 'innerDAO'
         }
       ],
+      code: function(innerDAO) {
+        return innerDAO;
+      },
       javaCode: `
         return innerDAO;
       `
@@ -1281,7 +1284,10 @@ dao loading, which improves overall startup time.`,
         });
       }
 
-      return dao;
+      // Apply user-specific outer decorators (mirrors the Java delegate
+      // factory). On the client this is where program-aware DAOs get wrapped
+      // in ProgramAwareDAO so they scope and purge on program switch.
+      return this.getOuterDAO(dao);
     },
 
     /** Only relevant if using postgresdao */


### PR DESCRIPTION
The Java delegate factory wraps the built DAO through getOuterDAO so an app can add its own outer decorators. The JS delegateFactory never called it, so client builds skipped those decorators while server builds got them.

- **Call** getOuterDAO at the end of the JS delegateFactory, matching the Java factory
- **Add** a JS no-op getOuterDAO on the base so the hook is callable in JS and refinements can override it