### PR TITLE
PT-FIXES:DOS-4048 fix(ClientBuilder): apply CACHE_TIMEOUT ttl to client EasyDAOs

### DIFF
--- a/src/foam/core/client/ClientBuilder.js
+++ b/src/foam/core/client/ClientBuilder.js
@@ -208,8 +208,8 @@ foam.CLASS({
                         };
                         if ( cls === foam.dao.EasyDAO ) {
                           defaults.cache              = true;
-                          defaults.ttlSelectPurgeTime = this.CACHE_TIMEOUT; // for select()
-                          defaults.ttlPurgeTime       = this.CACHE_TIMEOUT; // for find()
+                          defaults.ttlSelectPurgeTime = self.CACHE_TIMEOUT; // for select()
+                          defaults.ttlPurgeTime       = self.CACHE_TIMEOUT; // for find()
                           defaults.daoType            = 'CLIENT';
                         }
                         for ( var k in defaults ) {


### PR DESCRIPTION
ClientBuilder sets the per-client DAO cache defaults inside a property factory pushed onto the generated client class. Inside that factory `this` is the client instance, but CACHE_TIMEOUT is a constant on the ClientBuilder, so `this.CACHE_TIMEOUT` resolved to undefined.

Every top-level client EasyDAO then got `cache: true` with `ttlSelectPurgeTime`/`ttlPurgeTime` undefined — a "Unable to parse property" warn at parse time, and a full-warm cache instead of the intended timed one.

Fix:

- read the timeout off the captured builder (`self.CACHE_TIMEOUT`) so the select/find TTL actually applies