### PR TITLE
PT-FIXES:DOS-4051 Fix date tooltip showing "foam.lang.ExpressionSlot"

### DIFF
--- a/src/foam/u2/view/RODateTimeView.js
+++ b/src/foam/u2/view/RODateTimeView.js
@@ -34,7 +34,7 @@ foam.CLASS({
       this.SUPER();
       var self = this;
       this.start('div', {
-          tooltip: this.data$.map(d => d ? new Date(d).toLocaleString(foam.util.getClientLocale(), {
+          tooltip$: this.data$.map(d => d ? new Date(d).toLocaleString(foam.util.getClientLocale(), {
             day: 'numeric',
             month: 'long',
             year: 'numeric',

--- a/src/foam/u2/view/date/RODateView.js
+++ b/src/foam/u2/view/date/RODateView.js
@@ -15,7 +15,7 @@ foam.CLASS({
     function render() {
       this.SUPER();
       this.start('div', {
-          tooltip: this.data$.map(d => d ? d.toLocaleDateString(foam.util.getClientLocale(), {
+          tooltip$: this.data$.map(d => d ? d.toLocaleDateString(foam.util.getClientLocale(), {
             day: 'numeric',
             month: 'long',
             year: 'numeric'


### PR DESCRIPTION
The read-only date views passed the tooltip a Slot (`this.data$.map(...)`) under the plain `tooltip:` init key. `tooltip` is a String property on Element, so `create({tooltip: slot})` assigns the Slot literally and its `toString()` — "foam.lang.ExpressionSlot" — becomes the tooltip text.

The element body rendered the date fine because `add()` accepts Slots; the `tooltip:` init key does not — it sets the property value directly.

Fix:

- `tooltip:` → `tooltip$:` in `RODateTimeView` and `RODateView`, so the Slot binds reactively and the tooltip shows the formatted date.

