### PR TITLE
fix: render reflow flows themed when opened directly on refresh

### DIFF
--- a/src/foam/core/controller/ApplicationController.js
+++ b/src/foam/core/controller/ApplicationController.js
@@ -512,9 +512,15 @@ foam.CLASS({
 
         // For anonymous users, we shouldn't reinstall the language
         // because the user's language setting isn't meaningful.
+        // onUserAgentAndGroupLoaded() routes to the initial menu itself; only
+        // fall back to initMenu() when that path is skipped, otherwise the route
+        // is pushed twice and the first (superseded) render poisons document-global
+        // one-shot CSS installs (e.g. reflow Layout) with an unthemed context.
         if ( self?.subject?.realUser && ! isAnonymous ) {
           await self.maybeReinstallLanguage(self.client);
           await self.onUserAgentAndGroupLoaded();
+        } else {
+          await self.initMenu();
         }
 
         self.subToNotifications();
@@ -536,8 +542,6 @@ foam.CLASS({
             return this.subject.realUser;
           }
         });
-
-        await self.initMenu();
       });
     },
 


### PR DESCRIPTION
On login, onClientLoad pushes the initial route twice: onUserAgentAndGroupLoaded() routes to the menu, then a trailing initMenu() routes again. On a reflow route the second push supersedes the first, orphaning the first Console into a nameless, service-less context — but its render() has already run.

Reflow CSS installs once per document (first writer wins), and token colors like $backgroundDefault resolve against the installing context. The orphan installs the reflow Layout <style> with raw framework defaults (dark), because its dead context has no cssTokenOverrideService. The single reloadStyles recovery pass fires when the theme cache loads — before this late install — so the orphaned style is never re-themed. The real Console reuses it. Result: reflow flows render dark when landed on directly (only the shell re-themes on other menus, so the effect is reflow-specific and visible only on a hard refresh onto a flow).

Fix:

- route once — onUserAgentAndGroupLoaded() already routes for the logged-in path; initMenu() is now the else-branch fallback, run only when that path is skipped (anonymous / early return)