### PR TITLE
PT-FIXES:DOS-3982 SslContextFactory: thread caller Context through secret resolution

### DIFF
--- a/src/foam/box/socket/SocketConnectionBoxManager.js
+++ b/src/foam/box/socket/SocketConnectionBoxManager.js
@@ -186,7 +186,7 @@ foam.CLASS({
           SslContextFactory contextFactory = (SslContextFactory) getX().get("sslContextFactory");
 
           if ( contextFactory != null && contextFactory.getEnableSSL() ) {
-            SSLContext sslContext = contextFactory.getSSLContext();
+            SSLContext sslContext = contextFactory.getSSLContext(getX());
             socket = (SSLSocket)sslContext.getSocketFactory().createSocket();
           } else {
             socket = new Socket();

--- a/src/foam/box/socket/SocketServer.js
+++ b/src/foam/box/socket/SocketServer.js
@@ -63,7 +63,7 @@ foam.CLASS({
           SslContextFactory contextFactory = (SslContextFactory) getX().get("sslContextFactory");
 
           if ( contextFactory != null && contextFactory.getEnableSSL() ) {
-            SSLServerSocket sslServerSocket = (SSLServerSocket) contextFactory.getSSLContext().getServerSocketFactory().createServerSocket(getPort());
+            SSLServerSocket sslServerSocket = (SSLServerSocket) contextFactory.getSSLContext(getX()).getServerSocketFactory().createServerSocket(getPort());
             sslServerSocket.setNeedClientAuth(true);
             serverSocket0 = sslServerSocket;
           } else {

--- a/src/foam/box/socket/SslContextFactory.js
+++ b/src/foam/box/socket/SslContextFactory.js
@@ -87,6 +87,10 @@ foam.CLASS({
       javaType: 'KeyManager[]',
       args: [
         {
+          name: 'x',
+          type: 'Context'
+        },
+        {
           name: 'storePath',
           type: 'String'
         },
@@ -101,7 +105,7 @@ foam.CLASS({
         KeyStore keyStore = null;
 
         try {
-          keyStore = getKeystore(storePath, storePass);
+          keyStore = getKeystore(x, storePath, storePass);
           factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
           factory.init(keyStore, storePass == null ? null : storePass.toCharArray());
         } catch ( UnrecoverableKeyException e ) {
@@ -123,6 +127,10 @@ foam.CLASS({
       javaType: 'TrustManager[]',
       args: [
         {
+          name: 'x',
+          type: 'Context'
+        },
+        {
           name: 'storePath',
           type: 'String'
         },
@@ -137,7 +145,7 @@ foam.CLASS({
         KeyStore keyStore = null;
 
         try {
-          keyStore = getKeystore(storePath, storePass);
+          keyStore = getKeystore(x, storePath, storePass);
           factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
           factory.init(keyStore);
         } catch ( KeyStoreException e ) {
@@ -156,6 +164,10 @@ foam.CLASS({
       javaType: 'KeyStore',
       args: [
         {
+          name: 'x',
+          type: 'Context'
+        },
+        {
           name: 'storePath',
           type: 'String'
         },
@@ -168,7 +180,7 @@ foam.CLASS({
         KeyStore keyStore = null;
         try {
           if ( ! foam.util.SafetyUtil.isEmpty(getVault()) ) {
-            keyStore = resolveKeyStore(getX(), storePath, getStoreType(), storePass);
+            keyStore = resolveKeyStore(x, storePath, getStoreType(), storePass);
           } else {
             InputStream is = getStorage().getInputStream(storePath);
             if ( is == null ) {
@@ -204,14 +216,20 @@ foam.CLASS({
     {
       name: 'getSSLContext',
       javaType: 'SSLContext',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        }
+      ],
       javaCode: `
         // getLogger().debug("getSSLContext");
         SSLContext sslContext = null;
         try {
           sslContext = SSLContext.getInstance(getProtocol());
           sslContext.init(
-            getKeyManagers(getKeyStorePath(), resolveSecret(getX(), getKeyStorePass())),
-            getTrustManagers(getTrustStorePath(), resolveSecret(getX(), getTrustStorePass())),
+            getKeyManagers(x, getKeyStorePath(), resolveSecret(x, getKeyStorePass())),
+            getTrustManagers(x, getTrustStorePath(), resolveSecret(x, getTrustStorePass())),
             null
           );
         } catch ( NoSuchAlgorithmException e ) {
@@ -229,6 +247,10 @@ foam.CLASS({
       javaType: 'SSLContext',
       args: [
         {
+          name: 'x',
+          type: 'Context'
+        },
+        {
           name: 'keyAlias',
           type: 'String'
         }
@@ -236,7 +258,7 @@ foam.CLASS({
       javaCode: `
         SSLContext sslContext = null;
         try {
-          KeyManager[] keyManagers = getKeyManagers(getKeyStorePath(), resolveSecret(getX(), getKeyStorePass()));
+          KeyManager[] keyManagers = getKeyManagers(x, getKeyStorePath(), resolveSecret(x, getKeyStorePass()));
           if ( keyManagers == null || keyManagers.length < 1 ) return sslContext;
 
           sslContext = SSLContext.getInstance(getProtocol());
@@ -278,7 +300,7 @@ foam.CLASS({
                 return k;
               }
             }).toArray(KeyManager[]::new),
-            getTrustManagers(getTrustStorePath(), resolveSecret(getX(), getTrustStorePass())),
+            getTrustManagers(x, getTrustStorePath(), resolveSecret(x, getTrustStorePass())),
               null);
 
         } catch ( NoSuchAlgorithmException e ) {

--- a/src/foam/core/dig/DIG.js
+++ b/src/foam/core/dig/DIG.js
@@ -545,7 +545,7 @@ NOTE: when using the java client, the first call to a newly started instance may
       if ( getSecure() ) {
         SslContextFactory contextFactory = (SslContextFactory) getX().get("sslContextFactory");
         if ( contextFactory != null && contextFactory.getEnableSSL() ) {
-          SSLContext sslContext = contextFactory.getSSLContext();
+          SSLContext sslContext = contextFactory.getSSLContext(getX());
           builder = builder.sslContext(sslContext);
         } else if ( contextFactory == null ) {
           new foam.core.logger.StdoutLogger(getX()).warning("DIG", "sslContextFactory", "not found");

--- a/src/foam/core/http/BroadcastWebAgent.js
+++ b/src/foam/core/http/BroadcastWebAgent.js
@@ -106,7 +106,7 @@ Otherwise, using AsyncAssemblyLine waits for all calls to fail before reporting 
       if ( getIsSecure() ) {
         SslContextFactory contextFactory = (SslContextFactory) getX().get("sslContextFactory");
         if ( contextFactory != null && contextFactory.getEnableSSL() ) {
-          SSLContext sslContext = contextFactory.getSSLContext();
+          SSLContext sslContext = contextFactory.getSSLContext(getX());
           builder = builder.sslContext(sslContext);
         } else if ( contextFactory == null ) {
           new foam.core.logger.StdoutLogger(getX()).warning("BroadcastWebAgent", "sslContextFactory", "not found");


### PR DESCRIPTION
getSSLContext and its keystore helpers resolved keyStorePass, trustStorePass, and the keystore itself through getX() — the factory's own context. A secret or keystore service registered in the caller's context, not the factory's, was unreachable, so resolveSecret and resolveKeyStore missed it.

Fix:

- add a Context arg to getSSLContext, getSSLContextByAlias, getKeyManagers, getTrustManagers, and getKeystore; each passes it down to resolveSecret / resolveKeyStore

- update the framework callers (SocketServer, SocketConnectionBoxManager, DIG, BroadcastWebAgent) to pass their own getX()

DOS-3982