### PR TITLE
fix(EasyDAO): honor refreshSessionTimer so polling DAOs don't refresh the session

### DIFF
--- a/src/foam/box/SessionClientBox.js
+++ b/src/foam/box/SessionClientBox.js
@@ -15,6 +15,12 @@ foam.CLASS({
     {
       class: 'Object',
       name: 'message'
+    },
+    {
+      class: 'Boolean',
+      name: 'refreshSession',
+      documentation: 'When false, the server treats this request as background activity and does not touch the session (no sliding-TTL refresh).',
+      value: true
     }
   ]
 });
@@ -60,7 +66,7 @@ foam.CLASS({
       name: 'send',
       code: function send(envelope) {
         this.delegate.send(this.Envelope.create({
-          message: this.SessionedMessage.create({ sessionId: this.sessionID, message: envelope.message }),
+          message: this.SessionedMessage.create({ sessionId: this.sessionID, message: envelope.message, refreshSession: this.refreshSessionTimer }),
           replyBox: this.SessionReplyBox.create({
             envelope,
             clientBox: this,
@@ -80,7 +86,7 @@ msg.attributes["replyBox"] = SessionReplyBox_create([
 try delegate.send(msg)
       `,
       javaCode: `
-getDelegate().send(new foam.box.Envelope(new foam.box.SessionedMessage(getSessionID(), envelope.getMessage()), envelope.getReplyBox()));
+getDelegate().send(new foam.box.Envelope(new foam.box.SessionedMessage(getSessionID(), envelope.getMessage(), getRefreshSessionTimer()), envelope.getReplyBox()));
 `
     }
   ]

--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -63,12 +63,14 @@ public class SessionServerBox
     DAO     sessionDAO = (DAO) x.get("localSessionDAO");
     Session session    = null;
     String  sessionID  = null;
+    boolean refreshSession = true;
     PM      pm         = PM.create(x, "SessionServerBox", spec.getName());
 
     try {
       if ( sessionID == null && message instanceof SessionedMessage sessionedMessage) {
         sessionID = sessionedMessage.getSessionId();
         message = sessionedMessage.getMessage();
+        refreshSession = sessionedMessage.getRefreshSession();
       }
 
       if ( sessionID == null && authenticate ) {
@@ -149,7 +151,9 @@ public class SessionServerBox
       // Make context available to thread-local XLocator
       XLocator.set(effectiveContext);
       session.setContext(effectiveContext);
-      session.touch();
+      // Background requests (e.g. notification polling) pass refreshSession=false
+      // so they don't reset the session's sliding TTL and keep an idle user logged in.
+      if ( refreshSession ) session.touch();
 
       try {
         spec.checkAuthorization(effectiveContext);

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -749,6 +749,13 @@ dao loading, which improves overall startup time.`,
       units: 'ms'
     },
     {
+      class: 'Boolean',
+      name: 'refreshSessionTimer',
+      generateJava: false,
+      documentation: 'When false, requests from this client DAO are treated as background activity: they do not reset the client-side inactivity timer nor touch the server session TTL. Used by polling DAOs so an open tab does not keep an idle user logged in.',
+      value: true
+    },
+    {
       documentation: 'Destination address for server',
       name: 'serverBox',
       generateJava: false,
@@ -772,7 +779,7 @@ dao loading, which improves overall startup time.`,
           });
         }
 
-        return this.SessionClientBox.create({delegate: box});
+        return this.SessionClientBox.create({delegate: box, refreshSessionTimer: this.refreshSessionTimer});
       }
     },
     {


### PR DESCRIPTION
A client EasyDAO can set `refreshSessionTimer: false` to mark its requests as background activity, so an open tab running a polling DAO doesn't keep an idle user logged in. The flag was declared on SessionClientBox and SessionReplyBox but never reached them.

EasyDAO's serverBox factory built the SessionClientBox without passing it, and EasyDAO had no such property, so the client config key was dropped and the box kept its default `true`. The client inactivity timer reset on every poll reply.

Separately, SessionServerBox called `session.touch()` on every authenticated request, refreshing the sliding TTL regardless of the flag, so even a purely background poll kept the server session alive.

Fix:

- add `refreshSessionTimer` to EasyDAO and pass it into the SessionClientBox that its serverBox builds

- carry the flag on the wire with a new `refreshSession` field on SessionedMessage, set from the client box

- SessionServerBox skips `session.touch()` when `refreshSession` is false, so background polls no longer extend the session TTL

All three default to true, so existing DAOs and clients keep current behavior; only a DAO that opts in with `refreshSessionTimer: false` is treated as background.