### PR TITLE
Emit analytic events around session-expired reload in SessionReplyBox

### DIFF
--- a/src/foam/box/SessionReplyBox.js
+++ b/src/foam/box/SessionReplyBox.js
@@ -67,7 +67,25 @@ foam.CLASS({
 
           if ( this.loginSuccess && ( ! promptlogin || authResult ) ) {
             try {
+              this.logAnalyticEvent?.({
+                name: 'SESSION_EXPIRED_RELOAD',
+                userId: this.subject?.realUser.id,
+                extra: foam.json.stringify({
+                  'promptlogin': promptlogin,
+                  'authResult': authResult,
+                  'url': globalThis.window.location.href
+                })
+              });
               this.ctrl.reload();
+              this.logAnalyticEvent?.({
+                name: 'SESSION_EXPIRED_RELOAD',
+                userId: this.subject?.realUser.id,
+                extra: foam.json.stringify({
+                  'promptlogin': promptlogin,
+                  'authResult': authResult,
+                  'url': globalThis.window.location.href
+                })
+              });
             } catch ( e ) {
               console.error(e, 'WINDOW_RELOAD');
               // Failed ApplicationController reload, so

--- a/src/foam/box/SessionReplyBox.js
+++ b/src/foam/box/SessionReplyBox.js
@@ -78,7 +78,7 @@ foam.CLASS({
               });
               this.ctrl.reload();
               this.logAnalyticEvent?.({
-                name: 'SESSION_EXPIRED_RELOAD',
+                name: 'SESSION_EXPIRED_RELOAD_AFTER',
                 userId: this.subject?.realUser.id,
                 extra: foam.json.stringify({
                   'promptlogin': promptlogin,

--- a/src/foam/box/SessionReplyBox.js
+++ b/src/foam/box/SessionReplyBox.js
@@ -68,7 +68,7 @@ foam.CLASS({
           if ( this.loginSuccess && ( ! promptlogin || authResult ) ) {
             try {
               this.logAnalyticEvent?.({
-                name: 'SESSION_EXPIRED_RELOAD',
+                name: 'SESSION_EXPIRED_RELOAD_BEFORE',
                 userId: this.subject?.realUser.id,
                 extra: foam.json.stringify({
                   'promptlogin': promptlogin,


### PR DESCRIPTION
Add analytic events around the controller reload SessionReplyBox triggers when a logged-in user's session is destroyed server-side (auth.promptlogin path).

- **Emit** — a SESSION_EXPIRED_RELOAD analytic event before and after ctrl.reload(), so the reload path is traceable when a live session dies and the client re-authenticates.