### PR TITLE
PT-FIXES:DOS-3773 Fix missing icon on Reflow Benchmark flow button

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -404,7 +404,7 @@ foam.CLASS({
       label: 'Benchmark flow',
       buttonStyle: foam.u2.ButtonStyle.SECONDARY,
       size: 'SMALL',
-      themeIcon: 'health',
+      themeIcon: 'speed',
       // Show only when the loadPerf command it invokes is runnable (same permission).
       availablePermissions: [ 'command.read.loadPerf' ],
       isEnabled: function(data$value$name) { return !! data$value$name; },

--- a/src/foam/u2/theme/ThemeGlyphs.js
+++ b/src/foam/u2/theme/ThemeGlyphs.js
@@ -30,6 +30,16 @@ foam.CLASS({
       }
     },
     {
+      name: 'speed',
+      class: 'GlyphProperty',
+      of: 'foam.lang.Glyph',
+      factory: function() {
+        return { template: `
+        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="/*%FILL%*/ #ffffff"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1 10 10 0 0 0-.27-10.44zM10.59 15.41a2 2 0 0 0 2.83 0l5.66-8.49-8.49 5.66a2 2 0 0 0 0 2.83z"/></svg>
+        ` };
+      }
+    },
+    {
       name: 'exclamation',
       class: 'GlyphProperty',
       of: 'foam.lang.Glyph',


### PR DESCRIPTION
The Benchmark flow action set `themeIcon: 'health'`, but ThemeGlyphs has no `health` glyph, so the button rendered with no icon.

Fix:

- add a `speed` speedometer glyph to ThemeGlyphs

- point the Benchmark action at `speed`
<img width="300" height="257" alt="image" src="https://github.com/user-attachments/assets/7256cded-95fd-45ff-9713-4834001a8e94" />

