### PR TITLE
PT-FIXES:DOS-4128 fix(In): match Date/object values by value, not Set reference

### DIFF
--- a/src/foam/mlang/predicate/In.js
+++ b/src/foam/mlang/predicate/In.js
@@ -55,9 +55,13 @@ foam.CLASS({
 
         if ( ! rhs ) return false;
 
-        // Fast path when arg2 is a Constant of Object[]
-        if ( foam.mlang.Constant.isInstance(this.arg2) ) {
-          if ( foam.Array.isInstance(rhs) ) {
+        // Fast path when arg2 is a Constant of Object[]. A JS Set only matches
+        // primitives by value; Dates, FObjects and other objects compare by
+        // reference, so restrict the Set path to primitive lhs and fall through
+        // to the foam.util.equals loop below for everything else.
+        if ( foam.mlang.Constant.isInstance(this.arg2) && foam.Array.isInstance(rhs) ) {
+          if ( foam.Null.isInstance(lhs)    || foam.String.isInstance(lhs) ||
+               foam.Number.isInstance(lhs)  || foam.Boolean.isInstance(lhs) ) {
             let set = this.arg2AsSet;
             if ( set === undefined ) {
               set = new Set(rhs);

--- a/src/foam/mlang/predicate/In.js
+++ b/src/foam/mlang/predicate/In.js
@@ -55,21 +55,20 @@ foam.CLASS({
 
         if ( ! rhs ) return false;
 
-        // Fast path when arg2 is a Constant of Object[]. A JS Set only matches
-        // primitives by value; Dates, FObjects and other objects compare by
-        // reference, so restrict the Set path to primitive lhs and fall through
-        // to the foam.util.equals loop below for everything else.
+        // Fast path when arg2 is a Constant of Object[].
+        // DO NOT drop the `+ ''`: a JS Set matches objects by REFERENCE, so an
+        // IN over Date (or any object) values would never match — two Date
+        // instances at the same instant are different references. Stringifying
+        // BOTH sides (the set members and the lookup key) makes membership a
+        // value comparison. Both sides must be stringified or nothing matches
+        // (raw set + stringified key, or vice-versa, silently returns false).
         if ( foam.mlang.Constant.isInstance(this.arg2) && foam.Array.isInstance(rhs) ) {
-          if ( foam.Null.isInstance(lhs)    || foam.String.isInstance(lhs) ||
-               foam.Number.isInstance(lhs)  || foam.Boolean.isInstance(lhs) ) {
-            let set = this.arg2AsSet;
-            if ( set === undefined ) {
-              set = new Set(rhs);
-              this.arg2AsSet = set;
-            }
-
-            return set.has(lhs);
+          let set = this.arg2AsSet;
+          if ( set === undefined ) {
+            set = new Set(rhs.map(function(v){ return v + ''; }));
+            this.arg2AsSet = set;
           }
+          return set.has(lhs + '');
         }
 
         for ( var i = 0 ; i < rhs.length ; i++ ) {


### PR DESCRIPTION
In's Set fast-path (when arg2 is a Constant array) tests membership with `new Set(rhs).has(lhs)`. A JS Set compares objects by reference, so an `IN` over Date values never matches — the Date read from a record is a different instance than the Dates in the constant array, even at the same instant. The shortcut returns before the value-equality loop can run.

The loop below it (`foam.util.equals`, date-aware via `getTime()`) is the correct comparison, but the Set fast-path ran first for every array arg2 and short-circuited to false.

Fix:

- guard the Set fast-path to primitive lhs (`null`/`string`/`number`/`boolean`), where Set membership is value equality

- Dates, FObjects, and other objects fall through to the `foam.util.equals` loop

The Java path (`HashSet` + `Date.equals`) already compares by value, so this is a JS-only change.