### PR TITLE
PT-FIXES:DOS-4133 12-hour AM/PM datetime parsing

### DIFF
--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -629,11 +629,11 @@ foam.CLASS({
         ),
 
         // 12-hour clock hour: 1-12 or 01-12 (single- or two-digit)
-        hour12: str(alt(
-          seq('1', range('0', '2')),  // 10, 11, 12
-          seq('0', range('1', '9')),  // 01-09
-          range('1', '9')             // 1-9
-        )),
+        hour12: alt(
+          str(seq('1', range('0', '2'))),  // 10, 11, 12
+          str(seq('0', range('1', '9'))),  // 01-09
+          range('1', '9')                  // 1-9
+        ),
 
         // Meridiem indicator (case-insensitive)
         meridiem: alt(literalIC('AM'), literalIC('PM')),

--- a/src/foam/parse/DateGrammar.js
+++ b/src/foam/parse/DateGrammar.js
@@ -99,6 +99,9 @@ foam.CLASS({
           sym('jsdatetostring'),
           // Support: DDD MMM DD HH:MM:SS TZ YYYY (e.g., "Tue Apr 01 05:17:59 GMT 2025")
           sym('unixdatetostring'),
+          // Support: MMM dd yyyy hh:mm:ss(AM|PM) (e.g., Jun 30 2026 02:59:02AM)
+          // Must precede mmmddyyyyspace so the full match wins over the date-only prefix
+          sym('mmmddyyyyspacetime'),
           // Support: MMM dd yyyy (e.g., Jan 02 2025)
           sym('mmmddyyyyspace'),
           // Support: DD MMM YYYY (e.g., 15 JAN 2025)
@@ -199,10 +202,19 @@ foam.CLASS({
         // MMDDYYYY - tries all variants (compact, separated)
         // Covers: MMDDYYYY, MM-DD-YYYY, MM/DD/YYYY with optional time
         mmddyyyy: alt(
+          sym('mmddyyyyampm'),  // MM/DD/YYYY hh:mm:ss(AM|PM), e.g. "3/8/2026 12:00:00 AM" - must precede plain sep
           sym('mmddyyyycompact'),
           sym('mmddyyyysep'),
           sym('mmddyysep'),
           sym('mmddyycompact')
+        ),
+
+        // MM/DD/YYYY with 12-hour clock time: "3/8/2026 12:00:00 AM"
+        // Meridiem optionally space-separated from the seconds
+        mmddyyyyampm: seq(
+          sym('monthFlexible'), chars('-/'), sym('dayFlexible'), chars('-/'), sym('year4'),
+          sym('datetimesep'), sym('hour12'), ':', sym('minute2'), ':', sym('second2'),
+          optional(' '), sym('meridiem')
         ),
 
         // MMDDYYYY with separators and optional time
@@ -608,6 +620,23 @@ foam.CLASS({
         mmmddyyyyspace: seq(
           sym('month3alpha'), ' ', sym('dayFlexible'), ' ', sym('year4')
         ),
+
+        // MMM dd yyyy hh:mm:ss(AM|PM) with spaces: "Jun 30 2026 02:59:02AM"
+        // 12-hour clock, meridiem fused to the seconds (no space), no timezone
+        mmmddyyyyspacetime: seq(
+          sym('month3alpha'), ' ', sym('dayFlexible'), ' ', sym('year4'), ' ',
+          sym('hour12'), ':', sym('minute2'), ':', sym('second2'), optional(' '), sym('meridiem')
+        ),
+
+        // 12-hour clock hour: 1-12 or 01-12 (single- or two-digit)
+        hour12: str(alt(
+          seq('1', range('0', '2')),  // 10, 11, 12
+          seq('0', range('1', '9')),  // 01-09
+          range('1', '9')             // 1-9
+        )),
+
+        // Meridiem indicator (case-insensitive)
+        meridiem: alt(literalIC('AM'), literalIC('PM')),
 
         // DD MMM YYYY with spaces: "15 JAN 2025" or "5 JAN 2025"
         // Supports single-digit days

--- a/src/foam/parse/DateParser.java
+++ b/src/foam/parse/DateParser.java
@@ -666,6 +666,7 @@ public class DateParser {
     grammar.addSymbol("date-monthname", new Alt(
       grammar.sym("js-date-tostring"),   // JS Date.toString(): "Thu Feb 19 2026 16:20:23 GMT-0400 (Atlantic Standard Time)"
       grammar.sym("unix-date-tostring"), // Unix/Java Date.toString(): "Tue Apr 01 05:17:59 GMT 2025"
+      grammar.sym("mmmddyyyy-space-time"), // MMM dd yyyy hh:mm:ss(AM|PM) (e.g., Jun 30 2026 02:59:02AM) - must precede date-only
       grammar.sym("mmmddyyyy-space"),    // MMM dd yyyy (e.g., Jan 02 2025)
       grammar.sym("ddmmmyyyy-space"),    // DD MMM YYYY (e.g., 15 JAN 2025)
       grammar.sym("ddmmmyyyy-sep"),
@@ -858,10 +859,19 @@ public class DateParser {
     // ========== MMDDYYYY Formats ==========
 
     grammar.addSymbol("mmddyyyy", new Alt(
+      grammar.sym("mmddyyyy-ampm"),  // MM/DD/YYYY hh:mm:ss(AM|PM), e.g. "3/8/2026 12:00:00 AM" - must precede plain sep
       grammar.sym("mmddyyyy-compact"),
       grammar.sym("mmddyyyy-sep"),
       grammar.sym("mmddyy-sep"),
       grammar.sym("mmddyy-compact")
+    ));
+
+    // MM/DD/YYYY with 12-hour clock time: "3/8/2026 12:00:00 AM"
+    // Meridiem optionally space-separated from the seconds
+    grammar.addSymbol("mmddyyyy-ampm", new Seq(
+      grammar.sym("monthFlexible"), new Chars("-/"), grammar.sym("dayFlexible"), new Chars("-/"), grammar.sym("year4"),
+      grammar.sym("datetimesep"), grammar.sym("hour12"), Literal.create(":"), grammar.sym("minute2"),
+      Literal.create(":"), grammar.sym("second2"), new Optional(Literal.create(" ")), grammar.sym("meridiem")
     ));
 
     // MMDDYYYY with separators - supports single-digit month/day (e.g., 7/2/2025)
@@ -1291,6 +1301,23 @@ public class DateParser {
       grammar.sym("month3alpha"), Literal.create(" "), grammar.sym("dayFlexible"), Literal.create(" "), grammar.sym("year4")
     ));
 
+    // MMM dd yyyy hh:mm:ss(AM|PM) with spaces: "Jun 30 2026 02:59:02AM"
+    // 12-hour clock, meridiem fused to the seconds (no space), no timezone
+    grammar.addSymbol("mmmddyyyy-space-time", new Seq(
+      grammar.sym("month3alpha"), Literal.create(" "), grammar.sym("dayFlexible"), Literal.create(" "), grammar.sym("year4"), Literal.create(" "),
+      grammar.sym("hour12"), Literal.create(":"), grammar.sym("minute2"), Literal.create(":"), grammar.sym("second2"), new Optional(Literal.create(" ")), grammar.sym("meridiem")
+    ));
+
+    // 12-hour clock hour: 1-12 or 01-12 (single- or two-digit)
+    grammar.addSymbol("hour12", new Alt(
+      new Join(new Seq(Literal.create("1"), Range.create('0', '2'))),  // 10-12
+      new Join(new Seq(Literal.create("0"), Range.create('1', '9'))),  // 01-09
+      new Join(Range.create('1', '9'))                                 // 1-9 (single digit)
+    ));
+
+    // Meridiem indicator (case-insensitive)
+    grammar.addSymbol("meridiem", new Alt(new LiteralIC("AM"), new LiteralIC("PM")));
+
     // DD MMM YYYY with spaces: "15 JAN 2025" or "5 JAN 2025" - supports single-digit days
     grammar.addSymbol("ddmmmyyyy-space", new Seq(
       grammar.sym("dayFlexible"), Literal.create(" "), grammar.sym("month3alpha"), Literal.create(" "), grammar.sym("year4")
@@ -1417,6 +1444,26 @@ public class DateParser {
         self.parseIntOrDefault(v, 10, -1),
         -1,
         self.extractTimezone(v));
+    });
+
+    // MMDDYYYY 12-hour action: "3/8/2026 12:00:00 AM"
+    // v = [MM, sep, DD, sep, YYYY, datetimesep, HH, ':', MM, ':', SS, optional(' '), meridiem]
+    grammar.addAction("mmddyyyy-ampm", (val, x) -> {
+      Object[] v = (Object[]) val;
+      DateParseMode mode = (DateParseMode) x.get("dateParseMode");
+      int hour = Integer.parseInt((String) v[6]);
+      String meridiem = ((String) v[12]).toUpperCase();
+      if ( meridiem.equals("PM") && hour < 12 ) hour += 12;
+      if ( meridiem.equals("AM") && hour == 12 ) hour = 0;
+      return self.buildDate(mode,
+        Integer.parseInt((String) v[4]),
+        Integer.parseInt((String) v[0]) - 1,
+        Integer.parseInt((String) v[2]),
+        hour,
+        Integer.parseInt((String) v[8]),
+        Integer.parseInt((String) v[10]),
+        -1,
+        null);
     });
 
     // MMDDYYYY-Compact action: "01152025"
@@ -1644,6 +1691,25 @@ public class DateParser {
         self.parseMonthName((String) v[0]),
         Integer.parseInt((String) v[2]),
         -1, -1, -1, -1, null);
+    });
+
+    // MMM dd yyyy hh:mm:ss(AM|PM) space action: [MMM, ' ', DD, ' ', YYYY, ' ', HH, ':', MM, ':', SS, optional(' '), meridiem]
+    grammar.addAction("mmmddyyyy-space-time", (val, x) -> {
+      Object[] v = (Object[]) val;
+      DateParseMode mode = (DateParseMode) x.get("dateParseMode");
+      int hour = Integer.parseInt((String) v[6]);
+      String meridiem = ((String) v[12]).toUpperCase();
+      if ( meridiem.equals("PM") && hour < 12 ) hour += 12;
+      if ( meridiem.equals("AM") && hour == 12 ) hour = 0;
+      return self.buildDate(mode,
+        Integer.parseInt((String) v[4]),    // year
+        self.parseMonthName((String) v[0]), // month
+        Integer.parseInt((String) v[2]),    // day
+        hour,                                // hour (24h)
+        Integer.parseInt((String) v[8]),    // minute
+        Integer.parseInt((String) v[10]),   // second
+        -1,                                  // ms
+        null);
     });
 
     // DD MMM YYYY space action: [DD, ' ', MMM, ' ', YYYY]

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -236,6 +236,24 @@ foam.CLASS({
 
     // MMDDYYYY with separators: MM-DD-YYYY, MM/DD/YYYY with optional time
     // v = [MM, sep, DD, sep, YYYY] or [MM, sep, DD, sep, YYYY, space, HH, :, MM, :, SS, ., fractionalSecs, timezone]
+    // MMDDYYYY with 12-hour clock: "3/8/2026 12:00:00 AM"
+    // v = [MM, sep, DD, sep, YYYY, datetimesep, HH, ':', MM, ':', SS, optional(' '), meridiem]
+    function mmddyyyyampmAction(v) {
+      var hour = parseInt(v[6]);
+      var meridiem = v[12].toUpperCase();
+      if ( meridiem === 'PM' && hour < 12 ) hour += 12;
+      if ( meridiem === 'AM' && hour === 12 ) hour = 0;
+      return this.buildDate(this.dateParseMode,
+        parseInt(v[4]),
+        parseInt(v[0]) - 1,
+        parseInt(v[2]),
+        hour,
+        parseInt(v[8]),
+        parseInt(v[10]),
+        -1,
+        null);
+    },
+
     function mmddyyyysepAction(v) {
       var ms = -1;
       if ( v[12] !== undefined ) {
@@ -525,6 +543,24 @@ foam.CLASS({
         this.parseMonthName(v[0]),
         parseInt(v[2]),
         -1, -1, -1, -1, null);
+    },
+
+    // MMM dd yyyy hh:mm:ss(AM|PM) with spaces: "Jun 30 2026 02:59:02AM"
+    // v = [MMM, ' ', DD, ' ', YYYY, ' ', HH, ':', MM, ':', SS, optional(' '), meridiem]
+    function mmmddyyyyspacetimeAction(v) {
+      var hour = parseInt(v[6]);
+      var meridiem = v[12].toUpperCase();
+      if ( meridiem === 'PM' && hour < 12 ) hour += 12;
+      if ( meridiem === 'AM' && hour === 12 ) hour = 0;
+      return this.buildDate(this.dateParseMode,
+        parseInt(v[4]),
+        this.parseMonthName(v[0]),
+        parseInt(v[2]),
+        hour,
+        parseInt(v[8]),
+        parseInt(v[10]),
+        -1,
+        null);
     },
 
     // DD MMM YYYY with spaces: "15 JAN 2025"

--- a/src/foam/parse/test/DateParserJavaTest.js
+++ b/src/foam/parse/test/DateParserJavaTest.js
@@ -32,6 +32,7 @@ foam.CLASS({
         DateParserTest_MMDDYYYY_Separated();
         DateParserTest_MMDDYYYY_Compact();
         DateParserTest_MMDDYYYY_WithTime();
+        DateParserTest_MMDDYYYY_AmPm();
 
         // YYMMDD Format Tests
         DateParserTest_YYMMDD_Separated();
@@ -80,6 +81,7 @@ foam.CLASS({
         DateParserTest_Timestamps();
         DateParserTest_SingleDigitMonthDay();
         DateParserTest_SpaceSeparatedMonthNames();
+        DateParserTest_MMMDDYYYY_AmPm();
         DateParserTest_MMDDYY_Format();
         DateParserTest_FractionalSeconds();
 
@@ -270,6 +272,38 @@ foam.CLASS({
         test(cal1.get(Calendar.HOUR_OF_DAY) == 14, "MMDDYYYY with time: hour 14");
         test(cal1.get(Calendar.MINUTE) == 30, "MMDDYYYY with time: minute 30");
         test(cal1.get(Calendar.SECOND) == 45, "MMDDYYYY with time: second 45");
+      `
+    },
+
+    {
+      name: 'DateParserTest_MMDDYYYY_AmPm',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // MM/DD/YYYY with 12h time, space before meridiem (AFS March Transaction_Date)
+        Date d1 = parser.parseDateTimeUTC("3/8/2026 12:00:00 AM");
+        Calendar c1 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c1.setTime(d1);
+        test(c1.get(Calendar.MONTH) == 2, "MMDDYYYY 12AM: month 2 (Mar)");
+        test(c1.get(Calendar.DAY_OF_MONTH) == 8, "MMDDYYYY 12AM: day 8");
+        test(c1.get(Calendar.HOUR_OF_DAY) == 0, "MMDDYYYY 12AM: hour 0 (midnight)");
+
+        Date d2 = parser.parseDateTimeUTC("3/8/2026 12:00:00 PM");
+        Calendar c2 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c2.setTime(d2);
+        test(c2.get(Calendar.HOUR_OF_DAY) == 12, "MMDDYYYY 12PM: hour 12 (noon)");
+
+        Date d3 = parser.parseDateTimeUTC("3/8/2026 01:30:45 PM");
+        Calendar c3 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c3.setTime(d3);
+        test(c3.get(Calendar.HOUR_OF_DAY) == 13, "MMDDYYYY PM: hour 13");
+        test(c3.get(Calendar.MINUTE) == 30, "MMDDYYYY PM: minute 30");
+
+        // No space before meridiem
+        Date d4 = parser.parseDateTimeUTC("3/8/2026 09:15:00AM");
+        Calendar c4 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c4.setTime(d4);
+        test(c4.get(Calendar.HOUR_OF_DAY) == 9, "MMDDYYYY no-space AM: hour 9");
       `
     },
 
@@ -1005,6 +1039,57 @@ foam.CLASS({
         test(cal5.get(Calendar.YEAR) == 2025, "mmm dd yyyy (lowercase): year 2025");
         test(cal5.get(Calendar.MONTH) == 11, "mmm dd yyyy (lowercase): month 11 (Dec)");
         test(cal5.get(Calendar.DAY_OF_MONTH) == 25, "mmm dd yyyy (lowercase): day 25");
+      `
+    },
+
+    {
+      name: 'DateParserTest_MMMDDYYYY_AmPm',
+      javaCode: `
+        DateParser parser = new DateParser();
+
+        // "Jun 30 2026 02:59:02AM" (AFS datetime_tran_local) - AM keeps hour
+        Date d1 = parser.parseDateTimeUTC("Jun 30 2026 02:59:02AM");
+        Calendar c1 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c1.setTime(d1);
+        test(c1.get(Calendar.YEAR) == 2026, "MMM dd yyyy AM: year 2026");
+        test(c1.get(Calendar.MONTH) == 5, "MMM dd yyyy AM: month 5 (Jun)");
+        test(c1.get(Calendar.DAY_OF_MONTH) == 30, "MMM dd yyyy AM: day 30");
+        test(c1.get(Calendar.HOUR_OF_DAY) == 2, "MMM dd yyyy AM: hour 2");
+        test(c1.get(Calendar.MINUTE) == 59, "MMM dd yyyy AM: minute 59");
+        test(c1.get(Calendar.SECOND) == 2, "MMM dd yyyy AM: second 2");
+
+        // Space before meridiem (optional): "Mar 07 2026 03:00:26 AM"
+        Date d1b = parser.parseDateTimeUTC("Mar 07 2026 03:00:26 AM");
+        Calendar c1b = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c1b.setTime(d1b);
+        test(c1b.get(Calendar.MONTH) == 2, "MMM dd yyyy space-AM: month 2 (Mar)");
+        test(c1b.get(Calendar.HOUR_OF_DAY) == 3, "MMM dd yyyy space-AM: hour 3");
+        test(c1b.get(Calendar.SECOND) == 26, "MMM dd yyyy space-AM: second 26");
+
+        // PM adds 12 to hours below noon
+        Date d2 = parser.parseDateTimeUTC("Jun 30 2026 02:59:02PM");
+        Calendar c2 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c2.setTime(d2);
+        test(c2.get(Calendar.HOUR_OF_DAY) == 14, "MMM dd yyyy PM: hour 14");
+
+        // 12AM = midnight (hour 0)
+        Date d3 = parser.parseDateTimeUTC("Jan 01 2026 12:00:00AM");
+        Calendar c3 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c3.setTime(d3);
+        test(c3.get(Calendar.HOUR_OF_DAY) == 0, "12AM: hour 0 (midnight)");
+
+        // 12PM = noon (hour 12)
+        Date d4 = parser.parseDateTimeUTC("Jan 01 2026 12:00:00PM");
+        Calendar c4 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c4.setTime(d4);
+        test(c4.get(Calendar.HOUR_OF_DAY) == 12, "12PM: hour 12 (noon)");
+
+        // Single-digit hour
+        Date d5 = parser.parseDateTimeUTC("Jan 01 2026 3:04:05PM");
+        Calendar c5 = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        c5.setTime(d5);
+        test(c5.get(Calendar.HOUR_OF_DAY) == 15, "single-digit hour PM: hour 15");
+        test(c5.get(Calendar.MINUTE) == 4, "single-digit hour PM: minute 4");
       `
     },
 

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -25,6 +25,7 @@ foam.CLASS({
       this.testDDMMMYYFormats(x);
       this.testUnixDateToStringFormat(x);
       this.testJSDateToStringFormat(x);
+      this.testMmmDdYyyyAmPmFormat(x);
       this.testDateTimeFormats(x);
       this.testFractionalSeconds(x);
       this.testParseDateString(x);
@@ -312,6 +313,23 @@ foam.CLASS({
       mmddyyyyFractional.forEach((testCase, i) => {
         let result = this.testParseDTWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second, testCase.millisecond);
         let testName = `MMDDYYYY-Fractional Test${i + 1}: ${testCase.input}`;
+        if ( ! result.pass && result.message ) {
+          testName += ` - ${result.message}`;
+        }
+        x.test(result.pass, testName);
+      });
+
+      // MMDDYYYY with 12-hour clock time, space optional before meridiem (AFS March Transaction_Date)
+      let mmddyyyyAmPm = [
+        { input: '3/8/2026 12:00:00 AM', year: 2026, month: 2, day: 8, hour: 0, minute: 0, second: 0 }, // midnight
+        { input: '3/8/2026 12:00:00 PM', year: 2026, month: 2, day: 8, hour: 12, minute: 0, second: 0 }, // noon
+        { input: '3/8/2026 01:30:45 PM', year: 2026, month: 2, day: 8, hour: 13, minute: 30, second: 45 },
+        { input: '3/8/2026 09:15:00AM', year: 2026, month: 2, day: 8, hour: 9, minute: 15, second: 0 } // no space
+      ];
+
+      mmddyyyyAmPm.forEach((testCase, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, testCase.input, testCase.year, testCase.month, testCase.day, testCase.hour, testCase.minute, testCase.second);
+        let testName = `MMDDYYYY-AmPm Test${i + 1}: ${testCase.input} (UTC)`;
         if ( ! result.pass && result.message ) {
           testName += ` - ${result.message}`;
         }
@@ -1870,6 +1888,28 @@ foam.CLASS({
     },
 
     // Helper functions
+    function testMmmDdYyyyAmPmFormat(x) {
+      let parser = this.DateParser.create();
+
+      // MMM DD YYYY hh:mm:ss(AM|PM) - e.g. AFS datetime_tran_local "Jun 30 2026 02:59:02AM"
+      let cases = [
+        { input: 'Jun 30 2026 02:59:02AM', year: 2026, month: 5, day: 30, hour: 2, minute: 59, second: 2 },
+        { input: 'Mar 07 2026 03:00:26 AM', year: 2026, month: 2, day: 7, hour: 3, minute: 0, second: 26 }, // space before meridiem
+        { input: 'Jun 30 2026 02:59:02PM', year: 2026, month: 5, day: 30, hour: 14, minute: 59, second: 2 },
+        { input: 'Jan 01 2026 12:00:00AM', year: 2026, month: 0, day: 1, hour: 0, minute: 0, second: 0 }, // midnight
+        { input: 'Jan 01 2026 12:00:00PM', year: 2026, month: 0, day: 1, hour: 12, minute: 0, second: 0 }, // noon
+        { input: 'Jan 01 2026 3:04:05PM', year: 2026, month: 0, day: 1, hour: 15, minute: 4, second: 5 }, // single-digit hour
+        { input: 'dec 25 2025 11:30:00pm', year: 2025, month: 11, day: 25, hour: 23, minute: 30, second: 0 } // lowercase
+      ];
+
+      cases.forEach((tc, i) => {
+        let result = this.testParseDTUTCWithDetails(parser, tc.input, tc.year, tc.month, tc.day, tc.hour, tc.minute, tc.second);
+        let testName = `MMMDDYYYY-AmPm Test${i + 1}: ${tc.input} (UTC)`;
+        if ( ! result.pass && result.message ) testName += ` - ${result.message}`;
+        x.test(result.pass, testName);
+      });
+    },
+
     function testParseDate(parser, dateStr, expectedYear, expectedMonth, expectedDay) {
       try {
         let result = parser.parseString(dateStr);


### PR DESCRIPTION
Add 12-hour clock parsing to DateParser (JS + Java), so timestamps carrying an AM/PM meridiem parse on both sides.

- **Month-name** — `MMM DD YYYY hh:mm:ss(AM|PM)`, e.g. `Jun 30 2026 02:59:02AM`

- **Numeric** — `M/D/YYYY hh:mm:ss AM/PM`, e.g. `3/8/2026 12:00:00 AM`

- **Space before the meridiem is optional**; `12AM` maps to hour 0, `12PM` to hour 12

- Cases added to DateParserTest (JS) and DateParserJavaTest (server)