### PR TITLE
PT-FIXES:DOS-4132 reject invalid dates on CSV upload with strict parsing

### DIFF
--- a/src/foam/core/reflow/FromCsvRefines.js
+++ b/src/foam/core/reflow/FromCsvRefines.js
@@ -106,7 +106,7 @@ foam.CLASS({
       value: function(str, format) {
         // format is the parser symbol name: 'START', 'ddmmyyyy', or 'yyyyddmm'
         if ( ! str || str === '' ) return null;
-        return foam.util.DateUtil.parseDateString(str, format);
+        return foam.util.DateUtil.parseDateString(str, format, true);
       }
     }
   ]
@@ -124,7 +124,7 @@ foam.CLASS({
       value: function(str, format) {
         // format is the parser symbol name: 'START', 'ddmmyyyy', or 'yyyyddmm'
         if ( ! str || str === '' ) return null;
-        return foam.util.DateUtil.parseDateTime(str, format);
+        return foam.util.DateUtil.parseDateTime(str, format, true);
       }
     }
   ]
@@ -142,7 +142,7 @@ foam.CLASS({
       value: function(str, format) {
         // format is the parser symbol name: 'START', 'ddmmyyyy', or 'yyyyddmm'
         if ( ! str || str === '' ) return null;
-        return foam.util.DateUtil.parseDateTimeUTC(str, format);
+        return foam.util.DateUtil.parseDateTimeUTC(str, format, true);
       }
     }
   ]

--- a/src/foam/parse/DateParser.java
+++ b/src/foam/parse/DateParser.java
@@ -50,6 +50,15 @@ public class DateParser {
   public void setStrictValidation(boolean v) { strictValidation_ = v; }
 
   /**
+   * Per-call strict override. Set for the duration of a single parse call.
+   * Instance field is safe because DateUtil creates a fresh DateParser per call.
+   */
+  private boolean callStrict_ = false;
+
+  /** Effective strict = per-call override OR the legacy global flag. */
+  private boolean isStrict() { return callStrict_ || strictValidation_; }
+
+  /**
    * Maximum cache size per method to prevent unbounded growth.
    */
   private static final int MAX_CACHE_SIZE = 10000;
@@ -92,11 +101,9 @@ public class DateParser {
    * Build cache key: use str directly when opt_name is null (common case),
    * otherwise concatenate opt_name:str (rare case).
    */
-  private String buildCacheKey(String str, String opt_name) {
-    if ( opt_name == null || opt_name.isEmpty() ) {
-      return str;
-    }
-    return opt_name + ":" + str;
+  private String buildCacheKey(String str, String opt_name, boolean strict) {
+    String key = ( opt_name == null || opt_name.isEmpty() ) ? str : opt_name + ":" + str;
+    return strict ? "S:" + key : key;
   }
 
   /**
@@ -155,36 +162,46 @@ public class DateParser {
    * @return Parsed Date object
    * @throws RuntimeException if format is unsupported and strictValidation is true
    */
+  public Date parseString(String str, String opt_name, boolean strict) {
+    boolean prevStrict = callStrict_;
+    callStrict_ = strict;
+    try {
+      if ( str == null || str.trim().isEmpty() ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported Date format: empty or null string");
+        }
+        System.err.println("Warning: Invalid date: empty or null string; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      str = str.trim();
+
+      // Check cache first - use str directly as key when opt_name is null (common case)
+      String cacheKey = buildCacheKey(str, opt_name, isStrict());
+      Date cached = cacheGet(stringCache_, cacheKey);
+      if ( cached != null ) return cached;
+
+      StringPStream sps = new StringPStream(str);
+      ParserContext x = new ParserContextImpl();
+      x.set("dateParseMode", DateParseMode.STRING);
+
+      PStream parseResult = grammar_.parse(sps, x, opt_name);
+      if ( parseResult == null || parseResult.value() == null ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported Date format: " + str);
+        }
+        System.err.println("Warning: Invalid date: \"" + str + "\"; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      return cacheSet(stringCache_, cacheKey, (Date) parseResult.value());
+    } finally {
+      callStrict_ = prevStrict;
+    }
+  }
+
   public Date parseString(String str, String opt_name) {
-    if ( str == null || str.trim().isEmpty() ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported Date format: empty or null string");
-      }
-      System.err.println("Warning: Invalid date: empty or null string; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    str = str.trim();
-
-    // Check cache first - use str directly as key when opt_name is null (common case)
-    String cacheKey = buildCacheKey(str, opt_name);
-    Date cached = cacheGet(stringCache_, cacheKey);
-    if ( cached != null ) return cached;
-
-    StringPStream sps = new StringPStream(str);
-    ParserContext x = new ParserContextImpl();
-    x.set("dateParseMode", DateParseMode.STRING);
-
-    PStream parseResult = grammar_.parse(sps, x, opt_name);
-    if ( parseResult == null || parseResult.value() == null ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported Date format: " + str);
-      }
-      System.err.println("Warning: Invalid date: \"" + str + "\"; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    return cacheSet(stringCache_, cacheKey, (Date) parseResult.value());
+    return parseString(str, opt_name, false);
   }
 
   /**
@@ -203,36 +220,46 @@ public class DateParser {
    * @param opt_name Optional grammar symbol name
    * @return Parsed Date object at noon GMT, or MAX_DATE if invalid and strictValidation is false
    */
+  public Date parseDateString(String str, String opt_name, boolean strict) {
+    boolean prevStrict = callStrict_;
+    callStrict_ = strict;
+    try {
+      if ( str == null || str.trim().isEmpty() ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported Date format: empty or null string");
+        }
+        System.err.println("Warning: Invalid date: empty or null string; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      str = str.trim();
+
+      // Check cache first - use str directly as key when opt_name is null (common case)
+      String cacheKey = buildCacheKey(str, opt_name, isStrict());
+      Date cached = cacheGet(dateCache_, cacheKey);
+      if ( cached != null ) return cached;
+
+      StringPStream sps = new StringPStream(str);
+      ParserContext x = new ParserContextImpl();
+      x.set("dateParseMode", DateParseMode.DATE);
+
+      PStream parseResult = grammar_.parse(sps, x, opt_name);
+      if ( parseResult == null || parseResult.value() == null ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported Date format: " + str);
+        }
+        System.err.println("Warning: Invalid date: \"" + str + "\"; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      return cacheSet(dateCache_, cacheKey, (Date) parseResult.value());
+    } finally {
+      callStrict_ = prevStrict;
+    }
+  }
+
   public Date parseDateString(String str, String opt_name) {
-    if ( str == null || str.trim().isEmpty() ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported Date format: empty or null string");
-      }
-      System.err.println("Warning: Invalid date: empty or null string; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    str = str.trim();
-
-    // Check cache first - use str directly as key when opt_name is null (common case)
-    String cacheKey = buildCacheKey(str, opt_name);
-    Date cached = cacheGet(dateCache_, cacheKey);
-    if ( cached != null ) return cached;
-
-    StringPStream sps = new StringPStream(str);
-    ParserContext x = new ParserContextImpl();
-    x.set("dateParseMode", DateParseMode.DATE);
-
-    PStream parseResult = grammar_.parse(sps, x, opt_name);
-    if ( parseResult == null || parseResult.value() == null ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported Date format: " + str);
-      }
-      System.err.println("Warning: Invalid date: \"" + str + "\"; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    return cacheSet(dateCache_, cacheKey, (Date) parseResult.value());
+    return parseDateString(str, opt_name, false);
   }
 
   /**
@@ -253,36 +280,46 @@ public class DateParser {
    * @param opt_name Optional grammar symbol name
    * @return Parsed Date object in local time, or MAX_DATE if invalid and strictValidation is false
    */
+  public Date parseDateTime(String str, String opt_name, boolean strict) {
+    boolean prevStrict = callStrict_;
+    callStrict_ = strict;
+    try {
+      if ( str == null || str.trim().isEmpty() ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported DateTime format: empty or null string");
+        }
+        System.err.println("Warning: Invalid datetime: empty or null string; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      str = str.trim();
+
+      // Check cache first - use str directly as key when opt_name is null (common case)
+      String cacheKey = buildCacheKey(str, opt_name, isStrict());
+      Date cached = cacheGet(dateTimeCache_, cacheKey);
+      if ( cached != null ) return cached;
+
+      StringPStream sps = new StringPStream(str);
+      ParserContext x = new ParserContextImpl();
+      x.set("dateParseMode", DateParseMode.DATETIME);
+
+      PStream parseResult = grammar_.parse(sps, x, opt_name);
+      if ( parseResult == null || parseResult.value() == null ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported DateTime format: " + str);
+        }
+        System.err.println("Warning: Invalid datetime: \"" + str + "\"; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      return cacheSet(dateTimeCache_, cacheKey, (Date) parseResult.value());
+    } finally {
+      callStrict_ = prevStrict;
+    }
+  }
+
   public Date parseDateTime(String str, String opt_name) {
-    if ( str == null || str.trim().isEmpty() ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported DateTime format: empty or null string");
-      }
-      System.err.println("Warning: Invalid datetime: empty or null string; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    str = str.trim();
-
-    // Check cache first - use str directly as key when opt_name is null (common case)
-    String cacheKey = buildCacheKey(str, opt_name);
-    Date cached = cacheGet(dateTimeCache_, cacheKey);
-    if ( cached != null ) return cached;
-
-    StringPStream sps = new StringPStream(str);
-    ParserContext x = new ParserContextImpl();
-    x.set("dateParseMode", DateParseMode.DATETIME);
-
-    PStream parseResult = grammar_.parse(sps, x, opt_name);
-    if ( parseResult == null || parseResult.value() == null ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported DateTime format: " + str);
-      }
-      System.err.println("Warning: Invalid datetime: \"" + str + "\"; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    return cacheSet(dateTimeCache_, cacheKey, (Date) parseResult.value());
+    return parseDateTime(str, opt_name, false);
   }
 
   /**
@@ -303,36 +340,46 @@ public class DateParser {
    * @param opt_name Optional grammar symbol name
    * @return Parsed Date object in UTC, or MAX_DATE if invalid and strictValidation is false
    */
+  public Date parseDateTimeUTC(String str, String opt_name, boolean strict) {
+    boolean prevStrict = callStrict_;
+    callStrict_ = strict;
+    try {
+      if ( str == null || str.trim().isEmpty() ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported DateTime format: empty or null string");
+        }
+        System.err.println("Warning: Invalid datetime: empty or null string; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      str = str.trim();
+
+      // Check cache first - use str directly as key when opt_name is null (common case)
+      String cacheKey = buildCacheKey(str, opt_name, isStrict());
+      Date cached = cacheGet(dateTimeUtcCache_, cacheKey);
+      if ( cached != null ) return cached;
+
+      StringPStream sps = new StringPStream(str);
+      ParserContext x = new ParserContextImpl();
+      x.set("dateParseMode", DateParseMode.DATETIME_UTC);
+
+      PStream parseResult = grammar_.parse(sps, x, opt_name);
+      if ( parseResult == null || parseResult.value() == null ) {
+        if ( isStrict() ) {
+          throw new RuntimeException("Unsupported DateTime format: " + str);
+        }
+        System.err.println("Warning: Invalid datetime: \"" + str + "\"; assuming MAX_DATE.");
+        return MAX_DATE;
+      }
+
+      return cacheSet(dateTimeUtcCache_, cacheKey, (Date) parseResult.value());
+    } finally {
+      callStrict_ = prevStrict;
+    }
+  }
+
   public Date parseDateTimeUTC(String str, String opt_name) {
-    if ( str == null || str.trim().isEmpty() ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported DateTime format: empty or null string");
-      }
-      System.err.println("Warning: Invalid datetime: empty or null string; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    str = str.trim();
-
-    // Check cache first - use str directly as key when opt_name is null (common case)
-    String cacheKey = buildCacheKey(str, opt_name);
-    Date cached = cacheGet(dateTimeUtcCache_, cacheKey);
-    if ( cached != null ) return cached;
-
-    StringPStream sps = new StringPStream(str);
-    ParserContext x = new ParserContextImpl();
-    x.set("dateParseMode", DateParseMode.DATETIME_UTC);
-
-    PStream parseResult = grammar_.parse(sps, x, opt_name);
-    if ( parseResult == null || parseResult.value() == null ) {
-      if ( strictValidation_ ) {
-        throw new RuntimeException("Unsupported DateTime format: " + str);
-      }
-      System.err.println("Warning: Invalid datetime: \"" + str + "\"; assuming MAX_DATE.");
-      return MAX_DATE;
-    }
-
-    return cacheSet(dateTimeUtcCache_, cacheKey, (Date) parseResult.value());
+    return parseDateTimeUTC(str, opt_name, false);
   }
 
   /**
@@ -465,7 +512,7 @@ public class DateParser {
       case "NOV": return 10;
       case "DEC": return 11;
       default:
-        if ( strictValidation_ ) {
+        if ( isStrict() ) {
           throw new RuntimeException("Invalid month name: \"" + monthName + "\"");
         }
         System.err.println("Warning: Invalid month name: \"" + monthName + "\"; assuming January.");
@@ -478,6 +525,18 @@ public class DateParser {
    */
   private Date buildDate(DateParseMode mode, int year, int month, int day,
                          int hour, int minute, int second, int ms, String tz) {
+    // Strict mode: reject out-of-range month/day instead of letting Calendar silently roll over.
+    if ( isStrict() ) {
+      if ( month < 0 || month > 11 )
+        throw new RuntimeException("Date out of range: month " + ( month + 1 ) + " in \"" + year + "-" + ( month + 1 ) + "-" + day + "\"");
+      Calendar dim = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+      dim.clear();
+      dim.set(year, month, 1);
+      int daysInMonth = dim.getActualMaximum(Calendar.DAY_OF_MONTH);
+      if ( day < 1 || day > daysInMonth )
+        throw new RuntimeException("Date out of range: day " + day + " in \"" + year + "-" + ( month + 1 ) + "-" + day + "\"");
+    }
+
     Calendar cal;
     switch (mode) {
       case DATE:

--- a/src/foam/parse/DateParser.js
+++ b/src/foam/parse/DateParser.js
@@ -40,6 +40,12 @@ foam.CLASS({
       documentation: 'If true, throws errors for invalid dates. If false, logs warnings and returns MAX_DATE.'
     },
     {
+      class: 'Boolean',
+      name: 'callStrict_',
+      transient: true,
+      documentation: 'Per-call strict override. Set at the start of each public parse method; OR-ed with strictValidation via isStrict(). Never leaks because every entry point sets it.'
+    },
+    {
       name: 'stringCache_',
       documentation: 'LRU cache for parseString results. Stores timestamps (Date.getTime()) instead of Date objects.',
       factory: function() { return new Map(); }
@@ -67,17 +73,21 @@ foam.CLASS({
   ],
 
   methods: [
+    function isStrict() {
+      // Effective strict = per-call override OR the legacy global flag.
+      return this.callStrict_ || this.strictValidation;
+    },
+
     // ========== Cache Helper Methods ==========
 
     /**
      * Build cache key: use str directly when opt_name is null (common case),
-     * otherwise concatenate opt_name:str (rare case).
+     * otherwise concatenate opt_name:str (rare case), and prefix with 'S:' when strict
+     * (strict and lenient results for the same input must never collide).
      */
-    function buildCacheKey_(str, opt_name) {
-      if ( ! opt_name ) {
-        return str;
-      }
-      return opt_name + ':' + str;
+    function buildCacheKey_(str, opt_name, strict) {
+      var key = opt_name ? opt_name + ':' + str : str;
+      return strict ? 'S:' + key : key;
     },
 
     function cacheGet_(cache, key) {
@@ -127,6 +137,15 @@ foam.CLASS({
     },
 
     function buildDate(mode, year, month, day, hour, minute, second, ms, tz) {
+      // Strict mode: reject out-of-range month/day instead of letting JS Date silently roll over.
+      // Raw pre-rollover month/day only exist here; check month first so daysInMonth is well-defined.
+      if ( this.isStrict() ) {
+        if ( month < 0 || month > 11 )
+          throw new Error('Date out of range: month ' + ( month + 1 ) + ' in "' + year + '-' + ( month + 1 ) + '-' + day + '"');
+        var daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+        if ( day < 1 || day > daysInMonth )
+          throw new Error('Date out of range: day ' + day + ' in "' + year + '-' + ( month + 1 ) + '-' + day + '"');
+      }
       var offset, utcTime;
       switch ( mode ) {
         case 'DATE':
@@ -781,7 +800,7 @@ foam.CLASS({
     function validateDate(date, str) {
       // Check if date is NaN
       if ( isNaN(date.getTime()) ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Invalid date: "' + str + '"');
         }
         date = foam.Date.MAX_DATE;
@@ -794,7 +813,7 @@ foam.CLASS({
     function validateDateUTC(date, str) {
       // Check if date is NaN
       if ( isNaN(date.getTime()) ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Invalid date: "' + str + '"');
         }
         date = foam.Date.MAX_DATE;
@@ -823,7 +842,7 @@ foam.CLASS({
         'SEP': 8, 'OCT': 9, 'NOV': 10, 'DEC': 11
       };
       if ( months[month] === undefined ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Invalid month name: "' + monthName + '"');
         }
         console.warn('Invalid month name: "' + monthName + '"; assuming January.');
@@ -832,9 +851,11 @@ foam.CLASS({
       return months[month];
     },
 
-    function parseString(str, opt_name) {
+    function parseString(str, opt_name, strict) {
+      this.callStrict_ = !! strict;
+      try {
       if ( ! str || str.trim() === '' ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported Date format: empty or null string');
         }
         console.warn('Invalid date: empty or null string; assuming MAX_DATE.');
@@ -843,7 +864,7 @@ foam.CLASS({
       str = str.trim();
 
       // Check cache first - use str directly as key when opt_name is null (common case)
-      var cacheKey = this.buildCacheKey_(str, opt_name);
+      var cacheKey = this.buildCacheKey_(str, opt_name, this.isStrict());
       var cached = this.cacheGet_(this.stringCache_, cacheKey);
       if ( cached ) return cached;
 
@@ -853,7 +874,7 @@ foam.CLASS({
       var parseResult = this.parse(this.StringPStream.create({ str: str }), this, opt_name);
 
       if ( ! parseResult || ! parseResult.value ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported Date format: ' + str);
         }
         console.warn('Invalid date: "' + str + '"; assuming MAX_DATE.');
@@ -895,11 +916,16 @@ foam.CLASS({
       }
 
       return this.cacheSet_(this.stringCache_, cacheKey, this.validateDate(ret, str), this.maxCacheSize_ / 10);
+      } finally {
+        this.callStrict_ = false;
+      }
     },
 
-    function parseDateString(str, opt_name) {
+    function parseDateString(str, opt_name, strict) {
+      this.callStrict_ = !! strict;
+      try {
       if ( ! str || str.trim() === '' ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported Date format: empty or null string');
         }
         console.warn('Invalid date: empty or null string; assuming MAX_DATE.');
@@ -908,7 +934,7 @@ foam.CLASS({
       str = str.trim();
 
       // Check cache first - use str directly as key when opt_name is null (common case)
-      var cacheKey = this.buildCacheKey_(str, opt_name);
+      var cacheKey = this.buildCacheKey_(str, opt_name, this.isStrict());
       var cached = this.cacheGet_(this.dateCache_, cacheKey);
       if ( cached ) return cached;
 
@@ -940,11 +966,16 @@ foam.CLASS({
       }
 
       return this.cacheSet_(this.dateCache_, cacheKey, parseResult.value, this.maxCacheSize_ / 10);
+      } finally {
+        this.callStrict_ = false;
+      }
     },
 
-    function parseDateTime(str, opt_name) {
+    function parseDateTime(str, opt_name, strict) {
+      this.callStrict_ = !! strict;
+      try {
       if ( ! str || str.trim() === '' ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported DateTime format: empty or null string');
         }
         console.warn('Invalid datetime: empty or null string; assuming MAX_DATE.');
@@ -953,7 +984,7 @@ foam.CLASS({
       str = str.trim();
 
       // Check cache first - use str directly as key when opt_name is null (common case)
-      var cacheKey = this.buildCacheKey_(str, opt_name);
+      var cacheKey = this.buildCacheKey_(str, opt_name, this.isStrict());
       var cached = this.cacheGet_(this.dateTimeCache_, cacheKey);
       if ( cached ) return cached;
 
@@ -963,7 +994,7 @@ foam.CLASS({
       var parseResult = this.parse(this.StringPStream.create({ str: str }), this, opt_name);
 
       if ( ! parseResult || ! parseResult.value ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported DateTime format: ' + str);
         }
         console.warn('Invalid datetime: "' + str + '"; assuming MAX_DATE.');
@@ -1031,11 +1062,16 @@ foam.CLASS({
       }
 
       return this.cacheSet_(this.dateTimeCache_, cacheKey, this.validateDate(ret, str), this.maxCacheSize_);
+      } finally {
+        this.callStrict_ = false;
+      }
     },
 
-    function parseDateTimeUTC(str, opt_name) {
+    function parseDateTimeUTC(str, opt_name, strict) {
+      this.callStrict_ = !! strict;
+      try {
       if ( ! str || str.trim() === '' ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported DateTime format: empty or null string');
         }
         console.warn('Invalid datetime: empty or null string; assuming MAX_DATE.');
@@ -1044,7 +1080,7 @@ foam.CLASS({
       str = str.trim();
 
       // Check cache first - use str directly as key when opt_name is null (common case)
-      var cacheKey = this.buildCacheKey_(str, opt_name);
+      var cacheKey = this.buildCacheKey_(str, opt_name, this.isStrict());
       var cached = this.cacheGet_(this.dateTimeUtcCache_, cacheKey);
       if ( cached ) return cached;
 
@@ -1054,7 +1090,7 @@ foam.CLASS({
       var parseResult = this.parse(this.StringPStream.create({ str: str }), this, opt_name);
 
       if ( ! parseResult || ! parseResult.value ) {
-        if ( this.strictValidation ) {
+        if ( this.isStrict() ) {
           throw new Error('Unsupported DateTime format: ' + str);
         }
         console.warn('Invalid datetime: "' + str + '"; assuming MAX_DATE.');
@@ -1087,6 +1123,9 @@ foam.CLASS({
       }
 
       return this.cacheSet_(this.dateTimeUtcCache_, cacheKey, parseResult.value, this.maxCacheSize_);
+      } finally {
+        this.callStrict_ = false;
+      }
     }
   ]
 });

--- a/src/foam/parse/test/DateParserJavaTest.js
+++ b/src/foam/parse/test/DateParserJavaTest.js
@@ -73,6 +73,8 @@ foam.CLASS({
 
         // Strict Validation Mode Tests
         DateParserTest_StrictValidation_ThrowsForInvalid();
+        DateParserTest_StrictValidation_OutOfRange();
+        DateParserTest_StrictValidation_PerCallParam();
         DateParserTest_StrictValidation_ValidDatesWork();
         DateParserTest_LenientValidation_ReturnsMaxDate();
         DateParserTest_LenientValidation_ValidDatesWork();
@@ -830,6 +832,68 @@ foam.CLASS({
         } catch (RuntimeException e) {
           test(true, "StrictMode parseDateTimeUTC: throws for invalid input");
         }
+      `
+    },
+
+    {
+      name: 'DateParserTest_StrictValidation_OutOfRange',
+      javaCode: `
+        DateParser parser = new DateParser();
+        parser.setStrictValidation(true);
+
+        String[] bad = { "2025-13-40", "2025-13-01", "2025-02-30", "2025-04-31" };
+        for ( int i = 0 ; i < bad.length ; i++ ) {
+          try {
+            parser.parseDateString(bad[i]);
+            test(false, "StrictRange: \\"" + bad[i] + "\\" should throw");
+          } catch (RuntimeException e) {
+            test(e.getMessage().toLowerCase().contains("out of range"), "StrictRange: \\"" + bad[i] + "\\" throws out-of-range");
+          }
+        }
+
+        // Wrong-format-hint landing month 13 must throw.
+        try {
+          parser.parseDateString("13/04/2026");
+          test(false, "StrictRange: 13/04/2026 as MM/DD should throw");
+        } catch (RuntimeException e) {
+          test(e.getMessage().toLowerCase().contains("out of range"), "StrictRange: 13/04/2026 throws (wrong-hint caught)");
+        }
+
+        // Valid in-range date still parses.
+        Date ok = parser.parseDateString("2025-02-28");
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        cal.setTime(ok);
+        test(cal.get(Calendar.MONTH) == 1 && cal.get(Calendar.DAY_OF_MONTH) == 28, "StrictRange: valid 2025-02-28 parses");
+
+        // 12-hour AM/PM supported (ticket example stale) - must parse.
+        Date dt = parser.parseDateTime("Mar 07 2026 03:00:26AM");
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTime(dt);
+        test(cal2.get(Calendar.YEAR) == 2026 && cal2.get(Calendar.MONTH) == 2, "StrictRange: 12-hour AM/PM parses (supported)");
+
+        parser.setStrictValidation(false);
+      `
+    },
+    {
+      name: 'DateParserTest_StrictValidation_PerCallParam',
+      javaCode: `
+        DateParser parser = new DateParser();
+        test(parser.getStrictValidation() == false, "PerCall: static flag starts false");
+
+        // Per-call strict=true rejects out-of-range without setStrictValidation.
+        try {
+          parser.parseDateString("2025-13-40", null, true);
+          test(false, "PerCall strict=true: 2025-13-40 should throw");
+        } catch (RuntimeException e) {
+          test(e.getMessage().toLowerCase().contains("out of range"), "PerCall strict=true: 2025-13-40 throws");
+        }
+
+        // Static flag untouched by the per-call arg.
+        test(parser.getStrictValidation() == false, "PerCall: static flag still false after per-call strict");
+
+        // Lenient default rolls over, no throw.
+        Date rolled = parser.parseDateString("2025-13-40");
+        test(rolled != null, "PerCall lenient: 2025-13-40 rolls over (no throw)");
       `
     },
 

--- a/src/foam/parse/test/DateParserTest.js
+++ b/src/foam/parse/test/DateParserTest.js
@@ -46,6 +46,8 @@ foam.CLASS({
       this.testStrictValidationMode(x);
       this.testLenientValidationMode(x);
       this.testInvalidMonthNameValidation(x);
+      this.testStrictOutOfRange(x);
+      this.testStrictPerCallParam(x);
       this.testJulianDateFormats(x);
       this.testYearConstraintInCompactFormats(x);
     },
@@ -2721,6 +2723,79 @@ foam.CLASS({
       parser.strictValidation = false;
       let result = parser.parseString('15-XYZ-2025');
       x.test(result.getTime() === foam.Date.MAX_DATE.getTime(), 'LenientMode: unparseable returns MAX_DATE');
+    },
+
+    function testStrictOutOfRange(x) {
+      // Out-of-range month/day must be REJECTED in strict mode (no JS Date rollover).
+      let parser = this.DateParser.create();
+      parser.strictValidation = true;
+      try {
+        let bad = [
+          { input: '2025-13-40', desc: 'month 13 and day 40' },
+          { input: '2025-13-01', desc: 'month 13' },
+          { input: '2025-02-30', desc: 'Feb 30' },
+          { input: '2025-04-31', desc: 'Apr 31' }
+        ];
+        bad.forEach((tc, i) => {
+          try {
+            parser.parseDateString(tc.input);
+            x.test(false, `StrictRange Test${i + 1}: "${tc.input}" should throw (${tc.desc})`);
+          } catch (e) {
+            x.test(/out of range/i.test(e.message), `StrictRange Test${i + 1}: "${tc.input}" throws out-of-range (${tc.desc})`);
+          }
+        });
+
+        // Wrong-format-hint that lands month 13 must throw (13/04/2026 read as MM/DD).
+        try {
+          parser.parseDateString('13/04/2026');
+          x.test(false, 'StrictRange: 13/04/2026 as MM/DD should throw (month 13)');
+        } catch (e) {
+          x.test(/out of range/i.test(e.message), 'StrictRange: 13/04/2026 throws (wrong-format-hint caught)');
+        }
+
+        // Valid in-range date still parses in strict mode.
+        try {
+          let ok = parser.parseDateString('2025-02-28');
+          x.test(ok.getUTCMonth() === 1 && ok.getUTCDate() === 28, 'StrictRange: valid 2025-02-28 parses');
+        } catch (e) {
+          x.test(false, 'StrictRange: valid date should not throw - ' + e.message);
+        }
+
+        // 12-hour AM/PM is SUPPORTED (ticket example is stale) - must parse, not reject.
+        try {
+          let dt = parser.parseDateTime('Mar 07 2026 03:00:26AM');
+          x.test(dt.getFullYear() === 2026 && dt.getMonth() === 2, 'StrictRange: 12-hour AM/PM parses (supported)');
+        } catch (e) {
+          x.test(false, 'StrictRange: 12-hour AM/PM should parse - ' + e.message);
+        }
+      } finally {
+        parser.strictValidation = false;
+      }
+    },
+
+    function testStrictPerCallParam(x) {
+      // Per-call strict param must throw WITHOUT flipping the shared flag; lenient default rolls over.
+      let parser = this.DateParser.create();
+      x.test(parser.strictValidation === false, 'PerCall: flag starts false');
+
+      // strict=true rejects out-of-range.
+      try {
+        parser.parseDateString('2025-13-40', null, true);
+        x.test(false, 'PerCall strict=true: 2025-13-40 should throw');
+      } catch (e) {
+        x.test(/out of range/i.test(e.message), 'PerCall strict=true: 2025-13-40 throws');
+      }
+
+      // Flag stays false after a strict call (restored in finally).
+      x.test(parser.strictValidation === false, 'PerCall: flag restored to false after strict call');
+
+      // Lenient default: same input rolls over, no throw.
+      try {
+        let rolled = parser.parseDateString('2025-13-40');
+        x.test(! isNaN(rolled.getTime()), 'PerCall lenient: 2025-13-40 rolls over (no throw)');
+      } catch (e) {
+        x.test(false, 'PerCall lenient: should not throw - ' + e.message);
+      }
     },
 
     function testJulianDateFormats(x) {

--- a/src/foam/util/DateUtil.js
+++ b/src/foam/util/DateUtil.js
@@ -51,10 +51,10 @@ foam.CLASS({
   static: [
     {
       name: 'parseDateTime',
-      args: 'String d, String opt_name',
+      args: 'String d, String opt_name, Boolean strict',
       type: 'Date',
       documentation: 'Parses datetime strings using DateParser in local time. Optional opt_name to specify format.',
-      code: function(d, opt_name) {
+      code: function(d, opt_name, strict) {
         // Handle null/undefined
         if ( d === null || d === undefined ) return d;
 
@@ -64,20 +64,20 @@ foam.CLASS({
         }
 
         var parser = foam.parse.DateParser.create();
-        return parser.parseDateTime(d, opt_name);
+        return parser.parseDateTime(d, opt_name, strict);
       },
       javaCode: `
         // Parses datetime string in local timezone using grammar-based DateParser
         DateParser parser = new DateParser();
-        return parser.parseDateTime(d, opt_name);
+        return parser.parseDateTime(d, opt_name, strict);
       `
     },
     {
       name: 'parseDateTimeUTC',
-      args: 'String d, String opt_name',
+      args: 'String d, String opt_name, Boolean strict',
       type: 'Date',
       documentation: 'Parses datetime strings using DateParser in UTC time. Optional opt_name to specify format.',
-      code: function(d, opt_name) {
+      code: function(d, opt_name, strict) {
         // Handle null/undefined
         if ( d === null || d === undefined ) return d;
 
@@ -87,20 +87,20 @@ foam.CLASS({
         }
 
         var parser = foam.parse.DateParser.create();
-        return parser.parseDateTimeUTC(d, opt_name);
+        return parser.parseDateTimeUTC(d, opt_name, strict);
       },
       javaCode: `
         // Parses datetime string in UTC timezone using grammar-based DateParser
         DateParser parser = new DateParser();
-        return parser.parseDateTimeUTC(d, opt_name);
+        return parser.parseDateTimeUTC(d, opt_name, strict);
       `
     },
     {
       name: 'parseDateString',
-      args: 'String d, String opt_name',
+      args: 'String d, String opt_name, Boolean strict',
       type: 'Date',
       documentation: 'Parses date strings using DateParser. Supports YYYY/MM/DD, MM/DD/YYYY, YY/MM/DD and compact formats. Optional opt_name to specify format (e.g., "ddmmyyyy").',
-      code: function(d, opt_name) {
+      code: function(d, opt_name, strict) {
         // Handle null/undefined
         if ( d === null || d === undefined ) return d;
 
@@ -110,14 +110,14 @@ foam.CLASS({
         }
 
         var parser = foam.parse.DateParser.create();
-        return parser.parseDateString(d, opt_name);
+        return parser.parseDateString(d, opt_name, strict);
       },
       javaCode: `
         // Parses date string using grammar-based DateParser
         // Supports YYYY/MM/DD, MM/DD/YYYY, YY/MM/DD and compact formats
         // Optional opt_name to specify format (e.g., "ddmmyyyy")
         DateParser parser = new DateParser();
-        return parser.parseDateString(d, opt_name);
+        return parser.parseDateString(d, opt_name, strict);
       `
     },
     {
@@ -182,7 +182,7 @@ foam.CLASS({
         }
 
         if ( o instanceof String ) {
-          return parseDateString((String) o, null);
+          return parseDateString((String) o, null, false);
         }
 
         if ( o instanceof Number ) return new Date(((Number) o).longValue());
@@ -470,8 +470,8 @@ foam.CLASS({
      *
      * FOAM's static array doesn't support method overloading - you cannot define
      * two methods with the same name but different parameters. JavaScript doesn't
-     * support method overloading either, so only the 1-parameter versions are needed
-     * in the static array above.
+     * support method overloading either, so only the 3-parameter (strict) versions
+     * are needed in the static array above.
      *
      * However, the original Java code had overloaded methods (1-param and 2-param versions)
      * for backward compatibility with existing code. These Java-only overloads are defined
@@ -479,19 +479,34 @@ foam.CLASS({
      * the FOAM static method definitions.
      */
 
+    // Java method overload for parseDateTime (2-parameter version for backward compatibility)
+    public static Date parseDateTime(String d, String opt_name) {
+      return parseDateTime(d, opt_name, false);
+    }
+
     // Java method overload for parseDateTime (1-parameter version for backward compatibility)
     public static Date parseDateTime(String d) {
-      return parseDateTime(d, null);
+      return parseDateTime(d, null, false);
+    }
+
+    // Java method overload for parseDateTimeUTC (2-parameter version for backward compatibility)
+    public static Date parseDateTimeUTC(String d, String opt_name) {
+      return parseDateTimeUTC(d, opt_name, false);
     }
 
     // Java method overload for parseDateTimeUTC (1-parameter version for backward compatibility)
     public static Date parseDateTimeUTC(String d) {
-      return parseDateTimeUTC(d, null);
+      return parseDateTimeUTC(d, null, false);
+    }
+
+    // Java method overload for parseDateString (2-parameter version for backward compatibility)
+    public static Date parseDateString(String d, String opt_name) {
+      return parseDateString(d, opt_name, false);
     }
 
     // Java method overload for parseDateString (1-parameter version for backward compatibility)
     public static Date parseDateString(String d) {
-      return parseDateString(d, null);
+      return parseDateString(d, null, false);
     }
 
     // Java method overload for format (1-parameter version for backward compatibility)


### PR DESCRIPTION
Reflow CSV upload parses each date cell through DateParser in lenient mode, which never fails. An unknown month name falls back to January, an unsupported format returns MAX_DATE, and JS Date silently rolls an out-of-range value over — `2025-13-40` becomes a valid 2026 date, Feb 30 becomes Mar 2. Corrupt dates land in imported rows instead of failing the upload.

The rollover is the subtle one: the value parses, `isNaN` never fires, so even the existing strict path could not catch it. Catching it needs a range check while the raw month and day still exist, inside `buildDate`.

Fix:

- thread a per-call `strict` argument through `DateUtil.parseDateString/parseDateTime/parseDateTimeUTC` into `DateParser` (default lenient, so journal replay and every other caller stay unchanged); the three date `fromCSV` refines pass `strict:true`

- under strict, reject out-of-range month (1-12) and day (1-daysInMonth, so Feb 30 fails) in `buildDate`, before JS Date can normalize them — month is checked first so the days-in-month bound is never computed from a bogus month

- carry strict without mutating the shared singleton flag: a transient `callStrict_` read via `isStrict()`, plus a strict-prefixed cache key so a lenient MAX_DATE never satisfies a strict lookup

- mirror all of it in the Java `DateParser` for JS/Java parity

An invalid date now surfaces as a per-row validation error in the upload output (through the existing `UploadSink` catch) and keeps that row out of the import; a valid file imports unchanged. A wrong per-column format hint gets caught for free when the swap lands a day in the month slot — `13/04/2026` read as MM/DD throws on month 13.

Covered both parser suites: out-of-range month and day, the wrong-hint case, and valid dates plus 12-hour AM/PM still parsing.