### PR TITLE
fix(mlang): Unique.toString references undefined uniqueValues, use values

### DIFF
--- a/src/foam/mlang/sink/Unique.js
+++ b/src/foam/mlang/sink/Unique.js
@@ -51,12 +51,12 @@ foam.CLASS({
     function eof() { },
 
     function clone() {
-      // Don't use the default clone because we don't want to copy 'uniqueValues'.
+      // Don't use the default clone because we don't want to copy 'values'.
       return this.cls_.create({ expr: this.expr, delegate: this.delegate });
     },
 
     function toString() {
-      return this.uniqueValues.toString();
+      return this.values.toString();
     }
   ]
 });


### PR DESCRIPTION
Unique.toString() reads this.uniqueValues, a property that no longer exists — the accumulator map was renamed to values. Any caller that stringifies a Unique sink, such as a caching DAO building a select cache key, throws "Cannot read properties of undefined (reading 'toString')".

Fix:

- toString() reads this.values, the actual map property (clone comment updated to match)