### PR TITLE
fix(mlang): Concat.f Java path evaluates its exprs

### DIFF
--- a/src/foam/mlang/expr/Concat.js
+++ b/src/foam/mlang/expr/Concat.js
@@ -30,7 +30,7 @@ foam.CLASS({
       javaCode: `
         StringBuilder sb = new StringBuilder();
         for ( int i = 0 ; i < getExprs().length ; i++ ) {
-          sb.append(getExprs()[i]);
+          sb.append(getExprs()[i].f(obj));
         }
         return sb.toString();
       `


### PR DESCRIPTION
The Java `f()` appended each `Expr` in `getExprs()` straight to the StringBuilder, so it concatenated the expressions' `toString()` output instead of their evaluated values. The JS path already evaluates each one via `e.f(obj)`, so the two diverged.

Fix:

- **append** — `getExprs()[i].f(obj)` instead of the raw `Expr`, matching the JS path and the `Cond`/`Ifs` convention.