### PR TITLE
Reflow: load/loadPerf of an unchanged flow silently does nothing

### DIFF
--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -623,7 +623,13 @@ foam.CLASS({
         this.maybeCallScript(loaded.preLoadScript);
         this.flow.loadComplete.sub(() => this.maybeCallScript(loaded.postLoadScript));
         this.selected = this.flow;
+        // When the saved script is identical to the current one, copyFrom's set
+        // is suppressed by the propertyChange equality gate, so the Console's
+        // onScriptChange reload never runs and loadComplete never fires. Force
+        // the pub so load/loadPerf on an unchanged flow still re-executes.
+        var sameScript = this.flow.script === loaded.script;
         this.flow.copyFrom(loaded);
+        if ( sameScript ) this.flow.pub('propertyChange', 'script', this.flow.script$);
         // After loading, revert the revision back to 0
         this.flow.loadComplete.sub(foam.events.oneTime(() => {
           this.mementoMgr.clear();


### PR DESCRIPTION
The load command reloads a flow by writing the saved script into value.script — the Console's onScriptChange listener does the actual rebuild and pubs loadComplete. When the saved script is byte-identical to the current one (the normal state right after a save, since save writes the regenerated script), the property setter suppresses the propertyChange, so the listener never fires.

Nothing reloads and loadComplete never pubs. For loadPerf (the Benchmark flow action) that means the capture starts, waits on loadComplete forever, and the click appears to do nothing — with fetch and console.warn left wrapped by the abandoned capture.

Fix:

- **Force the pub** — load compares the incoming script before copyFrom and, when identical, pubs the script propertyChange manually so the reload runs and loadComplete fires.

The memento link is value-guarded, so the forced pub adds no undo entry and leaves the revision at 0.