### PR TITLE
DOS-4286 Make disabled more explicit

### DIFF
--- a/src/foam/u2/CheckBox.js
+++ b/src/foam/u2/CheckBox.js
@@ -45,6 +45,7 @@ foam.CLASS({
     ^:disabled {
       border-color: $borderLight;
       background-color: $backgroundSecondary;
+      cursor: not-allowed;
     }
     ^:checked {
       background-color: $checkboxColor;

--- a/src/foam/u2/Switch.js
+++ b/src/foam/u2/Switch.js
@@ -38,6 +38,7 @@ foam.CLASS({
     ^:disabled {
       border-color: $borderLight;
       background-color: $backgroundSecondary;
+      cursor: not-allowed;
     }
     ^:before {
       content: "";


### PR DESCRIPTION
DOS-4286 Make disabled more explicit by adding appropriate cursor for disabled state.
Screenshot didn't include the cursor - hence the photo.
<img width="480" height="640" alt="IMG_1773 Large" src="https://github.com/user-attachments/assets/f857b99a-db40-430f-9582-ab5b9c4e802a" />
<img width="480" height="640" alt="IMG_1772 Large" src="https://github.com/user-attachments/assets/344ac2e2-8f29-470d-98e4-d2e6e740dbfb" />
