### PR TITLE
PT-Fixes DOS-4185 and DOS-4187: Created ChangeAnalyticEvents and made AnalyticEvents spid-aware

### DIFF
--- a/src/foam/core/analytics/AnalyticEvent.js
+++ b/src/foam/core/analytics/AnalyticEvent.js
@@ -18,7 +18,8 @@ foam.CLASS({
     'foam.core.auth.AuthorizationException',
     'foam.core.auth.Subject',
     'foam.core.auth.User',
-    'foam.core.session.Session'
+    'foam.core.session.Session',
+    'foam.core.auth.ServiceProviderAware'
   ],
 
   properties: [

--- a/src/foam/core/analytics/ChangeAnalyticEvent.js
+++ b/src/foam/core/analytics/ChangeAnalyticEvent.js
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.analytics',
+  name: 'ChangeAnalyticEvent',
+  extends: 'foam.core.analytics.AnalyticEvent',
+
+  css: `
+    ^pill, ^pill-before, ^pill-after, ^pill-custom-color {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 10px;
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 18px;
+      border-radius: 12px;
+      white-space: nowrap;
+    }
+    ^pill-before {
+      background-color: $grey100;
+      color: $grey500;
+    }
+    ^pill-after {
+      background-color: $green50;
+      color: $green600;
+    }
+    /* Subclasses of ChangeAnalyticEvent can overload pill-custom-color to change the pill color */
+    ^pill-custom-color {
+      background-color: $grey100;
+      color: $grey500;
+    }
+    ^label {
+      line-height: 1;
+      min-height: 1em;
+      width: 100%;
+      font-weight: 600;
+    }
+    ^supportingLabel {
+      line-height: 1;
+      min-height: 1em;
+      width: 100%;
+      color: $textTertiary;
+    }
+  `,
+
+  properties: [
+    {
+      class: 'String',
+      name: 'field',
+      documentation: 'The property that was changed.',
+      hidden: true
+    },
+    {
+      class: 'String',
+      name: 'before',
+      documentation: 'The value of whatever this AnalyticEvent was triggered on *before* the change happened.',
+      tableCellFormatter: function(value, obj) {
+        this.start('span')
+          .addClass(foam.String.cssClassize(obj.cls_.id) + '-pill-before')
+          .add(value)
+        .end();
+      }
+    },
+    {
+      class: 'String',
+      name: 'after',
+      documentation: 'The value of whatever this AnalyticEvent was triggered on *after* the change happened.',
+      tableCellFormatter: function(value, obj) {
+        this.start('span')
+          .addClass(foam.String.cssClassize(obj.cls_.id) + '-pill-after')
+          .add(value)
+        .end();
+      }
+    },
+    {
+      class: 'String',
+      name: 'component',
+      documentation: 'The component / category this AnalyticEvent is related to (e.g. "User Management", "Input")',
+      tableCellFormatter: function(value, obj) {
+        this.start('span')
+          .addClass(foam.String.cssClassize(obj.cls_.id) + '-pill-custom-color')
+          .add(value)
+        .end();
+      }
+    },
+    {
+      class: 'String',
+      name: 'changedObjPrefix',
+      documentation: 'Prefix used to describe changedObjName. (e.g. objPrefix == Case && ObjName == SWAM-1 will render as: "Case SWAM-1")',
+      hidden: true
+    },
+    {
+      class: 'String',
+      name: 'changedObjName',
+      label: 'Object',
+      documentation: 'Name / description of the object that whose field was changed',
+      tableCellFormatter: function(value, obj) {
+        this.start().addClass(foam.String.cssClassize(obj.cls_.id) + '-supportingLabel').add(obj.changedObjPrefix).end();
+        this.start().addClass(foam.String.cssClassize(obj.cls_.id) + '-label').add(value).end();
+      }
+    },
+    {
+      // Overload spid to display their name as that is more meaningful
+      name: 'spid',
+      label: 'Client',
+      tableCellFormatter: function(value) {
+        this.__context__.capabilityDAO.find(value).then((result) => {
+          if ( ! result ) {
+            this.add(value); // If we can't find the name, fallback to spid
+          } else {
+            this.add(result.name);
+          }
+        });
+      }
+    },
+    {
+      // Overload userId to display the user's name, instead
+      name: 'userId',
+      label: 'Actor',
+      tableCellFormatter: function(value) {
+        this.style({ 'font-weight': '600' });
+        this.__context__.userDAO.find(value).then((result) => {
+          if ( ! result ) {
+            this.add("Unknown");
+          } else {
+            this.add(result.firstName == "system" ? result.firstName : result.firstName[0] + ". " + result.lastName);
+          }
+        });
+      }
+    },
+    {
+      name: 'name',
+      label: 'Change', // Name of event = change that occurred
+      tableCellFormatter: function(value, obj) {
+        this.start().addClass(foam.String.cssClassize(obj.cls_.id) + '-label').add(obj.field).end();
+        this.start().addClass(foam.String.cssClassize(obj.cls_.id) + '-supportingLabel').add(value).end();
+      }
+    }
+  ]
+});

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -535,7 +535,8 @@ foam.POM({
     { name: "benchmark/JSONFormatterBenchmark",                       flags: "js&test|java&test" },
     { name: "benchmark/F3JournalReplayBenchmark",                     flags: "js&test|java&test" },
     { name: "benchmark/FileJournalBenchmark",                         flags: "js&test|java&test" },
-    { name: "notification/NotificationGroupingDAOList",               flags: "web" }
+    { name: "notification/NotificationGroupingDAOList",               flags: "web" },
+    { name: "analytics/ChangeAnalyticEvent",                          flags: 'js|java'           }
   ],
 
   javaFiles: [


### PR DESCRIPTION
Added ChangeAnalyticEvents that track the before and after state of a given property, as well as information about who made the change. Made AnalyticEvents ServiceProvider (said) aware.

**DOS Links:**
[DOS-4185](https://payticconnect.atlassian.net/browse/DOS-4185)
[DOS-4187](https://payticconnect.atlassian.net/browse/DOS-4187)