### PR TITLE
fix(tools): put build/classes before build/lib on the CORE run classpath

### DIFF
--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -488,7 +488,10 @@ foam.POM({
 
       // this.info(`Starting CORE ${APP_NAME}`);
       // Acquires environment variables via JAVA_TOOL_OPTIONS (JAVA_OPTS)
-      this.execSync(`java -cp "${BUILD_DIR}/lib/\*:${BUILD_DIR}/classes" ${JAVA_MAIN_CLASS} "${JAVA_MAIN_ARGS}"`, { stdio: 'inherit' });
+      // build/classes precedes build/lib/* so freshly compiled classes always win
+      // over any stale jar sitting in build/lib (e.g. an app/test package left by a
+      // prior run) — otherwise the jar shadows the recompiled classes silently.
+      this.execSync(`java -cp "${BUILD_DIR}/classes:${BUILD_DIR}/lib/\*" ${JAVA_MAIN_CLASS} "${JAVA_MAIN_ARGS}"`, { stdio: 'inherit' });
     }],
 
     startCOREAsync: ['start-core-async', 'Start CORE server (CLASSPATH) as an asynchronous/detached child process. When re-run the previous process will be terminated.', ['stopCORE', 'setupDirs', 'deployJournals', 'deployDocuments', 'deployLib', 'buildJavaOpts', 'buildJavaMainArgs','java'], function() {
@@ -507,7 +510,7 @@ foam.POM({
       if ( BUILD_ONLY ) return;
 
       // this.info(`Starting CORE ${APP_NAME}`);
-      var proc = this.spawn(JAVA, ['-server', '-cp', `${BUILD_DIR}/lib/\*:${BUILD_DIR}/classes`, JAVA_MAIN_CLASS, JAVA_MAIN_ARGS], {
+      var proc = this.spawn(JAVA, ['-server', '-cp', `${BUILD_DIR}/classes:${BUILD_DIR}/lib/\*`, JAVA_MAIN_CLASS, JAVA_MAIN_ARGS], {
         stdio: 'inherit',
         shell: '/bin/bash',
         detached: true,

--- a/tools/setup/ProjectTooling.js
+++ b/tools/setup/ProjectTooling.js
@@ -124,7 +124,7 @@ foam.POM({
         this.execute('genJava');
         // TODO: just compile foam.util.Password.java and foam.util.SecurityUtil.java
       }
-      ADMIN_PASSWORD_HASH = this.execSync(`java -cp "${BUILD_DIR}/lib/\*:${BUILD_DIR}/classes" foam.util.Password ${ADMIN_PASSWORD.trim()}`).toString().trim();
+      ADMIN_PASSWORD_HASH = this.execSync(`java -cp "${BUILD_DIR}/classes:${BUILD_DIR}/lib/\*" foam.util.Password ${ADMIN_PASSWORD.trim()}`).toString().trim();
     }],
 
     templateMerge: ['template-merge', 'Populate template fields and copy template into final file location', [],


### PR DESCRIPTION
The CORE run classpath listed build/lib/* before build/classes, so a stale jar in build/lib (e.g. an app/test package left by a prior build) shadowed freshly compiled classes — a recompile + restart silently ran the old code with no error, only wrong runtime behavior.

Java classpath resolution is first-match-wins, so the jar's classes loaded instead of the just-recompiled ones in build/classes.

Fix:

- **startCORE / startCOREAsync** — put build/classes ahead of build/lib/* so freshly compiled classes always win over any jar in build/lib.

- **setup password hasher** — same reorder for consistency.

Deploy/packaged runs are unchanged: they run from the built jars (BIN_JAR:RES_JAR:app/lib), which never include build/classes.

Verified with a class present in both a dir and a jar: -cp dir:jar loads the dir copy, -cp jar:dir loads the jar copy — confirming the reorder makes compiled classes win.