### PR TITLE
fix(ascript): match longest function name first to avoid prefix shadowing

### DIFF
--- a/src/foam/ascript/AScriptParser.js
+++ b/src/foam/ascript/AScriptParser.js
@@ -214,7 +214,11 @@ foam.CLASS({
     function generateFuncNames(alt, sug, literalIC) {
       let self = this;
 
-      return alt.apply(alt, Object.keys(this.FUNCTIONS).map(key => {
+      // Longest-first so a shorter name doesn't shadow a longer one that shares
+      // its prefix: alt() returns the first match and literalIC('LOG') would match
+      // the start of 'LOG10(' , consuming only 'LOG' and failing the funcall. Same
+      // sort the property-name matcher already applies to `fields`.
+      return alt.apply(alt, Object.keys(this.FUNCTIONS).sort((a, b) => b.length - a.length).map(key => {
         let f = self.FUNCTIONS[key];
         return sug(literalIC(key), {text: key, category: 'function', label: f.documentation});
       }));


### PR DESCRIPTION
The function-name matcher builds an ordered alternation over the registered names in insertion order. `alt()` returns the first match and a case-insensitive literal matches a prefix, so a short name registered ahead of a longer one that shares its prefix consumes only the prefix: `LOG` swallows the `LOG` in `LOG10(`, the trailing `10(` then fails the call, the whole expression fails to parse, and the value silently falls back to a default.

Shadowed in practice: `LOG10` (by `LOG`), `ROUNDUP` / `ROUNDDOWN` (by `ROUND`), `DATEDIF` (by `DATE`), `MINUTE` / `MINUTES` (by `MIN`).

Fix:

- Sort the names longest-first before building the alternation — the same order the property-name matcher already applies to its fields.