### PR TITLE
fix(ascript): box literal operands so nested binary ops serialize as Expr

### DIFF
--- a/src/foam/ascript/AScriptParser.js
+++ b/src/foam/ascript/AScriptParser.js
@@ -231,12 +231,17 @@ foam.CLASS({
       var NO_PARSE = foam.parse.ParserWithAction.NO_PARSE;
 
       // Left-fold a flat operator tail: v = [ first, [ [opName, rhs], ... ] ].
-      // MLangs adapt literal args to Constant, so no manual boxing needed.
+      // Box BOTH operands as Exprs: not every arithmetic mlang adapts a raw
+      // literal arg to a Constant (Add/Subtract do, Multiply/Divide do not), so
+      // a nested `x / 3` would serialize a bare `3` the server can't rehydrate
+      // into an Expr[] (top-level partialEval would fix it, but a binary op
+      // nested inside a function is never partialEval'd).
+      function box(x) { return foam.mlang.ExprProperty.prototype.adaptValue(x); }
       function fold(v) {
-        var acc = foam.mlang.ExprProperty.prototype.adaptValue(v[0]);
+        var acc = box(v[0]);
         v = v[1];
         for ( let i = 0 ; i < v.length ; i++ )
-          acc = m[v[i][0]].call(m, acc, v[i][1]);
+          acc = m[v[i][0]].call(m, acc, box(v[i][1]));
         return acc;
       }
 


### PR DESCRIPTION
The grammar fold builds binary-operator expressions (`+ - * /`) leaving numeric literal operands as raw numbers, relying on top-level `partialEval` to box them into a `Constant`. A binary op **nested inside a function** (e.g. `ROUND(a * b / 3, 2)`) is never reached by `partialEval` — only the outer expression is — so the bare `3` survives into the serialized `exprStr`.

On deserialization the server can't rehydrate a raw number into a `Formula`'s `Expr[]`, so that arg resolves to nothing, `Formula.f` returns null, and the enclosing function throws `NullPointerException` on `((Number) f(obj)).doubleValue()` — the whole evaluation fails.

`Add` / `Subtract` masked this because their builders box literals; `Multiply` / `Divide` do not, so only expressions with a nested `*` or `/` literal broke.

Fix:

- **Box both operands** — run each fold operand through `ExprProperty.adaptValue`, so a literal becomes a `Constant` at build time, independent of whether `partialEval` ever visits that node.