### PR TITLE
fix(json): output null for non-finite numbers instead of invalid NaN/Infinity

### DIFF
--- a/src/foam/lang/JSON.js
+++ b/src/foam/lang/JSON.js
@@ -524,7 +524,8 @@ foam.CLASS({
         Undefined: function(o) { this.out('null'); },
         Null:      function(o) { this.out('null'); },
         String:    function(o) { this.outputString(o); },
-        Number:    function(o) { this.out(o); },
+        // JSON has no NaN / Infinity literal; emit null for non-finite numbers.
+        Number:    function(o) { this.out(Number.isFinite(o) ? o : 'null'); },
         Boolean:   function(o) { this.out(o); },
         Date:      function(o) { this.outputDate(o); },
         Function:  function(o) { this.outputFunction(o); },

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -130,16 +130,28 @@ public class JSONFObjectFormatter
   public void output(long val) { append(val); }
 
 
-  public void output(float val) { append(val); }
+  public void output(float val) {
+    if ( Float.isNaN(val) || Float.isInfinite(val) ) { append("null"); return; }
+    append(val);
+  }
 
 
-  public void output(double val) { append(val); }
+  public void output(double val) {
+    if ( Double.isNaN(val) || Double.isInfinite(val) ) { append("null"); return; }
+    append(val);
+  }
 
 
   public void output(boolean val) { append(val); }
 
 
-  protected void outputNumber(Number value) { append(value); }
+  protected void outputNumber(Number value) {
+    if ( value instanceof Double || value instanceof Float ) {
+      double d = value.doubleValue();
+      if ( Double.isNaN(d) || Double.isInfinite(d) ) { append("null"); return; }
+    }
+    append(value);
+  }
 
   public void output(String[] arr) { output((Object[]) arr); }
 
@@ -681,11 +693,13 @@ public class JSONFObjectFormatter
   }
 
   public void output(float val, int precision) {
+    if ( Float.isNaN(val) || Float.isInfinite(val) ) { append("null"); return; }
     // TODO: faster
     append(String.format("%." + precision + "f", val));
   }
 
   public void output(double val, int precision) {
+    if ( Double.isNaN(val) || Double.isInfinite(val) ) { append("null"); return; }
     // TODO: faster
     append(String.format("%." + precision + "f", val));
   }

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -161,6 +161,16 @@ public class Outputter
   }
 
   protected void outputNumber(Number value) {
+    // JSON has no NaN / Infinity literal; value.toString() would emit a bare
+    // `NaN` / `Infinity` token that is invalid JSON and breaks the parser on
+    // read. Emit null for non-finite doubles/floats, matching JSON.stringify.
+    if ( value instanceof Double || value instanceof Float ) {
+      double d = value.doubleValue();
+      if ( Double.isNaN(d) || Double.isInfinite(d) ) {
+        writer_.append("null");
+        return;
+      }
+    }
     // TODO: don't do this, creates extra garbage
     writer_.append(value.toString());
   }


### PR DESCRIPTION
A `Double` / `Float` that is `NaN` or `Infinity` has no JSON literal, but the serializers wrote it via `toString()` / raw append — emitting the bare token `NaN` or `Infinity`. That is invalid JSON: a consumer parsing the payload fails on the *whole* message, not just the one field. It bites both directions — a server response carrying a non-finite value, and a client writing one up.

Fix — emit `null` for a non-finite `Double`/`Float` (matching `JSON.stringify`); finite numbers unchanged. Applied across all three JSON serializers so neither side can produce an invalid token:

- **Network formatter** — `JSONFObjectFormatter` (the box / HTTP response path) guards `output(double)`, `output(float)`, `outputNumber`, and the fixed-precision variants

- **JSON Outputter** — `Outputter.outputNumber` guards the same

- **Client outputter** — `JSON.js` `Number` output emits `null` for non-finite, so the client never sends an invalid token