### PR TITLE
DOS-4334 Preserve section-level view overrides in fromSectionAxiom

### DIFF
--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -143,6 +143,13 @@ foam.CLASS({
         
       }
       this.copyFrom(a);
+      // copyFrom() skips 'view' here: Section and SectionAxiom are different classes, so
+      // copyFrom() takes its cross-class path, which respects each property's copyValueFrom
+      // hook -- and foam.u2.ViewSpec (the class of 'view') hardcodes copyValueFrom to always
+      // return false. That's correct for typical clone/copy use (don't let a view spec leak
+      // across unrelated objects), but wrong here: transferring the axiom's declared view is
+      // the whole point of fromSectionAxiom, so carry it across explicitly.
+      if ( a.hasOwnProperty('view') ) this.view = a.view;
       this.copyFrom({
         createIsAvailableFor: a.createIsAvailableFor.bind(a),
         fromClass: a.sourceCls_?.name || cls.name,


### PR DESCRIPTION
copyFrom() silently drops 'view' when building a Section from a SectionAxiom, since ViewSpec.copyValueFrom always returns false and Section/SectionAxiom don't share a class hierarchy. Any model's custom section view was silently falling back to the default SectionView with no error.