### PR TITLE
fix(dao): fire NotPartitionedDAO listeners on put and remove

### DIFF
--- a/src/foam/core/partition/NotPartitionedDAO.java
+++ b/src/foam/core/partition/NotPartitionedDAO.java
@@ -88,6 +88,7 @@ public class NotPartitionedDAO
 
   public void removeAll_(X x, long skip, long limit, Comparator order, Predicate predicate) {
     getDelegate().removeAll_(x, skip, limit, order, predicate);
+    onReset();
   }
 
   public FObject find_(X x, Object id) {

--- a/src/foam/core/partition/NotPartitionedDAO.java
+++ b/src/foam/core/partition/NotPartitionedDAO.java
@@ -8,6 +8,7 @@ package foam.core.partition;
 
 import foam.core.logger.Loggers;
 import foam.dao.*;
+import foam.dao.index.AddIndexCommand;
 import foam.dao.java.JDAO;
 import foam.lang.*;
 import foam.mlang.Expr;

--- a/src/foam/core/partition/NotPartitionedDAO.java
+++ b/src/foam/core/partition/NotPartitionedDAO.java
@@ -73,11 +73,17 @@ public class NotPartitionedDAO
   }
 
   public FObject put_(X x, FObject obj) {
-    return getDelegate().put_(x, obj);
+    FObject ret = getDelegate().put_(x, obj);
+    // Listeners registered via listen_ live on this DAO, not the soft-referenced
+    // delegate (they would be lost on unload), so fire them here.
+    if ( ret != null ) onPut(ret);
+    return ret;
   }
 
   public FObject remove_(X x, FObject obj) {
-    return getDelegate().remove_(x, obj);
+    FObject ret = getDelegate().remove_(x, obj);
+    if ( ret != null ) onRemove(ret);
+    return ret;
   }
 
   public FObject find_(X x, Object id) {


### PR DESCRIPTION
With `unloadable` enabled, EasyDAO's journal delegate is a `NotPartitionedDAO`, so `DAO.listen()` calls walking the ProxyDAO chain terminate there and register their sinks in its `listeners_`. Its `put_`/`remove_` only delegate to the inner soft-referenced JDAO, which fires its own (empty) listener list — the sinks registered on the shell never fire.

Services that invalidate caches through DAO listeners (CachingAuthService purge sinks on the user, group-permission-junction, and capability-junction DAOs) stop seeing writes, so permissions granted at runtime keep answering from a stale cache. This is what failed 24 auth assertions in the server-tests run.

Forwarding `listen_` to the inner DAO is not an option: the delegate is held by a SoftReference and rebuilt after unload, which would drop every registered listener.

Fix:

- **onPut/onRemove** — `NotPartitionedDAO.put_`/`remove_` fire the shell's own listeners after delegating, matching MDAO's convention.

Server tests: 2135/2135 pass with `unloadable` on (was 2057 pass / 24 fail).

Also on this branch after merging development:

- **onReset** — `removeAll_` fires the shell's `reset` event so listeners hear bulk removes too.

- **import** — add `foam.dao.index.AddIndexCommand` import; `cmd_` references it but `foam.dao.*` doesn't cover the `index` subpackage, so development doesn't compile without it.
