### PR TITLE
Have UserFeedbackException implement UserFeedbackAware

### DIFF
--- a/src/foam/comics/v2/userfeedback/UserFeedback.js
+++ b/src/foam/comics/v2/userfeedback/UserFeedback.js
@@ -13,6 +13,13 @@ foam.CLASS({
     inevitably making its way back to the client who views the feedback
   `,
 
+  javaCode: `
+  public UserFeedback(UserFeedbackStatus status, String message) {
+    setStatus(status);
+    setMessage(message);
+  }
+  `,
+
   properties: [
     {
       class: 'Enum',

--- a/src/foam/comics/v2/userfeedback/UserFeedbackException.js
+++ b/src/foam/comics/v2/userfeedback/UserFeedbackException.js
@@ -7,14 +7,21 @@
 foam.CLASS({
   package: 'foam.comics.v2.userfeedback',
   name: 'UserFeedbackException',
-
   extends: 'foam.lang.ClientRuntimeException',
+  implements: [ 'foam.comics.v2.userfeedback.UserFeedbackAware' ],
 
   documentation: `
     In cases where the object is not returned to client user after a request,
     a UserFeedbackException will be thrown which will chain the message at the time
     of the exception to the other feedback messages the object has collected on its
     path to the DAO
+  `,
+
+  javaCode: `
+  public UserFeedbackException(UserFeedback feedback, UserFeedbackAlertType alertType) {
+    setUserFeedback(feedback);
+    setAlertType(alertType);
+  }
   `,
 
   properties: [


### PR DESCRIPTION
Have UserFeedbackException implement UserFeedbackAware as client is testing for Aware implementation and has been skipping over UserFeedbackExceptions.

Add common constructors to avoid using builder pattern on each creation