### PR TITLE
ArrayView: updates to stop a Flow blocks infinite render

### DIFF
--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -280,7 +280,11 @@ foam.CLASS({
     function buildRow(e, i, self) {
       var row = self.Row.create({ index: i, value: e });
       e && e.sub && e.sub(self.updateDataWithoutFeedback);
-      row.onDetach(row.sub(self.updateDataWithoutFeedback));
+      row.onDetach(row.sub(
+        'propertyChange',
+        'value',
+        self.updateDataWithoutFeedback
+      ));
       return row;
     },
     function addAction() {


### PR DESCRIPTION
behavior removed is reacting to unrelated events emitted by the row’s UI element—such as children being added during rendering

low risk, targeted fix, and the removed behavior was not a legitimate data-update path.