### PR TITLE
Add DAO and property gotchas guides

### DIFF
--- a/doc/guides/DaoGotchas.md
+++ b/doc/guides/DaoGotchas.md
@@ -60,7 +60,7 @@ Re-homing the object is not a shortcut. Generated `setX` is literally `x_ = x;` 
 
 ### A later wrap is the outer decorator
 
-`EasyDAO` builds its delegate chain inner to outer in code order. `getOuterDAO` runs first (`src/foam/dao/EasyDAO.js:248`), `.setDecorator()` applies next (`:250-260`), and `RulerDAO` applies at `:294`. RulerDAO wraps later, so it is **outer** to whatever `.setDecorator()` installed.
+`EasyDAO` builds its delegate chain inner to outer in code order. `getOuterDAO` runs first (`src/foam/dao/EasyDAO.js:248`), `.setDecorator()` applies next (`:250-260`), and a `RulerDAO` wraps it at `:294`. RulerDAO wraps later, so it is **outer** to whatever `.setDecorator()` installed.
 
 Consequence: a `put()` reaches RulerDAO and evaluates rules **before** any `.setDecorator()` decorator's `put_`. If a decorator needs to set a field the rule engine reads, `.setDecorator()` cannot do it — the value has to be stamped upstream of the served DAO.
 
@@ -74,7 +74,7 @@ return getEnableInterfaceDecorators() && getOf().isAssignableTo(foam.core.auth.L
 
 (`lifecycleAware` at `EasyDAO.js:854`, with `createdAware`, `lastModifiedAware` and `serviceProviderAware` declared alongside it). When true, `build` wraps the decorator automatically — `LifecycleAwareDAO` at `EasyDAO.js:346-347`.
 
-So when auditing a DAO's service definition, never conclude "no `setLifecycleAware(true)` means hard delete" from the builder script alone. Check the `of` model's `implements:` list: `foam.core.auth.User` implements `LifecycleAware` (`src/foam/core/auth/User.js:12-20`), so any plain `EasyDAO` over `User` soft-deletes — `LifecycleAwareDAO.remove_` clones, sets `lifecycleState = DELETED`, and puts (`src/foam/core/auth/LifecycleAwareDAO.js`).
+So when auditing a DAO's service definition, never conclude "no `setLifecycleAware(true)` means hard delete" from the builder script alone. Check the `of` model's `implements:` list: `foam.core.auth.User` implements `LifecycleAware` (`src/foam/core/auth/User.js:12-20`), so any plain `EasyDAO` over `User` soft-deletes — `LifecycleAwareDAO.remove_` marks the object `DELETED` and puts it instead of removing it (`src/foam/core/auth/LifecycleAwareDAO.js:142`).
 
 The same reasoning applies to any application-level `*Aware` decorator wired through the same mechanism. Two corollaries:
 
@@ -275,7 +275,7 @@ The inherited `dao` expression depends on `predicate`, so it rebuilds the `where
 
 **Any `dao.put` in server code, including from a script or a cron, runs that DAO's `RulerDAO` rules for the put's operation.** A record you clone and re-put can have its fields rewritten before it lands.
 
-**Boot-time journal replay does NOT fire rules.** Entries replay straight into the DAO without `RulerDAO`, so a seed record keeps the values written in the file even when the same value written by a live put would be rewritten by a CREATE rule. When you need values to stick exactly as authored, prefer a static seed journal over a runtime clone-and-put script.
+**Journal replay writes below the decorator chain.** `JDAO` replays into its own **delegate** (`src/foam/dao/JDAO.js:31`), and the journal calls `dao.put_(x, obj)` on that delegate (`src/foam/dao/AbstractF3FileJournal.js:300`). Anything wrapped above the JDAO — a `RulerDAO` included — never sees a replayed entry. So a seed record keeps the values written in the file even where the same value written through the served DAO would be rewritten by a CREATE rule. When you need values to stick exactly as authored, prefer a static seed journal over a runtime clone-and-put script.
 
 **Operation semantics.** `foam.core.dao.Operation` is `CREATE`, `UPDATE`, or `CREATE_OR_UPDATE`. A `CREATE` rule fires only on a create — a new or non-existent id — and not on a re-put of an existing id.
 

--- a/doc/guides/DaoGotchas.md
+++ b/doc/guides/DaoGotchas.md
@@ -1,0 +1,363 @@
+# DAO Gotchas
+
+Behaviour of the DAO stack that is not obvious from reading a model: which context an operation runs in, what a decorator wraps, when a result is frozen or cached, and how predicates and sinks actually evaluate.
+
+Every claim here cites the code that proves it. Line numbers drift — anchor on the named method if a citation no longer lines up.
+
+For the basics, start with [Dao.md](Dao.md), [EasyDao.md](EasyDao.md) and [MLang.md](MLang.md). This guide covers the traps that survive knowing the basics.
+
+---
+
+## Which context a DAO operation runs in
+
+This is the highest-consequence section on the page. Getting it wrong produces data leaks across tenants that throw no error.
+
+### A decorator's predicate filters by the context the DAO was built in
+
+Two mechanics combine:
+
+- An `imports:` getter returns `this.__context__[key]` (`src/foam/lang/ImportsExports.js:110`). It resolves live, but always from the object's own `__context__`, fixed at construction.
+- DAO operations run with their own context. `AbstractDAO.removeAll()` is `removeAll_(this.__context__, ...)` (`src/foam/dao/AbstractDAO.js:444`); `select` and `find` do the same.
+
+So a context a caller passes at query time does not reach the decorator's predicate. The only way to push an override down is `dao.inX(ctx)`, which wraps a `ProxyDAO` whose `__context__` is `ctx` (`AbstractDAO.js:85`).
+
+A scoping decorator's `predicateIn(x)` must therefore read from the passed `x`, not from an imported instance. The Java `FilteredDAO.select_` does pass the call `x` down to `predicateIn(x)` (`src/foam/dao/FilteredDAO.js:67-68`), so `inX` works server-side.
+
+**The server-side trap is not just an ignored override.** Business logic that fetches a scoped service DAO out of the context and queries it bare:
+
+```java
+((DAO) x.get("someDAO")).where(pred).select(sink);
+```
+
+runs the filter against the DAO's **boot** context. If the scoping value is absent there, a well-written `predicateIn` returns `TRUE` and the select quietly scans everything the DAO holds, returning rows the caller was never entitled to. It fails open, silently, and only under a context the developer never tested. Scope it explicitly with `dao.inX(subContext)`, taking the scoping value from the entity in hand rather than from ambient state.
+
+### Argless convenience methods re-enter with the DAO's own context
+
+Java `find(id)` ends in `this.find_(this.getX(), id)` (`src/foam/dao/AbstractDAO.js:514`), and `select(sink)` in `select_(this.getX(), sink, ...)` (`:484`).
+
+For a service DAO built at boot, `getX()` is the system context. So a decorator that calls `getDelegate().find(oid)` runs the entire delegate stack — authorization, lifecycle filtering, PM — as system: permission checks pass unconditionally, deleted-row filtering is skipped, and PM attribution is wrong. The bug is invisible while the caller happens to hold the same permissions, and becomes a live bypass the moment they diverge.
+
+Inside a decorator, always call `find_(x, id)`, `select_(x, ...)`, `put_(x, obj)` with the request `x`. Reserve the bare forms for code where the DAO's own context is the right one.
+
+### Arity-1 `select(sink)` silently drops every query argument
+
+It resolves to `select_(x, sink, undefined, undefined, undefined, undefined)` (`AbstractDAO.js:478`). A `select_` override that ends with `getDelegate().select(proxySink)` therefore ignores the predicate, skip, limit and order the framework handed it. Symptom: every search returns all rows.
+
+### An object loaded from a DAO carries a serviceless context
+
+`MDAO` returns the stored object as-is (`src/foam/dao/MDAO.java:164`), so its `getX()` is whatever context it was deserialized with — not the caller's, and not changed by the `x` passed to `find` or `select`. `getX().get("someService")` returns null.
+
+Two ways out:
+
+- **The method takes, or can take, an `x`** — thread the caller's context. This is the dominant idiom; `Credential.getPasswordSecret(x)` (`src/foam/core/auth/Credential.js:98`) is typical. Fetch through `dao.inX(x)` and pass the same `x` in.
+- **No `x` argument and `getX()` is unreliable** (getters, factories, `javaPostSet`, a predicate's `f()`) — `foam.lang.XLocator.get()`, documented as the "last-resort method of locating thread-local session context" (`src/foam/lang/XLocator.java:9`). The hybrid form `getX() != null ? getX() : XLocator.get()` appears in `src/foam/core/logger/StdoutLogger.js:27`.
+
+Re-homing the object is not a shortcut. Generated `setX` is literally `x_ = x;` (`src/foam/java/refinements.js:689`) and does not cascade into nested `FObjectProperty` values, and `ContextualizingDAO` re-homes only the top object, only on `find_` and `put_` (not `select_`), and is opt-in through `EasyDAO`'s `contextualize` flag.
+
+---
+
+## Decorator stacking
+
+### A later wrap is the outer decorator
+
+`EasyDAO` builds its delegate chain inner to outer in code order. `getOuterDAO` runs first (`src/foam/dao/EasyDAO.js:248`), `.setDecorator()` applies next (`:250-260`), and `RulerDAO` applies at `:294`. RulerDAO wraps later, so it is **outer** to whatever `.setDecorator()` installed.
+
+Consequence: a `put()` reaches RulerDAO and evaluates rules **before** any `.setDecorator()` decorator's `put_`. If a decorator needs to set a field the rule engine reads, `.setDecorator()` cannot do it — the value has to be stamped upstream of the served DAO.
+
+### `*Aware` decorators wire implicitly from the model's `implements:` list
+
+`enableInterfaceDecorators` defaults to true (`EasyDAO.js:837`), and each decorator flag has a factory of the form:
+
+```javascript
+return getEnableInterfaceDecorators() && getOf().isAssignableTo(foam.core.auth.LifecycleAware.class);
+```
+
+(`lifecycleAware` at `EasyDAO.js:854`, with `createdAware`, `lastModifiedAware` and `serviceProviderAware` declared alongside it). When true, `build` wraps the decorator automatically — `LifecycleAwareDAO` at `EasyDAO.js:346-347`.
+
+So when auditing a DAO's service definition, never conclude "no `setLifecycleAware(true)` means hard delete" from the builder script alone. Check the `of` model's `implements:` list: `foam.core.auth.User` implements `LifecycleAware` (`src/foam/core/auth/User.js:12-20`), so any plain `EasyDAO` over `User` soft-deletes — `LifecycleAwareDAO.remove_` clones, sets `lifecycleState = DELETED`, and puts (`src/foam/core/auth/LifecycleAwareDAO.js`).
+
+The same reasoning applies to any application-level `*Aware` decorator wired through the same mechanism. Two corollaries:
+
+- `setEnableInterfaceDecorators(false)` kills all implicit decorators at once; an explicit flag forces just one on a model that does not implement the interface.
+- Disabling one decorator does not disable another. `setAuthorize(false)` turns off authorization and nothing else — a scoping decorator wired from the interface list still filters every select.
+- Because the `instanceof` check in `remove_` runs on the **object**, an adapter that puts a `User` through still soft-deletes even when the outer DAO's `of` is a facade model that does not implement the interface.
+
+### A `FilteredDAO` subclass built in code needs `of` passed
+
+A filter predicate computed from the model's properties — `this.EQ(this.of.SOME_PROP, value)` — throws `Cannot read properties of null` when `of` is null. A JSON spec happens to work because the parsed graph carries `of` down to the delegate, which masks the requirement until the wrapper is constructed programmatically:
+
+```javascript
+this.MyFilteredDAO.create({ of: this.of, delegate: delegate }, this.__subContext__);
+```
+
+If the predicate short-circuits to `TRUE` while its scoping value is unset, the crash only appears once a real value is selected.
+
+### A method with only `javaCode` has no JS implementation
+
+`javaCode` generates Java only, `code` generates JS only. Calling a `javaCode`-only method from JS throws `this.<name> is not a function`.
+
+That matters for base "hook" methods meant to be overridden. A hook needs a JS `code` body — even a no-op — or no JS caller can invoke it and no JS refinement can override it:
+
+```javascript
+{ name: 'getOuterDAO',
+  args: [ { type: 'foam.dao.DAO', name: 'innerDAO' } ],
+  code: function(innerDAO) { return innerDAO; },   // makes it JS-callable and overridable
+  javaCode: `return innerDAO;` }
+```
+
+`EasyDAO.getOuterDAO` (`EasyDAO.js:1058`) carries exactly this pair for that reason.
+
+---
+
+## Results: frozen, cached, refreshed
+
+### `put()` and `find()` return frozen objects
+
+Any setter on the returned instance throws `RuntimeException: Object is frozen.` Clone before mutating:
+
+```java
+SomeModel persisted = (SomeModel) dao.put(obj);
+SomeModel next = (SomeModel) persisted.fclone();
+next.setStatus(NEXT_STATE);
+dao.put(next);
+```
+
+This bites hardest when driving a multi-step lifecycle through a real DAO in a test. The freeze is deliberate: DAOs avoid sharing mutable references between writers and readers.
+
+### Client caching is decided by ClientBuilder, and only for a top-level `EasyDAO`
+
+When a client spec's top-level class is `foam.dao.EasyDAO` (or is absent, defaulting to it), the per-client property factory injects `cache: true`, `ttlSelectPurgeTime` and `ttlPurgeTime` from `CACHE_TIMEOUT`, and `daoType: CLIENT` (`src/foam/core/client/ClientBuilder.js:209-213`, constant at `:32`).
+
+A **decorator-wrapped** spec — `{class: SomeDecorator, delegate: {class: foam.dao.EasyDAO, ...}}` — has a top-level class that is not `EasyDAO`, so the nested EasyDAO gets only what its own JSON declares.
+
+That distinction decides whether you get a bounded cache or a full table load, because:
+
+### `cache: true` with no TTL is a full eager warm
+
+`EasyDAO`'s JS `delegateFactory` (`EasyDAO.js:1126-1160`) branches on the TTL values. With both at or below zero it builds a `CachingDAO`, whose first read runs an **unfiltered** `src.select()` and pulls the entire table into an MDAO (`src/foam/dao/CachingDAO.js:80-86`). With `ttlSelectPurgeTime > 0` it builds a `TTLSelectCachingDAO` instead — a per-query cache keyed on `[sink, skip, limit, order, predicate]`, no full warm.
+
+On a large table the difference is hundreds of megabytes pulled to the client on the first read. Levers: keep the spec a plain top-level `EasyDAO` so the TTL injection applies, set an explicit `ttlSelectPurgeTime`, or drop `cache: true` so aggregation sinks (`SUM`, `COUNT`, `GROUP_BY`) reduce server-side instead.
+
+### Refreshing a view: pick by how stale the data is
+
+| Call | What it does | Use when |
+|---|---|---|
+| `dao.on.reset.pub()` | Fires reset at this level only; subscribers re-select from what the chain already holds | The in-memory data is already correct |
+| `dao.cmd(DAO.RESET_CMD)` | Travels down to the client DAO, which re-publishes reset so it bubbles up to every listener (`src/foam/dao/RequestResponseClientDAO.js:121`) | Re-reading the client cache is enough |
+| `dao.cmd(DAO.PURGE_CMD)` | `CachingDAO.cmd_:143` → `onSrcReset:177` — clears the cache and re-fetches from the server | Server data changed elsewhere |
+
+The trap: an `EasyDAO` with `cache: true` reads from memory, so RESET re-reads the **stale cache** and the view shows nothing changed. A cached client DAO needs PURGE. Constants live at `src/foam/dao/DAO.js:28,39`. Use the public `cmd` (it supplies the context), not `cmd_`.
+
+Publish on the exact instance the view holds. A `where()` or `inX()` wrapper relays events from its base, so acting on the base reaches it — a *different* instance does not, which is the classic "I published and nothing refreshed" bug.
+
+Event mechanics worth knowing: leaf DAOs publish `put` and `remove` after the write (`src/foam/dao/MDAO.js:155,191`), and `removeAll` emits one `remove` **per row** (`MDAO.removeAll_:205`) rather than a single reset. Decorators forward through the ProxyDAO `topics:['on']` proxy (`src/foam/dao/ProxyDAO.js:25`). JS uses the topic bus while Java uses a `listeners_` list (`AbstractDAO.js:691-728`), so `this.on.sub(...)` is client-side only. `dao.listen(sink)` returns a detachable subscription (`AbstractDAO.js:241`), but the public `pipe` discards what `pipe_` returns (`AbstractDAO.js:200`) — so `this.onDetach(dao.pipe(sink))` detaches nothing.
+
+Constants and both cache paths are worth reading directly: `src/foam/dao/DAO.js`, `src/foam/dao/CachingDAO.js`, `src/foam/dao/TTLSelectCachingDAO.js`.
+
+---
+
+## Predicates, sinks and indexing
+
+### A transient getter property is queryable, as a full scan
+
+An MLang predicate referencing the property calls `Property.f(o)`, which is `return o ? o[name] : null` (`src/foam/lang/Property.js:256`) and so invokes the getter. The MDAO scan evaluates the predicate per row (`src/foam/dao/index/ValueIndex.js:72`).
+
+So `where(EQ(...))` and `orderBy` work on a computed property with no stored column — as an O(n) scan. You do not need to persist a field to filter or sort on it; storing and indexing buys index-accelerated speed on hot paths, not correctness.
+
+### Adding an index, and leading it correctly
+
+```java
+new foam.dao.EasyDAO.Builder(x)
+  ...
+  .build()
+  .addPropertyIndex(new foam.lang.PropertyInfo[] { Model.TENANT_ID, Model.CREATED });
+```
+
+A multi-element array is a **compound** index with `props[0]` outermost, built as a nested range-capable `TreeIndex` (`src/foam/dao/MDAO.java:145-148`), so it serves `Gt`/`Gte`/`Lt` as well as `Eq`. `EasyDAO.addPropertyIndex` sends an `AddIndexCommand` down the delegate chain (`EasyDAO.js:1325-1346`); the MDAO handles it and returns true (`MDAO.java:297`), otherwise it logs `Index not added, no access to MDAO`. Decorators are transparent to it.
+
+**Lead a compound index with the most selective term.** A query shaped `Eq(scopeId) AND Gt(date)` wants `(scopeId, date)` so the scan seeks the scope bucket first and then ranges the date. A date-only index cannot prune by scope.
+
+**"Unindexed search on MDAO" does not prove the index is missing.** That warning fires when `plan.cost() > 10 && plan.cost() >= index_.size(state)` (`MDAO.java:247-256`), and the cost equals the table size whenever a predicate matches essentially every row — a `> date` filter where every row is newer, for instance — even with a correct index attached. An index cannot prune a query that returns everything. Check predicate selectivity against the data before concluding anything about the index.
+
+### `MDAO.bulkLoad(dao)` reads the sink you passed in
+
+The JS implementation is `var sink = this.ArraySink.create(); dao.select(sink).then(() => this.index.bulkLoad(sink.array))` (`src/foam/dao/MDAO.js:137-142`), which assumes `select` mutates the sink it was handed. A decorated or proxy DAO resolves `select` with a **fresh** sink, so the passed one stays empty and the index loads zero rows — silently, with no exception. Loading from another plain MDAO works, which is what makes the bug look intermittent.
+
+Use the resolved sink instead:
+
+```javascript
+var rows = (await dao.select()).array;
+mdao.index.bulkLoad(rows);
+```
+
+### A `select_` that hydrates rows must filter on the sink
+
+When `select_` transforms each row before returning it — a facade DAO filling `storageTransient` fields by copying from another DAO, say — the query arguments have to be applied **after** the transform. `storageTransient` fields are not journaled (`src/foam/lang/JSON.js:753`), so the stored row has them empty and pushing the predicate down to the delegate filters the un-hydrated row: transient columns match nothing.
+
+`decorateSink_(sink, skip, limit, order, predicate)` builds the `LimitedSink → SkipSink → OrderedSink → PredicatedSink` chain, wrapping only the arguments that are set (`src/foam/dao/AbstractDAO.js:367-398`). Feed hydrated rows into that and the predicate evaluates the filled values.
+
+Note this compounds with the arity-1 trap above: an override ending in `getDelegate().select(proxySink)` both drops the args and filters the wrong object.
+
+### `LimitedSink` under `GROUP_BY` truncates the whole scan
+
+`LimitedSink.put` calls `sub.detach()` the moment `count >= limit` (`src/foam/dao/LimitedSink.js:27-29`, same in `javaCode`) — it detaches the subscription it was handed, not just its own accumulation. `GroupBy.putInGroup_` passes the **outer select's** `sub` into every cloned per-group sink: `group.put(obj, sub)` (`src/foam/mlang/sink/GroupBy.js:126`).
+
+So `GROUP_BY(keyProp, LimitedSink({limit: 1}), groupLimit)` is broken: the first group to fill kills the entire scan, and later records and groups never arrive. The result is silently **wrong**, not merely short.
+
+For "one row per distinct key, capped list", use a single sink over the whole stream:
+
+```javascript
+UNIQUE(keyProp, LimitedSink({ limit: N, delegate: projection }))
+```
+
+`Expressions.UNIQUE(expr, sink)` is `Unique.create({expr, delegate: sink})` (`src/foam/mlang/Expressions.js:137`). One sink dedupes by `expr` and the single `LimitedSink`'s detach at N is the intended global cap. Unwrap rows through `result.delegate.delegate.projectionWithClass`.
+
+Do not "fix" `LimitedSink` globally — detach-on-limit is exactly how top-level `.limit()` and `GroupBy`'s own `groupLimit` terminate early (`GroupBy.js:162`). The defect is only in nesting a limited sink under `GroupBy`, where the shared subscription is not the sink's to detach.
+
+### JS `IN` matches by stringified value, and both sides must stay stringified
+
+`In.f` has a fast path when `arg2` is a constant array: it builds a `Set` from the values and tests membership (`src/foam/mlang/predicate/In.js:58-72`).
+
+A JS `Set` matches objects by **reference**, so a naive `new Set(rhs).has(lhs)` never matches an `IN` over `Date` or `FObject` values — two `Date` instances at the same instant are different references, and the correct `foam.util.equals` loop below the fast path (`:74-80`) never runs because the Set path returns first. The current implementation avoids that by stringifying **both** the set members and the lookup key (`v + ''`), which turns membership back into a value comparison.
+
+Two things follow. Do not drop either `+ ''`: a raw set with a stringified key, or the reverse, silently returns false for everything. And be careful with `IN` over composite values — every `FObject` stringifies to `"[object Object]"`, so distinct objects collide. The Java path uses `HashSet` plus `Date.equals`, which is value-based, and needs none of this.
+
+### MLang `LTE` treats an unset Date as less than anything
+
+A record whose date property was never set satisfies `LTE(prop, now)`. Any deadline, expiry or retry sweep written as `dao.where(LTE(prop, now))` therefore also selects records that were never scheduled and runs the expiry handler on them — instant terminal transitions on records nobody ever started.
+
+Guard the sweep:
+
+```java
+MLang.AND(MLang.HAS(prop), MLang.LTE(prop, new Date()))
+```
+
+`HAS` filters unset values (`src/foam/mlang/MLang.java:232`). This is reachable in production whenever the code that stamps the deadline is tolerant of missing configuration and skips stamping — the tolerant skip plus the unguarded sweep combine into immediate expiry.
+
+### `foam.mlang.If` is an Expr, not a Predicate
+
+`If` extends `AbstractExpr` (`src/foam/mlang/If.js:9`) and its `f()` returns `trueExpr.f(obj)` or `falseExpr.f(obj)` — a **value**. It does not gate a query, and there is no `foam.mlang.predicate.If`; writing that class string asserts at journal replay.
+
+Express "if A then B else true" as its predicate equivalent:
+
+```
+OR( NOT(A), B )
+```
+
+Two companion mistakes appear in the same hand-written journal predicates:
+
+- The boolean constants are `foam.mlang.predicate.True` and `False` (`src/foam/mlang/predicate/True.js:9`). There is no `foam.mlang.expression.*` package.
+- `Has.arg1` must be a property expression — its factory is `PropertyExpr` (`src/foam/mlang/predicate/Has.js:20`). A dotted class-name **string** has no `.f()` and crashes at select. Write `{ "class": "__Property__", "forClass_": "pkg.Model", "name": "someProp" }`, or `Model.SOME_PROP` in JS.
+
+### A predicate's `obj` decides what it can read
+
+The same predicate class behaves differently depending on what it is applied to:
+
+- A **menu option** predicate is evaluated as `predicate.f(X)`, so `obj` is the **context** and `ContextObject` resolves: `ContextObject.f` returns `((X) obj).get(key)` (`src/foam/mlang/ContextObject.js:69`).
+- A **`DAOControllerConfig.predicate`** is applied through `dao.where(predicate)` (`src/foam/comics/v2/DAOControllerConfig.js:88-89`), so `f` runs **per record** and `obj` is a row. `ContextObject.f(record)` reads nothing useful.
+
+So a static journal cannot express "filter these config records by a context value". To scope one, subclass `DAOControllerConfig` and make `predicate` a **reactive expression** over the context value, deep-watching the field that changes so it re-fires:
+
+```javascript
+{ name: 'predicate',
+  expression: function(someContextObject$id) {
+    var P = this.SomeModel.SCOPE_ID;
+    if ( ! someContextObject$id ) return this.TRUE;
+    return this.OR(this.NOT(this.HAS(P)), this.EQ(P, someContextObject$id));
+  } }
+```
+
+The inherited `dao` expression depends on `predicate`, so it rebuilds the `where()` on every change. `HAS(P).f(record)` reads the property per row, so record types that do not define it fall through the pass-through arm — which a strict `EQ` scoping decorator cannot do, since it hides rows whose scope field is unset.
+
+---
+
+## Rules fire on put
+
+**Any `dao.put` in server code, including from a script or a cron, runs that DAO's `RulerDAO` rules for the put's operation.** A record you clone and re-put can have its fields rewritten before it lands.
+
+**Boot-time journal replay does NOT fire rules.** Entries replay straight into the DAO without `RulerDAO`, so a seed record keeps the values written in the file even when the same value written by a live put would be rewritten by a CREATE rule. When you need values to stick exactly as authored, prefer a static seed journal over a runtime clone-and-put script.
+
+**Operation semantics.** `foam.core.dao.Operation` is `CREATE`, `UPDATE`, or `CREATE_OR_UPDATE`. A `CREATE` rule fires only on a create — a new or non-existent id — and not on a re-put of an existing id.
+
+Two levers when a rule keeps overwriting a value you need:
+
+- **Two-put.** Put the record (the CREATE rule clobbers the field), then re-put the same id. The CREATE rule cannot fire on the update, so the second write sticks. Capture the returned object to get the sequence-assigned id.
+- **Neutralize the rule.** Change `CREATE_OR_UPDATE` to `CREATE`, or set `enabled = false`, in the rule DAO for the duration and restore in a `finally`. `RulerDAO` live-refreshes its cached rule lists through a rule-DAO listener (`src/foam/core/ruler/RulerDAO.js:250`, `UpdateRulesListSink` → `updateRules`), so the change takes effect for subsequent puts.
+
+And when auditing what a deployment actually does: **the runtime rule set can differ from the journals in the repository.** Read the live rule DAO, not the checked-in files.
+
+### `where(pred).removeAll()` is a targeted delete
+
+`FilteredDAO.removeAll_` forwards to the delegate with `predicate == null ? predicateIn(x) : AND(predicateIn(x), predicate)` (`src/foam/dao/FilteredDAO.js:92`). A bare `removeAll()` passes null, so the delete runs with the `where` predicate and clears only the matching subset.
+
+When reviewing a destructive script, `where(...).removeAll()` is scoped; a bare `dao.removeAll()` is the full wipe to worry about.
+
+---
+
+## Enumeration, export, diagnostics
+
+### Enumerating DAOs through `cSpecDAO`
+
+All `foam.core.boot.CSpec` records live in `cSpecDAO`, and the built-in `DAOS` canned query filters them with `ENDS_WITH(CSpec.NAME, 'DAO')` (`src/foam/core/boot/CSpec.js:63`; `SERVED_DAOS` adds `EQ(SERVE, true)` at `:73`).
+
+The trap: **a CSpec record carries no built service in the common case.** The `service` property (`CSpec.js:184`) is null whenever the DAO comes from a `serviceScript`, which is how most application DAOs are defined — `createService` (`:299`) runs the script at boot and registers the result in the context, and the live DAO is reached through `this.__context__[this.name]` (`:488`). There is no forward reference from the CSpec to the built DAO.
+
+So no pure-MLang predicate can test a trait of the **built** DAO (its `of`, its decorators). Narrow with MLang, then resolve and test in JS:
+
+```javascript
+var E = foam.mlang.Expressions.create(), CS = foam.core.boot.CSpec;
+(await x.cSpecDAO.where(E.ENDS_WITH(CS.NAME, 'DAO')).select()).array
+  .map(cs => cs.name)
+  .filter(n => { var d = x[n]; return d && d.of && SomeInterface.isSubClass(d.of); });
+```
+
+To make it look like pure MLang for a canned query or a `RichChoiceView`, either add a `storageTransient` computed getter on CSpec that resolves `this.__context__[this.name]` and test that with a full scan, or run the JS filter and feed the matches into an in-memory MDAO used as the dropdown's DAO.
+
+### Exporting a DAO as a journal
+
+Two paths, and `DownloadDAOAgent` picks between them by asking `dao.cmd('serviceName?')` (`src/foam/core/reflow/AbstractDAOAgent.js:1250`, probing at `:1110`):
+
+1. **DIG, for server-registered DAOs** — `GET /service/dig?dao=<serviceName>&format=jsonj&sessionId=<id>` (parameters at `src/foam/core/dig/DigWebAgent.java:32-34`, JSONJ output at `DigUtil.java:130`). Serialization happens server-side, so the browser never materializes the objects; safe for very large tables. **Page size defaults to 1000 and a `limit` parameter can only lower it** (`src/foam/core/dig/drivers/DigFormatDriver.js:41,199-213`) — `limit=1000000` is silently ignored and you still get 1000 rows. `limit=0` means all but requires the `service.dig.read-all-records` permission; without it, paginate with `skip`.
+2. **Client export drivers, for anything local** — `foam.core.export.JSONJDriver.exportDAO(x, dao)` selects everything into the browser and stringifies. This is the only option for an in-memory MDAO that DIG cannot see, and it is memory-bound.
+
+`DownloadDAOAgent` also shows a useful trick: a fake `ArraySink` whose `setPredicate` throws captures the DAO's active filter, which is then appended to the DIG URL as `&q=` plus `p.toMQL()` (`:1154`), so an export honours the current view filter.
+
+### A client `select()` aborts on an enum the loaded build does not define
+
+`Attempt to set invalid Enum value` is thrown from the enum adapt when a stored row carries a value the browser's JS does not define — an older or newer deployment, or a value added server-side but not yet in the served bundle. The whole select fails, not just the offending row.
+
+Read such a DAO with a **server-side projection**, which returns scalar arrays and never constructs the object on the client:
+
+```javascript
+var E = foam.mlang.Expressions.create();
+var res = await dao.where(E.INSTANCE_OF(SomeClass))
+                   .select(E.PROJECTION(Model.ID, Model.SOME_STRING));
+var rows = res.projection || res.array || [];
+```
+
+`INSTANCE_OF` also splits a polymorphic DAO — one `setOf(AbstractThing)` journal holding several concrete subclasses — by type without materializing each. `PROJECTION` is at `src/foam/mlang/Expressions.js:155`.
+
+### A `FileArray` strips content from the embedded copy
+
+`FileArrayDAODecorator` stores each file in the file DAO and then blanks the content on the copy embedded in the owning record: `f2.dataString = undefined; f2.data = undefined` (`src/foam/core/fs/FileArrayDAODecorator.js:73-76`). The embedded copy keeps only metadata.
+
+Where the bytes actually live depends on size. `maxStringDataSize` defaults to 3 KB (`:27`):
+
+- **Larger than 3 KB** — content goes to the blob store and the `digest` on the embedded copy still resolves it, so a careless write-back survives.
+- **3 KB or smaller** — content lives only in the file DAO row's `dataString`, and nothing on the embedded copy can reconstruct it.
+
+So taking a file out of the record, cloning it, setting a field, and putting it back overwrites the stored row with a content-less copy. `FileDataDAO.put_` with neither `dataString` nor a blob falls straight through to the delegate (`src/foam/core/fs/FileDataDAO.js:82-88`) — no error, no warning. Small files are destroyed while large ones look fine, so the bug hides until someone attaches a short text file.
+
+When you must write back, re-read the stored row and restore its content onto the clone first:
+
+```java
+if ( SafetyUtil.isEmpty(clone.getDataString()) && clone.getData() == null ) {
+  Object existing = fileDAO.find(doc.getId());
+  if ( existing instanceof foam.core.fs.File stored ) {
+    if ( ! SafetyUtil.isEmpty(stored.getDataString()) ) clone.setDataString(stored.getDataString());
+    else if ( stored.getData() != null )                clone.setData(stored.getData());
+  }
+}
+```
+
+The same applies to any sender that needs the bytes: resolve the content through the file DAO rather than trusting the embedded copy.

--- a/doc/guides/PropertyGotchas.md
+++ b/doc/guides/PropertyGotchas.md
@@ -92,7 +92,7 @@ So `javaCompare: 'return 0;'` on an array property is discarded with no warning.
 
 **`transient: true` sets both `networkTransient` and `storageTransient`** — each defaults to the value of `transient` (`src/foam/lang/EndBoot.js:229,243`). A transient property is therefore neither journaled nor sent over the wire, and each side recomputes it locally.
 
-**`networkTransient` is encode-only.** It suppresses output — `foam.json.Network` will not encode the field (`EndBoot.js:205-206`) — but the JSON **parser** has no networkTransient filter, so an incoming value IS set on the object even when the receiver's own PropertyInfo marks it networkTransient.
+**`networkTransient` is encode-only.** It suppresses output — `foam.json.Network` will not encode the field (`EndBoot.js:205-206`) — but the JSON **parser** has no networkTransient filter — the flag appears nowhere under `src/foam/lib/json` — so an incoming value IS set on the object even when the receiver's own PropertyInfo marks it networkTransient.
 
 That asymmetry is a useful lever: a staging field that must reach the server on a put but never be journaled is `storageTransient: true`, **not** `transient: true` (which also sets `networkTransient` and drops it on the wire). Because decode never filters, the client simply starting to send the field is enough — the server reads it with no recompile.
 
@@ -119,7 +119,7 @@ Two flags, two questions: `transient` means "not stored", `searchable` means "ma
 
 **To expose a computed property to search while keeping it out of journals, use `storageTransient: true` alone.** The literal `transient` flag stays false, so `searchable` stays true and `networkTransient` stays false.
 
-**The `searchable` gate is JS-only.** `SimpleQueryParser.js` skips a non-searchable property, but the Java `SimpleQueryParser.processProperty` has no such check — a real client/server difference in accepted query syntax.
+**The `searchable` gate is JS-only.** `SimpleQueryParser.js` skips a non-searchable property, while the Java parser iterates `getAxiomsByClass(PropertyInfo.class)` and builds its name map with no `searchable` check at all (`src/foam/parse/SimpleQueryParser.java:424-431`) — a real client/server difference in accepted query syntax.
 
 **A subclass override must reset the literal flag.** An override clones the parent axiom, so a parent's literal `transient: true` rides along and keeps forcing `networkTransient` on the child. To narrow a fully-transient parent property to storage-only in one subclass, set BOTH `transient: false` and `storageTransient: true` — `storageTransient: true` alone changes nothing.
 
@@ -232,11 +232,11 @@ So a child view can drive parent state with `this.selection = this.data`, and th
 | `obj.propName` | The current value, non-reactive |
 | `obj.propName$` | The reactive slot |
 
-**`writePermissionRequired` and `readPermissionRequired` are enforced only in `PropertyBorder.createVisibilityFor`** (`src/foam/u2/Element2.js`), where the `<classname>.rw.<propname>` check lives.
+**`writePermissionRequired` and `readPermissionRequired` are enforced only in `createVisibilityFor`** (`src/foam/u2/Element2.js:1850`), where the check runs `auth.check` against `<ClassName>.rw.<propName>` (`:1877`).
 
 Therefore `.add(prop)` never runs the permission gate: the field is read-write for everyone regardless of what the model declares, and no group configuration will change it. `.add(prop.__)` runs it.
 
-**This is a silent bug pattern.** A model can declare `writePermissionRequired: true` and still be globally editable because one caller renders it with the bare axiom. Diagnosing it means knowing that `Property.toE` and `Property.toPropertyView` are two different code paths and only the second checks permissions.
+**This is a silent bug pattern.** A model can declare `writePermissionRequired: true` and still be globally editable because one caller renders it with the bare axiom. Diagnosing it means knowing that `Property.toE` (`Element2.js:1781`) and `Property.toPropertyView` (`:1790`, reached through the `__` getter at `:1763`) are two different code paths, and only the second builds the border that checks permissions.
 
 To render with permissions but without the `PropertyBorder` chrome — inside a tight table cell, say — strip it through the `config` argument rather than dropping back to the bare form:
 
@@ -244,7 +244,7 @@ To render with permissions but without the `PropertyBorder` chrome — inside a 
 .tag(obj.SOME_PROP.__, { config: { label: '', reserveLabelSpace: false } })
 ```
 
-`PropertyBorder.render` clones the property and `copyFrom`s `this.config`. With an empty label and `reserveLabelSpace: false`, the label slot renders `display: contents`, so nothing is shown and no space is reserved — while the view still receives `mode$`, so the auth check fires. The same trick passes `view`, `units`, `helpText` and any other PropertyBorder property.
+`PropertyBorder.render` clones the property and `copyFrom`s `this.config` (`src/foam/u2/PropertyBorder.js:93`). With an empty label and `reserveLabelSpace: false`, the label slot renders `display: contents` (`:165-175`), so nothing is shown and no space is reserved — while the view still receives `mode$`, so the auth check fires. The same trick passes `view`, `units`, `helpText` and any other PropertyBorder property.
 
 | Goal | Use |
 |---|---|

--- a/doc/guides/PropertyGotchas.md
+++ b/doc/guides/PropertyGotchas.md
@@ -1,0 +1,363 @@
+# Property Gotchas
+
+How a property's value, view and label actually resolve: when `factory`, `expression` and `postSet` fire, what `transient` cascades into, which access form runs the permission check, and how axioms are reused and reflected over.
+
+Every claim cites the code that proves it. Line numbers drift — anchor on the named method if a citation no longer lines up.
+
+For the basics, start with [Axioms.md](Axioms.md), [Slots.md](Slots.md) and [Refinements.md](Refinements.md).
+
+---
+
+## Choosing where a computed value lives
+
+| Need | Use | Why not the others |
+|---|---|---|
+| Recompute on every read, both runtimes | `getter` + `javaGetter` | A `factory` caches; an `expression` is JS-only |
+| Compute once at first read, both runtimes | `factory` + `javaFactory` | Safe on frozen objects, see below |
+| React to a live change | `postSet` | Dead on initial state, see below |
+| Derived value that must push to a passive consumer | `dynamic()` writing a plain property | An `expression` goes cold, see below |
+| Server-side compute | `javaGetter` / `javaFactory` | `expression` generates no Java (`src/foam/lang/Property.js:657`) |
+
+### `postSet` is transition-only
+
+A `postSet` runs only when the **setter** is invoked. Three initialization paths never invoke it, so behaviour that must hold for the *initial* state silently never happens:
+
+1. **A `value:` default.** The getter returns the default without ever calling the setter, so a property declared `value: true` and never assigned fires `postSet` zero times.
+2. **A `prop$` slot binding.** The slot setter runs `prop.toSlot(this).linkFrom(slot2)` (`src/foam/lang/Property.js:507`), and `linkFrom`'s initial sync is guarded by `if ( ! foam.util.is(s1.get(), s2.get()) )` (`src/foam/lang/Slot.js:134`, initial call at `:163`). **If the bound values are already equal, no set happens and `postSet` never fires.** The classic trap is `value: true` on the view property plus a source that is already `true` — the `postSet` meant to build a predicate or switch a class runs never.
+3. **Deserialization and `copyFrom` ordering.** `postSet` fires per property in declaration order, so siblings it reads may not be set yet.
+
+Derive initial state instead of hooking it: `expression:` for a reactive derived value, `factory:` for once-at-first-read, or an explicit idempotent call in `init()`/`render()` for setup that must run even when the transition never happens. Keep `postSet` for reacting to a live change.
+
+### A property `expression` is lazy, one-shot, and can go cold
+
+An `expression` is pull-based, not a push-on-change binding. In `src/foam/lang/Property.js`:
+
+- The getter caches in a **private** slot: `eFactoryGetter` (`:546-550`) returns `getPrivate_(name)` if present, without recomputing.
+- On any dependency change, `exprFactory`'s listener clears the private cache (`:672`), publishes `propertyChange` **only if something is already subscribed**, then **detaches every dependency subscription** (`:679`).
+
+So the dependency subscription is one-shot: re-subscription happens only when the property is read again, which re-runs `exprFactory`. If nothing is actively subscribed at the instant a dependency fires, the cache clears, the deps detach, no event is published, and the slot stays cold until a manual read.
+
+A manually created `foam.lang.ExpressionSlot` has the same laziness — "updates will not be generated from calling .sub() unless you also call .get()" (`src/foam/lang/Slot.js:525-529`).
+
+This is why two expressions over the same dependency behave differently: one feeding a DAO table recomputes fine, because the table holds a permanent listener and re-reads on every change, while a sibling feeding a passive display keeps its empty-state value forever.
+
+For a derived value that must update on every change of an async-populated array, do not use an `expression`. Compute it in a `this.dynamic(function(dep) { this.x = ... })` block (`src/foam/lang/Slot.js:638`) and store it in a **plain** property — a plain `PropertySlot` pushes on every set, with no private-cache laziness and no one-shot detach.
+
+Corollary: because the cache lives in `private_`, `hasOwnProperty(name)` stays **false** even after the expression has fired, so code branching on `hasOwnProperty` treats an expression default as unset.
+
+### `javaFactory` is frozen-safe
+
+The intuitive worry is that a `factory` caching its value by writing the backing field throws when read off a frozen object. It does not.
+
+**Java** — codegen builds a `beforeFreeze()` that calls the getter for every property with a `javaFactory` (`src/foam/java/refinements.js:648-658`), and `freeze()` runs `beforeFreeze(); __frozen__ = true;` in that order (`:707-710`). Each factory resolves and sets its field while the object is still mutable. After the freeze, the generated getter hits its `if ( ! xIsSet_ )` guard, sees the field set, and returns it without reaching the setter's `assertNotFrozen()` (`:401`, `:496`). Cross-factory dependencies are safe for the same reason.
+
+**JS** — there is no freeze mechanism at all; `src/foam/lang/FObject.js` defines no `freeze`, `isFrozen` or `assertNotFrozen`.
+
+So do not avoid `javaFactory` on a computed property out of frozen-safety fear. Choose `getter`/`javaGetter` over `factory` when you actually want recompute-on-every-access, not because a factory would throw.
+
+### But do not use `javaFactory` for a value that needs request state
+
+Generated `compareTo` is a straight walk of **every** property in declaration order, with no filter for transient or derived:
+
+```javascript
+// src/foam/java/refinements.js:829
+return 'cmp = ' + foam.String.constantize(f.name) + '.compare(this, o2);\n'
+     + 'if ( cmp != 0 ) return cmp;';
+```
+
+`equals` is `compareTo(o) == 0` (`refinements.js:745`), and `RulerDAO.put_` calls `equals()` to decide whether a put changed anything. So every property is read on every put, including ones you expected to stay cold. A `javaFactory` that needs request-scoped state — a context, a resolved DAO, another object's class info — therefore runs during the put, long before whatever was meant to provide that state, and throws from inside the DAO layer:
+
+```
+at SomeModel.SomeProp_Factory_(SomeModel.java)
+at SomeModel$SomePropPropertyInfo.compare(SomeModel.java)
+at SomeModel.equals(SomeModel.java)
+at foam.core.ruler.RulerDAO.put_(RulerDAO.java)
+```
+
+Compute the value where its inputs are known and set it there. A factory also caches, so a lenient fallback pins a wrong value for the object's lifetime — failing loudly beats resolving against a half-built state.
+
+**`javaCompare` looks like the fix and is not, on array properties.** `AbstractArrayPropertyInfo.createJavaPropertyInfo_` overwrites the generated compare body unconditionally:
+
+```javascript
+// src/foam/java/refinements.js:2020 (also :2091, :2172, :2225 for the other array types)
+var compare = info.getMethod('compare');
+compare.body = this.compareTemplate();
+```
+
+So `javaCompare: 'return 0;'` on an array property is discarded with no warning. Scalar property types honour it.
+
+---
+
+## The transient flags and what they cascade into
+
+**`transient: true` sets both `networkTransient` and `storageTransient`** — each defaults to the value of `transient` (`src/foam/lang/EndBoot.js:229,243`). A transient property is therefore neither journaled nor sent over the wire, and each side recomputes it locally.
+
+**`networkTransient` is encode-only.** It suppresses output — `foam.json.Network` will not encode the field (`EndBoot.js:205-206`) — but the JSON **parser** has no networkTransient filter, so an incoming value IS set on the object even when the receiver's own PropertyInfo marks it networkTransient.
+
+That asymmetry is a useful lever: a staging field that must reach the server on a put but never be journaled is `storageTransient: true`, **not** `transient: true` (which also sets `networkTransient` and drops it on the wire). Because decode never filters, the client simply starting to send the field is enough — the server reads it with no recompile.
+
+**`searchable` is derived from `transient`, not defaulted:**
+
+```javascript
+// src/foam/parse/QueryParser.js:25-26
+{ name: 'searchable', expression: function(transient) { return ! transient; } }
+```
+
+and the query grammar drops any property that fails it before adding comparison rules:
+
+```javascript
+// src/foam/parse/SimpleQueryParser.js:325
+function processProp(prop, propertyParser) {
+  if ( ! prop.searchable ) return;
+```
+
+So `transient: true` silently removes the property from every `=`, `!=`, `>`, `>=`, `<`, `<=` rule, and from the search bar and its autocomplete. Note the operator set — there is no `==`, and writing it is itself a parse error.
+
+The confusing part is that **a bare reference still resolves.** An expression language that looks a field up by name, rather than through the grammar's field list, will happily compile a plain mention of the column while a comparison over the same column fails to parse — the formula stores empty and the value renders blank with no error anywhere.
+
+Two flags, two questions: `transient` means "not stored", `searchable` means "may appear in a predicate". A value resolved on read is legitimately both, so set `searchable: true` explicitly on a transient property that should stay queryable.
+
+**To expose a computed property to search while keeping it out of journals, use `storageTransient: true` alone.** The literal `transient` flag stays false, so `searchable` stays true and `networkTransient` stays false.
+
+**The `searchable` gate is JS-only.** `SimpleQueryParser.js` skips a non-searchable property, but the Java `SimpleQueryParser.processProperty` has no such check — a real client/server difference in accepted query syntax.
+
+**A subclass override must reset the literal flag.** An override clones the parent axiom, so a parent's literal `transient: true` rides along and keeps forcing `networkTransient` on the child. To narrow a fully-transient parent property to storage-only in one subclass, set BOTH `transient: false` and `storageTransient: true` — `storageTransient: true` alone changes nothing.
+
+---
+
+## isSet: the gate that makes derived values disappear
+
+**Java serialization gates on isSet and never consults getters.** `Outputter.maybeOutputProperty` returns early unless the property is set: `if ( ! outputDefaultValues_ && ! prop.isSet(fo) ) return false;` (`src/foam/lib/json/Outputter.java:355-357`). Only past that line does it call `prop.get(fo)` (`:359`).
+
+So a value that exists only in a `javaGetter` derivation — never set — is invisible to full-object network serialization no matter what `networkTransient` says. The flag predicate filters the property list, the isSet check gates each row, and the getter is consulted only after both pass. Symptom: the server derives the value correctly (search, scripts and projections all see it) while every DAO select ships rows without it and the client renders blank.
+
+Two asymmetries hide the bug:
+
+- **Projection sinks evaluate the property server-side.** `Projection.put` calls `exprs[i].f(o)`, which runs the `javaGetter` (`src/foam/mlang/sink/Projection.js:142-152`). A projection select carries the derived value; a full-object select drops it. So an export or a dashboard works while a table forced into full-object mode shows blank.
+- **The client-to-server direction has no such gate.** `foam.json.Network` uses `outputDefaultValues: true` (`src/foam/lang/JSON.js:719-730`), so a client put sends set values including defaults. A value set in a wizard round-trips fine until a server restart, when journal replay leaves a `storageTransient` property unset.
+
+Levers, in order of preference:
+
+1. **Set-on-write isSet flip.** A sibling property's `javaPostSet` sets the backing flag — `javaPostSet: 'derivedPropIsSet_ = true;'` on the driving property. Journal replay and puts both run setters, so every record with the driver set becomes serializable, while the value itself still comes fresh from the getter at output time. Do **not** do DAO lookups in that postSet: deserialization contexts have no DAOs.
+2. **Persist the value.** Costs storage and adds staleness risk.
+3. **Resolve client-side.** No server change, but per-row async and no server-side search benefit.
+
+**There is no isSet override hook.** The generated `PropertyInfo.isSet` body is hardcoded to `return o.<name>IsSet_;` (`src/foam/java/PropertyInfo.js:212-217`); there is no `javaIsSet` counterpart to `javaGetter`/`javaSetter` (`src/foam/java/refinements.js:239-243`). Adding one would be the framework-level fix for "derived and serializable".
+
+### Client-side, `hasOwnProperty` is the isSet check
+
+`FObject` overrides `hasOwnProperty` to return true only when `instance_` holds a non-undefined value for the name (`src/foam/lang/FObject.js:449-455`), which is what the property getters test internally (`Property.js:547,601-603`). It is the JS analogue of Java's `p.isSet(obj)`.
+
+**This is the only way to handle the Enum trap.** An Enum property has no null value: an unset Enum reads back as its ordinal-0 value, the first `values:` entry. So `obj.enumProp` is never null, and `obj.enumProp ? label : blank` always takes the truthy branch — the field displays the first enum as though it had been chosen. `obj.hasOwnProperty('enumProp')` is the only client-side way to tell "never set" from "showing the ordinal-0 default".
+
+Gate the display on it in a read view, a `tableCellFormatter`, or a `visibility` function. Note that inside a property `view` the value slot is the enum itself and cannot tell set from unset — reach the parent object through `X.data$` to run the check.
+
+Two caveats that flip the check:
+
+- A transient property is never serialized, so a DAO-loaded client object starts unset and stays `hasOwnProperty`-false until something derives it. Do not rely on an async `init()` derivation to fill a table cell: it resolves late or not at all for row objects, and a non-reactive `tableCellFormatter` never repaints. The durable fix is to make the server ship the value, per the isSet levers above.
+- An `expression` value caches in `private_`, so `hasOwnProperty` stays false even after it fires.
+
+### `copyFrom` copies only isSet source properties
+
+Java `FObject.copyFrom(obj)` (`src/foam/lang/FObject.java:299-317`) has two semantics that bite adapter and facade models:
+
+1. **Only `isSet` source properties copy** — same-class `if ( p.isSet(obj) ) p.set(this, p.get(obj))` (`:305`), and the same guard on the name-matched property cross-class (`:309`). A `value:` default is not set, so it never propagates; only an explicit setter call reaches the target.
+2. **A cross-class copy matches by property name and silently drops the rest.** It iterates the TARGET's properties and pulls same-named ones from the source (`:307-309`), with a per-property `ClassCastException` swallowed at `:312`. Facade-only properties vanish on the way into the delegate model and can never be reconstructed on the reverse copy — reads show type defaults rather than stored values.
+
+For an adapter DAO built on `copyFrom` in both directions, assume a round trip preserves only properties that exist on both models and were explicitly set. Defaults need explicit setters on the create path; facade-only display fields need derivation on the read path or they render blank. JS `copyFrom` behaves equivalently.
+
+---
+
+## Reusing, naming and writing properties
+
+### `__copyFrom__` clones another model's Property axiom
+
+```javascript
+properties: [
+  { __copyFrom__: 'foam.core.auth.User.USER_NAME', order: 3, storageTransient: true }
+]
+```
+
+At model build, the `properties` AxiomArray adapter walks `globalThis` down the dotted path to that Property, `clone()`s it, then `copyFrom(o)` layers your overrides on top (`src/foam/lang/EndBoot.js:66-77`). A bad path logs `UNKNOWN __copyFrom__:` and silently falls through — no error.
+
+It is a JS-only key that still produces a real Java axiom, because genjava runs the JS model: getters and PropertyInfo generate normally.
+
+**Gotcha:** the clone carries `javaPostSet`/`javaPreSet` into a class that may not be able to compile them. A hook that references a sibling backing field (`otherPropIsSet_ = true;`) fails javac with "cannot find symbol" in a target class that has no such sibling. Override the hook locally to void it: `javaPostSet: '// not applicable here'`.
+
+Use it when a facade or simplified model needs a field from an unrelated model it cannot `extends`. This is distinct from the runtime `copyFrom(o)` method (`src/foam/lang/FObject.js:982`), which merges another object's **values** into `this`.
+
+### Property names take no trailing underscore
+
+A trailing underscore is FOAM's convention for transient internal scratch fields, so using it on a real property mislabels intent. Java accessors derive from the name by capitalizing — `resolvedValue` becomes `getResolvedValue()`/`setResolvedValue()` — so renaming the property later renames every accessor.
+
+### An assignment with no matching Property axiom is a silent dead write
+
+Property behaviour — setter routing, `adapt`/`preSet`/`postSet`, slots, serialization — exists only where a Property axiom installed an accessor on the prototype. `obj.foo = x` with no Property named `foo` creates a plain disconnected own-property: no setter runs, nothing serializes, nothing reacts, and no error or warning fires.
+
+**Interface methods give you nothing here.** `foam.INTERFACE` methods are `InterfaceMethod` axioms whose `installInProto` is an empty function (`src/foam/lang/Interface.js:37-38`). Declaring a `setFoo`/`getFoo` pair on an interface does NOT create a `foo` property or accessor — the method pair and the property are unrelated namespaces in JS FOAM.
+
+Verify before trusting an assignment: `obj.cls_.getAxiomByName('foo')` should return a Property. If only methods exist, call the method or assign the real underlying property.
+
+### `shortName` halves the wire payload and is journal-safe to add
+
+The HTTP and WebSocket boxes serialize with short names — `setOutputShortNames(true)` in `src/foam/box/HTTPBox.js:140`, `HTTPReplyBox.js:40`, `RawWebSocketBox.js:53` — and the outputter emits the shortName when set (`src/foam/lib/json/Outputter.java:491`). A model with no short names ships full property keys, roughly doubling the payload on wide records.
+
+Adding one to an existing model is safe: the Java parser registers BOTH the full name and the shortName as parse keys (`src/foam/lib/json/ModelParserFactory.java:93-97`), so journals written with long keys still replay. Aliases are not registered as Java parse keys, so a shortName may reuse an alias code without conflict on the server path.
+
+`shortName` must be **unique within the class including inherited properties** — FOAM asserts on a duplicate at class load — so check the parents and interfaces before adding one to a subclass.
+
+### Imports are writable
+
+An import axiom installs both a getter and a setter, and the setter writes back to the exporter's slot:
+
+```javascript
+// src/foam/lang/ImportsExports.js:126
+set: function importsSetter(v) {
+  var slot = this[slotName];
+  if ( slot ) slot.set(v);
+  else console.warn('Attempt to set missing import:', name);
+}
+```
+
+So a child view can drive parent state with `this.selection = this.data`, and the parent reacts through `this.selection$` or uses it directly in `enableClass`/`attrs`. If nothing upstream exports the name the set falls through with a console warning and no error; an optional import (`'name?'`) silently no-ops.
+
+---
+
+## The four property access forms, and the permission trap
+
+| Form | What it is |
+|---|---|
+| `OBJ.PROP` | The Property **axiom**. `.add(OBJ.PROP)` calls `Property.toE` and renders the **bare view** |
+| `OBJ.PROP.__` | The same property wrapped in a `PropertyBorder` — label, inline validation, units, permission check. A **getter**, never called with `()` |
+| `obj.propName` | The current value, non-reactive |
+| `obj.propName$` | The reactive slot |
+
+**`writePermissionRequired` and `readPermissionRequired` are enforced only in `PropertyBorder.createVisibilityFor`** (`src/foam/u2/Element2.js`), where the `<classname>.rw.<propname>` check lives.
+
+Therefore `.add(prop)` never runs the permission gate: the field is read-write for everyone regardless of what the model declares, and no group configuration will change it. `.add(prop.__)` runs it.
+
+**This is a silent bug pattern.** A model can declare `writePermissionRequired: true` and still be globally editable because one caller renders it with the bare axiom. Diagnosing it means knowing that `Property.toE` and `Property.toPropertyView` are two different code paths and only the second checks permissions.
+
+To render with permissions but without the `PropertyBorder` chrome — inside a tight table cell, say — strip it through the `config` argument rather than dropping back to the bare form:
+
+```javascript
+.tag(obj.SOME_PROP.__, { config: { label: '', reserveLabelSpace: false } })
+```
+
+`PropertyBorder.render` clones the property and `copyFrom`s `this.config`. With an empty label and `reserveLabelSpace: false`, the label slot renders `display: contents`, so nothing is shown and no space is reserved — while the view still receives `mode$`, so the auth check fires. The same trick passes `view`, `units`, `helpText` and any other PropertyBorder property.
+
+| Goal | Use |
+|---|---|
+| Editor with full label, validation and permission UI | `.add(prop.__)` |
+| Compact editor WITH the permission gate | `.tag(prop.__, { config: { label: '', reserveLabelSpace: false } })` |
+| Compact editor, forced read-only locally | `.startContext({ controllerMode: foam.u2.ControllerMode.VIEW })` … `.endContext()` |
+| Compact editor, mode driven by your own slot | `.tag(prop, { mode$: someSlot })` |
+| Compact editor with no mode awareness | `.add(prop)` — not when permissions matter |
+
+---
+
+## Labels, references, messages
+
+### Every axiom without an explicit label gets a derived one
+
+- **Enum values** — the `label` factory at `src/foam/lang/Enum.js:329`: an ALL_CAPS name splits on `_`, each word lowercased then capitalized, joined with spaces, so `AWAITING_SUBMISSION` renders "Awaiting Submission". A non-ALL_CAPS name is used as-is.
+- **Properties and actions** — `foam.String.labelize(name)` (`src/foam/lang/Property.js:59`, `Action.js:58`): underscores become spaces, camelCase splits on case boundaries, first letter capitalized.
+
+An explicit `label:` always wins. The raw name never appears in the UI, so quoting an enum constant in user-facing documentation is always wrong — grep for an explicit `label:` first, and write the derived form when there is none.
+
+### A reference column's cell value is a `{id, summary}` projection
+
+In a DAO table, a reference column's value is the RefSummary projection shape, not the raw id: the server resolves `toSummary()` during the projection, one pass over the DAO, instead of an N+1 find per row (`src/foam/mlang/expr/Ref.js`, `src/foam/core/column/TableColumnOutputter.js`).
+
+`Reference.adapt` unwraps that shape on assignment — it stores `n.id` and caches `n.summary` into the generated `prop$summary_` slot (`src/foam/lang/types.js:1196-1204`) — and `ReferenceToSummaryCellFormatter` then renders the cached summary.
+
+**Any `Reference` subclass that overrides `adapt` bypasses that unwrap.** If the override just returns `n`, it stores the raw `{id, summary}` object, the summary is never cached, and every column of that reference type renders blank. A custom `adapt` must mirror the branch:
+
+```javascript
+if ( n && ! foam.lang.FObject.isInstance(n) && typeof n === 'object' && n.id !== undefined ) {
+  if ( n.summary != undefined ) this[`${(prop || this).name}$summary_`] = n.summary;
+  return n.id;
+}
+```
+
+### `CurrencyCode` normalizes numeric codes; `CountryCode` does not
+
+`foam.lang.CurrencyCode` (`src/foam/lang/types.js:1450`) adds an async `normalize` that looks a numeric string up in the currency DAO by `NUMERIC_CODE` and returns the alpha id, so `"840"` becomes `"USD"` on load. Journals may use either form, and a mapping needs no numeric-to-alpha transform because the property does the conversion itself.
+
+`foam.lang.CountryCode` (same file, `:1591`) is a plain Reference with no `normalize`, and the country DAO is keyed by alpha code. A numeric `"840"` stays `"840"` and the lookup fails, so country values in journals must be alpha.
+
+### Localize a message with `messageMap`
+
+Replace the plain `message: '...'` form with `messageMap: { en: '...', fr: '...' }`. The getter resolves `messageMap[foam.locale] || messageMap[foam.language]`, falling back to `messageMap.en` (`src/foam/i18n/Messages.js:90-105`). `foam.language` is always the first two characters of `foam.locale`, set by the `foam.locale` setter (`src/foam/lang/Boot.js:208-214`), so a hand-written `foam.language === 'fr'` branch in a render closure stays in sync with the map.
+
+Two install paths decide how the message is called:
+
+- **`template: true` with `${var}` placeholders** makes it a **callable**: `this.MY_MSG({ count: n })` returns the interpolated string, built from a `MessageTemplateParser` (`Messages.js:140`).
+- **A plain message** installs as a constant on the **prototype** (`:137`), so it resolves off any instance of the defining class — which is what makes `obj.MY_MSG` work inside `tableCellFormatter: function(_, obj)` where `obj` is a row instance. It also installs on the class (`:122`) for `Cls.MY_MSG`.
+
+---
+
+## Reflection, interfaces and cloning
+
+### Iterating property axioms returns framework internals
+
+`cls_.getAxiomsByClass(foam.lang.Property)` in JS, or `getClassInfo().getAxiomsByClass(PropertyInfo.class)` in Java, includes `reactions_`, `reactionError_`, `reactionErrors_` and other trailing-underscore properties — not only the ones you declared. Code that digests "all properties", such as a generic `toSummary`, must exclude names ending in `_` or it stringifies them into `[object Object]`.
+
+Related: an `FObjectProperty` rendered as a **table cell** shows blank or `[object Object]` unless its `of` model defines `toSummary()`, because the default citation path calls `data.toSummary?.()` (`src/foam/u2/CitationView.js`). A recursive `toSummary` must itself recurse through each value's `toSummary` rather than `String(v)`, or nested objects leak the same string.
+
+### "Does this class implement interface X" is `X.isSubClass(model)`
+
+`isSubClass(c)` returns true when `c` is this class, a subclass, or implements it — it tests `c.getAxiomByName('implements_' + this.id)` (`src/foam/lang/FObject.js:208`), and the result is memoized per class id. A class that does `implements: ['pkg.X']` directly, through `mixins:`, or by inheritance carries that axiom.
+
+`isInstance(o)` is `!!( o && o.cls_ && this.isSubClass(o.cls_) )` (`FObject.js:199`) — the same check with an **object** operand. So use `isSubClass` when you hold a class (a DAO's or property's `of`, for instance) and `isInstance` when you hold an instance. A falsy argument returns false rather than throwing, so it is safe on a possibly-unset `of`.
+
+**There is no MLang predicate for it.** `IsInstanceOf.f` does `of.isInstance(value)` (`src/foam/mlang/predicate/IsInstanceOf.js:46`) and `IsClassOf.f` does an exact class-id match (`IsClassOf.js:41`) — both test a *value's* runtime class, not a class-to-interface relationship. "Does model X implement interface Y" can only run in JS, never inside a DAO `where()`.
+
+### `clone()` re-runs `init()`
+
+JS `clone()` is `this.cls_.create(this, opt_X)` (`src/foam/lang/FObject.js:948`), so the clone goes through `create()` → `initArgs` → `init()`. Every `init()` side effect runs again: subscriptions, context lookups, UI writes, async default assignment.
+
+For a service singleton whose `init()` touches shared state, a clone is destructive. If `init()` builds a UI element bound to `self` and asynchronously assigns a default from storage, each clone hijacks that shared element while other subscribers stay bound to the original, and the clone's async default races any override away.
+
+Levers:
+
+- **A context override needs data, not a live object.** `x.createSubContext({ someService: { id: 0 } })` and bind the callback to `{ __subContext__: subX }`. Plain objects are valid context exports, so readers doing `x.someService.id` work unchanged.
+- If cloning an init-heavy class is unavoidable, audit its `init()` first for writes to imported or shared state.
+
+Diagnostic: when two UI elements bound to "the same" service disagree, suspect an instance split. Log `this.$UID` at the writer and at every reader — differing UIDs prove a second live instance, and then you can find who created it.
+
+### A modelled PropertyInfo serializes as its whole self, not as a reference
+
+Both JSON outputters dispatch in this order: `OutputJSON` → `String` → `FObject` → `PropertyInfo` → `ClassInfo` (`src/foam/lib/json/Outputter.java:273-284`, mirrored in `JSONFObjectFormatter.java:336-347`).
+
+A PropertyInfo that is a plain Java class falls through to the `PropertyInfo` branch and is emitted as a compact reference:
+
+```json
+{"class":"__Property__","forClass_":"<owning class id>","name":"<prop name>"}
+```
+
+A PropertyInfo declared as a `foam.CLASS` model is also an `FObject`, so it matches the **earlier** branch and goes out whole — class id plus every modelled property. If that class is `flags: 'java'`, the receiving client has no such class and cannot reconstruct the expression at all.
+
+Where it bites: anything that echoes resolved property references back to the client, most importantly a `Projection` select, whose client-side row rebuild then fails silently. Symptom: a column renders blank while its value is present in the network response.
+
+The fix is to implement `foam.lib.json.OutputJSON` on the modelled PropertyInfo — it is checked before both other branches — and emit the reference form yourself:
+
+```java
+public void outputJSON(foam.lib.json.Outputter outputter) {
+  outputter.outputMap("class", "__Property__",
+                      "forClass_", owner().getId(),
+                      "name", getName());
+}
+```
+
+`outputMap` and `outputRawString` are public on `Outputter`, and `append` is public on `AbstractFObjectFormatter`, so the `formatJSON` half can be written by hand.
+
+Getting the owning class is the hard part. The reference needs `forClass_`; `AbstractPropertyInfo.setClassInfo` stores it (`src/foam/lang/AbstractPropertyInfo.java:31`) but `ProxyPropertyInfo.setClassInfo` discards it, and a modelled PropertyInfo's generated `getClassInfo()` returns its own class, not the owner. Store the owner in a **modelled property**, not a plain Java field: `fclone()` copies properties only, and sinks are cloned on the way back from a select, so a plain field arrives null and the outputter throws mid-response.
+
+### Column auto-mapping is last-write-wins
+
+`foam.core.reflow.ColumnParser.parseString` resolves a file header to a model property (`src/foam/core/reflow/ColumnParser.js:69-114`). For every property it writes into a case-insensitive `exactMap` keyed on the property's `name` (`:73`), `shortName` (`:82`) and each `alias` (`:91`), plus a camelCase-normalized `normalizedMap` guarded by a first-write-wins check (`:84-85`, `:93-94`). `parseString` then resolves a header by exact match first, falling back to normalized.
+
+The trap: `exactMap` is **last-write-wins** — plain assignment with no guard — across the axiom iteration order. So an alias equal to an inherited framework property's name collides, and which property wins depends on iteration order. The framework property often does, and a string value then coerces into a numeric field and throws `Invalid number (NaN/Infinity) in field '<name>'`.
+
+Present a header that exact-matches the intended property's own name, and never alias an upload field onto a name that collides with an inherited property such as `id`.

--- a/doc/guides/claude.md
+++ b/doc/guides/claude.md
@@ -237,6 +237,10 @@ Invoice.AMOUNT      // the Property axiom object
 inv.AMOUNT.name     // 'amount'
 ```
 
+For the parts that surprise people — when `postSet` does not fire, why an `expression` can go
+cold, what `transient` cascades into, and why a `javaGetter`-derived value never reaches the
+client — see [PropertyGotchas.md](PropertyGotchas.md).
+
 ---
 
 ## 4. Methods
@@ -606,6 +610,10 @@ Nothing above says anything about *where* the data is stored. That is intentiona
 
 The DAO interface is the complete contract. Code that depends on knowing the underlying storage mechanism forfeits the caching, authorisation, audit logging, and other layers that FOAM composes transparently above any DAO.
 
+That composition has sharp edges: which context an operation runs in, what a decorator wraps,
+when a result is frozen or cached, and how sinks and predicates evaluate. Those are collected in
+[DaoGotchas.md](DaoGotchas.md).
+
 ---
 
 ## 9. Inheritance and Mixins
@@ -719,6 +727,12 @@ Use optional imports (`'myService?'`) when a service might not always be present
 ### Prefer `expression` over `factory` for computed values
 `expression` declares dependencies and auto-invalidates. `factory` only runs once.
 
+One caveat: an `expression` is lazy and its dependency subscriptions are one-shot. With no active
+subscriber at the moment a dependency changes, it clears its cache, detaches, publishes nothing,
+and stays cold until the property is read again. Behind a view that re-reads on every change this
+is invisible; behind a passive consumer it shows a stale value. See
+[PropertyGotchas.md](PropertyGotchas.md).
+
 ### Use `requires` instead of direct class references
 `this.Invoice.create()` uses the context; `com.example.Invoice.create()` bypasses it. Replacements, singletons, and multitons only work through `requires`.
 
@@ -770,6 +784,12 @@ Things the LLM does *not* need to generate: getters, setters, change notificatio
 | Mutating array property directly | Replace: `this.items = [...this.items, newItem]` |
 | `async init()` | FOAM `init()` is synchronous; do async work in an `expression` or separate method |
 | Forgetting to `detach()` listeners | Causes memory leaks; attach subs to `this.onDetach(sub)` |
+| `getDelegate().find(id)` inside a decorator | `getDelegate().find_(x, id)` — the argless form re-enters with the DAO's own context, so the stack runs as system ([DaoGotchas](DaoGotchas.md)) |
+| `getDelegate().select(sink)` in a `select_` override | `select_(x, sink, skip, limit, order, predicate)` — the arity-1 form drops every query argument |
+| Mutating an object returned by `put()`/`find()` | `fclone()` first; the returned instance is frozen |
+| `where(LTE(dateProp, now))` for a deadline sweep | `where(AND(HAS(dateProp), LTE(dateProp, now)))` — an unset Date satisfies `LTE` |
+| `LimitedSink` nested under `GROUP_BY` | `UNIQUE(key, LimitedSink(N))` — the nested form detaches the outer scan and truncates it silently |
+| `.add(prop)` for a permission-gated field | `.add(prop.__)` — the permission check lives in `PropertyBorder`, not the bare view ([PropertyGotchas](PropertyGotchas.md)) |
 
 ---
 
@@ -1258,6 +1278,10 @@ Invoice.AMOUNT      // the Property axiom object
 inv.AMOUNT.name     // 'amount'
 ```
 
+For the parts that surprise people — when `postSet` does not fire, why an `expression` can go
+cold, what `transient` cascades into, and why a `javaGetter`-derived value never reaches the
+client — see [PropertyGotchas.md](PropertyGotchas.md).
+
 ---
 
 ## 4. Methods
@@ -1566,6 +1590,12 @@ Use optional imports (`'myService?'`) when a service might not always be present
 ### Prefer `expression` over `factory` for computed values
 `expression` declares dependencies and auto-invalidates. `factory` only runs once.
 
+One caveat: an `expression` is lazy and its dependency subscriptions are one-shot. With no active
+subscriber at the moment a dependency changes, it clears its cache, detaches, publishes nothing,
+and stays cold until the property is read again. Behind a view that re-reads on every change this
+is invisible; behind a passive consumer it shows a stale value. See
+[PropertyGotchas.md](PropertyGotchas.md).
+
 ### Use `requires` instead of direct class references
 `this.Invoice.create()` uses the context; `com.example.Invoice.create()` bypasses it. Replacements, singletons, and multitons only work through `requires`.
 
@@ -1617,6 +1647,12 @@ Things the LLM does *not* need to generate: getters, setters, change notificatio
 | Mutating array property directly | Replace: `this.items = [...this.items, newItem]` |
 | `async init()` | FOAM `init()` is synchronous; do async work in an `expression` or separate method |
 | Forgetting to `detach()` listeners | Causes memory leaks; attach subs to `this.onDetach(sub)` |
+| `getDelegate().find(id)` inside a decorator | `getDelegate().find_(x, id)` — the argless form re-enters with the DAO's own context, so the stack runs as system ([DaoGotchas](DaoGotchas.md)) |
+| `getDelegate().select(sink)` in a `select_` override | `select_(x, sink, skip, limit, order, predicate)` — the arity-1 form drops every query argument |
+| Mutating an object returned by `put()`/`find()` | `fclone()` first; the returned instance is frozen |
+| `where(LTE(dateProp, now))` for a deadline sweep | `where(AND(HAS(dateProp), LTE(dateProp, now)))` — an unset Date satisfies `LTE` |
+| `LimitedSink` nested under `GROUP_BY` | `UNIQUE(key, LimitedSink(N))` — the nested form detaches the outer scan and truncates it silently |
+| `.add(prop)` for a permission-gated field | `.add(prop.__)` — the permission check lives in `PropertyBorder`, not the bare view ([PropertyGotchas](PropertyGotchas.md)) |
 
 ---
 

--- a/doc/guides/index.html
+++ b/doc/guides/index.html
@@ -21,6 +21,7 @@
     <li><a href="ControllerModeAndVisibility.html">Controller Mode and Visibility</a></li>
     <li><a href="Dao.html">DAO</a></li>
     <li><a href="DaoExamples.html">DAO Examples</a></li>
+    <li><a href="DaoGotchas.html">DAO Gotchas</a></li>
     <li><a href="Dashboard.html">Dashboard</a></li>
     <li><a href="DateTimeUTC.html">DateTime UTC</a></li>
     <li><a href="Debugging.html">Debugging</a></li>
@@ -49,6 +50,7 @@
     <li><a href="Permissions.html">Permissions</a></li>
     <li><a href="POM.html">POM</a></li>
     <li><a href="Porting.html">Porting</a></li>
+    <li><a href="PropertyGotchas.html">Property Gotchas</a></li>
     <li><a href="ReactivePatterns.html">Reactive Patterns</a></li>
     <li><a href="ReactiveUI.html">Reactive UI</a></li>
     <li><a href="Refinements.html">Refinements</a></li>


### PR DESCRIPTION
Two guides for the framework behaviour a model does not show you, every claim cited to `file:line` and checked against the current tip.

- **DAO context** — which context an operation actually runs in. A decorator's predicate filters by the context the DAO was built in, argless `find(id)`/`select(sink)` re-enter with the DAO's own context, and arity-1 `select(sink)` drops the predicate, skip, limit and order the framework handed it.

- **Decorator stacking** — `RulerDAO` wraps outside `.setDecorator()`, so rules evaluate before that decorator's `put_`, and `*Aware` decorators wire implicitly from the model's `implements:` list, so a missing builder call does not mean a missing decorator.

- **Results and caching** — `put()` and `find()` return frozen objects, `ClientBuilder` injects a TTL only for a top-level `EasyDAO` spec, and `cache: true` with no TTL is a full eager warm of the table. RESET re-reads that cache; only PURGE refetches.

- **Sinks and predicates** — a `LimitedSink` nested under `GROUP_BY` detaches the outer subscription and truncates the whole scan silently, `MDAO.bulkLoad` reads the sink you passed so a decorated DAO loads nothing, and `LTE` matches an unset Date, which fires a deadline sweep on records that were never scheduled.

- **Property resolution** — when `postSet` never fires, why an `expression` goes cold behind a passive consumer, the isSet gate that keeps a `javaGetter`-derived value off the wire, what `transient` cascades into, and why `.add(prop)` skips the permission check that `.add(prop.__)` runs.

Both guides are listed in the guides index and linked from the DAO and property sections of the LLM guide, whose "Common Mistakes to Avoid" table gains the six traps most likely to be hit. That guide's "prefer `expression` over `factory`" pattern now carries the one-shot caveat as well, since "auto-invalidates" on its own is what leads to the stale-value bug.