### PR TITLE
 PT-Fixes DOS-4172: Added Support for Custom X and Y Axis Scaling for Line Charts and Multi-Line Charts (for real this time)

### DIFF
--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -1118,7 +1118,8 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'toggleCustomXScale', 'xAxisMinScale', 'xAxisMaxScale', 'xDateAxisMinScale', 'xDateAxisMaxScale', 'toggleCustomYScale', 'yAxisMinScale', 'yAxisMaxScale', 'autoSkip']
+      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'toggleCustomXScale', 'xAxisMinScale', 'xAxisMaxScale', 'xDateAxisMinScale', 'xDateAxisMaxScale','toggleCustomYScale', 'yAxisMinScale', 'yAxisMaxScale', 'autoSkip'],
+      actions: ['resetXScale', 'resetYScale']
     },
     {
       name: 'colors',
@@ -1173,11 +1174,9 @@ foam.CLASS({
     // Define visibility for periodCount (from mixin)
     {
       name: 'periodCount',
-      visibility: function(xProp) {
+      visibility: function(isDateXProp_) {
         // Only show for date/time properties on X-axis
-        var isDateProp = xProp && xProp.delegate &&
-          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
-        return isDateProp ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+        return isDateXProp_ ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
     },
     {
@@ -1261,42 +1260,34 @@ foam.CLASS({
       class: 'Double',
       name: 'xAxisMinScale',
       label: 'X Axis Min',
-      value: 0,
-      visibility: function(toggleCustomXScale, xProp) {
+      visibility: function(toggleCustomXScale, isDateXProp_) {
         // Only show for non-date/time properties on X-axis
-        var isDateProp = xProp && xProp.delegate &&
-          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
-        return ( ! isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+        return ( ! isDateXProp_ && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       },
     },
     {
       class: 'Double',
       name: 'xAxisMaxScale',
       label: 'X Axis Max',
-      value: 9999,
-      visibility: function(toggleCustomXScale, xProp) {
+      visibility: function(toggleCustomXScale, isDateXProp_) {
         // Only show for non-date/time properties on X-axis
-        var isDateProp = xProp && xProp.delegate &&
-          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
-        return ( ! isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+        return ( ! isDateXProp_ && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       },
     },
     {
       class: 'Double',
       name: 'yAxisMinScale',
       label: 'Y Axis Min',
-      value: 0,
       visibility: function(toggleCustomYScale) {
-        return toggleCustomYScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+        return toggleCustomYScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       },
     },
     {
       class: 'Double',
       name: 'yAxisMaxScale',
       label: 'Y Axis Max',
-      value: 9999,
       visibility: function(toggleCustomYScale) {
-        return toggleCustomYScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+        return toggleCustomYScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       },
     },
     {
@@ -1309,29 +1300,38 @@ foam.CLASS({
       class: 'DateTime',
       name: 'xDateAxisMinScale',
       label: 'X Axis Min',
-      factory: function() { return new Date( new Date().getTime() - (365 * 24 * 60 * 60 * 1000) ); }, // Default to today - 1yr for now
-      visibility: function(toggleCustomXScale, xProp) {
+      visibility: function(toggleCustomXScale, isDateXProp_) {
         // Only show for date/time properties on X-axis
-        var isDateProp = xProp && xProp.delegate &&
-          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
-        return ( isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+        return ( isDateXProp_ && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
     },
     {
       class: 'DateTime',
       name: 'xDateAxisMaxScale',
       label: 'X Axis Max',
-      factory: function() { return new Date( new Date().getTime() + (365 * 24 * 60 * 60 * 1000) ); }, // Default to today + 1yr for now
-      visibility: function(toggleCustomXScale, xProp) {
+      visibility: function(toggleCustomXScale, isDateXProp_) {
         // Only show for date/time properties on X-axis
-        var isDateProp = xProp && xProp.delegate &&
-          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
-        return ( isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+        return ( isDateXProp_ && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
-    }
+    },
+    { // Taken from Claude
+      class: 'Boolean',
+      name: 'isDateXProp_',
+      transient: true,
+      visibility: 'HIDDEN',
+      expression: function(xProp) { return this.isDateProp(xProp); }
+    },
+    { name: 'sink_', transient: true, visibility: 'HIDDEN' }
   ],
 
   methods: [
+    function isDateProp(p) {
+      return p && ( 
+        ( foam.lang.Date.isInstance(p) || foam.lang.DateTime.isInstance(p) ) ||
+        ( p.delegate && (foam.lang.Date.isInstance(p.delegate) || foam.lang.DateTime.isInstance(p.delegate)) )
+      );
+    },
+
     function getDatePropertyForFiltering() {
       // For line charts, the date property is 'xProp'
       return this.xProp;
@@ -1377,13 +1377,14 @@ foam.CLASS({
           periodCount: this.periodCount,
           toggleCustomXScale: this.toggleCustomXScale,
           toggleCustomYScale: this.toggleCustomYScale,
-          xAxisMinScale: this.xAxisMinScale,
-          xAxisMaxScale: this.xAxisMaxScale,
-          yAxisMinScale: this.yAxisMinScale,
-          yAxisMaxScale: this.yAxisMaxScale,
+          xAxisMinScale: this.hasOwnProperty('xAxisMinScale') ? this.xAxisMinScale : null,
+          xAxisMaxScale: this.hasOwnProperty('xAxisMaxScale') ? this.xAxisMaxScale : null,
+          yAxisMinScale: this.hasOwnProperty('yAxisMinScale') ? this.yAxisMinScale : null,
+          yAxisMaxScale: this.hasOwnProperty('yAxisMaxScale') ? this.yAxisMaxScale : null,
           autoSkip: this.autoSkip,
           xDateAxisMinScale: this.xDateAxisMinScale,
-          xDateAxisMaxScale: this.xDateAxisMaxScale
+          xDateAxisMaxScale: this.xDateAxisMaxScale,
+          isTimeScale: this.isDateXProp_
         });
       } else {
         // Single-line chart: Use GroupBy-based sink
@@ -1412,13 +1413,14 @@ foam.CLASS({
           periodCount: this.periodCount,
           toggleCustomXScale: this.toggleCustomXScale,
           toggleCustomYScale: this.toggleCustomYScale,
-          xAxisMinScale: this.xAxisMinScale,
-          xAxisMaxScale: this.xAxisMaxScale,
-          yAxisMinScale: this.yAxisMinScale,
-          yAxisMaxScale: this.yAxisMaxScale,
+          xAxisMinScale: this.hasOwnProperty('xAxisMinScale') ? this.xAxisMinScale : null,
+          xAxisMaxScale: this.hasOwnProperty('xAxisMaxScale') ? this.xAxisMaxScale : null,
+          yAxisMinScale: this.hasOwnProperty('yAxisMinScale') ? this.yAxisMinScale : null,
+          yAxisMaxScale: this.hasOwnProperty('yAxisMaxScale') ? this.yAxisMaxScale : null,
           autoSkip: this.autoSkip,
           xDateAxisMinScale: this.xDateAxisMinScale,
-          xDateAxisMaxScale: this.xDateAxisMaxScale
+          xDateAxisMaxScale: this.xDateAxisMaxScale,
+          isTimeScale: this.isDateXProp_
         });
       }
     },
@@ -1431,13 +1433,14 @@ foam.CLASS({
       var self = this;
       // Add the sink once
       e.add(s);
+      this.sink_ = s;
       
       // Then update its properties reactively
       this.onDetach(this.dynamic(function(colors, xAxisLabel, yAxisLabel, fill, tension, stepped, showPoints, pointRadius, showGridLines,
                                   maintainAspectRatio, height, showLegend, legendPosition,
                                   showTooltips, showTooltipSum, animate, animationDuration, alignment,
                                   periodCount, toggleCustomXScale, toggleCustomYScale,
-                                  xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
+                                  xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale, isDateXProp_) {
         s.colors = colors;
         s.xAxisLabel = xAxisLabel;
         s.yAxisLabel = yAxisLabel;
@@ -1459,17 +1462,32 @@ foam.CLASS({
         s.periodCount = periodCount;
         s.toggleCustomXScale = toggleCustomXScale;
         s.toggleCustomYScale = toggleCustomYScale;
-        s.xAxisMinScale = xAxisMinScale;
-        s.xAxisMaxScale = xAxisMaxScale;
-        s.yAxisMinScale = yAxisMinScale;
-        s.yAxisMaxScale = yAxisMaxScale;
+        s.xAxisMinScale = self.hasOwnProperty('xAxisMinScale') ? self.xAxisMinScale : null;
+        s.xAxisMaxScale = self.hasOwnProperty('xAxisMaxScale') ? self.xAxisMaxScale : null;
+        s.yAxisMinScale = self.hasOwnProperty('yAxisMinScale') ? self.yAxisMinScale : null;
+        s.yAxisMaxScale = self.hasOwnProperty('yAxisMaxScale') ? self.yAxisMaxScale : null;
         s.autoSkip = autoSkip;
         s.xDateAxisMinScale = xDateAxisMinScale;
         s.xDateAxisMaxScale = xDateAxisMaxScale;
+        s.isTimeScale = isDateXProp_;
         
         // Force chart to update/redraw
         if ( s.updateChart ) s.updateChart();
-       }));
+      }));
+
+      // Taken from Claude
+      this.onDetach(s.dataXMin_$.sub(function() {
+        if ( s.dataXMin_ && ! self.hasOwnProperty('xDateAxisMinScale') ) self.xDateAxisMinScale = s.dataXMin_;
+      }));
+      this.onDetach(s.dataXMax_$.sub(function() {
+        if ( s.dataXMax_ && ! self.hasOwnProperty('xDateAxisMaxScale') ) self.xDateAxisMaxScale = s.dataXMax_;
+      }));
+      this.onDetach(s.dataXNumMin_$.sub(function() {
+        if ( s.dataXNumMin_ != null && ! self.hasOwnProperty('xAxisMinScale') ) self.xAxisMinScale = s.dataXNumMin_;
+      }));
+      this.onDetach(s.dataXNumMax_$.sub(function() {
+        if ( s.dataXNumMax_ != null && ! self.hasOwnProperty('xAxisMaxScale') ) self.xAxisMaxScale = s.dataXNumMax_;
+      }));
     },
     
     function addToE(e) {
@@ -1522,6 +1540,41 @@ foam.CLASS({
       clone.xDateAxisMinScale$ = this.xDateAxisMinScale$;
       clone.xDateAxisMaxScale$ = this.xDateAxisMaxScale$;
       return clone;
+    }
+  ],
+
+  actions: [
+    {
+      name: 'resetXScale',
+      label: 'Reset X Scale',
+      isAvailable: function(toggleCustomXScale) { return toggleCustomXScale; },
+      code: function() {
+        this.clearProperty('xDateAxisMinScale');
+        this.clearProperty('xDateAxisMaxScale');
+        this.clearProperty('xAxisMinScale');
+        this.clearProperty('xAxisMaxScale');
+
+        var s = this.sink_;
+        if ( ! s ) return;
+        if ( s.dataXMin_ ) this.xDateAxisMinScale = s.dataXMin_;
+        if ( s.dataXMax_ ) this.xDateAxisMaxScale = s.dataXMax_;
+        if ( s.dataXNumMin_ != null ) this.xAxisMinScale = s.dataXNumMin_;
+        if ( s.dataXNumMax_ != null ) this.xAxisMaxScale = s.dataXNumMax_;
+      }
+    },
+    {
+      name: 'resetYScale',
+      label: 'Reset Y Scale',
+      isAvailable: function(toggleCustomYScale) { return toggleCustomYScale; },
+      code: function() {
+        this.clearProperty('yAxisMinScale');
+        this.clearProperty('yAxisMaxScale');
+
+        var s = this.sink_;
+        if ( ! s ) return;
+        if ( s.dataYNumMin_ != null ) this.yAxisMinScale = s.dataYNumMin_;
+        if ( s.dataYNumMax_ != null ) this.yAxisMaxScale = s.dataYNumMax_;
+      }
     }
   ]
 });

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -1176,7 +1176,7 @@ foam.CLASS({
       name: 'periodCount',
       visibility: function(isDateXProp_) {
         // Only show for date/time properties on X-axis
-        return isDateXProp_ ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+        return hasDateSource_ ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
     },
     {
@@ -1321,7 +1321,24 @@ foam.CLASS({
       visibility: 'HIDDEN',
       expression: function(xProp) { return this.isDateProp(xProp); }
     },
-    { name: 'sink_', transient: true, visibility: 'HIDDEN' }
+    { name: 'sink_', transient: true, visibility: 'HIDDEN' },
+    {
+      class: 'Boolean',
+      name: 'isDateXProp_',
+      transient: true,
+      visibility: 'HIDDEN',
+      expression: function(xProp) {
+        return !! xProp && ( foam.lang.Date.isInstance(xProp) || foam.lang.DateTime.isInstance(xProp) );
+      }
+    },
+    // Claude says: keeps the delegate aware behaviour for the DAO date filter
+    {
+      class: 'Boolean',
+      name: 'hasDateSource_',
+      transient: true,
+      visibility: 'HIDDEN',
+      expression: function(xProp) { return this.isDateProp(xProp); }
+    },
   ],
 
   methods: [
@@ -1487,6 +1504,12 @@ foam.CLASS({
       }));
       this.onDetach(s.dataXNumMax_$.sub(function() {
         if ( s.dataXNumMax_ != null && ! self.hasOwnProperty('xAxisMaxScale') ) self.xAxisMaxScale = s.dataXNumMax_;
+      }));
+      this.onDetach(s.dataYNumMin_$.sub(function() {
+        if ( s.dataYNumMin_ != null && ! self.hasOwnProperty('yAxisMinScale') ) self.yAxisMinScale = s.dataYNumMin_;
+      }));
+      this.onDetach(s.dataYNumMax_$.sub(function() {
+        if ( s.dataYNumMax_ != null && ! self.hasOwnProperty('yAxisMaxScale') ) self.yAxisMaxScale = s.dataYNumMax_;
       }));
     },
     

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -1118,7 +1118,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'toggleCustomXScale', 'xAxisMinScale', 'xAxisMaxScale', 'toggleCustomYScale', 'yAxisMinScale', 'yAxisMaxScale', 'autoSkip']
+      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'toggleCustomXScale', 'xAxisMinScale', 'xAxisMaxScale', 'xDateAxisMinScale', 'xDateAxisMaxScale', 'toggleCustomYScale', 'yAxisMinScale', 'yAxisMaxScale', 'autoSkip']
     },
     {
       name: 'colors',
@@ -1262,8 +1262,11 @@ foam.CLASS({
       name: 'xAxisMinScale',
       label: 'X Axis Min',
       value: 0,
-      visibility: function(toggleCustomXScale) {
-        return toggleCustomXScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+      visibility: function(toggleCustomXScale, xProp) {
+        // Only show for non-date/time properties on X-axis
+        var isDateProp = xProp && xProp.delegate &&
+          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
+        return ( ! isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       },
     },
     {
@@ -1271,8 +1274,11 @@ foam.CLASS({
       name: 'xAxisMaxScale',
       label: 'X Axis Max',
       value: 9999,
-      visibility: function(toggleCustomXScale) {
-        return toggleCustomXScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+      visibility: function(toggleCustomXScale, xProp) {
+        // Only show for non-date/time properties on X-axis
+        var isDateProp = xProp && xProp.delegate &&
+          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
+        return ( ! isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       },
     },
     {
@@ -1298,6 +1304,30 @@ foam.CLASS({
       name: 'autoSkip',
       label: 'Hide Overlapping Labels',
       value: true
+    },
+    {
+      class: 'DateTime',
+      name: 'xDateAxisMinScale',
+      label: 'X Axis Min',
+      factory: function() { return new Date( new Date().getTime() - (365 * 24 * 60 * 60 * 1000) ); }, // Default to today - 1yr for now
+      visibility: function(toggleCustomXScale, xProp) {
+        // Only show for date/time properties on X-axis
+        var isDateProp = xProp && xProp.delegate &&
+          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
+        return ( isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      }
+    },
+    {
+      class: 'DateTime',
+      name: 'xDateAxisMaxScale',
+      label: 'X Axis Max',
+      factory: function() { return new Date( new Date().getTime() + (365 * 24 * 60 * 60 * 1000) ); }, // Default to today + 1yr for now
+      visibility: function(toggleCustomXScale, xProp) {
+        // Only show for date/time properties on X-axis
+        var isDateProp = xProp && xProp.delegate &&
+          (foam.lang.Date.isInstance(xProp.delegate) || foam.lang.DateTime.isInstance(xProp.delegate));
+        return ( isDateProp && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
+      }
     }
   ],
 
@@ -1351,7 +1381,9 @@ foam.CLASS({
           xAxisMaxScale: this.xAxisMaxScale,
           yAxisMinScale: this.yAxisMinScale,
           yAxisMaxScale: this.yAxisMaxScale,
-          autoSkip: this.autoSkip
+          autoSkip: this.autoSkip,
+          xDateAxisMinScale: this.xDateAxisMinScale,
+          xDateAxisMaxScale: this.xDateAxisMaxScale
         });
       } else {
         // Single-line chart: Use GroupBy-based sink
@@ -1384,7 +1416,9 @@ foam.CLASS({
           xAxisMaxScale: this.xAxisMaxScale,
           yAxisMinScale: this.yAxisMinScale,
           yAxisMaxScale: this.yAxisMaxScale,
-          autoSkip: this.autoSkip
+          autoSkip: this.autoSkip,
+          xDateAxisMinScale: this.xDateAxisMinScale,
+          xDateAxisMaxScale: this.xDateAxisMaxScale
         });
       }
     },
@@ -1403,7 +1437,7 @@ foam.CLASS({
                                   maintainAspectRatio, height, showLegend, legendPosition,
                                   showTooltips, showTooltipSum, animate, animationDuration, alignment,
                                   periodCount, toggleCustomXScale, toggleCustomYScale,
-                                  xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
+                                  xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
         s.colors = colors;
         s.xAxisLabel = xAxisLabel;
         s.yAxisLabel = yAxisLabel;
@@ -1430,6 +1464,8 @@ foam.CLASS({
         s.yAxisMinScale = yAxisMinScale;
         s.yAxisMaxScale = yAxisMaxScale;
         s.autoSkip = autoSkip;
+        s.xDateAxisMinScale = xDateAxisMinScale;
+        s.xDateAxisMaxScale = xDateAxisMaxScale;
         
         // Force chart to update/redraw
         if ( s.updateChart ) s.updateChart();
@@ -1483,6 +1519,8 @@ foam.CLASS({
       clone.yAxisMinScale$ = this.yAxisMinScale$;
       clone.yAxisMaxScale$ = this.yAxisMaxScale$;
       clone.autoSkip$ = this.autoSkip$;
+      clone.xDateAxisMinScale$ = this.xDateAxisMinScale$;
+      clone.xDateAxisMaxScale$ = this.xDateAxisMaxScale$;
       return clone;
     }
   ]

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -1174,7 +1174,7 @@ foam.CLASS({
     // Define visibility for periodCount (from mixin)
     {
       name: 'periodCount',
-      visibility: function(isDateXProp_) {
+      visibility: function(hasDateSource_) {
         // Only show for date/time properties on X-axis
         return hasDateSource_ ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
@@ -1314,13 +1314,7 @@ foam.CLASS({
         return ( isDateXProp_ && toggleCustomXScale ) ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.HIDDEN;
       }
     },
-    { // Taken from Claude
-      class: 'Boolean',
-      name: 'isDateXProp_',
-      transient: true,
-      visibility: 'HIDDEN',
-      expression: function(xProp) { return this.isDateProp(xProp); }
-    },
+    // Taken from Claude
     { name: 'sink_', transient: true, visibility: 'HIDDEN' },
     {
       class: 'Boolean',

--- a/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
+++ b/src/foam/core/reflow/dashboard/DashboardDAOAgents.js
@@ -1118,7 +1118,7 @@ foam.CLASS({
       title: 'Display Options',
       order: 4,
       collapsable: true,
-      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration']
+      properties: [ 'alignment', 'maintainAspectRatio', 'height',  'showLegend', 'legendPosition', 'showTooltips', 'showTooltipSum', 'animate', 'animationDuration', 'toggleCustomXScale', 'xAxisMinScale', 'xAxisMaxScale', 'toggleCustomYScale', 'yAxisMinScale', 'yAxisMaxScale', 'autoSkip']
     },
     {
       name: 'colors',
@@ -1143,6 +1143,7 @@ foam.CLASS({
     {
       name: 'yProp', 
       label: 'Y Property',
+      visibility: 'HIDDEN', // Property is not needed for Line Charts so we should hide it (removal causes errors)
       view: function(_, X) {
         return { 
           class: 'foam.core.reflow.PropertyChoiceView', 
@@ -1243,6 +1244,60 @@ foam.CLASS({
       name: 'showGridLines',
       label: 'Show Grid Lines',
       value: true
+    },
+    {
+      class: 'Boolean',
+      name: 'toggleCustomXScale',
+      label: 'Custom X Scale',
+      help: 'Toggles custom scale for the X axis'
+    },
+    {
+      class: 'Boolean',
+      name: 'toggleCustomYScale',
+      label: 'Custom Y Scale',
+      help: 'Toggles custom scale for the Y axis'
+    },
+    {
+      class: 'Double',
+      name: 'xAxisMinScale',
+      label: 'X Axis Min',
+      value: 0,
+      visibility: function(toggleCustomXScale) {
+        return toggleCustomXScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+      },
+    },
+    {
+      class: 'Double',
+      name: 'xAxisMaxScale',
+      label: 'X Axis Max',
+      value: 9999,
+      visibility: function(toggleCustomXScale) {
+        return toggleCustomXScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+      },
+    },
+    {
+      class: 'Double',
+      name: 'yAxisMinScale',
+      label: 'Y Axis Min',
+      value: 0,
+      visibility: function(toggleCustomYScale) {
+        return toggleCustomYScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+      },
+    },
+    {
+      class: 'Double',
+      name: 'yAxisMaxScale',
+      label: 'Y Axis Max',
+      value: 9999,
+      visibility: function(toggleCustomYScale) {
+        return toggleCustomYScale ? foam.u2.DisplayMode.RW : foam.u2.DisplayMode.RO;
+      },
+    },
+    {
+      class: 'Boolean',
+      name: 'autoSkip',
+      label: 'Hide Overlapping Labels',
+      value: true
     }
   ],
 
@@ -1262,7 +1317,7 @@ foam.CLASS({
 
       // Use the aggregationSink if provided, otherwise COUNT (like StackedBar does)
       var valueSink = this.aggregationSink ? this.aggregationSink.createSink() : this.COUNT();
-      
+
       // Choose sink based on whether groupBy is set
       if ( this.groupBy ) {
         // Multi-line chart: Use GridBy-based sink
@@ -1289,7 +1344,14 @@ foam.CLASS({
           animate: this.animate,
           animationDuration: this.animationDuration,
           alignment: this.alignment,
-          periodCount: this.periodCount
+          periodCount: this.periodCount,
+          toggleCustomXScale: this.toggleCustomXScale,
+          toggleCustomYScale: this.toggleCustomYScale,
+          xAxisMinScale: this.xAxisMinScale,
+          xAxisMaxScale: this.xAxisMaxScale,
+          yAxisMinScale: this.yAxisMinScale,
+          yAxisMaxScale: this.yAxisMaxScale,
+          autoSkip: this.autoSkip
         });
       } else {
         // Single-line chart: Use GroupBy-based sink
@@ -1315,7 +1377,14 @@ foam.CLASS({
           animate: this.animate,
           animationDuration: this.animationDuration,
           alignment: this.alignment,
-          periodCount: this.periodCount
+          periodCount: this.periodCount,
+          toggleCustomXScale: this.toggleCustomXScale,
+          toggleCustomYScale: this.toggleCustomYScale,
+          xAxisMinScale: this.xAxisMinScale,
+          xAxisMaxScale: this.xAxisMaxScale,
+          yAxisMinScale: this.yAxisMinScale,
+          yAxisMaxScale: this.yAxisMaxScale,
+          autoSkip: this.autoSkip
         });
       }
     },
@@ -1333,7 +1402,8 @@ foam.CLASS({
       this.onDetach(this.dynamic(function(colors, xAxisLabel, yAxisLabel, fill, tension, stepped, showPoints, pointRadius, showGridLines,
                                   maintainAspectRatio, height, showLegend, legendPosition,
                                   showTooltips, showTooltipSum, animate, animationDuration, alignment,
-                                  periodCount) {
+                                  periodCount, toggleCustomXScale, toggleCustomYScale,
+                                  xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
         s.colors = colors;
         s.xAxisLabel = xAxisLabel;
         s.yAxisLabel = yAxisLabel;
@@ -1353,6 +1423,13 @@ foam.CLASS({
         s.animationDuration = animationDuration;
         s.alignment = alignment;
         s.periodCount = periodCount;
+        s.toggleCustomXScale = toggleCustomXScale;
+        s.toggleCustomYScale = toggleCustomYScale;
+        s.xAxisMinScale = xAxisMinScale;
+        s.xAxisMaxScale = xAxisMaxScale;
+        s.yAxisMinScale = yAxisMinScale;
+        s.yAxisMaxScale = yAxisMaxScale;
+        s.autoSkip = autoSkip;
         
         // Force chart to update/redraw
         if ( s.updateChart ) s.updateChart();
@@ -1366,8 +1443,9 @@ foam.CLASS({
             width: '100%',
             display: 'flex',
             flexDirection: 'column',
-            alignItems: this.alignment$.map(function(a) { return a.alignmentStyle; }),
-            textAlign: this.alignment$.map(function(a) { return a.textAlign; })
+            // These lines are changing the alignment in the UI rather than the chart
+            // alignItems: this.alignment$.map(function(a) { return a.alignmentStyle; }),
+            // textAlign: this.alignment$.map(function(a) { return a.textAlign; })
           })
           .tag(this.ReactiveSectionedDetailView, {
             data: this,
@@ -1398,6 +1476,13 @@ foam.CLASS({
       clone.showTooltipSum$ = this.showTooltipSum$;
       clone.animate$ = this.animate$;
       clone.animationDuration$ = this.animationDuration$;
+      clone.toggleCustomXScale$ = this.toggleCustomXScale$;
+      clone.toggleCustomYScale$ = this.toggleCustomYScale$;
+      clone.xAxisMinScale$ = this.xAxisMinScale$;
+      clone.xAxisMaxScale$ = this.xAxisMaxScale$;
+      clone.yAxisMinScale$ = this.yAxisMinScale$;
+      clone.yAxisMaxScale$ = this.yAxisMaxScale$;
+      clone.autoSkip$ = this.autoSkip$;
       return clone;
     }
   ]

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -1240,13 +1240,21 @@ foam.CLASS({
     { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' },
     { class: 'Boolean', name: 'toggleCustomXScale' },
     { class: 'Boolean', name: 'toggleCustomYScale' },
-    { class: 'Double', name: 'xAxisMaxScale' },
-    { class: 'Double', name: 'xAxisMinScale' },
-    { class: 'Double', name: 'yAxisMaxScale' },
-    { class: 'Double', name: 'yAxisMinScale' },
+    { name: 'xAxisMaxScale' }, // untyped: null means "no bound" (says Claude)
+    { name: 'xAxisMinScale' },
+    { name: 'yAxisMaxScale' },
+    { name: 'yAxisMinScale' },
     { class: 'Boolean', name: 'autoSkip' },
     { class: 'DateTime', name: 'xDateAxisMinScale' },
-    { class: 'DateTime', name: 'xDateAxisMaxScale' }
+    { class: 'DateTime', name: 'xDateAxisMaxScale' },
+    { class: 'Boolean', name: 'isTimeScale' },
+    { class: 'DateTime', name: 'dataXMin_', transient: true, visibility: 'HIDDEN' },
+    { class: 'DateTime', name: 'dataXMax_', transient: true, visibility: 'HIDDEN' },
+    { name: 'xScaleType_',  transient: true, visibility: 'HIDDEN' },
+    { name: 'dataXNumMin_', transient: true, visibility: 'HIDDEN' },
+    { name: 'dataXNumMax_', transient: true, visibility: 'HIDDEN' },
+    { name: 'dataYNumMin_', transient: true, visibility: 'HIDDEN' },
+    { name: 'dataYNumMax_', transient: true, visibility: 'HIDDEN' },
   ],
 
   methods: [
@@ -1254,7 +1262,8 @@ foam.CLASS({
                                responsive, maintainAspectRatio, showLegend, legendPosition,
                                showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
                                xPropForLabels, yPropForLabels, toggleCustomXScale, toggleCustomYScale,
-                               xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
+                               xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip,
+                               xDateAxisMinScale,xDateAxisMaxScale, labels) {
       var chartJSOptions = {
         responsive: responsive,
         maintainAspectRatio: maintainAspectRatio,
@@ -1302,8 +1311,8 @@ foam.CLASS({
             grid: {
               display: showGridLines
             },
-            min: toggleCustomYScale ? yAxisMinScale : undefined,
-            max: toggleCustomYScale ? yAxisMaxScale : undefined
+            min: toggleCustomYScale && yAxisMinScale != null ? yAxisMinScale : undefined,
+            max: toggleCustomYScale && yAxisMaxScale != null ? yAxisMaxScale : undefined
           }
         }
       };
@@ -1321,24 +1330,34 @@ foam.CLASS({
         }
 
         if ( toggleCustomXScale ) {
-          chartJSOptions.scales.x.min = xDateAxisMinScale;
-          chartJSOptions.scales.x.max = xDateAxisMaxScale;
+          if ( xDateAxisMinScale ) chartJSOptions.scales.x.min = xDateAxisMinScale;
+          if ( xDateAxisMaxScale ) chartJSOptions.scales.x.max = xDateAxisMaxScale;
         }
 
-      } else if ( toggleCustomXScale ) { // If using a custom scale...
-        // Figure out what the type the data on the X axis is and set the chart type to match
-        var firstX = datasets[0] && datasets[0].data[0] ? datasets[0].data[0].x : null;
-        chartJSOptions.scales.x.type = Number.isNaN(firstX) ? 'category' : 'linear';
-        chartJSOptions.scales.x.min = xAxisMinScale;
-        chartJSOptions.scales.x.max = xAxisMaxScale;
+      } else {
+        chartJSOptions.scales.x.type = this.xScaleType_ || 'category';
+
+        if ( toggleCustomXScale ) {
+          if ( xAxisMinScale != null ) chartJSOptions.scales.x.min = xAxisMinScale;
+          if ( xAxisMaxScale != null ) chartJSOptions.scales.x.max = xAxisMaxScale;
+        }
       }
 
       return this.Line2.create({
-        data: { datasets: datasets },
+        data: { labels: labels || [], datasets: datasets },
         options: chartJSOptions,
         width$: this.width$,
         height$: this.height$
       });
+    },
+
+    function parseXValue(prop, xValue, isTimeScale) {
+      if ( ! isTimeScale ) {
+        return ( prop && prop.chartJsFormatter ) ? prop.chartJsFormatter(xValue) : xValue;
+      }
+      if ( xValue instanceof Date ) return xValue;
+      var d = ( typeof xValue === 'number' ) ? new Date(xValue) : new Date(String(xValue));
+      return isNaN(d.getTime()) ? null : d;
     },
 
     function addToE(e) {
@@ -1413,7 +1432,8 @@ foam.CLASS({
                         responsive, maintainAspectRatio, showLegend, legendPosition,
                         showTooltips, showTooltipSum, animate, animationDuration,
                         periodCount, width, toggleCustomXScale, toggleCustomYScale,
-                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
+                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip,
+                        xDateAxisMinScale, xDateAxisMaxScale, isTimeScale) {
 
       if ( !arg1 || !arg2 ) return null;
 
@@ -1423,20 +1443,14 @@ foam.CLASS({
       }
 
       var data = [];
+      var labels = [];
+      var minX = null, maxX = null;
+      var minY = null, maxY = null;
+      var minXNum = null, maxXNum = null, allNumeric = true;
       var sortedKeys = this.sortedKeys ? this.sortedKeys() : Object.keys(groups);
 
-      // Check if arg1 is a date property for period range display
-      var isDateAxis = false;
-      if ( arg1 ) {
-        if ( foam.lang.Date.isInstance(arg1) || foam.lang.DateTime.isInstance(arg1) ) {
-          isDateAxis = true;
-        } else if ( arg1.delegate && (foam.lang.Date.isInstance(arg1.delegate) || foam.lang.DateTime.isInstance(arg1.delegate)) ) {
-          isDateAxis = true;
-        }
-      }
-
       // Apply period range if enabled (periodCount > 0) and x-axis is a date
-      if ( periodCount > 0 && isDateAxis ) {
+      if ( periodCount > 0 && isTimeScale ) {
         sortedKeys = this.fillTimeGapKeys(sortedKeys, groups, periodCount, arg1);
       }
 
@@ -1446,20 +1460,50 @@ foam.CLASS({
         var aggregatedSink = groups[xValue];
         var yValue = aggregatedSink ? aggregatedSink.value : 0;
 
-        // Format x value for Chart.js
-        var xVal = xValue;
-        if ( arg1 && arg1.chartJsFormatter ) {
-          xVal = arg1.chartJsFormatter(xValue);
-        } else if ( foam.lang.Date.isInstance(arg1) || foam.lang.DateTime.isInstance(arg1) ) {
-          if ( typeof xValue === 'number' ) {
-            xVal = new Date(xValue);
-          } else if ( typeof xValue === 'string' ) {
-            xVal = new Date(xValue);
+        // Taken from Claude -----------------------------------------
+        var xVal = this.parseXValue(arg1, xValue, isTimeScale);
+        if ( xVal === null ) continue;
+
+        if ( isTimeScale ) {
+          if ( ! minX || xVal.getTime() < minX.getTime() ) minX = xVal;
+          if ( ! maxX || xVal.getTime() > maxX.getTime() ) maxX = xVal;
+        } else {
+          var n = Number(xVal);
+          if ( xVal === '' || xVal == null || isNaN(n) ) {
+            allNumeric = false;
+          } else {
+            if ( minXNum === null || n < minXNum ) minXNum = n;
+            if ( maxXNum === null || n > maxXNum ) maxXNum = n;
           }
         }
+        // ------------------------------------------------------------
 
+        labels.push(xVal);
         data.push({ x: xVal, y: yValue });
+        var yn = Number(yValue);
+        if ( ! isNaN(yn) ) {
+          if ( minY === null || yn < minY ) minY = yn;
+          if ( maxY === null || yn > maxY ) maxY = yn;
+        }
       }
+
+      // Pre-set the date range
+      if ( isTimeScale ) {
+        this.xScaleType_ = 'time';
+        this.dataXMin_ = minX;
+        this.dataXMax_ = maxX;
+      } else if ( allNumeric && data.length ) {
+        this.xScaleType_ = 'linear';
+        this.dataXNumMin_ = minXNum;
+        this.dataXNumMax_ = maxXNum;
+      } else {
+        this.xScaleType_ = 'category';
+        this.dataXNumMin_ = 0;
+        this.dataXNumMax_ = Math.max(0, labels.length - 1);
+      }
+
+      this.dataYNumMin_ = minY;
+      this.dataYNumMax_ = maxY;
 
       // Create single dataset
       var datasetConfig = {
@@ -1486,14 +1530,14 @@ foam.CLASS({
       }
 
       var datasets = [datasetConfig];
-      var isTimeScale = arg1 && (foam.lang.Date.isInstance(arg1) || foam.lang.DateTime.isInstance(arg1));
 
       // Use the mixin method instead of duplicating chart options
       return this.createChartOptions(datasets, isTimeScale, xAxisLabel, yAxisLabel, showGridLines,
                                    responsive, maintainAspectRatio, showLegend, legendPosition,
                                    showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
                                    arg1, arg2, toggleCustomXScale, toggleCustomYScale,
-                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale);
+                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale,
+                                   isTimeScale ? null : labels);
     }
 
   }
@@ -1580,7 +1624,8 @@ foam.CLASS({
                         responsive, maintainAspectRatio, showLegend, legendPosition,
                         showTooltips, showTooltipSum, animate, animationDuration,
                         periodCount, width, toggleCustomXScale, toggleCustomYScale,
-                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
+                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip,
+                        xDateAxisMinScale, xDateAxisMaxScale, isTimeScale) {
 
       if ( !xFunc || !yFunc || !acc ) return null;
 
@@ -1598,19 +1643,52 @@ foam.CLASS({
       var sortedColKeys = cols && cols.sortedKeys ? cols.sortedKeys() : Object.keys(colGroups);
       var sortedRowKeys = rows && rows.sortedKeys ? rows.sortedKeys() : Object.keys(rowGroups);
 
-      // Check if xFunc is a date property for period range display
-      var isDateAxis = false;
-      if ( xFunc ) {
-        if ( foam.lang.Date.isInstance(xFunc) || foam.lang.DateTime.isInstance(xFunc) ) {
-          isDateAxis = true;
-        } else if ( xFunc.delegate && (foam.lang.Date.isInstance(xFunc.delegate) || foam.lang.DateTime.isInstance(xFunc.delegate)) ) {
-          isDateAxis = true;
-        }
+      // Apply period range if enabled (periodCount > 0) and x-axis is a date
+      if ( periodCount > 0 && isTimeScale ) {
+        sortedColKeys = this.fillTimeGapKeys(sortedColKeys, colGroups, periodCount, xFunc);
       }
 
-      // Apply period range if enabled (periodCount > 0) and x-axis is a date
-      if ( periodCount > 0 && isDateAxis ) {
-        sortedColKeys = this.fillTimeGapKeys(sortedColKeys, colGroups, periodCount, xFunc);
+      // Parse the column keys once — they're shared by every line
+      var xVals = [], colKeys = [], labels = [];
+      var minX = null, maxX = null;
+      var minY = null, maxY = null;
+      var minXNum = null, maxXNum = null, allNumeric = true;
+
+      for ( var i = 0; i < sortedColKeys.length; i++ ) {
+        var xValue = sortedColKeys[i];
+        var xVal = this.parseXValue(xFunc, xValue, isTimeScale);
+        if ( xVal === null ) continue;
+
+        if ( isTimeScale ) {
+          if ( ! minX || xVal.getTime() < minX.getTime() ) minX = xVal;
+          if ( ! maxX || xVal.getTime() > maxX.getTime() ) maxX = xVal;
+        } else {
+          var n = Number(xVal);
+          if ( xVal === '' || xVal == null || isNaN(n) ) {
+            allNumeric = false;
+          } else {
+            if ( minXNum === null || n < minXNum ) minXNum = n;
+            if ( maxXNum === null || n > maxXNum ) maxXNum = n;
+          }
+        }
+
+        colKeys.push(xValue);   // original group key, for lookups
+        xVals.push(xVal);       // parsed value, for the chart
+        labels.push(xVal);
+      }
+
+      if ( isTimeScale ) {
+        this.xScaleType_ = 'time';
+        this.dataXMin_ = minX;
+        this.dataXMax_ = maxX;
+      } else if ( allNumeric && xVals.length ) {
+        this.xScaleType_ = 'linear';
+        this.dataXNumMin_ = minXNum;
+        this.dataXNumMax_ = maxXNum;
+      } else {
+        this.xScaleType_ = 'category';
+        this.dataXNumMin_ = 0;
+        this.dataXNumMax_ = Math.max(0, labels.length - 1);
       }
 
       // Create a dataset for each line (row group)
@@ -1619,27 +1697,18 @@ foam.CLASS({
         var rowGroup = rowGroups[lineKey];
         var data = [];
 
-        for ( var i = 0; i < sortedColKeys.length; i++ ) {
-          var xValue = sortedColKeys[i];
+        for ( var i = 0; i < xVals.length; i++ ) {
           var yValue = 0;
-
-          if ( rowGroup && rowGroup.groups && rowGroup.groups[xValue] ) {
-            yValue = rowGroup.groups[xValue].value || 0;
+          if ( rowGroup && rowGroup.groups && rowGroup.groups[colKeys[i]] ) {
+            yValue = rowGroup.groups[colKeys[i]].value || 0;
           }
+          data.push({ x: xVals[i], y: yValue });
 
-          // Format x value for Chart.js
-          var xVal = xValue;
-          if ( xFunc && xFunc.chartJsFormatter ) {
-            xVal = xFunc.chartJsFormatter(xValue);
-          } else if ( foam.lang.Date.isInstance(xFunc) || foam.lang.DateTime.isInstance(xFunc) ) {
-            if ( typeof xValue === 'number' ) {
-              xVal = new Date(xValue);
-            } else if ( typeof xValue === 'string' ) {
-              xVal = new Date(xValue);
-            }
+          var yn = Number(yValue);
+          if ( ! isNaN(yn) ) {
+            if ( minY === null || yn < minY ) minY = yn;
+            if ( maxY === null || yn > maxY ) maxY = yn;
           }
-
-          data.push({ x: xVal, y: yValue });
         }
 
         var datasetConfig = {
@@ -1669,14 +1738,16 @@ foam.CLASS({
         colorIndex++;
       }
 
-      var isTimeScale = xFunc && (foam.lang.Date.isInstance(xFunc) || foam.lang.DateTime.isInstance(xFunc));
+      this.dataYNumMin_ = minY;
+      this.dataYNumMax_ = maxY;
 
       // Use the mixin method instead of duplicating chart options
       return this.createChartOptions(datasets, isTimeScale, xAxisLabel, yAxisLabel, showGridLines,
                                    responsive, maintainAspectRatio, showLegend, legendPosition,
                                    showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
                                    xFunc, yFunc, toggleCustomXScale, toggleCustomYScale,
-                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale);
+                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip,
+                                   xDateAxisMinScale, xDateAxisMaxScale, isTimeScale ? null : labels);
       }
     }
 

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -1237,14 +1237,22 @@ foam.CLASS({
     { class: 'Boolean', name: 'showTooltipSum', value: false, help: 'Show sum total in tooltip footer (for multiple lines)' },
     { class: 'Boolean', name: 'animate', value: true },
     { class: 'Int', name: 'animationDuration', value: 1000 },
-    { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' }
+    { class: 'Enum', of: 'foam.core.reflow.dashboard.MetricAlignment', name: 'alignment', value: 'CENTER' },
+    { class: 'Boolean', name: 'toggleCustomXScale' },
+    { class: 'Boolean', name: 'toggleCustomYScale' },
+    { class: 'Double', name: 'xAxisMaxScale' },
+    { class: 'Double', name: 'xAxisMinScale' },
+    { class: 'Double', name: 'yAxisMaxScale' },
+    { class: 'Double', name: 'yAxisMinScale' },
+    { class: 'Boolean', name: 'autoSkip' }
   ],
 
   methods: [
     function createChartOptions(datasets, isTimeScale, xAxisLabel, yAxisLabel, showGridLines,
                                responsive, maintainAspectRatio, showLegend, legendPosition,
                                showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
-                               xPropForLabels, yPropForLabels) {
+                               xPropForLabels, yPropForLabels, toggleCustomXScale, toggleCustomYScale,
+                               xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
       var chartJSOptions = {
         responsive: responsive,
         maintainAspectRatio: maintainAspectRatio,
@@ -1275,10 +1283,13 @@ foam.CLASS({
           x: {
             title: {
               display: !!xAxisLabel || !!(xPropForLabels && xPropForLabels.label),
-              text: xAxisLabel || (xPropForLabels ? xPropForLabels.label : '')
+              text: xAxisLabel || (xPropForLabels ? xPropForLabels.label : ''),
             },
             grid: {
               display: showGridLines
+            },
+            ticks: {
+              autoSkip: autoSkip
             }
           },
           y: {
@@ -1288,7 +1299,9 @@ foam.CLASS({
             },
             grid: {
               display: showGridLines
-            }
+            },
+            min: toggleCustomYScale ? yAxisMinScale : undefined,
+            max: toggleCustomYScale ? yAxisMaxScale : undefined
           }
         }
       };
@@ -1304,6 +1317,12 @@ foam.CLASS({
         if ( timeUnit.displayFormat ) {
           chartJSOptions.scales.x.time.displayFormats[timeUnit.chartJsUnit || 'day'] = timeUnit.displayFormat;
         }
+      } else if ( toggleCustomXScale ) { // If using a custom scale...
+        // Figure out what the type the data on the X axis is and set the chart type to match
+        var firstX = datasets[0] && datasets[0].data[0] ? datasets[0].data[0].x : null;
+        chartJSOptions.scales.x.type = foam.String.isInstance(firstX) ? 'category' : 'linear';
+        chartJSOptions.scales.x.min = xAxisMinScale;
+        chartJSOptions.scales.x.max = xAxisMaxScale;
       }
 
       return this.Line2.create({
@@ -1385,7 +1404,8 @@ foam.CLASS({
                         fill, tension, stepped, showPoints, pointRadius, showGridLines,
                         responsive, maintainAspectRatio, showLegend, legendPosition,
                         showTooltips, showTooltipSum, animate, animationDuration,
-                        periodCount, width) {
+                        periodCount, width, toggleCustomXScale, toggleCustomYScale,
+                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
 
       if ( !arg1 || !arg2 ) return null;
 
@@ -1464,7 +1484,8 @@ foam.CLASS({
       return this.createChartOptions(datasets, isTimeScale, xAxisLabel, yAxisLabel, showGridLines,
                                    responsive, maintainAspectRatio, showLegend, legendPosition,
                                    showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
-                                   arg1, arg2);
+                                   arg1, arg2, toggleCustomXScale, toggleCustomYScale,
+                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip);
     }
 
   }
@@ -1550,7 +1571,8 @@ foam.CLASS({
                         fill, tension, stepped, showPoints, pointRadius, showGridLines,
                         responsive, maintainAspectRatio, showLegend, legendPosition,
                         showTooltips, showTooltipSum, animate, animationDuration,
-                        periodCount, width) {
+                        periodCount, width, toggleCustomXScale, toggleCustomYScale,
+                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
 
       if ( !xFunc || !yFunc || !acc ) return null;
 
@@ -1645,7 +1667,8 @@ foam.CLASS({
       return this.createChartOptions(datasets, isTimeScale, xAxisLabel, yAxisLabel, showGridLines,
                                    responsive, maintainAspectRatio, showLegend, legendPosition,
                                    showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
-                                   xFunc, yFunc);
+                                   xFunc, yFunc, toggleCustomXScale, toggleCustomYScale,
+                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip);
       }
     }
 

--- a/src/foam/core/reflow/dashboard/DashboardSinks.js
+++ b/src/foam/core/reflow/dashboard/DashboardSinks.js
@@ -1244,7 +1244,9 @@ foam.CLASS({
     { class: 'Double', name: 'xAxisMinScale' },
     { class: 'Double', name: 'yAxisMaxScale' },
     { class: 'Double', name: 'yAxisMinScale' },
-    { class: 'Boolean', name: 'autoSkip' }
+    { class: 'Boolean', name: 'autoSkip' },
+    { class: 'DateTime', name: 'xDateAxisMinScale' },
+    { class: 'DateTime', name: 'xDateAxisMaxScale' }
   ],
 
   methods: [
@@ -1252,7 +1254,7 @@ foam.CLASS({
                                responsive, maintainAspectRatio, showLegend, legendPosition,
                                showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
                                xPropForLabels, yPropForLabels, toggleCustomXScale, toggleCustomYScale,
-                               xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
+                               xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
       var chartJSOptions = {
         responsive: responsive,
         maintainAspectRatio: maintainAspectRatio,
@@ -1317,10 +1319,16 @@ foam.CLASS({
         if ( timeUnit.displayFormat ) {
           chartJSOptions.scales.x.time.displayFormats[timeUnit.chartJsUnit || 'day'] = timeUnit.displayFormat;
         }
+
+        if ( toggleCustomXScale ) {
+          chartJSOptions.scales.x.min = xDateAxisMinScale;
+          chartJSOptions.scales.x.max = xDateAxisMaxScale;
+        }
+
       } else if ( toggleCustomXScale ) { // If using a custom scale...
         // Figure out what the type the data on the X axis is and set the chart type to match
         var firstX = datasets[0] && datasets[0].data[0] ? datasets[0].data[0].x : null;
-        chartJSOptions.scales.x.type = foam.String.isInstance(firstX) ? 'category' : 'linear';
+        chartJSOptions.scales.x.type = Number.isNaN(firstX) ? 'category' : 'linear';
         chartJSOptions.scales.x.min = xAxisMinScale;
         chartJSOptions.scales.x.max = xAxisMaxScale;
       }
@@ -1405,7 +1413,7 @@ foam.CLASS({
                         responsive, maintainAspectRatio, showLegend, legendPosition,
                         showTooltips, showTooltipSum, animate, animationDuration,
                         periodCount, width, toggleCustomXScale, toggleCustomYScale,
-                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
+                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
 
       if ( !arg1 || !arg2 ) return null;
 
@@ -1485,7 +1493,7 @@ foam.CLASS({
                                    responsive, maintainAspectRatio, showLegend, legendPosition,
                                    showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
                                    arg1, arg2, toggleCustomXScale, toggleCustomYScale,
-                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip);
+                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale);
     }
 
   }
@@ -1572,7 +1580,7 @@ foam.CLASS({
                         responsive, maintainAspectRatio, showLegend, legendPosition,
                         showTooltips, showTooltipSum, animate, animationDuration,
                         periodCount, width, toggleCustomXScale, toggleCustomYScale,
-                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip) {
+                        xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale) {
 
       if ( !xFunc || !yFunc || !acc ) return null;
 
@@ -1668,7 +1676,7 @@ foam.CLASS({
                                    responsive, maintainAspectRatio, showLegend, legendPosition,
                                    showTooltips, showTooltipSum, animate, animationDuration, timeUnit,
                                    xFunc, yFunc, toggleCustomXScale, toggleCustomYScale,
-                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip);
+                                   xAxisMinScale, xAxisMaxScale, yAxisMinScale, yAxisMaxScale, autoSkip, xDateAxisMinScale, xDateAxisMaxScale);
       }
     }
 


### PR DESCRIPTION
- Added support for independent custom min and max values for the X and Y axes on Line Charts and Multi-Line Charts
- Added explicit toggle for hiding overlapping axes labels
- Fixed issue where the Display Options alignment property was changing the alignment of the UI rather than the chart
- Hid the Y property in the UI as Line Charts and Multi-Line Charts do not actually use it. (Aggregate property handles the Y axis)
- Fixed issues with DateTime charts not respecting custom scaling
- Added reset scale buttons to set custom scales back to default values
- Added proper default values to custom scales

Note that when using custom scaling for the X axis, Line Charts and Multi-Line Charts now automatically switch to either the 'linear', 'category', or 'time'/'timeseries' chart types rather than the default 'logarithm' type. (Logarithm charts do not seem to like custom scaling)

[DOS Link](https://payticconnect.atlassian.net/browse/DOS-4172?atlOrigin=eyJpIjoiYmE1NDQ2NDhjNjNmNDM1NThjNjBhODcxNmIzNWVjYzUiLCJwIjoiaiJ9)