### PR TITLE
Perf: report real response sizes instead of zero

### DIFF
--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -440,6 +440,17 @@ foam.CLASS({
       this.warnCount_ = 0;
       this.report = this.PerfReport.create({ startSnapshot: this.takeSnapshot_() }, this);
 
+      // Resource Timing is how response sizes get resolved at the end of the
+      // window (see resolveResponseSizes_), and its buffer defaults to 250
+      // entries - which a FOAM app fills with script tags before the first
+      // service call is ever made, leaving nothing to match against. Clear it
+      // and raise the ceiling so the capture window is what gets recorded.
+      try {
+        var perf = this.window && this.window.performance;
+        if ( perf && perf.setResourceTimingBufferSize ) perf.setResourceTimingBufferSize(10000);
+        if ( perf && perf.clearResourceTimings ) perf.clearResourceTimings();
+      } catch (e) { /* sizes fall back to content-length */ }
+
       try {
         this.observer_ = new PerformanceObserver(function(list) {
           list.getEntries().forEach(function(e) {
@@ -471,6 +482,7 @@ foam.CLASS({
     async function finishCapture_() {
       /** End the capture window and compute the report. Callable headlessly.
           Async because the JS Self-Profiling API resolves its trace on stop(). **/
+      this.resolveResponseSizes_(this.netCalls_ || []);
       var net    = this.summarizeNetwork_(this.netCalls_ || []);
       var prof   = await this.stopProfile_();          // {supported, trace} - need trace for per-block hot
       var blocks = this.summarizeBlocks_(prof.trace);  // drains buffer, attributes hot fns per block
@@ -620,7 +632,10 @@ foam.CLASS({
         } catch (e) { /* never break the real request */ }
         var p = orig.apply(this, arguments);
         if ( call ) {
-          // Response wire size from content-length (cheap, no body read).
+          // content-length when the server sends one. It usually does not: a
+          // chunked response has no such header, and every FOAM service reply is
+          // chunked - which reported every one of them as 0 bytes. Resource
+          // Timing fills those in at finishCapture_ (see resolveResponseSizes_).
           p.then(function(resp) {
             try { call.respBytes = parseInt(resp.headers.get('content-length'), 10) || 0; } catch (e) {}
           }, function() {});
@@ -733,6 +748,51 @@ foam.CLASS({
         delete g.variants_;
         return foam.core.reflow.perf.PerfServiceCall.create(g);
       }).sort(function(a, b) { return b.count - a.count || b.responseBytes - a.responseBytes; });
+    },
+
+    function resolveResponseSizes_(calls) {
+      /** Fill in response sizes the content-length header could not give us.
+
+        A chunked response carries no content-length, so the header read in
+        wrapFetch_ yields 0 - which is every FOAM service call. Resource Timing
+        knows the real transfer size and costs nothing to read, unlike cloning
+        the body: this runs inside a tool that reports heap, and duplicating a
+        multi-megabyte response would corrupt the number it exists to measure.
+
+        Entries are matched per URL in request order, because the same URL is
+        typically hit several times in one capture. **/
+      var w = this.window, self = this;
+      if ( ! w || ! w.performance || ! w.performance.getEntriesByType ) return;
+
+      var byUrl = {};
+      try {
+        w.performance.getEntriesByType('resource').forEach(function(e) {
+          // Match on the URL rather than initiatorType: a fetch issued through a
+          // wrapper can be reported as xmlhttprequest or with no type at all.
+          if ( ! e.name || ! self.isServiceCall_(e.name) ) return;
+          ( byUrl[e.name] || ( byUrl[e.name] = [] ) ).push(e);
+        });
+      } catch (e) { return; }
+
+      Object.keys(byUrl).forEach(function(u) {
+        byUrl[u].sort(function(a, b) { return a.startTime - b.startTime; });
+      });
+
+      var taken = {};
+      calls.slice().sort(function(a, b) { return ( a.t || 0 ) - ( b.t || 0 ); })
+        .forEach(function(c) {
+          if ( c.respBytes ) return;                  // header already told us
+          var list = byUrl[c.url];
+          if ( ! list ) return;
+          var i = taken[c.url] || 0;
+          if ( i >= list.length ) return;
+          taken[c.url] = i + 1;
+          var e = list[i];
+          // transferSize includes headers and is what a network panel shows;
+          // encodedBodySize is the body alone. Either beats reporting zero, and
+          // both read 0 cross-origin without Timing-Allow-Origin.
+          c.respBytes = e.transferSize || e.encodedBodySize || 0;
+        });
     },
 
     function summarizeNetwork_(calls) {

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -789,13 +789,18 @@ foam.CLASS({
       var taken = {};
       calls.slice().sort(function(a, b) { return ( a.t || 0 ) - ( b.t || 0 ); })
         .forEach(function(c) {
-          if ( c.respBytes ) return;                  // header already told us
-          var list = byUrl[abs(c.url)];
-          if ( ! list ) return;
           var k = abs(c.url);
+          var list = byUrl[k];
+          if ( ! list ) return;
           var i = taken[k] || 0;
           if ( i >= list.length ) return;
+          // Consume this call's entry whether or not we need it. Several
+          // operations share one service URL - a short unchunked reply gets its
+          // size from content-length, but it still owns an entry. Skipping the
+          // cursor for it hands its entry to the next unsized call, so a
+          // multi-megabyte chunked select reports the size of a small cmd.
           taken[k] = i + 1;
+          if ( c.respBytes ) return;                  // header already told us
           var e = list[i];
           // transferSize includes headers and is what a network panel shows;
           // encodedBodySize is the body alone. Either beats reporting zero, and

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -764,13 +764,21 @@ foam.CLASS({
       var w = this.window, self = this;
       if ( ! w || ! w.performance || ! w.performance.getEntriesByType ) return;
 
+      // Resource Timing always names the absolute URL; fetch is usually called
+      // with a relative one. Key both through the same normalisation or nothing
+      // ever matches and every size stays at its content-length value.
+      function abs(u) {
+        try { return new w.URL(u, w.location && w.location.href).href; } catch (e) { return u; }
+      }
+
       var byUrl = {};
       try {
         w.performance.getEntriesByType('resource').forEach(function(e) {
           // Match on the URL rather than initiatorType: a fetch issued through a
           // wrapper can be reported as xmlhttprequest or with no type at all.
           if ( ! e.name || ! self.isServiceCall_(e.name) ) return;
-          ( byUrl[e.name] || ( byUrl[e.name] = [] ) ).push(e);
+          var k = abs(e.name);
+          ( byUrl[k] || ( byUrl[k] = [] ) ).push(e);
         });
       } catch (e) { return; }
 
@@ -782,11 +790,12 @@ foam.CLASS({
       calls.slice().sort(function(a, b) { return ( a.t || 0 ) - ( b.t || 0 ); })
         .forEach(function(c) {
           if ( c.respBytes ) return;                  // header already told us
-          var list = byUrl[c.url];
+          var list = byUrl[abs(c.url)];
           if ( ! list ) return;
-          var i = taken[c.url] || 0;
+          var k = abs(c.url);
+          var i = taken[k] || 0;
           if ( i >= list.length ) return;
-          taken[c.url] = i + 1;
+          taken[k] = i + 1;
           var e = list[i];
           // transferSize includes headers and is what a network panel shows;
           // encodedBodySize is the body alone. Either beats reporting zero, and


### PR DESCRIPTION
`wrapFetch_` sizes a response from its `content-length` header. A chunked response carries no such header, so `parseInt(null)` is `NaN`, `|| 0` turns that into zero, and the Services table reports **0 B received** for the calls that moved the most data.

Reading the body instead would be worse: cloning a multi-megabyte response inside a tool whose headline metric is heap growth corrupts the number it exists to measure. Resource Timing already knows the transfer size and costs nothing to read.

Fix:

- **Fallback** — `resolveResponseSizes_` fills any call the header could not size from its Resource Timing entry, preferring `transferSize` and falling back to `encodedBodySize`. A header, where present, still wins.

- **Buffer** — `startCapture_` clears the resource buffer and raises it to 10,000. This is what makes the fallback work at all: the buffer holds 250 entries by default and an app fills every one with script loads before the first service call, leaving nothing to match against.

- **Matching** — entries are keyed on the absolute URL. Resource Timing always reports absolute; `fetch` is usually called with a relative path, so an unnormalised key never matches.

- **Cursor** — several operations share one service URL, so entries are consumed one per call in request order. A call already sized from its header still consumes its own entry; otherwise it leaves that entry for the next unsized call, and a large chunked response reports the size of a small one made to the same endpoint.

- **Detection** — service calls are recognised by URL rather than `initiatorType`, which reports as `xmlhttprequest` or empty when a fetch goes through a wrapper.

Verified end to end against a capture containing five selects over the same endpoint shape at 1:5:10:50:100 row ratios. Reported sizes now scale linearly with the payload — 181.2 KB, 892.3 KB, 1.7 MB, 8.8 MB, 17.6 MB — where previously the three largest each read a few hundred bytes and the two smallest reported one call's size instead of both.