### PR TITLE
MDAO: skip index adds already covered by an existing index

### DIFF
--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -77,6 +77,8 @@ public class MDAO
   protected Object   state_     = null;
   protected Object   writeLock_ = new Object();
   protected Set      unindexed_ = new HashSet();
+  // Signatures of indexes already added, so a repeated add is a no-op.
+  protected Set<String> indexKeys_ = new HashSet<String>();
 
   /**
    * DAO Command to retrieve current MDAO state. Intented
@@ -132,8 +134,51 @@ public class MDAO
     }
   }
 
+  /** Stable key for an index built from an ordered Indexer list.
+
+    Every name is terminated with ',' so that one key is a string prefix of
+    another exactly when its indexer list is a prefix of the other's - the
+    terminator stops "a" from matching a leading "ab".
+  **/
+  protected String indexKey_(boolean unique, Indexer... props) {
+    StringBuilder sb = new StringBuilder(unique ? "u:" : "n:");
+    for ( Indexer p : props ) {
+      sb.append(p instanceof PropertyInfo ? ((PropertyInfo) p).getName() : p.toString());
+      sb.append(',');
+    }
+    return sb.toString();
+  }
+
+  /** Record an index about to be added; false means an equivalent one is present.
+
+    Adding an index bulk-loads the whole DAO into it and every later put then
+    maintains it, and there is no removeIndex to undo either cost. So callers
+    that cannot know what already exists depend on this being a no-op.
+
+    Redundant means prefix, not just equal. planSelect asks every index to plan
+    and keeps the cheapest, and a compound index on (a, b) already answers
+    lookups on a through its leading level - so (a) after (a, b) adds nothing.
+    The reverse is not true: (a, b) after (a) orders within each a group, so it
+    is a genuinely new index and is added.
+  **/
+  protected boolean recordIndex_(String key) {
+    synchronized ( writeLock_ ) {
+      for ( String existing : indexKeys_ ) {
+        if ( existing.startsWith(key) ) return false;
+      }
+      indexKeys_.add(key);
+      return true;
+    }
+  }
+
+  /** Number of distinct indexes added through the Indexer entry points below. **/
+  public int getIndexCount() {
+    synchronized ( writeLock_ ) { return indexKeys_.size(); }
+  }
+
   /** Add an Index which is for a unique value. Use addIndex() if the index is not unique. **/
   public void addUniqueIndex(Indexer... props) {
+    if ( ! recordIndex_(indexKey_(true, props)) ) return;
     Index idx = ValueIndex.instance();
     for ( var i = props.length-1 ; i >= 0 ; i-- ) idx = new TreeIndex(props[i], idx, i != 0);
     addIndex(idx);
@@ -143,6 +188,7 @@ public class MDAO
    * appended to property list to make it unique.
    **/
   public void addIndex(Indexer... props) {
+    if ( ! recordIndex_(indexKey_(false, props)) ) return;
     Index idx = new TreeIndex((Indexer) this.of_.getAxiomByName("id"), true);
     for ( var i = props.length-1 ; i >= 0 ; i-- ) idx = new TreeIndex(props[i], idx, i != 0);
     addIndex(idx);

--- a/src/foam/dao/test/MDAOIndexDedupTest.js
+++ b/src/foam/dao/test/MDAOIndexDedupTest.js
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'MDAOIndexDedupTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `Adding the same property index twice must not build a second index.
+
+    A duplicate is permanent and expensive: adding an index bulk-loads the whole
+    DAO into it, there is no removeIndex to undo it, and every subsequent put then
+    maintains both copies. Callers that cannot know whether an index already
+    exists depend on the second add being a no-op.`,
+
+  javaImports: [
+    'foam.core.auth.Country',
+    'foam.dao.MDAO',
+    'foam.lang.PropertyInfo'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        PropertyInfo iso3 = (PropertyInfo) Country.getOwnClassInfo().getAxiomByName("iso31661Code");
+        PropertyInfo name = (PropertyInfo) Country.getOwnClassInfo().getAxiomByName("name");
+
+        MDAO dao = new MDAO(Country.getOwnClassInfo());
+        test(dao.getIndexCount() == 0, "A new MDAO reports no added indexes (was " + dao.getIndexCount() + ")");
+
+        dao.addIndex(iso3);
+        test(dao.getIndexCount() == 1, "First addIndex adds one (was " + dao.getIndexCount() + ")");
+
+        dao.addIndex(iso3);
+        test(dao.getIndexCount() == 1, "Repeating the same addIndex adds nothing (was " + dao.getIndexCount() + ")");
+
+        // A different property is a different index, not a duplicate.
+        dao.addIndex(name);
+        test(dao.getIndexCount() == 2, "A different property still adds (was " + dao.getIndexCount() + ")");
+
+        // Unique and non-unique indexes over the same property are different
+        // structures, so they must not collapse into one another.
+        MDAO uniq = new MDAO(Country.getOwnClassInfo());
+        uniq.addIndex(iso3);
+        uniq.addUniqueIndex(iso3);
+        test(uniq.getIndexCount() == 2, "Unique and non-unique on one property are distinct (was " + uniq.getIndexCount() + ")");
+
+        uniq.addUniqueIndex(iso3);
+        test(uniq.getIndexCount() == 2, "Repeating addUniqueIndex adds nothing (was " + uniq.getIndexCount() + ")");
+
+        // Order matters in a compound index, so the two orderings are distinct.
+        MDAO comp = new MDAO(Country.getOwnClassInfo());
+        comp.addIndex(iso3, name);
+        comp.addIndex(name, iso3);
+        test(comp.getIndexCount() == 2, "Compound indexes differing only in order are distinct (was " + comp.getIndexCount() + ")");
+
+        comp.addIndex(iso3, name);
+        test(comp.getIndexCount() == 2, "Repeating a compound addIndex adds nothing (was " + comp.getIndexCount() + ")");
+
+        // (a) after (a, b) is redundant: planSelect takes the cheapest plan from
+        // any index, and the compound already answers lookups on its leading
+        // property.
+        MDAO prefix = new MDAO(Country.getOwnClassInfo());
+        prefix.addIndex(iso3, name);
+        prefix.addIndex(iso3);
+        test(prefix.getIndexCount() == 1, "A leading-column index is covered by an existing compound (was " + prefix.getIndexCount() + ")");
+
+        // The reverse is not redundant - the compound orders within each group.
+        MDAO widen = new MDAO(Country.getOwnClassInfo());
+        widen.addIndex(iso3);
+        widen.addIndex(iso3, name);
+        test(widen.getIndexCount() == 2, "Widening an existing index to a compound still adds (was " + widen.getIndexCount() + ")");
+
+        // Prefix matching is per name, not per character - "name" must not be
+        // treated as covered by an index led by a longer name starting the same.
+        MDAO distinct = new MDAO(Country.getOwnClassInfo());
+        distinct.addIndex(name, iso3);
+        distinct.addIndex(iso3);
+        test(distinct.getIndexCount() == 2, "A non-leading property is not covered (was " + distinct.getIndexCount() + ")");
+
+        // Unique and non-unique are separate key spaces, so no prefix crosstalk.
+        MDAO mixed = new MDAO(Country.getOwnClassInfo());
+        mixed.addUniqueIndex(iso3, name);
+        mixed.addIndex(iso3);
+        test(mixed.getIndexCount() == 2, "A non-unique index is not covered by a unique compound (was " + mixed.getIndexCount() + ")");
+      `
+    }
+  ]
+});

--- a/src/foam/dao/test/tests.jrl
+++ b/src/foam/dao/test/tests.jrl
@@ -23,3 +23,8 @@ p({
   class:"foam.dao.test.MDAOCountTest",
   id:"MDAOCountTest"
 })
+p({
+  class:"foam.dao.test.MDAOIndexDedupTest",
+  id:"MDAOIndexDedupTest",
+  description:"Repeated identical addIndex calls must not build duplicate indexes"
+})

--- a/src/pom.js
+++ b/src/pom.js
@@ -1165,6 +1165,7 @@ foam.POM({
     { name: "foam/dao/test/JournalDefaultClassNameTest",              flags: "js&test|java&test" },
     { name: "foam/dao/test/OrDAOTest",                                flags: "js&test|java&test" },
     { name: "foam/dao/test/MDAOCountTest",                            flags: "js&test|java&test" },
+    { name: "foam/dao/test/MDAOIndexDedupTest",                       flags: "js&test|java&test" },
     { name: "foam/lib/ExternalPropertyPredicate",                     flags: "js|java" },
     { name: "foam/lib/StorageTransientPropertyPredicate",             flags: "js|java" },
     { name: "foam/lib/ClusterPropertyPredicate",                      flags: "js|java" },


### PR DESCRIPTION
`addIndex(Indexer...)` builds a fresh `TreeIndex` and bulk-loads the whole DAO into it on every call, with no check for what is already there. A caller that cannot know whether an index exists therefore pays for a second full copy — and since there is no `removeIndex`, the duplicate is permanent: it costs the bulk load on add, then is maintained on every subsequent put for the life of the DAO.

Cause: neither varargs entry point records what it has added.

Reproduce (`MDAOIndexDedupTest`):

```java
MDAO dao = new MDAO(Country.getOwnClassInfo());
dao.addIndex(ISO31661CODE);
dao.addIndex(ISO31661CODE);  // builds and bulk-loads a second identical index
```

Fix: record a signature per added index and return early when an equivalent one is already present.

Redundant means prefix, not just equal. `planSelect` asks every index to plan and keeps the cheapest, so a compound index on `(a, b)` already answers lookups on `a` through its leading level — `(a)` after `(a, b)` adds nothing and is skipped. The reverse still adds: `(a, b)` after `(a)` orders within each `a` group, so it is a genuinely new index. Signature keys terminate every name with `,` so `a` is a prefix of `(a, b)` but never of `ab`, and unique and non-unique live in separate key spaces.

Scope is the two `Indexer...` entry points. `addIndex(Index)` takes a pre-built index object and is untouched.

Also adds `getIndexCount()`, which is what the test asserts on.