### PR TITLE
MDAO: skip an index already covered by an existing one

### DIFF
--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -121,18 +121,6 @@ public class MDAO
 
   public void addIndex(Index index) {
     synchronized ( writeLock_ ) {
-      // Adding an index bulk-loads the whole DAO into it and every later put
-      // maintains it, and there is no removeIndex to undo either cost. Callers
-      // that cannot know what already exists rely on this being a no-op.
-      if ( index_.covers(index) ) {
-        // Say so - a silently dropped index looks the same as one that was
-        // never requested, and the difference matters when a query is slow.
-        foam.lang.X x = foam.lang.XLocator.get();
-        Logger logger = x == null ? null : (Logger) x.get("logger");
-        if ( logger != null )
-          logger.info("Index already covered, not added", getOf().getId(), index.toString());
-        return;
-      }
       setState(index_.addIndex(state_, index));
     }
   }

--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -121,8 +121,25 @@ public class MDAO
 
   public void addIndex(Index index) {
     synchronized ( writeLock_ ) {
+      // Adding an index bulk-loads the whole DAO into it and every later put
+      // maintains it, and there is no removeIndex to undo either cost. Callers
+      // that cannot know what already exists rely on this being a no-op.
+      if ( index_.covers(index) ) {
+        // Say so - a silently dropped index looks the same as one that was
+        // never requested, and the difference matters when a query is slow.
+        foam.lang.X x = foam.lang.XLocator.get();
+        Logger logger = x == null ? null : (Logger) x.get("logger");
+        if ( logger != null )
+          logger.info("Index already covered, not added", getOf().getId(), index.toString());
+        return;
+      }
       setState(index_.addIndex(state_, index));
     }
+  }
+
+  /** Number of indexes held, counting the primary. **/
+  public int getIndexCount() {
+    synchronized ( writeLock_ ) { return index_.getIndexCount(); }
   }
 
   // Add Index which skips bulkload

--- a/src/foam/dao/index/AltIndex.java
+++ b/src/foam/dao/index/AltIndex.java
@@ -37,6 +37,18 @@ public class AltIndex
   }
 
   public Object addIndex(Object state, Index i) {
+    // Adding an index bulk-loads the whole DAO into it and every later put
+    // maintains it, and there is no removeIndex to undo either cost. Callers
+    // that cannot know what already exists rely on this being a no-op.
+    if ( covers(i) ) {
+      // Say so - a silently dropped index looks the same as one that was never
+      // requested, and the difference matters when a query turns out slow.
+      foam.lang.X x = foam.lang.XLocator.get();
+      foam.core.logger.Logger logger = x == null ? null : (foam.core.logger.Logger) x.get("logger");
+      if ( logger != null ) logger.info("Index already covered, not added", i.toString());
+      return state;
+    }
+
     delegates_.add(i);
 
     // No data to copy when just adding first index

--- a/src/foam/dao/index/AltIndex.java
+++ b/src/foam/dao/index/AltIndex.java
@@ -25,6 +25,17 @@ public class AltIndex
       addIndex(null, indices[i]);
   }
 
+  /** The number of indexes held, so callers can tell whether an add took. */
+  public int getIndexCount() { return delegates_.size(); }
+
+  /** Covered when any one of the alternatives already covers it. */
+  public boolean covers(Index other) {
+    for ( int i = 0 ; i < delegates_.size() ; i++ ) {
+      if ( delegates_.get(i).covers(other) ) return true;
+    }
+    return false;
+  }
+
   public Object addIndex(Object state, Index i) {
     delegates_.add(i);
 

--- a/src/foam/dao/index/Index.java
+++ b/src/foam/dao/index/Index.java
@@ -39,6 +39,22 @@ public interface Index {
     planSelect(state, sink, skip, limit, order, predicate).select(state, sink, skip, limit, order, predicate);
   }
 
+  /**
+   * True when this Index already answers everything the given Index would, so
+   * adding that one would be redundant.
+   *
+   * Redundant is not the same as equal: an index on (a, b) also answers lookups
+   * on a through its leading level, because planSelect asks every index to plan
+   * and keeps the cheapest. The reverse does not hold - (a, b) after (a) orders
+   * within each a group and is a genuinely new index.
+   *
+   * Answering false is always safe; it only means a redundant index may be
+   * built. Answering true wrongly loses an index, and there is no removeIndex.
+   */
+  default boolean covers(Index other) {
+    return false;
+  }
+
   // Return number of objects stored in this Index
   public long size(Object state);
 

--- a/src/foam/dao/index/TreeIndex.java
+++ b/src/foam/dao/index/TreeIndex.java
@@ -45,6 +45,59 @@ public class TreeIndex
     isPrimary_   = isPrimary;
   }
 
+  public Indexer getIndexer() { return indexer_; }
+
+  public Index getTail() { return tail_; }
+
+  /**
+   * This index covers another when that one's property chain is a prefix of
+   * this one's, so every lookup it could answer this one answers too.
+   *
+   * Two indexers are the same property when their PropertyInfo names match;
+   * anything else falls back to equals, and an indexer we cannot compare
+   * reports not-covered rather than guessing.
+   */
+  public boolean covers(Index other) {
+    if ( ! ( other instanceof TreeIndex ) ) return false;
+
+    TreeIndex mine = this, theirs = (TreeIndex) other;
+
+    while ( true ) {
+      if ( ! sameIndexer(mine.indexer_, theirs.indexer_) ) return false;
+
+      // Their chain ended first, so theirs is a prefix of mine - covered.
+      if ( ended(theirs) ) return true;
+
+      // Mine ended first, so theirs goes deeper - not covered.
+      if ( ended(mine) ) return false;
+
+      mine   = (TreeIndex) mine.tail_;
+      theirs = (TreeIndex) theirs.tail_;
+    }
+  }
+
+  /**
+   * Whether a chain has no more property levels.
+   *
+   * addIndex(Indexer...) appends the primary key to make a non-unique index
+   * unique, so (a) is really (a, id) and (a, b) is (a, b, id). That trailing
+   * level is a tiebreaker, not a property anyone queries on, and counting it
+   * would make (a) look unrelated to (a, b) instead of a prefix of it.
+   */
+  protected static boolean ended(TreeIndex t) {
+    if ( ! ( t.tail_ instanceof TreeIndex ) ) return true;
+    TreeIndex next = (TreeIndex) t.tail_;
+    return next.isPrimary_ && ! ( next.tail_ instanceof TreeIndex );
+  }
+
+  protected static boolean sameIndexer(Indexer a, Indexer b) {
+    if ( a == b ) return true;
+    if ( a == null || b == null ) return false;
+    if ( a instanceof foam.lang.PropertyInfo && b instanceof foam.lang.PropertyInfo )
+      return ((foam.lang.PropertyInfo) a).getName().equals(((foam.lang.PropertyInfo) b).getName());
+    return a.equals(b);
+  }
+
   public Object bulkLoad(FObject[] a) {
     Arrays.parallelSort(a);
     return TreeNode.getNullNode().bulkLoad(tail_, indexer_, 0, a.length-1, a);

--- a/src/foam/dao/index/TreeIndex.java
+++ b/src/foam/dao/index/TreeIndex.java
@@ -60,20 +60,17 @@ public class TreeIndex
   public boolean covers(Index other) {
     if ( ! ( other instanceof TreeIndex ) ) return false;
 
-    TreeIndex mine = this, theirs = (TreeIndex) other;
+    TreeIndex theirs = (TreeIndex) other;
 
-    while ( true ) {
-      if ( ! sameIndexer(mine.indexer_, theirs.indexer_) ) return false;
+    if ( ! sameIndexer(indexer_, theirs.indexer_) ) return false;
 
-      // Their chain ended first, so theirs is a prefix of mine - covered.
-      if ( ended(theirs) ) return true;
+    // Their chain ended first, so theirs is a prefix of mine - covered.
+    if ( ended(theirs) ) return true;
 
-      // Mine ended first, so theirs goes deeper - not covered.
-      if ( ended(mine) ) return false;
+    // Mine ended first, so theirs goes deeper - not covered.
+    if ( ended(this) ) return false;
 
-      mine   = (TreeIndex) mine.tail_;
-      theirs = (TreeIndex) theirs.tail_;
-    }
+    return tail_.covers(theirs.tail_);
   }
 
   /**

--- a/src/foam/dao/test/MDAOIndexDedupTest.js
+++ b/src/foam/dao/test/MDAOIndexDedupTest.js
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'MDAOIndexDedupTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `An index already covered by an existing one must not be added.
+
+    Adding an index bulk-loads the whole DAO into it, every later put maintains
+    it, and there is no removeIndex to undo either cost - so a caller that
+    cannot know what already exists depends on the add being a no-op.
+
+    Covered means prefix, not equal: planSelect asks every index to plan and
+    keeps the cheapest, so a compound index on (a, b) already answers lookups
+    on a through its leading level.`,
+
+  javaImports: [
+    'foam.core.auth.Country',
+    'foam.dao.MDAO',
+    'foam.lang.PropertyInfo'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        PropertyInfo iso3 = (PropertyInfo) Country.getOwnClassInfo().getAxiomByName("iso31661Code");
+        PropertyInfo name = (PropertyInfo) Country.getOwnClassInfo().getAxiomByName("name");
+
+        // A new MDAO already holds the primary index on id.
+        MDAO dao = new MDAO(Country.getOwnClassInfo());
+        int base = dao.getIndexCount();
+        test(base == 1, "A new MDAO holds one index, the primary (was " + base + ")");
+
+        dao.addIndex(iso3);
+        test(dao.getIndexCount() == base + 1, "First addIndex adds one (was " + dao.getIndexCount() + ")");
+
+        dao.addIndex(iso3);
+        test(dao.getIndexCount() == base + 1, "Repeating the same addIndex adds nothing (was " + dao.getIndexCount() + ")");
+
+        // A different property is a different index, not a duplicate.
+        dao.addIndex(name);
+        test(dao.getIndexCount() == base + 2, "A different property still adds (was " + dao.getIndexCount() + ")");
+
+        // The primary index must not swallow a property index.
+        MDAO pk = new MDAO(Country.getOwnClassInfo());
+        pk.addIndex(name);
+        test(pk.getIndexCount() == 2, "The primary index does not cover a property index (was " + pk.getIndexCount() + ")");
+
+        // (a) after (a, b) is redundant - the compound answers lookups on a
+        // through its leading level.
+        MDAO prefix = new MDAO(Country.getOwnClassInfo());
+        prefix.addIndex(iso3, name);
+        int afterCompound = prefix.getIndexCount();
+        prefix.addIndex(iso3);
+        test(prefix.getIndexCount() == afterCompound,
+          "A leading-column index is covered by an existing compound (was " + prefix.getIndexCount() + ")");
+
+        // The reverse is not redundant - the compound orders within each group.
+        MDAO widen = new MDAO(Country.getOwnClassInfo());
+        widen.addIndex(iso3);
+        int afterSingle = widen.getIndexCount();
+        widen.addIndex(iso3, name);
+        test(widen.getIndexCount() == afterSingle + 1,
+          "Widening an existing index to a compound still adds (was " + widen.getIndexCount() + ")");
+
+        // Order matters in a compound index, so the two orderings are distinct.
+        MDAO comp = new MDAO(Country.getOwnClassInfo());
+        comp.addIndex(iso3, name);
+        comp.addIndex(name, iso3);
+        test(comp.getIndexCount() == base + 2, "Compound indexes differing only in order are distinct (was " + comp.getIndexCount() + ")");
+
+        comp.addIndex(iso3, name);
+        test(comp.getIndexCount() == base + 2, "Repeating a compound addIndex adds nothing (was " + comp.getIndexCount() + ")");
+
+        // A non-leading property is not covered by a compound led by another.
+        MDAO distinct = new MDAO(Country.getOwnClassInfo());
+        distinct.addIndex(name, iso3);
+        distinct.addIndex(iso3);
+        test(distinct.getIndexCount() == base + 2, "A non-leading property is not covered (was " + distinct.getIndexCount() + ")");
+
+        // Repeating a unique index is still a no-op.
+        MDAO uniq = new MDAO(Country.getOwnClassInfo());
+        uniq.addUniqueIndex(iso3);
+        int afterUnique = uniq.getIndexCount();
+        uniq.addUniqueIndex(iso3);
+        test(uniq.getIndexCount() == afterUnique, "Repeating addUniqueIndex adds nothing (was " + uniq.getIndexCount() + ")");
+      `
+    }
+  ]
+});

--- a/src/foam/dao/test/tests.jrl
+++ b/src/foam/dao/test/tests.jrl
@@ -23,3 +23,8 @@ p({
   class:"foam.dao.test.MDAOCountTest",
   id:"MDAOCountTest"
 })
+p({
+  class:"foam.dao.test.MDAOIndexDedupTest",
+  id:"MDAOIndexDedupTest",
+  description:"An index covered by an existing one must not be added"
+})

--- a/src/pom.js
+++ b/src/pom.js
@@ -1165,6 +1165,7 @@ foam.POM({
     { name: "foam/dao/test/JournalDefaultClassNameTest",              flags: "js&test|java&test" },
     { name: "foam/dao/test/OrDAOTest",                                flags: "js&test|java&test" },
     { name: "foam/dao/test/MDAOCountTest",                            flags: "js&test|java&test" },
+    { name: "foam/dao/test/MDAOIndexDedupTest",                       flags: "js&test|java&test" },
     { name: "foam/lib/ExternalPropertyPredicate",                     flags: "js|java" },
     { name: "foam/lib/StorageTransientPropertyPredicate",             flags: "js|java" },
     { name: "foam/lib/ClusterPropertyPredicate",                      flags: "js|java" },


### PR DESCRIPTION
`addIndex` builds the index and bulk-loads the whole DAO into it with no check for what is already there, so a caller that cannot know whether an index exists pays for a second copy — and since there is no `removeIndex`, that duplicate is permanent: the bulk load on add, then maintenance on every put for the life of the DAO.

Rather than have `MDAO` keep its own bookkeeping of what it has added, the index answers the question, so the rule sits with the structure that defines it and applies to every entry point including a hand-built `Index`.

Fix:

- **Index** — new `covers(Index)` defaulting to false. False is always safe, since it only risks a redundant index, while a wrong true loses one with no way to add it back.

- **TreeIndex** — covered when the other's property chain is a prefix of this one's. `planSelect` asks every index to plan and keeps the cheapest, so a compound on `(a, b)` already answers lookups on `a` through its leading level. The reverse still adds: `(a, b)` after `(a)` orders within each `a` group.

- **AltIndex** — covered when any alternative covers it, which is what lets an add see the primary index and every index it did not create.

- **MDAO** — one check in `addIndex`, and an ignored index logs at info with the model id and the index. A silently dropped index is indistinguishable from one never requested, and that difference matters when a query turns out slow.

One wrinkle worth flagging for review: `addIndex(Indexer...)` appends the primary key to make a non-unique index unique, so `(a)` is really `(a, id)` and `(a, b)` is `(a, b, id)`. A plain prefix test reads those as unrelated, so the trailing primary level is treated as the end of the chain.

Test covers both directions of the prefix rule, order-sensitivity of compound indexes, a non-leading property, repeated unique adds, and that the primary index does not swallow a property index.