### PR TITLE
HTTPResponse: release fetch bodies that nothing reads

### DIFF
--- a/src/foam/net/web/HTTPRequest.js
+++ b/src/foam/net/web/HTTPRequest.js
@@ -157,6 +157,12 @@ foam.CLASS({
 
         if ( resp.success && ! resp.redirect_to_url ) return resp;
 
+        // Nothing reads payload on the failure path, and an unread fetch body
+        // holds its connection open until the Response is garbage collected,
+        // so release the stream here. cancel() rejects if the body already
+        // errored, which is exactly the case we're in, so swallow that.
+        resp.resp.body?.cancel().catch(() => {});
+
         // Use Promise.reject so crappy debuggers don't pause here
         // throw resp;
         return Promise.reject(resp);

--- a/src/foam/net/web/HTTPResponse.js
+++ b/src/foam/net/web/HTTPResponse.js
@@ -47,7 +47,7 @@ foam.CLASS({
         switch ( this.responseType ) {
           case 'text':        return this.resp.text();
           case 'blob':        return this.resp.blob();
-          case 'arraybuffer': return this.resp.arraybuffer();
+          case 'arraybuffer': return this.resp.arrayBuffer();
           case 'json':        return this.resp.json();
         }
 
@@ -82,12 +82,17 @@ foam.CLASS({
     {
       class: 'String',
       name: 'redirect_to_url'
+    },
+    {
+      name: 'reader_',
+      hidden: true,
+      transient: true
     }
   ],
 
   methods: [
     function start() {
-      var reader = this.resp.body.getReader();
+      var reader = this.reader_ = this.resp.body.getReader();
       this.streaming = true;
 
       var onError = e => {
@@ -111,6 +116,11 @@ foam.CLASS({
 
     function stop() {
       this.streaming = false;
+      // Clearing the flag only stops us reading further chunks; the reader
+      // still holds a lock on an open body stream, so cancel it to release
+      // the connection. cancel() rejects on an already errored stream.
+      this.reader_?.cancel().catch(() => {});
+      this.reader_ = null;
     },
 
     function copyHeaders_(r) {


### PR DESCRIPTION
Noticed three issues in the browser fetch path. An unread `Response.body` is still an open `ReadableStream`, so its connection stays checked out until the `Response` gets garbage collected — whenever that happens to be.

- **Failure path** — `HTTPRequest.send` rejects with the `HTTPResponse` on any non-2xx or redirect. `payload` is a lazy factory and no reject-branch caller touches it (`HTTPBox` reads `redirect_to_url` and `message`, never `payload`), so every error response leaks its body. `RetryHTTPRequest` multiplies that by `numTries`.

- **stop()** — clears `streaming` but never cancels the reader, which still holds the lock on an open stream. On a stalled stream `onData` never fires again, so nothing ever releases it.

- **arraybuffer** — `payload` calls `this.resp.arraybuffer()`. The real method is `arrayBuffer()`, so `responseType: 'arraybuffer'` threw a `TypeError` and left the body unread as well.

Fix:

- cancel the body before `Promise.reject` on the failure path

- keep the reader in `reader_` so `stop()` can cancel it

- call `arrayBuffer()`

Both `cancel()` calls swallow their rejection, coz it rejects on an already-errored stream and that's the normal state on these paths.