### PR TITLE
Skip the after-rule clone and deep compare when a DAO has no after rules

### DIFF
--- a/src/foam/core/ruler/RulerDAO.js
+++ b/src/foam/core/ruler/RulerDAO.js
@@ -191,16 +191,19 @@ try {
 
 if ( ret != null ) {
   ret = ret.fclone();
-  FObject before = ret.fclone();
-  if ( oldObj == null ) {
-    applyRules(x, ret, oldObj, getCreateAfter());
-  } else {
-    applyRules(x, ret, oldObj, getUpdateAfter());
-  }
 
-  // Test for changes during 'after' rule
-  if ( ! before.equals(ret) ) {
-    ret = getDelegate().put_(x, ret);
+  // The second clone and the deep compare below only pay off if an 'after'
+  // rule can run and change something. Most DAOs have none, and then the
+  // snapshot is compared against an object nothing has touched.
+  Predicate after = oldObj == null ? getCreateAfter() : getUpdateAfter();
+  if ( hasRules(after) ) {
+    FObject before = ret.fclone();
+    applyRules(x, ret, oldObj, after);
+
+    // Test for changes during 'after' rule
+    if ( ! before.equals(ret) ) {
+      ret = getDelegate().put_(x, ret);
+    }
   }
 }
 
@@ -221,6 +224,18 @@ FObject ret =  getDelegate().remove_(x, obj);
 applyRules(x, ret, oldObj, getRemoveAfter());
 applyRules(x, ret, oldObj, getRemoveAsync());
 return ret;`
+    },
+    {
+      name: 'hasRules',
+      type: 'boolean',
+      args: 'Predicate pred',
+      documentation: `Whether applyRules has anything to run for pred.
+
+        Reads the same cached list applyRules iterates. A group key only exists
+        once a rule lands in it, so an empty list means no rule can run, and a
+        caller can skip setup that only an executing rule justifies.`,
+      javaCode: `List<RuleGroup> groups = getRuleGroups().get(pred);
+return groups != null && ! groups.isEmpty();`
     },
     {
       name: 'applyRules',

--- a/src/foam/core/ruler/test/RulerDAOTest.java
+++ b/src/foam/core/ruler/test/RulerDAOTest.java
@@ -5,6 +5,7 @@ import foam.lang.ContextAwareAgent;
 import foam.lang.X;
 import foam.dao.ArraySink;
 import foam.dao.DAO;
+import foam.dao.MDAO;
 import foam.mlang.predicate.Predicate;
 import foam.core.auth.LifecycleState;
 import foam.core.auth.User;
@@ -45,6 +46,59 @@ public class RulerDAOTest extends Test {
     removeData(x);
     testCompositeRuleAction(x);
     removeData(x);
+    testAfterRules(x);
+  }
+
+  /**
+   * put_ only clones a second time and deep-compares when an 'after' rule can
+   * run. Both sides of that branch have to keep behaving: no rule returns the
+   * object untouched, and a rule that mutates still gets written back.
+   */
+  public void testAfterRules(X x) {
+    // Its own dao key, so the rules the rest of this test registers against
+    // localUserDAO cannot reach it and 'no after rule' really means none.
+    DAO afterDAO = new RulerDAO(x, new MDAO(User.getOwnClassInfo()), "afterUserDAO");
+
+    // Nothing targets this dao key yet, so the 'after' block has no work.
+    User quiet = new User();
+    quiet.setId(20);
+    quiet.setFirstName("Nadia");
+    quiet.setLastName("Original");
+    quiet = (User) afterDAO.put_(x, quiet);
+    test(quiet != null, "A put with no 'after' rule returns the object");
+    test(quiet.getLastName().equals("Original"),
+      "A put with no 'after' rule returns it unchanged");
+
+    RuleGroup rg = new RuleGroup();
+    rg.setId("users:after rule");
+    rgDAO.put(rg);
+
+    Rule afterRule = new Rule();
+    afterRule.setId("after1");
+    afterRule.setName("rule. after rule renames");
+    afterRule.setRuleGroup("users:after rule");
+    afterRule.setDaoKey("afterUserDAO");
+    afterRule.setOperation(Operation.CREATE);
+    afterRule.setAfter(true);
+    afterRule.setLifecycleState(LifecycleState.ACTIVE);
+    afterRule.setAction((x1, obj, oldObj, ruler, rule, agent) -> ((User) obj).setLastName("Renamed"));
+    afterRule = (Rule) localRuleDAO.put_(x, afterRule);
+
+    User renamed = new User();
+    renamed.setId(21);
+    renamed.setFirstName("Omar");
+    renamed.setLastName("Original");
+    renamed = (User) afterDAO.put_(x, renamed);
+    test(renamed.getLastName().equals("Renamed"),
+      "An 'after' rule mutation shows on the returned object");
+
+    // The mutation happens on a clone, so it only survives if put_ noticed the
+    // change and wrote it back to the delegate.
+    User found = (User) afterDAO.find_(x, 21L);
+    test(found != null && found.getLastName().equals("Renamed"),
+      "An 'after' rule mutation is written back to the delegate");
+
+    localRuleDAO.remove_(x, afterRule);
   }
 
   public void testUsers(X x) {


### PR DESCRIPTION
`put_` clones the result twice: once to hand back something unfrozen, once as a snapshot to diff against after the `after` rules run. Then it deep-compares the two to decide whether to re-put.

Most DAOs have no `after` rules at all, so the snapshot gets compared against an object nothing ever touched — a clone plus a property-by-property `equals` on every single put, to discover that nothing changed.

Fix: gate the snapshot, the `applyRules` call, and the compare behind `hasRules(pred)`.

`hasRules` reads the same cached `ruleGroups` list `applyRules` iterates, so it's one HashMap lookup — no DAO hit, and no chance of it disagreeing with what the engine would actually run. A group key only exists once a rule lands in it, so an empty list means nothing can run. In the no-rules case that's 1 lookup replacing 2 lookups, a clone, and a deep compare.

I kept the first `fclone`. It's what makes `put_` return an unfrozen object, and dropping it would hand back the delegate's frozen result — a contract change for every rule-backed DAO, worth doing but not here.

The `after` path had no coverage (every rule in `RulerDAOTest` sets `setAfter(false)`), so both branches are tested now: no rule returns the object unchanged, and a mutating after rule still survives a `find_`, which is what proves the write-back fired.