### PR TITLE
PT-FIXES:DOS-4496 fix(journal): write the full object when a put changes the class

### DIFF
--- a/doc/guides/DaoGotchas.md
+++ b/doc/guides/DaoGotchas.md
@@ -279,6 +279,9 @@ The inherited `dao` expression depends on `predicate`, so it rebuilds the `where
 
 **Operation semantics.** `foam.core.dao.Operation` is `CREATE`, `UPDATE`, or `CREATE_OR_UPDATE`. A `CREATE` rule fires only on a create — a new or non-existent id — and not on a re-put of an existing id.
 
+**A re-put that changes the object's class is journaled as a full object, not a delta.** An existing id takes the delta path (`src/foam/dao/AbstractF3FileJournal.js:298-309`), and a delta between two classes is not computable: the writer walks the new class's properties and compares each against the old object, so a property the old class does not own raises a `ClassCastException`. The journal catches `Throwable`, logs `Failed to format put` and resets its buffer, so before this was guarded the entry vanished — the live DAO held the subclass and the next replay handed back the original class. `maybeOutputDelta` now detects the class change and writes the whole object instead (`src/foam/lib/formatter/JSONFObjectFormatter.java:440-447`).
+
+
 Two levers when a rule keeps overwriting a value you need:
 
 - **Two-put.** Put the record (the CREATE rule clobbers the field), then re-put the same id. The CREATE rule cannot fire on the update, so the second write sticks. Capture the returned object to get the sequence-assigned id.

--- a/src/foam/dao/test/JournalClassChangeTest.js
+++ b/src/foam/dao/test/JournalClassChangeTest.js
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'JournalClassChangeTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `
+    Re-putting a stored record under a subclass, with every property value equal,
+    must still be journaled. The delta writer counts only property differences, so
+    a class-only change used to produce no entry at all and the record came back as
+    the original class on replay.
+  `,
+
+  javaImports: [
+    'foam.core.auth.UserLifecycleTicket',
+    'foam.core.ticket.Ticket',
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.dao.ProxyDAO',
+    'foam.lang.X',
+    'foam.lib.StoragePropertyPredicate',
+    'foam.lib.formatter.JSONFObjectFormatter',
+    'java.util.Scanner'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        String file = "classChangeJournal";
+
+        // Plain MDAO under the journal: no LastModifiedAware, nothing that would
+        // stamp a field and give the put a property delta of its own.
+        foam.dao.java.JDAO dao = new foam.dao.java.JDAO();
+        dao.setX(x);
+        dao.setFilename(file);
+        dao.setDelegate(new MDAO(Ticket.getOwnClassInfo()));
+        x = x.put("classChangeTicketDAO", new ProxyDAO.Builder(x).setDelegate(dao).build());
+
+        Ticket base = new Ticket(x);
+        base.setId("class-change-1");
+        base.setTitle("same title");
+        dao.put(base);
+
+        // Same id, same values, subclass instead.
+        Ticket stored = (Ticket) dao.find("class-change-1");
+        UserLifecycleTicket sub = new UserLifecycleTicket(x);
+        sub.copyFrom(stored);
+        dao.put(sub);
+
+        Ticket live = (Ticket) dao.find("class-change-1");
+        test(live instanceof UserLifecycleTicket,
+          "live record carries the subclass, got " + live.getClass().getSimpleName());
+
+        // Formatter level, same settings the journal uses: a class-only change is a delta.
+        JSONFObjectFormatter fmt = new JSONFObjectFormatter();
+        fmt.setPropertyPredicate(new StoragePropertyPredicate());
+        fmt.setOutputShortNames(true);
+        fmt.setOutputDefaultClassNames(false);
+        fmt.setX(x);
+        boolean wrote = fmt.maybeOutputDelta(stored, sub, null, Ticket.getOwnClassInfo());
+        test(wrote, "formatter reports a delta for a class-only change");
+        test(fmt.builder().indexOf("UserLifecycleTicket") >= 0,
+          "the delta names the new class, got: " + fmt.builder());
+
+        int entries = countEntries(x, file);
+        test(entries == 2,
+          "the class change is journaled as a second entry, found " + entries);
+
+        // Replay into a fresh DAO reading the same journal.
+        foam.dao.java.JDAO replayed = new foam.dao.java.JDAO();
+        replayed.setX(x);
+        replayed.setFilename(file);
+        replayed.setDelegate(new MDAO(Ticket.getOwnClassInfo()));
+
+        Ticket after = (Ticket) replayed.find("class-change-1");
+        test(after != null, "record survives the replay");
+        test(after != null && after instanceof UserLifecycleTicket,
+          "class survives the replay, got " + ( after == null ? "null" : after.getClass().getSimpleName() ));
+        test(after != null && "same title".equals(after.getTitle()),
+          "values survive the replay");
+      `
+    },
+    {
+      name: 'countEntries',
+      args: 'X x, String fileName',
+      type: 'Integer',
+      javaCode: `
+        foam.core.fs.FileSystemStorage fs = (foam.core.fs.FileSystemStorage) x.get(foam.core.fs.FileSystemStorage.class);
+        int count = 0;
+        try ( Scanner sc = new Scanner(fs.getInputStream(fileName)) ) {
+          while ( sc.hasNextLine() ) {
+            String line = sc.nextLine();
+            if ( line.startsWith(foam.dao.AbstractF3FileJournal.OPEN_CREATE) ||
+                 line.startsWith(foam.dao.AbstractF3FileJournal.OPEN_PUT) ) {
+              count++;
+            }
+          }
+        } catch ( Exception e ) {
+          return -1;
+        }
+        return count;
+      `
+    }
+  ]
+});

--- a/src/foam/dao/test/tests.jrl
+++ b/src/foam/dao/test/tests.jrl
@@ -20,6 +20,10 @@ p({
   id:"JournalDefaultClassNameTest"
 })
 p({
+  class:"foam.dao.test.JournalClassChangeTest",
+  id:"JournalClassChangeTest"
+})
+p({
   class:"foam.dao.test.MDAOCountTest",
   id:"MDAOCountTest"
 })

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -437,6 +437,17 @@ public class JSONFObjectFormatter
       return true;
     }
 
+    // A delta between two different classes is not computable: the loop below walks
+    // the new class's properties and compares each against the old object, so a
+    // property the old class does not have throws a ClassCastException, which the
+    // journal swallows and then writes nothing. Output the whole object instead, so
+    // re-putting a record under a subclass survives a replay.
+    if ( oldFObject != null && newFObject.getClassInfo() != oldFObject.getClassInfo() ) {
+      outputFObjectPropertyHeader(parentProp);
+      output(newFObject, defaultClass, parentProp);
+      return true;
+    }
+
     ClassInfo newInfo     = newFObject.getClassInfo();
     String    of          = newInfo.getSimpleName().toLowerCase();
     List      axioms      = getProperties(parentProp, newInfo);

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -443,8 +443,12 @@ public class JSONFObjectFormatter
     // journal swallows and then writes nothing. Output the whole object instead, so
     // re-putting a record under a subclass survives a replay.
     if ( oldFObject != null && newFObject.getClassInfo() != oldFObject.getClassInfo() ) {
+      int mark = builder().length();
       outputFObjectPropertyHeader(parentProp);
       output(newFObject, defaultClass, parentProp);
+      // output() undoes itself when it wrote no properties, so roll the header back
+      // with it rather than leaving a dangling key.
+      if ( builder().length() == mark ) return false;
       return true;
     }
 

--- a/src/pom.js
+++ b/src/pom.js
@@ -1164,6 +1164,7 @@ foam.POM({
     { name: "foam/dao/test/FileRollCmdTest",                          flags: "js&test|java&test" },
     { name: "foam/dao/test/F3FileJournalTest",                        flags: "js&test|java&test" },
     { name: "foam/dao/test/JournalDefaultClassNameTest",              flags: "js&test|java&test" },
+    { name: "foam/dao/test/JournalClassChangeTest",                    flags: "js&test|java&test" },
     { name: "foam/dao/test/OrDAOTest",                                flags: "js&test|java&test" },
     { name: "foam/dao/test/MDAOCountTest",                            flags: "js&test|java&test" },
     { name: "foam/dao/test/MDAOIndexDedupTest",                       flags: "js&test|java&test" },


### PR DESCRIPTION
Re-putting a stored record under a subclass wrote nothing to the journal, so the live DAO held the subclass while the next replay handed back the original class.

Cause: the delta walks the new class's properties and compares each against the old object, so a property the old class does not own throws `ClassCastException`. `AbstractF3FileJournal.put` catches `Throwable`, logs `Failed to format put`, and skips the write.

```java
dao.put(base);                  // c({class:"...Ticket",id:"1",title:"t"})

sub.copyFrom(dao.find("1"));    // same id, same values, subclass instead
dao.put(sub);                   // before: nothing written

replayed.find("1");             // before: Ticket   after: UserLifecycleTicket
```

Fix: when the classes differ, skip the delta and write the whole object, since a delta across two classes is not computable. Covered by `JournalClassChangeTest`.