### PR TITLE
U2: Add RelativeDateTimeView: relative "time ago" rendering

### DIFF
--- a/src/foam/u2/test/RORelativeDateTimeViewTest.js
+++ b/src/foam/u2/test/RORelativeDateTimeViewTest.js
@@ -1,0 +1,85 @@
+/**
+* @license
+* Copyright 2026 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  package: 'foam.u2.test',
+  name: 'RORelativeDateTimeViewTest',
+  extends: 'foam.core.test.JSTest',
+
+  requires: [
+    'foam.u2.view.RelativeDateTimeView',
+    'foam.u2.view.RORelativeDateTimeView'
+  ],
+
+  methods: [
+    async function runTest(x) {
+      var MINUTE = 60000, HOUR = 3600000, DAY = 86400000;
+      var wait   = ms => new Promise(res => setTimeout(res, ms));
+
+      // The relativeDateString contract the view renders
+      x.test(foam.Date.relativeDateString(new Date(Date.now() - 3 * HOUR)) === '3 hours ago',
+        'relativeDateString renders past hours');
+      x.test(foam.Date.relativeDateString(new Date(Date.now() + 2 * DAY + HOUR)) === 'in 2 days',
+        'relativeDateString renders future days');
+
+      // View renders the relative string
+      var v = this.RORelativeDateTimeView.create(
+        { data: new Date(Date.now() - 3 * HOUR) }, x);
+      v.write();
+      await wait(50);
+      x.test(v.element_.textContent.includes('3 hours ago'),
+        'view renders relative string');
+
+      // Tooltip carries the absolute timestamp
+      var abs = v.formatAbsolute_(v.data);
+      x.test(!! abs && abs.includes('' + v.data.getFullYear()),
+        'absolute tooltip text includes the year');
+
+      // Data change re-renders
+      v.data = new Date(Date.now() - 2 * DAY);
+      await wait(50);
+      x.test(v.element_.textContent.includes('2 days ago'),
+        'view re-renders on data change');
+
+      // Timer schedules at sensible boundaries and never busy-loops
+      var d1 = v.nextUpdateDelay_(new Date(Date.now() - 10000));
+      x.test(d1 > 45000 && d1 <= MINUTE + 1050,
+        'seconds tier waits for the minute boundary, got ' + d1);
+      var d2 = v.nextUpdateDelay_(new Date(Date.now() - 90000));
+      x.test(d2 > 25000 && d2 <= 35000,
+        'minutes tier waits for the next minute, got ' + d2);
+      var d3 = v.nextUpdateDelay_(new Date(Date.now() - 3 * HOUR - 10 * MINUTE));
+      x.test(d3 > 45 * MINUTE && d3 <= 50 * MINUTE + 1050,
+        'hours tier waits for the next hour, got ' + d3);
+      var d4 = v.nextUpdateDelay_(new Date(Date.now() + 90000));
+      x.test(d4 > 25000 && d4 <= 35000,
+        'future values count down to the previous boundary, got ' + d4);
+      x.test(v.nextUpdateDelay_(new Date()) >= 1000,
+        'delay is clamped to at least a second');
+
+      x.test(!! v.timer_, 'timer is scheduled while attached');
+      v.element_.remove();
+      v.detach();
+      x.test(! v.timer_, 'timer is cleared on detach');
+
+      // No timer without data
+      var v2 = this.RORelativeDateTimeView.create({}, x);
+      v2.schedule_();
+      x.test(! v2.timer_, 'no timer scheduled when data is unset');
+      v2.detach();
+
+      // Wrapper delegates read mode to the relative view
+      var w = this.RelativeDateTimeView.create(
+        { data: new Date(Date.now() - 5 * HOUR), mode: foam.u2.DisplayMode.RO }, x);
+      w.write();
+      await wait(50);
+      x.test(w.element_.textContent.includes('5 hours ago'),
+        'RelativeDateTimeView read mode renders relative string');
+      w.element_.remove();
+      w.detach();
+    }
+  ]
+});

--- a/src/foam/u2/test/tests.jrl
+++ b/src/foam/u2/test/tests.jrl
@@ -1,1 +1,2 @@
 p({"class":"foam.u2.test.CSSTokensJSTest","id":"CSSTokensJSTest"})
+p({"class":"foam.u2.test.RORelativeDateTimeViewTest","id":"RORelativeDateTimeViewTest"})

--- a/src/foam/u2/view/RORelativeDateTimeView.js
+++ b/src/foam/u2/view/RORelativeDateTimeView.js
@@ -1,0 +1,131 @@
+/**
+* @license
+* Copyright 2026 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'RORelativeDateTimeView',
+  extends: 'foam.u2.View',
+
+  documentation: `A ReadOnly DateTime view which renders the value as a
+    relative time string ("3 hours ago", "in 2 days") via
+    foam.Date.relativeDateString, with the absolute timestamp shown in a
+    tooltip. The text self-updates as time passes: a timer fires at the
+    next boundary where the string can change (minute/hour/day) and is
+    cancelled when the view is detached. Values more than a week away
+    render as an absolute date, matching relativeDateString's fallback.
+    Purely client-side; makes no server calls.`,
+
+  constants: [
+    { name: 'MINUTE', value: 60000 },
+    { name: 'HOUR',   value: 3600000 },
+    { name: 'DAY',    value: 86400000 }
+  ],
+
+  properties: [
+    {
+      name: 'prop'
+    },
+    {
+      class: 'Long',
+      name: 'now_',
+      documentation: 'Bumped by tick to re-evaluate the relative string.',
+      factory: function() { return Date.now(); }
+    },
+    {
+      name: 'timer_'
+    }
+  ],
+
+  methods: [
+    function fromProperty(prop) {
+      this.SUPER(prop);
+      this.prop = prop;
+    },
+
+    function render() {
+      this.SUPER();
+      var self = this;
+      this.start('div', {
+          tooltip$: this.data$.map(d => d ?
+            self.formatAbsolute_(d) : foam.u2.DateTimeView.DATE_FORMAT)
+        }).
+        addClass(this.myClass()).
+        add(this.slot(function(data, now_) {
+          return data ?
+            foam.Date.relativeDateString(data) :
+            foam.u2.DateTimeView.DATE_FORMAT;
+        })).
+      end();
+      this.schedule_();
+      this.onDetach(function() { self.clearTimer_(); });
+    },
+
+    function formatAbsolute_(d) {
+      // Use the same absolute format the property renders elsewhere
+      // (RODateTimeView body / DateTime tableCellFormatter) so the tooltip
+      // agrees with other views of the same value. formatLocale also keeps
+      // DateTimeUTC properties in UTC.
+      if ( this.prop && this.prop.formatLocale ) return this.prop.formatLocale(d);
+      return new Date(d).toLocaleString(foam.util.getClientLocale(), {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZoneName: 'short'
+      });
+    },
+
+    function clearTimer_() {
+      if ( this.timer_ ) {
+        clearTimeout(this.timer_);
+        this.timer_ = null;
+      }
+    },
+
+    function schedule_() {
+      this.clearTimer_();
+      if ( ! this.data ) return;
+      this.timer_ = setTimeout(this.tick, this.nextUpdateDelay_(this.data));
+    },
+
+    function nextUpdateDelay_(date) {
+      /* Milliseconds until the displayed string can next change. Past
+         values age forward to the next minute/hour/day boundary; future
+         values count down to the previous one. Beyond that the string
+         only changes daily. */
+      var diff = Date.now() - date.getTime();
+      var abs  = Math.abs(diff);
+      var delay;
+      if ( abs < this.MINUTE ) {
+        delay = diff >= 0 ? this.MINUTE - diff : abs;
+      } else {
+        var unit = abs < this.HOUR ? this.MINUTE :
+                   abs < this.DAY  ? this.HOUR   : this.DAY;
+        delay = diff >= 0 ? unit - abs % unit : abs % unit;
+      }
+      // Clamp, and overshoot the boundary slightly so the re-evaluated
+      // string lands on the far side of it.
+      return Math.max(delay, 1000) + 50;
+    }
+  ],
+
+  listeners: [
+    {
+      name: 'onDataChange',
+      on: [ 'this.propertyChange.data' ],
+      code: function() { this.schedule_(); }
+    },
+    {
+      name: 'tick',
+      code: function() {
+        this.now_ = Date.now();
+        this.schedule_();
+      }
+    }
+  ]
+});

--- a/src/foam/u2/view/RORelativeDateTimeView.js
+++ b/src/foam/u2/view/RORelativeDateTimeView.js
@@ -53,6 +53,13 @@ foam.CLASS({
             self.formatAbsolute_(d) : foam.u2.DateTimeView.DATE_FORMAT)
         }).
         addClass(this.myClass()).
+        // FUTURE: support a fixed-unit option (eg. always "N days ago").
+        // relativeDateString takes no unit argument — it picks the unit
+        // from the value's age — so a unit option needs either a local
+        // formatter here or Intl.RelativeTimeFormat, whose format(n, unit)
+        // gives both the explicit unit and localized plurals. Adopting
+        // Intl inside relativeDateString would localize this view with
+        // no changes here, so deferring the option until that decision.
         add(this.slot(function(data, now_) {
           return data ?
             foam.Date.relativeDateString(data) :

--- a/src/foam/u2/view/RelativeDateTimeView.js
+++ b/src/foam/u2/view/RelativeDateTimeView.js
@@ -1,0 +1,29 @@
+/**
+* @license
+* Copyright 2026 The FOAM Authors. All Rights Reserved.
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'RelativeDateTimeView',
+  extends: 'foam.u2.view.DateTimeView',
+
+  documentation: `A DateTime property view whose read mode renders the value
+    as a relative time string ("3 hours ago") with the absolute timestamp in
+    a tooltip, and whose write mode is the standard DateTime editor. Drop-in
+    for any DateTime/DateTimeUTC property where recency matters more than
+    the exact timestamp:
+      view: { class: 'foam.u2.view.RelativeDateTimeView' }`,
+
+  requires: [ 'foam.u2.view.RORelativeDateTimeView' ],
+
+  properties: [
+    {
+      name: 'readView',
+      factory: function() {
+        return { class: 'foam.u2.view.RORelativeDateTimeView' };
+      }
+    }
+  ]
+});

--- a/src/pom.js
+++ b/src/pom.js
@@ -681,6 +681,7 @@ foam.POM({
     { name: "foam/u2/view/DateView",                                  flags: "web" },
     { name: "foam/u2/view/DateTimeView",                              flags: "web" },
     { name: "foam/u2/view/RODateTimeView",                            flags: "web" },
+    { name: "foam/u2/view/RORelativeDateTimeView",                    flags: "web" },
     { name: "foam/u2/view/TimeView",                                  flags: "web" },
     { name: "foam/u2/view/FloatView",                                 flags: "web" },
     { name: "foam/u2/view/PhoneNumberInputView",                      flags: "web" },

--- a/src/pom.js
+++ b/src/pom.js
@@ -681,6 +681,7 @@ foam.POM({
     { name: "foam/u2/view/DateView",                                  flags: "web" },
     { name: "foam/u2/view/DateTimeView",                              flags: "web" },
     { name: "foam/u2/view/RODateTimeView",                            flags: "web" },
+    { name: "foam/u2/view/RelativeDateTimeView",                      flags: "web" },
     { name: "foam/u2/view/RORelativeDateTimeView",                    flags: "web" },
     { name: "foam/u2/view/TimeView",                                  flags: "web" },
     { name: "foam/u2/view/FloatView",                                 flags: "web" },

--- a/src/pom.js
+++ b/src/pom.js
@@ -254,6 +254,7 @@ foam.POM({
     { name: "foam/u2/CSSTokens",                                      flags: "js|java" },
     { name: "foam/u2/parse/CSSParser",                                flags: "js" },
     { name: "foam/u2/test/CSSTokensJSTest",                           flags: "js&test|java&test" },
+    { name: "foam/u2/test/RORelativeDateTimeViewTest",                flags: "js&test|java&test" },
     { name: "foam/u2/ColorToken",                                     flags: "js|java" },
     { name: "foam/u2/ColorTokenRefinement",                           flags: "genjava" },
     { name: "foam/u2/StyleConfigurator",                              flags: "web" },


### PR DESCRIPTION
Adds the first consumer of foam.Date.relativeDateString (in stdlib since 2016, previously zero callers): a DateTime property view that reads "3 hours ago" instead of an absolute timestamp.

- **RORelativeDateTimeView** — read-only view: relative text with the absolute timestamp in the tooltip (via prop.formatLocale, so DateTimeUTC properties stay UTC), self-updating on a timer scheduled to the next minute/hour/day boundary and cleared on detach. Purely client-side, no polling.

- **RelativeDateTimeView** — thin wrapper extending foam.u2.view.DateTimeView (ModeAltView): read mode renders relative, write mode stays the standard DateTime editor incl. the Safari picker fallback. Drop-in on any DateTime/DateTimeUTC property: view: { class: 'foam.u2.view.RelativeDateTimeView' }.

- **RORelativeDateTimeViewTest** — 14 assertions covering rendering, tooltip, re-render on data change, timer boundary math (past and future values), detach cleanup, and wrapper read-mode delegation.

FUTURE noted in code: a fixed-unit option ("always N days ago") and Intl.RelativeTimeFormat adoption inside relativeDateString for localized plurals. Deferred the unit option until the Intl decision since format(n, unit) subsumes it.

---
feat(u2): add RORelativeDateTimeView, relative DateTime read view
<img width="167" height="121" alt="image" src="https://github.com/user-attachments/assets/93e44ca6-a3ad-45af-92c3-dc9ba2a8d910" />
<img width="129" height="53" alt="image" src="https://github.com/user-attachments/assets/9a1742c8-6480-4536-aed5-602375c887bf" />

### Usage:
```js
{
  class: 'DateTime',
  name: 'passwordLastModified',
  documentation: 'The date and time that the password was last modified.',
  // RelativeDateTimeView usage
  // Detail view: relative text in read mode, normal editor in edit mode.
  view: { class: 'foam.u2.view.RelativeDateTimeView' },
  // Table cell: relative text with absolute timestamp on hover.
  tableCellFormatter: function(date) {
    if ( ! date ) return;
    this.add(foam.Date.relativeDateString(date));
    this.tooltip = date.toLocaleString(foam.util.getClientLocale());
  }
},
```