### PR TITLE
CARE-1834 Add missing PredicatedMenu class to client build

### DIFF
--- a/src/foam/core/menu/PredicatedMenu.js
+++ b/src/foam/core/menu/PredicatedMenu.js
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.menu',
+  name: 'PredicatedMenuOption',
+
+  properties: [
+    {
+      class: 'foam.mlang.predicate.PredicateProperty',
+      name: 'predicate',
+      documentation: 'Predicate providing arbitrary checks, in addition to the regular menu auth checks.',
+      /*
+      view: {
+        class: 'foam.u2.view.JSONTextView'
+        },*/
+      factory: function() { return foam.mlang.predicate.True.create(); },
+      javaFactory: `
+        return foam.mlang.MLang.TRUE;
+      `,
+    },
+    {
+      __copyFrom__: 'foam.core.menu.Menu.HANDLER'
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core.menu',
+  name: 'PredicatedMenu',
+  extends: 'foam.core.menu.AbstractMenu',
+
+  documentation: `
+    A DAOMenu which can accept a DAOControllerConfig and uses
+    the v2 DAOController
+  `,
+
+  requires: [
+    'foam.comics.v2.DAOControllerConfig'
+  ],
+
+  properties: [
+    {
+      class: 'FObjectArray',
+      of: 'foam.core.menu.PredicatedMenuOption',
+      name: 'options'
+    }
+  ],
+
+  methods: [
+    function findHandler(X) {
+      for ( let i = 0 ; i < this.options.length ; i++ ) {
+        let option = this.options[i];
+        try {
+          if ( i == this.options.length - 1 || option.predicate.f(X) )
+            return option.handler;
+        } catch (x) {
+        }
+      }
+    },
+
+    function launch(X, menu, e) {
+      return this.findHandler(X).launch(X, menu, e);
+    },
+
+    function createView(X) {
+      return this.findHandler(X).createView(X);
+    },
+
+    function xxxselect(X, menu) {
+      return this.findHandler(X).select(X, menu);
+    }
+  ]
+});

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -144,6 +144,7 @@ foam.POM({
     { name: "menu/LinkMenu",                                                              flags: "js" },
     { name: "menu/ListMenu",                                                              flags: "js" },
     { name: "menu/Menu",                                                                  flags: "js|java" },
+    { name: "menu/PredicatedMenu",                                                        flags: "web" },
     { name: "menu/PseudoMenu",                                                            flags: "js|java" },
     { name: "menu/PseudoMenuView",                                                        flags: "web" },
     { name: "menu/MenuBar",                                                               flags: "js" },


### PR DESCRIPTION
The 3.21 client bundle references foam.core.menu.PredicatedMenu (used by the dispute and recon menus) but the class file was never present on this branch, so it loaded as "Unknown class". That aborts the menu TreeView render (.listen on an undefined children DAO), leaving flow dashboards such as Treasury Control blank in production.

Restore src/foam/core/menu/PredicatedMenu.js (identical to p-u-3.24) and register it in core/pom.js so the class is compiled into the web bundle.