### PR TITLE
Property autocomplete: try the longest property name first

### DIFF
--- a/src/foam/core/reflow/parser/PropertyParser.js
+++ b/src/foam/core/reflow/parser/PropertyParser.js
@@ -30,6 +30,10 @@ foam.CLASS({
       const ps = this.of.getAxiomsByClass(foam.lang.Property).
         filter(p => ! p.hidden).
         filter(p => this.predicate.f(p)).
+        // Longest name first: alt() takes the first alternative that matches, so
+        // with localDate ahead of localDateUTC the parse stops after localDate
+        // and reports an error at the leftover UTC.
+        sort((a, b) => comparator(a.name, b.name)).
         map(p =>
           sug(literalIC(p.name), {
             text:  p.name,


### PR DESCRIPTION
The property parser builds its alternation in axiom order and `alt()` takes the first alternative that matches, so a name that is a prefix of another one wins: `localDate` matches inside `localDateUTC`, and the parse then fails on the leftover `UTC`.

Fix: sort longest-first — the comparator the method already declared and never applied.