### PR TITLE
Prefix PropertyBorder's per-property class

### DIFF
--- a/src/foam/u2/PropertyBorder.js
+++ b/src/foam/u2/PropertyBorder.js
@@ -99,7 +99,12 @@ foam.CLASS({
         prop.name = oldProp.name;
       }
 
-      this.addClass(this.myClass(prop.name));
+      // Prefixed: this class is named after the property, and PropertyBorder's
+      // own classes are named after its parts, so a property called label, view
+      // or select would otherwise take that part's styling for its whole cell -
+      // a `label` property inherits line-height:1 and sits short of its
+      // neighbour in the same row.
+      this.addClass(this.myClass('prop-' + prop.name));
 
       this.SUPER();
 


### PR DESCRIPTION
PropertyBorder names its wrapper class after the property it renders, and names its own parts the same way. A property called `label` therefore lands on `^label`, which sets `line-height: 1` — so that cell renders ~10px shorter than the one beside it and their inputs stop lining up. `view`, `select` and `errorText` collide the same way.

Fix: prefix the generated class, `prop-<name>`, so a property name can never select a part's styling.

Nothing selects the generated per-property class — the styling hooks in use are the structural ones (`propHolder`, `view`, `select`, `errorText`, `helper-icon`), all untouched.