### PR TITLE
PT-FIXES:DOS-4520 Keep a session's local settings across a context rebuild

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -139,11 +139,6 @@ public class SessionServerBox
         return;
       }
 
-      if ( session.getContext().get("localLocalSettingDAO") == null && session.getUserId() != 0 ) {
-        DAO localLocalSettingDAO = new foam.dao.MDAO(foam.core.session.LocalSetting.getOwnClassInfo());
-        session.setContext(session.getContext().put("localLocalSettingDAO", localLocalSettingDAO));
-      }
-
       X effectiveContext = session.applyTo(x);
 
       // Make context available to thread-local XLocator

--- a/src/foam/core/auth/test/SessionContextTest.js
+++ b/src/foam/core/auth/test/SessionContextTest.js
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.auth.test',
+  name: 'SessionContextTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `A service that keeps per-session state has nowhere durable to put it.
+    applyTo derives the context it returns from x and rebuilds it whenever the user
+    record changes, so an entry written into applyContext is gone after the next
+    rebuild. sessionContext is the layer the session owns rather than derives: applyTo
+    composes it, so what a service puts there outlives a rebuild, and composes it
+    underneath the derived entries, so it cannot shadow them.`,
+
+  javaImports: [
+    'foam.core.auth.LifecycleState',
+    'foam.core.auth.Subject',
+    'foam.core.auth.User',
+    'foam.core.session.Session',
+    'foam.dao.DAO',
+    'foam.lang.X'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        DAO userDAO = (DAO) x.get("localUserDAO");
+
+        User user = new User();
+        user.setGroup("test");
+        user.setSpid("test");
+        user.setUserName(this.getClass().getSimpleName());
+        user.setFirstName(user.getUserName());
+        user.setLastName("before");
+        user.setEmail(user.getUserName() + "@test.com");
+        user.setLifecycleState(LifecycleState.ACTIVE);
+        user = (User) userDAO.put(user);
+
+        Session session = new Session.Builder(x).setUserId(user.getId()).build();
+        session.setContext(session.applyTo(x));
+
+        // A service hangs its per-session state off the session.
+        Object state = new Object();
+        session.setSessionContext(session.getSessionContext().put("testServiceState", state));
+
+        session.setContext(session.applyTo(x));
+        test(session.getContext().get("testServiceState") == state,
+          "a session's own entry reaches the applied context");
+
+        // Any edit to the user row makes the next applyTo rebuild from scratch.
+        user = (User) user.fclone();
+        user.setLastName("after");
+        userDAO.put(user);
+
+        session.setContext(session.applyTo(x));
+
+        User subjectUser = ((Subject) session.getContext().get("subject")).getUser();
+        test("after".equals(subjectUser.getLastName()),
+          "the user edit rebuilt the session context, got " + subjectUser.getLastName());
+
+        test(session.getContext().get("testServiceState") == state,
+          "the entry survives the rebuild");
+
+        // Derived entries still win, so nothing put here can stand in for one.
+        session.setSessionContext(session.getSessionContext().put("subject", null));
+        session.setContext(session.applyTo(x));
+        test(session.getContext().get("subject") != null,
+          "a session entry does not shadow a derived one");
+
+        userDAO.remove(user);
+      `
+    }
+  ]
+});

--- a/src/foam/core/auth/test/SessionLocalSettingTest.js
+++ b/src/foam/core/auth/test/SessionLocalSettingTest.js
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.auth.test',
+  name: 'SessionLocalSettingTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `localLocalSettingDAO holds a user's LocalSettings for the life of
+    their session, and localSettingDAO is served on top of it. Session.applyTo
+    rebuilds the session context whenever the user record changes, so the entry has
+    to survive that rebuild - otherwise any edit to the user row silently empties
+    the settings they had stored.`,
+
+  javaImports: [
+    'foam.core.auth.LifecycleState',
+    'foam.core.auth.Subject',
+    'foam.core.auth.User',
+    'foam.core.session.LocalSetting',
+    'foam.core.session.Session',
+    'foam.dao.DAO',
+    'foam.lang.X'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        DAO userDAO = (DAO) x.get("localUserDAO");
+
+        User user = new User();
+        user.setGroup("test");
+        user.setSpid("test");
+        user.setUserName(this.getClass().getSimpleName());
+        user.setFirstName(user.getUserName());
+        user.setLastName("before");
+        user.setEmail(user.getUserName() + "@test.com");
+        user.setLifecycleState(LifecycleState.ACTIVE);
+        user = (User) userDAO.put(user);
+
+        Session session = new Session.Builder(x).setUserId(user.getId()).build();
+
+        // One request: applyTo derives the context, the box stores it on the session.
+        session.setContext(session.applyTo(x));
+
+        DAO settings = (DAO) session.getContext().get("localLocalSettingDAO");
+        test(settings != null, "the session context carries a localLocalSettingDAO");
+
+        settings.put(new LocalSetting.Builder(x)
+          .setId("homeDenomination")
+          .setValue("CAD")
+          .build());
+        test(settings.find("homeDenomination") != null,
+          "a setting written through it is readable");
+
+        // Any edit to the user row makes the next applyTo rebuild rather than
+        // reuse its cached context.
+        user = (User) user.fclone();
+        user.setLastName("after");
+        userDAO.put(user);
+
+        session.setContext(session.applyTo(x));
+
+        User subjectUser = ((Subject) session.getContext().get("subject")).getUser();
+        test("after".equals(subjectUser.getLastName()),
+          "the user edit rebuilt the session context, got " + subjectUser.getLastName());
+
+        DAO rebuilt = (DAO) session.getContext().get("localLocalSettingDAO");
+        test(rebuilt != null, "the rebuilt context still carries a localLocalSettingDAO");
+        test(rebuilt != null && rebuilt.find("homeDenomination") != null,
+          "a setting stored before the rebuild is still there after it");
+
+        userDAO.remove(user);
+      `
+    }
+  ]
+});

--- a/src/foam/core/auth/test/pom.js
+++ b/src/foam/core/auth/test/pom.js
@@ -15,6 +15,7 @@ foam.POM({
     { name: "ServiceProviderAuthorizerTest",                          flags: "js|java" },
     { name: "UserAndGroupPermissionTest",                             flags: "js|java" },
     { name: "PasswordPolicyTest",                                     flags: "js|java" },
+    { name: "SessionContextTest",                                     flags: "js|java" },
     { name: "SessionLocalSettingTest",                                flags: "js|java" },
     { name: "UserLifecycleTicketTest",                                flags: "js|java" }
   ],

--- a/src/foam/core/auth/test/pom.js
+++ b/src/foam/core/auth/test/pom.js
@@ -15,6 +15,7 @@ foam.POM({
     { name: "ServiceProviderAuthorizerTest",                          flags: "js|java" },
     { name: "UserAndGroupPermissionTest",                             flags: "js|java" },
     { name: "PasswordPolicyTest",                                     flags: "js|java" },
+    { name: "SessionLocalSettingTest",                                flags: "js|java" },
     { name: "UserLifecycleTicketTest",                                flags: "js|java" }
   ],
   javaFiles: [

--- a/src/foam/core/auth/test/tests.jrl
+++ b/src/foam/core/auth/test/tests.jrl
@@ -23,3 +23,7 @@ p({
   class:"foam.core.auth.test.SessionLocalSettingTest",
   id:"SessionLocalSettingTest"
 })
+p({
+  class:"foam.core.auth.test.SessionContextTest",
+  id:"SessionContextTest"
+})

--- a/src/foam/core/auth/test/tests.jrl
+++ b/src/foam/core/auth/test/tests.jrl
@@ -19,3 +19,7 @@ p({
   class:"foam.core.auth.test.PreventDuplicateEmailTest",
   id:"PreventDuplicateEmailTest"
 })
+p({
+  class:"foam.core.auth.test.SessionLocalSettingTest",
+  id:"SessionLocalSettingTest"
+})

--- a/src/foam/core/session/Session.js
+++ b/src/foam/core/session/Session.js
@@ -395,7 +395,11 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
 
         rtn = rtn.put(foam.core.auth.LocaleSupport.CONTEXT_KEY, foam.core.auth.LocaleSupport.instance().findLanguageLocale(rtn));
 
-        rtn = rtn.put("localLocalSettingDAO", new foam.dao.MDAO(foam.core.session.LocalSetting.getOwnClassInfo()));
+        // Owned by the session, not derived from x, so carry it across a rebuild
+        // rather than handing the user an empty set of local settings.
+        Object localSettings = wasAnonymous ? null : getContext().get("localLocalSettingDAO");
+        rtn = rtn.put("localLocalSettingDAO", localSettings != null ? localSettings :
+          new foam.dao.MDAO(foam.core.session.LocalSetting.getOwnClassInfo()));
 
         rtn = rtn.put("logger",
           new foam.core.logger.PrefixLogger(

--- a/src/foam/core/session/Session.js
+++ b/src/foam/core/session/Session.js
@@ -175,6 +175,21 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       clusterTransient: true
     },
     {
+      class: 'Object',
+      name: 'sessionContext',
+      javaType: 'foam.lang.X',
+      javaFactory: 'return foam.lang.EmptyX.instance();',
+      documentation: `Context entries the session owns rather than derives. applyTo
+        composes these underneath the entries it derives, so a service can keep
+        per-session state here and have it outlive a context rebuild, and nothing put
+        here can stand in for a derived entry.`,
+      visibility: 'HIDDEN',
+      javaCompare: 'return 0;',
+      transient: true,
+      networkTransient: true,
+      clusterTransient: true
+    },
+    {
       class: 'Boolean',
       name: 'twoFactorSuccess',
       visibility: 'HIDDEN',
@@ -287,7 +302,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         HttpServletRequest req = x.get(HttpServletRequest.class);
         if ( req == null ) {
           // null during test runs
-          return rtn;
+          return withSessionContext(rtn);
         }
 
         Theme theme = ((Themes) x.get("themes")).findTheme(x);
@@ -306,7 +321,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         rtn = rtn.put(foam.core.auth.LocaleSupport.CONTEXT_KEY, foam.core.auth.LocaleSupport.instance().findLanguageLocale(rtn));
         rtn = rtn.put("logger", foam.core.logger.Loggers.logger(new OrX(x, rtn), true));
 
-        return rtn;
+        return withSessionContext(rtn);
       }
 
       X rtn = getApplyContext();
@@ -369,6 +384,8 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           .put(ServerCrunchService.CACHE_KEY, getContext().get(ServerCrunchService.CACHE_KEY))
           : rtn.put(ServerCrunchService.CACHE_KEY, null);
 
+        if ( wasAnonymous ) clearSessionContext();
+
         // We need to do this after the user and agent have been put since
         // 'getCurrentGroup' depends on them being in the context.
         Group group = auth.getCurrentGroup(rtn);
@@ -422,7 +439,21 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       } else {
         rtn = new OrX(reset(x), rtn);
       }
-      return rtn;
+      return withSessionContext(rtn);
+      `
+    },
+    {
+      name: 'withSessionContext',
+      type: 'Context',
+      args: 'Context x',
+      documentation: `
+        Compose the session's own entries underneath the given context, so a service
+        can keep per-session state across a context rebuild without any of it being
+        able to stand in for an entry applyTo derived.
+      `,
+      javaCode: `
+      X own = getSessionContext();
+      return own == null || own instanceof foam.lang.EmptyX ? x : new OrX(own, x);
       `
     },
     {


### PR DESCRIPTION
`Session.applyTo` caches the context it derives and rebuilds it whenever the user record changes. Each rebuild allocates a fresh empty `MDAO` for `localLocalSettingDAO`, so any edit to a user's row silently empties the LocalSettings stored for that session.

`SessionServerBox` looks like it covers that case — it creates the DAO when the session context is missing one. But the write goes through `setContext` seven lines before `setContext(effectiveContext)` replaces the whole session context, so that block has never survived its own request.

Fix:

- carry the session's existing local-setting DAO through the rebuild in `applyTo`, allocating only when there isn't one; a session that was anonymous still starts fresh, matching how the crunch cache is handled a line above

- delete the dead block in `SessionServerBox`

`SessionLocalSettingTest` covers it: store a setting, edit the user to force a rebuild, read it back. One failure before the fix, 5/5 after.
