### PR TITLE
DNM: PT-FIXES:DOS-4520 Give a session a context layer it owns

### DIFF
--- a/src/foam/core/auth/test/SessionContextTest.js
+++ b/src/foam/core/auth/test/SessionContextTest.js
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.auth.test',
+  name: 'SessionContextTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `A service that keeps per-session state has nowhere durable to put it.
+    applyTo derives the context it returns from x and rebuilds it whenever the user
+    record changes, so an entry written into applyContext is gone after the next
+    rebuild. sessionContext is the layer the session owns rather than derives: applyTo
+    composes it, so what a service puts there outlives a rebuild, and composes it
+    underneath the derived entries, so it cannot shadow them.`,
+
+  javaImports: [
+    'foam.core.auth.LifecycleState',
+    'foam.core.auth.Subject',
+    'foam.core.auth.User',
+    'foam.core.session.Session',
+    'foam.dao.DAO',
+    'foam.lang.X'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        DAO userDAO = (DAO) x.get("localUserDAO");
+
+        User user = new User();
+        user.setGroup("test");
+        user.setSpid("test");
+        user.setUserName(this.getClass().getSimpleName());
+        user.setFirstName(user.getUserName());
+        user.setLastName("before");
+        user.setEmail(user.getUserName() + "@test.com");
+        user.setLifecycleState(LifecycleState.ACTIVE);
+        user = (User) userDAO.put(user);
+
+        Session session = new Session.Builder(x).setUserId(user.getId()).build();
+        session.setContext(session.applyTo(x));
+
+        // A service hangs its per-session state off the session.
+        Object state = new Object();
+        session.setSessionContext(session.getSessionContext().put("testServiceState", state));
+
+        session.setContext(session.applyTo(x));
+        test(session.getContext().get("testServiceState") == state,
+          "a session's own entry reaches the applied context");
+
+        // Any edit to the user row makes the next applyTo rebuild from scratch.
+        user = (User) user.fclone();
+        user.setLastName("after");
+        userDAO.put(user);
+
+        session.setContext(session.applyTo(x));
+
+        User subjectUser = ((Subject) session.getContext().get("subject")).getUser();
+        test("after".equals(subjectUser.getLastName()),
+          "the user edit rebuilt the session context, got " + subjectUser.getLastName());
+
+        test(session.getContext().get("testServiceState") == state,
+          "the entry survives the rebuild");
+
+        // Derived entries still win, so nothing put here can stand in for one.
+        session.setSessionContext(session.getSessionContext().put("subject", null));
+        session.setContext(session.applyTo(x));
+        test(session.getContext().get("subject") != null,
+          "a session entry does not shadow a derived one");
+
+        userDAO.remove(user);
+      `
+    }
+  ]
+});

--- a/src/foam/core/auth/test/pom.js
+++ b/src/foam/core/auth/test/pom.js
@@ -15,6 +15,7 @@ foam.POM({
     { name: "ServiceProviderAuthorizerTest",                          flags: "js|java" },
     { name: "UserAndGroupPermissionTest",                             flags: "js|java" },
     { name: "PasswordPolicyTest",                                     flags: "js|java" },
+    { name: "SessionContextTest",                                     flags: "js|java" },
     { name: "SessionLocalSettingTest",                                flags: "js|java" },
     { name: "UserLifecycleTicketTest",                                flags: "js|java" }
   ],

--- a/src/foam/core/auth/test/tests.jrl
+++ b/src/foam/core/auth/test/tests.jrl
@@ -23,3 +23,7 @@ p({
   class:"foam.core.auth.test.SessionLocalSettingTest",
   id:"SessionLocalSettingTest"
 })
+p({
+  class:"foam.core.auth.test.SessionContextTest",
+  id:"SessionContextTest"
+})

--- a/src/foam/core/session/Session.js
+++ b/src/foam/core/session/Session.js
@@ -175,6 +175,21 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       clusterTransient: true
     },
     {
+      class: 'Object',
+      name: 'sessionContext',
+      javaType: 'foam.lang.X',
+      javaFactory: 'return foam.lang.EmptyX.instance();',
+      documentation: `Context entries the session owns rather than derives. applyTo
+        composes these underneath the entries it derives, so a service can keep
+        per-session state here and have it outlive a context rebuild, and nothing put
+        here can stand in for a derived entry.`,
+      visibility: 'HIDDEN',
+      javaCompare: 'return 0;',
+      transient: true,
+      networkTransient: true,
+      clusterTransient: true
+    },
+    {
       class: 'Boolean',
       name: 'twoFactorSuccess',
       visibility: 'HIDDEN',
@@ -287,7 +302,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         HttpServletRequest req = x.get(HttpServletRequest.class);
         if ( req == null ) {
           // null during test runs
-          return rtn;
+          return withSessionContext(rtn);
         }
 
         Theme theme = ((Themes) x.get("themes")).findTheme(x);
@@ -306,7 +321,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
         rtn = rtn.put(foam.core.auth.LocaleSupport.CONTEXT_KEY, foam.core.auth.LocaleSupport.instance().findLanguageLocale(rtn));
         rtn = rtn.put("logger", foam.core.logger.Loggers.logger(new OrX(x, rtn), true));
 
-        return rtn;
+        return withSessionContext(rtn);
       }
 
       X rtn = getApplyContext();
@@ -369,6 +384,8 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           .put(ServerCrunchService.CACHE_KEY, getContext().get(ServerCrunchService.CACHE_KEY))
           : rtn.put(ServerCrunchService.CACHE_KEY, null);
 
+        if ( wasAnonymous ) clearSessionContext();
+
         // We need to do this after the user and agent have been put since
         // 'getCurrentGroup' depends on them being in the context.
         Group group = auth.getCurrentGroup(rtn);
@@ -422,7 +439,21 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
       } else {
         rtn = new OrX(reset(x), rtn);
       }
-      return rtn;
+      return withSessionContext(rtn);
+      `
+    },
+    {
+      name: 'withSessionContext',
+      type: 'Context',
+      args: 'Context x',
+      documentation: `
+        Compose the session's own entries underneath the given context, so a service
+        can keep per-session state across a context rebuild without any of it being
+        able to stand in for an entry applyTo derived.
+      `,
+      javaCode: `
+      X own = getSessionContext();
+      return own == null || own instanceof foam.lang.EmptyX ? x : new OrX(own, x);
       `
     },
     {


### PR DESCRIPTION
A service with per-session state has nowhere durable to keep it. `applyTo` derives the context it returns from `x` and rebuilds it whenever the user record changes, so an entry written into `applyContext` is gone after the next rebuild, and `SessionServerBox` replaces `context` wholesale at the top of every request.

Today the two entries that have to outlive a rebuild are named one at a time — `twoFactorSuccess` and the crunch cache — and every service that wants the same thing has to get its key added to that list.

This adds `sessionContext`: the layer the session owns rather than derives. `applyTo` composes it instead of deriving it, so what a service puts there survives a rebuild.

Composed *underneath* the derived entries, so nothing put there can stand in for `subject`, `group` or `spid`. Cleared when a session that was anonymous becomes a real user, the same rule the crunch cache already follows. Costs nothing when unused — the default is `EmptyX` and `withSessionContext` returns the context untouched.

`SessionContextTest` covers it: store a value, edit the user to force a rebuild, read it back, then try to shadow `subject` and fail. Two failures before the layer was wired into `applyTo`, 4/4 after.

Follow-up: `localLocalSettingDAO` and `ServerCrunchService.CACHE_KEY` can both move onto this and drop their special cases in `applyTo`. Left alone here so this stays additive.