### PR TITLE
Fix "POM not found" warning

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -558,7 +558,7 @@ function pom() {
 
   var root = false;
   POMS && POMS.split(',').forEach(c => {
-    addPom(c && `${PROJECT_HOME}/${c}`);
+    addPom(c && c.startsWith(PROJECT_HOME) ? c : `${PROJECT_HOME}/${c}`);
     root = root || c == 'pom';
   });
   // backward compatibility - hithertoo, only the root directory pom
@@ -588,7 +588,7 @@ function pom() {
           fn = fn2;
         }
       }
-      if ( fn ) addPom(fn);
+      if ( fn && ! poms.includes(fn) ) addPom(fn);
     });
   }
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -552,7 +552,7 @@ function pom() {
   function addPom(fn) {
     if ( ! existsSync(fn + '.js') )
       warning('POM not found ' + fn + '.js');
-    else
+    else if ( ! poms.includes(fn) )
       poms.push(fn);
   };
 
@@ -588,7 +588,7 @@ function pom() {
           fn = fn2;
         }
       }
-      if ( fn && ! poms.includes(fn) ) addPom(fn);
+      if ( fn ) addPom(fn);
     });
   }
 


### PR DESCRIPTION
## Issues
> ./build.sh --task-not-found -Jtest,demo
```
INFO :: Starting Task :: tooling
INFO :: Finished Task :: tooling in 0.02 seconds
WARNING :: Added /pom
WARNING :: POM not found /path/to/your/project//path/to/your/project/deployment/test/pom.js
WARNING :: POM not found /path/to/your/project//path/to/your/project/deployment/demo/pom.js
...
```
## Changes
- Check pom file path before prefix with PROJECT_HOME
- Prevent duplicate pom entries