### PR TITLE
PT-FIXES:DOS-4589 Gate the DAO prompt's Create Test action on command.read.test

### DIFF
--- a/src/foam/core/reflow/DAOPrompt.js
+++ b/src/foam/core/reflow/DAOPrompt.js
@@ -592,6 +592,7 @@ foam.CLASS({
       toolTip: 'Create a Test from Results',
       section: 'actions',
       themeIcon: 'test',
+      availablePermissions: [ 'command.read.test' ],
       // TODO:
 //      isEnabled: function(value) { return this.value; },
       code: async function() {


### PR DESCRIPTION
The DAO prompt's Create Test action carried no permission, so it rendered for everyone — including users who can't run the `test` command it emits. The Script prompt's identical action has gated on `command.read.test` since it was added (`Script.js:78`); the DAO prompt was missed.

Fix: give `DAOPrompt.createTest` the same `availablePermissions`. `ActionView` drops an unavailable action to `display: none`, so the button disappears rather than sitting there disabled.