### PR TITLE
PT-FIXES:DOS-4373 fix(json): triple-quote multiline strings in JSON/J export

### DIFF
--- a/src/foam/core/export/JSONJDriver.js
+++ b/src/foam/core/export/JSONJDriver.js
@@ -23,7 +23,7 @@ foam.CLASS({
           formatDatesAsNumbers: true,
           outputDefaultValues: false,
           useShortNames: false,
-          useTemplateLiterals: true,
+          multiLineOutput: true,
           propertyPredicate: function(o, p) { return ! p.storageTransient; }
         };
        },

--- a/src/foam/core/reflow/Flow.js
+++ b/src/foam/core/reflow/Flow.js
@@ -203,6 +203,9 @@ foam.CLASS({
       preSet: function(o, n) { return n.trim(); },
       view: { class: 'foam.u2.tag.TextArea', rows: 10, cols: 60 },
       toJSON: function (value, outputter) {
+        // Triple-quoted output does its own escaping, and pre-escaping here
+        // would hide the newlines it selects on.
+        if ( outputter.multiLineOutput ) return value;
         return outputter.escape(value, true);
       }
     }

--- a/src/foam/lang/JSON.js
+++ b/src/foam/lang/JSON.js
@@ -214,6 +214,11 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
+      name: 'multiLineOutput',
+      help: 'If true, multiline strings will be outputted as triple-quoted blocks rather than a single escaped line. Matches foam.lib.json.Outputter.setMultiLineOutput().'
+    },
+    {
+      class: 'Boolean',
       name: 'alwaysQuoteKeys',
       help: 'If true, keys are always quoted, as required by the JSON standard. If false, only quote keys which aren\'tvalid JS identifiers.',
       value: true
@@ -345,6 +350,23 @@ foam.CLASS({
       return result;
     },
 
+    /**
+     * Escape a string for triple-quoted output.
+     *
+     * @param {string} str - The string to escape.
+     * @returns {string} The escaped string.
+     *
+     * @description
+     * Only backslashes are doubled; the delimiter does not terminate on a lone
+     * quote and control characters are legal inside the block. The reader
+     * (foam.lib.json.StringParser) halves them again, so a payload's own
+     * "\n" / "\uXXXX" / '\"' sequences survive verbatim.
+     * Mirrors foam.lib.json.Outputter.escapeMultiline().
+     */
+    function escapeMultiline(str) {
+      return str.replace(/\\/g, '\\\\');
+    },
+
     function maybeEscapeKey(str) {
       return this.alwaysQuoteKeys || ! /^[a-zA-Z\$_][0-9a-zA-Z$_]*$/.test(str) ?
         '"' + str + '"' :
@@ -415,7 +437,12 @@ foam.CLASS({
     },
 
     function outputString(str) {
-      if ( this.useTemplateLiterals && str.indexOf('\n') != -1 ) {
+      if ( this.multiLineOutput && str.indexOf('\n') != -1 ) {
+        // Drop the postColonStr padding so the block starts as `"key":\n"""`,
+        // byte-identical to the Java journal writer's styled output.
+        this.buf_ = this.buf_.replace(/[ \t]+$/, '');
+        this.out('\n', '"""', this.escapeMultiline(str), '"""');
+      } else if ( this.useTemplateLiterals && str.indexOf('\n') != -1 ) {
         this.out('`', str.replace(/`/g, '\\`'), '`');
       } else {
         this.out('"', this.escape(str), '"');


### PR DESCRIPTION
JSON/J export writes a Flow's script as one escaped line — every newline becomes `\u000a` — so exported journals can't be read or diffed.

Cause: `Flow.script`'s toJSON force-escapes before output (the guard against double-unescape on network puts), so the string reaching `outputString` has no raw newlines left and the `useTemplateLiterals` branch never fires. Where that branch does fire (a multiline string without a pre-escaping toJSON, e.g. `preLoadScript`), backticks don't double backslashes, so the journal reader swallows backslash content on unescape.

Before / after for the same flow:

```
"script": "[\u000a\u0009{\u000a\u0009\u0009\"flowName\": \"users1\",\u000a\u0009\u0009\"cmd\": \"dao user\", ...
```

```
"script":
"""[
	{
		"flowName": "users1",
		"cmd": "dao user",
...
]"""
```

Fix:

- **multiLineOutput** — new `foam.json.Outputter` flag: multiline strings emit as triple-quoted blocks with backslashes doubled (`escapeMultiline`), byte-identical to the Java journal writer's styled output; `foam.lib.json.StringParser` already parses them.

- **JSONJDriver** — opts in, so a downloaded .jrl matches the styled journals already in source control.

- **Flow.script** — toJSON skips the force-escape when the outputter is in multiline mode, so newlines survive for the block form; single-line behavior unchanged.

Verified on a live export: scripts round-trip through the journal reader's unescape and JSON.parse byte-for-byte.