### PR TITLE
PT-FIXES:DOS-4598 feat(dig): accept a serialized predicate in dig and MCP select

### DIFF
--- a/src/foam/core/ai/mcp/MCPWebAgent.java
+++ b/src/foam/core/ai/mcp/MCPWebAgent.java
@@ -97,7 +97,11 @@ public class MCPWebAgent
           "orderBy", Map.of("type", "object", "description",
             "Optional sort order. Single field ascending: {\"class\":\"__Property__\",\"forClass_\":\"...\",\"name\":\"field\"}. "
             + "Descending: {\"class\":\"foam.mlang.order.Desc\",\"arg1\":{...}}. "
-            + "Multiple fields: {\"class\":\"foam.mlang.order.ThenBy\",\"head\":{...},\"tail\":{...}}.")),
+            + "Multiple fields: {\"class\":\"foam.mlang.order.ThenBy\",\"head\":{...},\"tail\":{...}}."),
+          "predicate", Map.of("type", "object", "description",
+            "Optional FOAM MLang Predicate as JSON, used directly without query parsing. "
+            + "Example: {\"class\":\"foam.mlang.predicate.ContainsIC\",\"arg1\":{\"class\":\"__Property__\",\"forClass_\":\"...\",\"name\":\"name\"},\"arg2\":{\"class\":\"foam.mlang.Constant\",\"value\":\"abc\"}}. "
+            + "ANDs with 'query' when both are given.")),
         "required", List.of("dao"))),
 
     tool("dao_find", "",
@@ -293,6 +297,16 @@ public class MCPWebAgent
     if ( query != null && ! query.trim().isEmpty() ) {
       Predicate predicate = AQL(query.trim());
       dao = dao.where(predicate);
+    }
+
+    // Serialized MLang predicate, used directly — no query-language parsing.
+    Object predicateSpec = args.get("predicate");
+    if ( predicateSpec != null ) {
+      FObject po = jsonToFObject(x, asMap(predicateSpec));
+      if ( ! ( po instanceof Predicate ) ) {
+        throw new MCPError(-32602, "predicate must be a foam.mlang.predicate.Predicate");
+      }
+      dao = dao.where((Predicate) po);
     }
 
     // OrderBy

--- a/src/foam/core/dig/drivers/DigFormatDriver.js
+++ b/src/foam/core/dig/drivers/DigFormatDriver.js
@@ -143,7 +143,7 @@ foam.CLASS({
       Command   command   = (Command) p.get(Command.class);
       String   id         = p.getParameter("id");
       String   q          = p.getParameter("q");
-      String   aql        = p.getParameter("aql");
+      String   predicate  = p.getParameter("predicate");
       String   cols       = p.getParameter("columns");
       String   limit      = p.getParameter("limit");
       String   skip       = p.getParameter("skip");
@@ -171,15 +171,15 @@ foam.CLASS({
 
       Predicate pred = new WebAgentQueryParser(cInfo).parse(x, q);
 
-      // 'aql' filters with AQL (foam.parse.SimpleQueryParser) semantics — the
-      // same parser client views use — so a query matches the same rows on
-      // both sides. 'q' stays MQL for existing consumers; both AND together.
-      if ( ! SafetyUtil.isEmpty(aql) ) {
-        Predicate aqlPred = new foam.parse.SimpleQueryParser(cInfo).parseString(aql);
-        if ( aqlPred == null ) {
-          throw new IllegalArgumentException("failed to parse aql [" + aql + "]");
+      // 'predicate' carries a serialized foam.mlang Predicate, used directly —
+      // the exact predicate the caller's view filtered with, no query-language
+      // parsing involved. 'q' stays MQL for existing consumers; both AND together.
+      if ( ! SafetyUtil.isEmpty(predicate) ) {
+        Object po = x.create(foam.lib.json.JSONParser.class).parseString(predicate);
+        if ( ! ( po instanceof Predicate ) ) {
+          throw new IllegalArgumentException("failed to parse predicate [" + predicate + "]");
         }
-        pred = MLang.AND(pred, aqlPred);
+        pred = MLang.AND(pred, (Predicate) po);
       }
 
       getLogger().debug(pred.toString());

--- a/src/foam/core/dig/drivers/DigFormatDriver.js
+++ b/src/foam/core/dig/drivers/DigFormatDriver.js
@@ -143,6 +143,7 @@ foam.CLASS({
       Command   command   = (Command) p.get(Command.class);
       String   id         = p.getParameter("id");
       String   q          = p.getParameter("q");
+      String   aql        = p.getParameter("aql");
       String   cols       = p.getParameter("columns");
       String   limit      = p.getParameter("limit");
       String   skip       = p.getParameter("skip");
@@ -169,6 +170,18 @@ foam.CLASS({
       final ClassInfo cInfoFinal = cInfo;
 
       Predicate pred = new WebAgentQueryParser(cInfo).parse(x, q);
+
+      // 'aql' filters with AQL (foam.parse.SimpleQueryParser) semantics — the
+      // same parser client views use — so a query matches the same rows on
+      // both sides. 'q' stays MQL for existing consumers; both AND together.
+      if ( ! SafetyUtil.isEmpty(aql) ) {
+        Predicate aqlPred = new foam.parse.SimpleQueryParser(cInfo).parseString(aql);
+        if ( aqlPred == null ) {
+          throw new IllegalArgumentException("failed to parse aql [" + aql + "]");
+        }
+        pred = MLang.AND(pred, aqlPred);
+      }
+
       getLogger().debug(pred.toString());
       dao = dao.where(pred);
 

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -1148,33 +1148,20 @@ foam.CLASS({
 
       var title = daoKey;
 
-      // Send the block's own query text: its 'where' is already MQL ('q') and
-      // its 'aql' has a server-side AQL parser ('aql'), so each filters with
-      // the exact semantics the block used. The predicate probe below is the
-      // fallback for blocks without those properties — its toMQL() round-trip
-      // loses case-insensitive matches (ContainsIC parses back as Contains).
-      var v = this.block.value;
-      if ( v.aql || v.where ) {
-        if ( v.where ) {
-          url = url + '&q=' + encodeURIComponent(v.where);
-          title = title + ', query=' + v.where;
-        }
-        if ( v.aql ) {
-          url = url + '&aql=' + encodeURIComponent(v.aql);
-          title = title + ', query=' + v.aql;
-        }
-      } else {
-        // Probe DAO to find the actual full query being used
-        try {
-          var sink = foam.dao.ArraySink.create();
-          sink.setPredicate = function(p) {
-            url = url + '&q=' + encodeURIComponent(p.toMQL());
-            title = title + ', query=' + p.toMQL();
-            throw "just probing";
-          };
-          await dao.select(sink);
-        } catch (x) {
-        }
+      // Probe DAO to find the actual full query being used. Send the
+      // predicate itself, serialized, so the server filters with the EXACT
+      // predicate this block used — a toMQL() round-trip through the 'q'
+      // parser loses case-insensitive matches (ContainsIC parses back as
+      // Contains). toMQL() stays for the human-readable title only.
+      try {
+        var sink = foam.dao.ArraySink.create();
+        sink.setPredicate = function(p) {
+          url = url + '&predicate=' + encodeURIComponent(foam.json.Network.stringify(p));
+          title = title + ', query=' + p.toMQL();
+          throw "just probing";
+        };
+        await dao.select(sink);
+      } catch (x) {
       }
 
       if ( this.block.value.columns ) {

--- a/src/foam/core/reflow/AbstractDAOAgent.js
+++ b/src/foam/core/reflow/AbstractDAOAgent.js
@@ -1148,16 +1148,33 @@ foam.CLASS({
 
       var title = daoKey;
 
-      // Probe DAO to find the actual full query being used
-      try {
-        var sink = foam.dao.ArraySink.create();
-        sink.setPredicate = function(p) {
-          url = url + '&q=' + encodeURIComponent(p.toMQL());
-          title = title + ', query=' + p.toMQL();
-          throw "just probing";
-        };
-        await dao.select(sink);
-      } catch (x) {
+      // Send the block's own query text: its 'where' is already MQL ('q') and
+      // its 'aql' has a server-side AQL parser ('aql'), so each filters with
+      // the exact semantics the block used. The predicate probe below is the
+      // fallback for blocks without those properties — its toMQL() round-trip
+      // loses case-insensitive matches (ContainsIC parses back as Contains).
+      var v = this.block.value;
+      if ( v.aql || v.where ) {
+        if ( v.where ) {
+          url = url + '&q=' + encodeURIComponent(v.where);
+          title = title + ', query=' + v.where;
+        }
+        if ( v.aql ) {
+          url = url + '&aql=' + encodeURIComponent(v.aql);
+          title = title + ', query=' + v.aql;
+        }
+      } else {
+        // Probe DAO to find the actual full query being used
+        try {
+          var sink = foam.dao.ArraySink.create();
+          sink.setPredicate = function(p) {
+            url = url + '&q=' + encodeURIComponent(p.toMQL());
+            title = title + ', query=' + p.toMQL();
+            throw "just probing";
+          };
+          await dao.select(sink);
+        } catch (x) {
+        }
       }
 
       if ( this.block.value.columns ) {


### PR DESCRIPTION
The same query matches different rows in a view and in DIG: views parse with `foam.parse.SimpleQueryParser` (AQL, case-insensitive contains), DIG parses `q` with the legacy MQL parser (case-sensitive Contains), and the download URL rebuilds the query through a lossy `toMQL()` round-trip — so `ContainsIC` comes back as `Contains` and a table's download links return `[]` for rows the table shows.

Instead of teaching DIG another query language, callers can now send the predicate itself:

- **predicate param** — DIG select accepts `predicate`, a serialized MLang Predicate, parsed with `JSONParser` and used directly — the exact predicate the caller's view filtered with, no query-language parsing involved. `q` is untouched; both AND together when present.

- **Download links** — Reflow download links serialize the block's probed predicate (`foam.json.Network`, the same wire form the DAO box protocol uses) into `predicate`; `toMQL()` remains for the human-readable link title only.

- **MCP dao_select** — same-named `predicate` argument (MLang Predicate as JSON, like the existing `orderBy`), ANDed with the AQL `query` arg.

Verified live: a Download block with a lowercase CONTAINS filter downloads the same rows its table shows; `q`-only URLs behave as before.