### PR TITLE
Refactor: improve build resource jar/tar performance

### DIFF
--- a/src/foam/core/jetty/HttpServer.js
+++ b/src/foam/core/jetty/HttpServer.js
@@ -222,18 +222,7 @@ foam.CLASS({
         String root = System.getProperty("core.webroot");
         if ( ! SafetyUtil.isEmpty(root) ) return handler.newResource(root);
 
-        String resJar = System.getProperty("RES_JAR_HOME");
-        if ( SafetyUtil.isEmpty(resJar) ) {
-          resJar = System.getenv("RES_JAR_HOME");
-        }
-
-        if ( ! SafetyUtil.isEmpty(resJar) ) {
-          // In jar mode, prefer the explicit resources jar over classpath lookup so
-          // test resource jars do not shadow the app's timestamped foam-bin files.
-          String jarRoot = Paths.get(resJar).toUri().toString();
-          return handler.newResource(URI.create("jar:" + jarRoot + "!/webroot/"));
-        }
-
+        // Get webroot from the binary JAR
         URL webrootURL = this.getClass().getResource("/webroot/");
         if ( webrootURL != null ) return handler.newResource(webrootURL.toURI());
 

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -106,8 +106,10 @@ foam.POM({
       // Build binary JAR (compiled .class files only)
       this.info(`Building binary JAR: ${JAR_NAME}`);
       this.execSync(`jar cfm ${BUILD_DIR}/lib/${JAR_NAME} ${BUILD_DIR}/MANIFEST.MF ${JAR_INCLUDES}`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
+    }],
 
-      // Build resources JAR (journals, documents, images, webroot)
+    buildResourcesJar: ['build-resources-jar', 'Build resource JAR', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'copy', 'genJournals', 'genDocuments', 'genImages'], function() {
+      // Build resources JAR (journals, documents, images)
       this.info(`Building resources JAR: ${JAR_RES_NAME}`);
       this.execSync(`jar cf ${BUILD_DIR}/lib/${JAR_RES_NAME} ${JAR_RES_INCLUDES}`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
     }],
@@ -189,7 +191,7 @@ foam.POM({
       this.info(`Binary tarball created: ${binaryTarballPath}`);
     }],
 
-    buildResourcesTar: ['build-resources-tar', 'Package resources JAR only into a TAR archive (customer-specific)', [()=>TAR=true, 'buildJar'], function() {
+    buildResourcesTar: ['build-resources-tar', 'Package resources JAR only into a TAR archive (customer-specific)', [()=>TAR=true, 'buildResourcesJar'], function() {
       this.ensureDir(this.join(BUILD_DIR, 'package'));
       const resourcesTarball = APP_NAME + '-resources-' + VERSION + '.tar.gz';
       const resourcesTarballPath = BUILD_DIR + '/package/' + resourcesTarball;

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -100,13 +100,13 @@ foam.POM({
       }
     }],
 
-    buildJar: ['build-jar', 'Build binary and resources JAR files.', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'genJS', 'genJava', 'copy', 'versions', 'genJavaManifest', 'jarFOAM' ], function() {
+    buildJar: ['build-jar', 'Build binary JAR file.', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'genJS', 'genJava', 'copy', 'versions', 'genJavaManifest', 'jarFOAM' ], function() {
       // Build binary JAR (compiled .class files only)
       this.info(`Building binary JAR: ${JAR_NAME}`);
       this.execSync(`jar cfm ${BUILD_DIR}/lib/${JAR_NAME} ${BUILD_DIR}/MANIFEST.MF ${JAR_INCLUDES}`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
     }],
 
-    buildResourcesJar: ['build-resources-jar', 'Build resource JAR', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'copy', 'genJournals', 'genDocuments', 'genImages'], function() {
+    buildResourcesJar: ['build-resources-jar', 'Build resources JAR file.', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'copy', 'genJournals', 'genDocuments', 'genImages'], function() {
       // Build resources JAR (journals, documents, images)
       this.info(`Building resources JAR: ${JAR_RES_NAME}`);
       this.execSync(`jar cf ${BUILD_DIR}/lib/${JAR_RES_NAME} ${JAR_RES_INCLUDES}`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
@@ -377,7 +377,7 @@ foam.POM({
     }],
 
     genJournals: ['gen-journals', 'Concatenate repository journal files into .0 files', [], function() {
-      // Resources (documents) go into the resources JAR
+      // Resources (journals) go into the resources JAR
       JAR_RES_INCLUDES += ` -C ${BUILD_DIR} journals `;
 
       this.pmake.bind(this, `-makers=Journal -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -journaldir=${JOURNAL_OUT}`)();

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -370,7 +370,9 @@ foam.POM({
     }],
 
     genDocuments: ['gen-documents', 'Capture repository documentation - flow docs', [], function() {
-      JAR_INCLUDES += ` -C ${BUILD_DIR} documents `;
+      // Resources (documents) go into the resources JAR
+      JAR_RES_INCLUDES += ` -C ${BUILD_DIR} documents `;
+
       this.pmake(`-makers=Doc -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -documentdir=${DOCUMENT_OUT}`);
     }],
 
@@ -381,7 +383,9 @@ foam.POM({
     }],
 
     genJournals: ['gen-journals', 'Concatenate repository journal files into .0 files', [], function() {
-      JAR_INCLUDES += ` -C ${BUILD_DIR} journals `;
+      // Resources (documents) go into the resources JAR
+      JAR_RES_INCLUDES += ` -C ${BUILD_DIR} journals `;
+
       this.pmake.bind(this, `-makers=Journal -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -journaldir=${JOURNAL_OUT}`)();
     }],
 

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -99,10 +99,7 @@ foam.POM({
       }
     }],
 
-    buildJar: ['build-jar', 'Build binary and resources JAR files.', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'genJS', 'genJava', 'versions', 'copy', 'genImages', 'genJavaManifest', 'jarFOAM' ], function() {
-      // Webroot goes into the resources JAR
-      JAR_RES_INCLUDES += ` -C ${BUILD_DIR} webroot `;
-
+    buildJar: ['build-jar', 'Build binary and resources JAR files.', [()=>JAR=true, 'pomEnvs', 'setupDirs', 'genJS', 'genJava', 'copy', 'versions', 'genJavaManifest', 'jarFOAM' ], function() {
       // Build binary JAR (compiled .class files only)
       this.info(`Building binary JAR: ${JAR_NAME}`);
       this.execSync(`jar cfm ${BUILD_DIR}/lib/${JAR_NAME} ${BUILD_DIR}/MANIFEST.MF ${JAR_INCLUDES}`, { stdio: VERBOSE ? 'inherit' : 'ignore' });
@@ -166,7 +163,7 @@ foam.POM({
         JAVA_OPTS += ` -${SYSTEM_PROPERTY.split(',').join(' -')}`;
     }],
 
-    buildTar: ['build-tar', 'Package files into a TAR archive (both binary and resources JARs)', [()=>TAR=true, 'buildJar'], function() {
+    buildTar: ['build-tar', 'Package files into a TAR archive (both binary and resources JARs)', [()=>TAR=true, 'buildJar', 'buildResourcesJar'], function() {
       this.ensureDir(this.join(BUILD_DIR, 'package'));
       this.info(`Building full tarball with binary and resources JARs: ${TARBALL}`);
       const toolsDeploy = this.join(FOAM_TOOLS_DIR, 'deploy');
@@ -333,18 +330,14 @@ foam.POM({
       this.pmake.bind(this, `-makers=Image -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR}`)();
     }],
 
-    genJava: ['gen-java', 'Generate Java source from models and complile', ['cleanJava', 'javacParameters'], function() {
-      // Resources (journals, documents) go into the resources JAR
-      JAR_RES_INCLUDES += ` -C ${BUILD_DIR} journals `;
-      JAR_RES_INCLUDES += ` -C ${BUILD_DIR} documents `;
+    genJava: ['gen-java', 'Generate Java source from models and complile', ['cleanJava', 'javacParameters', 'genJournals', 'genDocuments'], function() {
       // Compiled classes go into the binary JAR
       JAR_INCLUDES += ` -C ${BUILD_DIR}/classes .`;
 
       var makers = VERBOSE ? 'Verbose,' : '';
       // NOTE: Java and Javac Maker must be run together as they share data through X
       makers += 'Java,Maven,Javac';
-      makers += ',Journal,Doc';
-      this.pmake.bind(this, `-makers=${makers} -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -d=${BUILD_DIR}/classes -journaldir=${JOURNAL_OUT} -documentdir=${DOCUMENT_OUT} -outdir=${BUILD_DIR}/src/java -libdir=${BUILD_DIR}/lib -javacParams=\'${JAVAC_PARAMETERS}\'`)();
+      this.pmake.bind(this, `-makers=${makers} -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -d=${BUILD_DIR}/classes -outdir=${BUILD_DIR}/src/java -libdir=${BUILD_DIR}/lib -javacParams=\'${JAVAC_PARAMETERS}\'`)();
     }],
 
     deployBin: ['deploy-bin', 'Copy bash files to deployment', [], function() {
@@ -389,7 +382,10 @@ foam.POM({
       this.pmake.bind(this, `-makers=Journal -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -journaldir=${JOURNAL_OUT}`)();
     }],
 
-    jarFOAM: ['jar-foam', 'Copy foam-bin files for inclusion in JAR file.', ['genJava'], function() {
+    jarFOAM: ['jar-foam', 'Copy foam-bin files for inclusion in JAR file.', [], function() {
+      // Webroot goes into the binary JAR
+      JAR_INCLUDES += ` -C ${BUILD_DIR} webroot `;
+
       this.ensureDir(this.join(BUILD_DIR, 'webroot'));
       this.execSync(`cp ${BUILD_DIR}/js/foam-bin-* ${BUILD_DIR}/webroot/`, {stdio: VERBOSE ? 'inherit' : 'ignore' });
     }],

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -86,6 +86,7 @@ foam.POM({
           this.execute('buildTar');
         } else if ( JAR ) {
           this.execute('buildJar');
+          this.execute('buildResourcesJar');
         } else {
           this.execute('genJava');
         }
@@ -409,6 +410,7 @@ foam.POM({
       BOOT_SCRIPT_AUX = 'benchmarkRunnerScript';
 
       this.execute('buildJar');
+      this.execute('buildResourcesJar');
       this.execute('startCORETest', 'benchmark');
     }],
 
@@ -451,6 +453,7 @@ foam.POM({
       this.execute('cleanTest');
       BOOT_SCRIPT_AUX = 'testRunnerScript';
       this.execute('buildJar');
+      this.execute('buildResourcesJar');
       this.execute('startCORETest', 'test');
     }],
 

--- a/tools/JavaTooling.js
+++ b/tools/JavaTooling.js
@@ -383,7 +383,7 @@ foam.POM({
       this.pmake.bind(this, `-makers=Journal -flags=${this.flag()} -pom=${POMS} -builddir=${BUILD_DIR} -journaldir=${JOURNAL_OUT}`)();
     }],
 
-    jarFOAM: ['jar-foam', 'Copy foam-bin files for inclusion in JAR file.', [], function() {
+    jarFOAM: ['jar-foam', 'Copy foam-bin files for inclusion in JAR file.', ['genJS'], function() {
       // Webroot goes into the binary JAR
       JAR_INCLUDES += ` -C ${BUILD_DIR} webroot `;
 


### PR DESCRIPTION
## Split binary and resources JAR into separate build tasks

Separates the binary JAR (compiled classes + foam-bin*.js) from the resources JAR (journals, documents, images) into independent build tasks. 

Improve the performance of `buildResourcesTar`
- before: `Finished Task :: buildResourcesTar in 106.15 seconds`
- after: `Finished Task :: buildResourcesTar in 2.50 seconds`


## Changes
- Extract `buildResourcesJar` — New standalone task for the resources JAR with its own dependency chain (genJournals, genDocuments, genImages)
- Simplify `buildJar` — Now only builds the binary JAR; webroot moves into the binary JAR via jarFOAM instead of resources
- Simplify webroot resolution — HttpServer.js no longer resolves webroot from RES_JAR_HOME system property; uses classpath lookup instead since webroot/ is now in the binary JAR
- Move resource inclusion — genJournals and genDocuments now append to JAR_RES_INCLUDES instead of JAR_INCLUDES
- Fix `jarFOAM` dependency — Changed from genJava to genJS (correct dependency for copying foam-bin-* files)
