### PR TITLE
Rebuild the unloadable delegate chain through EasyDAO, covering decorated DAOs

### DIFF
--- a/src/foam/core/partition/NotPartitionedDAO.java
+++ b/src/foam/core/partition/NotPartitionedDAO.java
@@ -30,6 +30,7 @@ public class NotPartitionedDAO
   extends AbstractPartitionedDAO
 {
   protected SoftReference<DAO> delegate_ = null;
+  protected EasyDAO easy_;
 
   public NotPartitionedDAO(X x) {
     setX(x);
@@ -39,6 +40,11 @@ public class NotPartitionedDAO
     setX(x);
     setOf(of);
     setDirName(journalName);
+  }
+
+  /** Set by EasyDAO so createDAO() can rebuild the same journalled chain on every reload. */
+  public void setEasyDAO(EasyDAO easy) {
+    easy_ = easy;
   }
 
   public synchronized DAO getDelegate() {
@@ -64,9 +70,9 @@ public class NotPartitionedDAO
     String journalName = getDirName();
     Loggers.logger(getX(), this).info("Creating underlying DAO", journalName);
 
-    System.err.println("******************************** CREATING UNLOADABLE DAO " + journalName);
-
-    DAO jdao = new JDAO(getX(), getOf(), journalName);
+    DAO jdao = easy_ != null ?
+      easy_.createJournalledDelegate(getX()) :
+      new JDAO(getX(), getOf(), journalName);
 
     addIndices(jdao);
 

--- a/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
+++ b/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'UnloadableDecoratedDAOTest',
   extends: 'foam.core.test.Test',
 
-  documentation: 'A SINGLE_JOURNAL EasyDAO with both setUnloadable(true) and a decorator set must still get the NotPartitionedDAO wrapper (regression for the getDecorator() == null exclusion), and the decorator plus seqNo stamping must survive an unload/reload cycle.',
+  documentation: 'A SINGLE_JOURNAL EasyDAO with both setUnloadable(true) and a decorator set must still get the NotPartitionedDAO wrapper (regression for the getDecorator() == null exclusion), and the decorator plus seqNo stamping must survive an unload/reload cycle. Also covers a dedup EasyDAO: it must now get the wrapper too, and its DeDupDAO must still be live in the rebuilt chain after reload, with getMdao() tracking the reloaded store.',
 
   javaImports: [
     'foam.core.fs.FileSystemStorage',
@@ -76,6 +76,40 @@ foam.CLASS({
         long id4 = ((Long) UnloadableDecoratedRecord.ID.get(p4)).longValue();
         test( id4 == id3 + 1,
           "seqNo continues after reload, got " + id4 + " expected " + (id3 + 1) );
+
+        // A dedup EasyDAO used to be excluded from the unloadable branch entirely
+        // (getUnloadable() && !getDedup()), so it never got the NotPartitionedDAO
+        // wrapper at all. It now rebuilds its inner chain (mdao + DeDupDAO + JDAO)
+        // from scratch via EasyDAO#createJournalledDelegate() on every reload, so
+        // dedup must still work after an unload/reload cycle.
+        String dedupJournalName = "unloadableDedup_" + System.nanoTime();
+        DAO dedupDao = new EasyDAO.Builder(tx)
+          .setAuthorize(false)
+          .setOf(UnloadableDecoratedRecord.getOwnClassInfo())
+          .setJournalType(JournalType.SINGLE_JOURNAL)
+          .setJournalName(dedupJournalName)
+          .setUnloadable(true)
+          .setDedup(true)
+          .build();
+        EasyDAO dedupEasyDao = (EasyDAO) dedupDao;
+
+        UnloadableDecoratedRecord dr = new UnloadableDecoratedRecord();
+        dr.setId(1);
+        dr.setData(new String("dedup-data"));
+        FObject putDr = dedupDao.put(dr);
+        test( UnloadableDecoratedRecord.DATA.get(putDr) == "dedup-data",
+          "dedup interns the data string on the initial put" );
+
+        Object dedupUnloadResult = dedupDao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+        test( Boolean.TRUE.equals(dedupUnloadResult),
+          "dedup EasyDAO now also gets the NotPartitionedDAO wrapper (unloadable no longer excludes dedup)" );
+
+        FObject reloadedDr = dedupDao.find_(tx, 1L);
+        test( reloadedDr != null && UnloadableDecoratedRecord.DATA.get(reloadedDr) == "dedup-data",
+          "rebuilt chain still dedups after reload: journal replay ran back through DeDupDAO" );
+
+        test( dedupEasyDao.getMdao() != null && dedupEasyDao.getMdao().find_(tx, 1L) != null,
+          "easy.getMdao() alias tracks the live (reloaded) store after unload/reload" );
       `
     },
     {

--- a/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
+++ b/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'UnloadableDecoratedDAOTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'A SINGLE_JOURNAL EasyDAO with both setUnloadable(true) and a decorator set must still get the NotPartitionedDAO wrapper (regression for the getDecorator() == null exclusion), and the decorator plus seqNo stamping must survive an unload/reload cycle.',
+
+  javaImports: [
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.partition.AbstractPartitionedDAO',
+    'foam.core.partition.test.UnloadableDecoratedRecord',
+    'foam.dao.DAO',
+    'foam.dao.EasyDAO',
+    'foam.dao.JournalType',
+    'foam.dao.ProxyDAO',
+    'foam.lang.FObject',
+    'foam.lang.X',
+    'java.io.File'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        X tx = newStorageContext(x);
+        String journalName = "unloadableDecorated_" + System.nanoTime();
+
+        CountingProxyDAO decorator = new CountingProxyDAO(tx);
+
+        DAO dao = new EasyDAO.Builder(tx)
+          .setAuthorize(false)
+          .setOf(UnloadableDecoratedRecord.getOwnClassInfo())
+          .setSeqNo(true)
+          .setJournalType(JournalType.SINGLE_JOURNAL)
+          .setJournalName(journalName)
+          .setUnloadable(true)
+          .setDecorator(decorator)
+          .build();
+
+        UnloadableDecoratedRecord r1 = new UnloadableDecoratedRecord(); r1.setData("r1");
+        UnloadableDecoratedRecord r2 = new UnloadableDecoratedRecord(); r2.setData("r2");
+        UnloadableDecoratedRecord r3 = new UnloadableDecoratedRecord(); r3.setData("r3");
+        FObject p1 = dao.put(r1);
+        FObject p2 = dao.put(r2);
+        FObject p3 = dao.put(r3);
+
+        long id1 = ((Long) UnloadableDecoratedRecord.ID.get(p1)).longValue();
+        long id2 = ((Long) UnloadableDecoratedRecord.ID.get(p2)).longValue();
+        long id3 = ((Long) UnloadableDecoratedRecord.ID.get(p3)).longValue();
+        test( id1 > 0 && id2 == id1 + 1 && id3 == id2 + 1,
+          "ids sequence-stamped: " + id1 + ", " + id2 + ", " + id3 );
+
+        test( decorator.count > 0,
+          "decorator saw put_ calls before unload, count=" + decorator.count );
+        int countBeforeUnload = decorator.count;
+
+        Object unloadResult = dao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+        test( Boolean.TRUE.equals(unloadResult),
+          "UNLOAD_CMD returns TRUE: the NotPartitionedDAO wrapper is present even with a decorator set" );
+
+        FObject found = dao.find_(tx, id2);
+        test( found != null && "r2".equals(UnloadableDecoratedRecord.DATA.get(found)),
+          "record 2 intact after unload/reload" );
+        test( decorator.count > countBeforeUnload,
+          "decorator is still in the chain after reload, count=" + decorator.count );
+
+        UnloadableDecoratedRecord r4 = new UnloadableDecoratedRecord(); r4.setData("r4");
+        FObject p4 = dao.put(r4);
+        long id4 = ((Long) UnloadableDecoratedRecord.ID.get(p4)).longValue();
+        test( id4 == id3 + 1,
+          "seqNo continues after reload, got " + id4 + " expected " + (id3 + 1) );
+      `
+    },
+    {
+      name: 'newStorageContext',
+      args: 'X x',
+      type: 'X',
+      documentation: 'Sub-context with a temp-dir FileSystemStorage so journals are isolated.',
+      javaCode: `
+        String dir = System.getProperty("java.io.tmpdir") + File.separator
+          + "unloadabledecorated_" + System.nanoTime();
+        new File(dir).mkdirs();
+        FileSystemStorage fs = new FileSystemStorage(dir);
+        return x.put(Storage.class, fs).put(FileSystemStorage.class, fs);
+      `
+    }
+  ],
+
+  javaCode: `
+    /** Counts put_/find_ calls to prove the decorator is live in the chain, before and after unload/reload. */
+    public static class CountingProxyDAO extends ProxyDAO {
+      public int count = 0;
+
+      public CountingProxyDAO(X x) {
+        setX(x);
+      }
+
+      public FObject put_(X x, FObject obj) {
+        count++;
+        return super.put_(x, obj);
+      }
+
+      public FObject find_(X x, Object id) {
+        count++;
+        return super.find_(x, id);
+      }
+    }
+  `
+});

--- a/src/foam/core/partition/test/UnloadableDecoratedRecord.js
+++ b/src/foam/core/partition/test/UnloadableDecoratedRecord.js
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'UnloadableDecoratedRecord',
+  documentation: 'Long-id test model for UnloadableDecoratedDAOTest. A Long id (rather than PartitionStrRecord\'s String id) is required so SequenceNumberDAO can stamp it.',
+  properties: [
+    { class: 'Long',   name: 'id' },
+    { class: 'String', name: 'data' }
+  ]
+});

--- a/src/foam/core/partition/test/pom.js
+++ b/src/foam/core/partition/test/pom.js
@@ -4,8 +4,10 @@ foam.POM({
   files: [
     { name: 'PartitionStrRecord',            flags: 'js&test|java&test' },
     { name: 'RefSourceRecord',               flags: 'js&test|java&test' },
+    { name: 'UnloadableDecoratedRecord',     flags: 'js&test|java&test' },
     { name: 'SingleToPartitionMigratorTest', flags: 'js&test|java&test' },
-    { name: 'ReferenceMigratorTest',         flags: 'js&test|java&test' }
+    { name: 'ReferenceMigratorTest',         flags: 'js&test|java&test' },
+    { name: 'UnloadableDecoratedDAOTest',    flags: 'js&test|java&test' }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/test/tests.jrl
+++ b/src/foam/core/partition/test/tests.jrl
@@ -1,2 +1,3 @@
 p({"class":"foam.core.partition.test.SingleToPartitionMigratorTest","id":"SingleToPartitionMigratorTest"})
 p({"class":"foam.core.partition.test.ReferenceMigratorTest","id":"ReferenceMigratorTest"})
+p({"class":"foam.core.partition.test.UnloadableDecoratedDAOTest","id":"UnloadableDecoratedDAOTest"})

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -1035,7 +1035,7 @@ dao loading, which improves overall startup time.`,
           } else if ( getUnloadable() && ! getDedup() ) {
             // getJournalDelegate() only replaces the journal delegate; the decorator,
             // ServiceProviderAwareDAO, and SequenceNumberDAO wrappers are all applied
-            // outside it (see the `delegate` property factory above) and survive
+            // outside it (see the 'delegate' property factory above) and survive
             // unload/reload untouched. Dedup is excluded because this branch discards
             // the "delegate" parameter (built above with the DeDupDAO wrapper) in favor
             // of NotPartitionedDAO's own lazily-created bare MDAO (see createDAO()), so

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -231,11 +231,21 @@ foam.CLASS({
             .build();
 
           // auto add index on spid
-          DAO dao = (DAO) getMdao();
-          if ( dao != null && dao instanceof foam.dao.MDAO ) {
+          // Route through delegate.cmd_() rather than grabbing getMdao() directly: with an
+          // unloadable NotPartitionedDAO in the chain, getMdao() is an orphaned instance
+          // discarded on reload, but AbstractPartitionedDAO.cmd_() records the
+          // AddIndexCommand and NotPartitionedDAO#createDAO() replays it on every reload.
+          if ( getMdao() != null ) {
             PropertyInfo pInfo = (PropertyInfo) getOf().getAxiomByName("spid");
             if ( pInfo != null ) {
-              ((foam.dao.MDAO)dao).addIndex(pInfo);
+              AddIndexCommand cmd = new AddIndexCommand();
+              cmd.setIndexers(new Indexer[] { pInfo });
+              Object result = delegate.cmd_(getX(), cmd);
+              if ( result == null ||
+                  ! ( result instanceof Boolean ) ||
+                  ((Boolean) result).booleanValue() != true ) {
+                logger.warning(getName(), "Index not added, no access to MDAO", pInfo);
+              }
             } else {
               logger.warning(getName(), "Index not added. Property not found. spid");
             }
@@ -1022,8 +1032,15 @@ dao loading, which improves overall startup time.`,
         } else if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
           if ( getWriteOnly() ) {
             delegate = new foam.dao.WriteOnlyJDAO(x, delegate, getOf(), getJournalName());
-          } else if ( getUnloadable() &&  getDecorator() == null ) {
-System.err.println("************************************* CREATING UNLOADABLE DAO " + getJournalName());
+          } else if ( getUnloadable() && ! getDedup() ) {
+            // getJournalDelegate() only replaces the journal delegate; the decorator,
+            // ServiceProviderAwareDAO, and SequenceNumberDAO wrappers are all applied
+            // outside it (see the `delegate` property factory above) and survive
+            // unload/reload untouched. Dedup is excluded because this branch discards
+            // the "delegate" parameter (built above with the DeDupDAO wrapper) in favor
+            // of NotPartitionedDAO's own lazily-created bare MDAO (see createDAO()), so
+            // a dedup EasyDAO would silently never get its DeDupDAO wrapper at all.
+            // FixedSizeDAO already self-excludes via setUnloadable(false) above.
             foam.core.partition.NotPartitionedDAO pdao = new foam.core.partition.NotPartitionedDAO(x, getOf(), getJournalName());
 
             // TODO: the delgate is lost, should it be sent as a prototype to be cloned?

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -543,7 +543,9 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'unloadable',
-      // TODO: remove, just temporary for testing purposes
+      // Unloadable-by-default is intended: SINGLE_JOURNAL EasyDAOs get memory
+      // management via lazy journal reload (NotPartitionedDAO) unless explicitly
+      // opted out; wrappers that can't safely rebuild (e.g. fixedSize) exclude themselves.
       value: true
     },
     {
@@ -1032,35 +1034,62 @@ dao loading, which improves overall startup time.`,
         } else if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
           if ( getWriteOnly() ) {
             delegate = new foam.dao.WriteOnlyJDAO(x, delegate, getOf(), getJournalName());
-          } else if ( getUnloadable() && ! getDedup() ) {
+          } else if ( getUnloadable() ) {
             // getJournalDelegate() only replaces the journal delegate; the decorator,
             // ServiceProviderAwareDAO, and SequenceNumberDAO wrappers are all applied
             // outside it (see the 'delegate' property factory above) and survive
-            // unload/reload untouched. Dedup is excluded because this branch discards
-            // the "delegate" parameter (built above with the DeDupDAO wrapper) in favor
-            // of NotPartitionedDAO's own lazily-created bare MDAO (see createDAO()), so
-            // a dedup EasyDAO would silently never get its DeDupDAO wrapper at all.
+            // unload/reload untouched. The inner chain (mdao, optionally dedup, JDAO)
+            // is rebuilt from scratch via createJournalledDelegate() on every reload
+            // (see NotPartitionedDAO.createDAO()), so dedup is included this time.
             // FixedSizeDAO already self-excludes via setUnloadable(false) above.
             foam.core.partition.NotPartitionedDAO pdao = new foam.core.partition.NotPartitionedDAO(x, getOf(), getJournalName());
-
-            // TODO: the delgate is lost, should it be sent as a prototype to be cloned?
-            // Setting of delegate must be last as it triggers replay
-            // jdao.setDelegate(delegate);
-
+            pdao.setEasyDAO(this);
             delegate = pdao;
+          } else if ( getFixedSize() != null ) {
+            // FixedSizeDAO already wraps the mdao/dedup chain above (see the
+            // 'delegate' property factory); wrap that existing chain in the
+            // journal rather than rebuilding it, or the size cap would be lost.
+            delegate = wrapInJDAO(x, delegate);
           } else {
-            foam.dao.java.JDAO jdao = new foam.dao.java.JDAO();
-            jdao.setX(x);
-            jdao.setFilename(getJournalName());
-            jdao.setCluster(getCluster() && !getSaf());
-            jdao.setWaitReplay(getWaitReplay());
-            jdao.setNdiff(getNdiff());
-            // Setting of delegate must be last as it triggers replay
-            jdao.setDelegate(delegate);
-            delegate = jdao;
+            delegate = createJournalledDelegate(x);
           }
         }
         return delegate;
+      `
+    },
+    {
+      name: 'createJournalledDelegate',
+      documentation: 'Builds a fresh SINGLE_JOURNAL inner chain: a new MDAO (aliased via setMdao so getMdao() tracks the live store), optionally wrapped in DeDupDAO, then wrapped in a JDAO over getJournalName(). Used for the initial non-unloadable, non-fixedSize construction, and by NotPartitionedDAO#createDAO() to rebuild the chain on every unload/reload.',
+      args: 'X x',
+      type: 'foam.dao.DAO',
+      javaCode: `
+        setMdao(new foam.dao.MDAO(getOf()));
+        foam.dao.DAO delegate = getMdao();
+
+        if ( getDedup() ) {
+          delegate = new foam.dao.DeDupDAO.Builder(x)
+            .setDelegate(delegate)
+            .build();
+        }
+
+        return wrapInJDAO(x, delegate);
+      `
+    },
+    {
+      name: 'wrapInJDAO',
+      documentation: 'Wraps delegate in a JDAO over getJournalName(), applying the cluster/waitReplay/ndiff settings shared by every SINGLE_JOURNAL construction path.',
+      args: 'X x, foam.dao.DAO delegate',
+      type: 'foam.dao.DAO',
+      javaCode: `
+        foam.dao.java.JDAO jdao = new foam.dao.java.JDAO();
+        jdao.setX(x);
+        jdao.setFilename(getJournalName());
+        jdao.setCluster(getCluster() && !getSaf());
+        jdao.setWaitReplay(getWaitReplay());
+        jdao.setNdiff(getNdiff());
+        // Setting of delegate must be last as it triggers replay
+        jdao.setDelegate(delegate);
+        return jdao;
       `
     },
     {


### PR DESCRIPTION
The unloadable branch in EasyDAO required `getDecorator() == null`, so every decorated DAO silently skipped the NotPartitionedDAO wrapper and could never unload. The guard existed because the wrapper used to rebuild a bare JDAO+MDAO on reload, discarding the inner chain ("TODO: the delegate is lost").

This closes that TODO instead of narrowing around it:

- **createJournalledDelegate** — EasyDAO's SINGLE_JOURNAL inner-chain construction (fresh MDAO aliased via `setMdao`, optional DeDupDAO, JDAO) is now one extracted method, used by both the initial build and every reload.

- **NotPartitionedDAO** — holds a reference to its EasyDAO and rebuilds through `createJournalledDelegate()` on every reload, so dedup survives and `getMdao()` always tracks the live store. Standalone constructions keep the plain-JDAO fallback.

- **Condition** — just `getUnloadable()`; decorator, ServiceProviderAwareDAO, and SequenceNumberDAO wrappers sit outside `getJournalDelegate()` and survive unload untouched. FixedSizeDAO still self-excludes (its cap chain is built before the journal and can't be rebuilt blind — e.g. loginAttemptDAO).

- **spid index** — the ServiceProviderAware auto-index goes through an `AddIndexCommand` on the delegate chain instead of `getMdao().addIndex()`; the wrapper records it and reapplies on every reload, where the old direct call landed on an orphaned MDAO.

- **unloadable default** — documented as intended (memory management via lazy journal reload) instead of the old "temporary for testing" TODO.

- **Test** — UnloadableDecoratedDAOTest, 10 assertions green: a decorated seqNo DAO answers `UNLOAD_CMD` with true and keeps records, decorator, and id sequence through reload; a dedup DAO gets the wrapper and still dedups after reload; `getMdao()` finds reloaded records.