### PR TITLE
PT-FIXES:DOS-3795 Partition load progress: status DAO, replay reporter, client toasts

### DIFF
--- a/src/foam/core/partition/AbstractPartitionedDAO.js
+++ b/src/foam/core/partition/AbstractPartitionedDAO.js
@@ -115,7 +115,26 @@ foam.CLASS({
       if ( f != null && f.isFile() ) total += f.length();
       java.io.File f0 = fss.get(journalName + ".0");
       if ( f0 != null && f0.isFile() ) total += f0.length();
+      if ( total > 0 ) return total;
+
+      // FileSystemStorage has no bytes for this name -- journals can be
+      // served read-only from a resource jar (resource.journals.dir). The
+      // read Storage may be a ResourceStorage, whose get() throws for jar
+      // entries, so size it off the stream it hands back instead.
+      foam.core.fs.Storage rs = (foam.core.fs.Storage) getX().get(foam.core.fs.Storage.class);
+      if ( rs != null && rs != fss ) {
+        total += streamSize(rs, journalName);
+        total += streamSize(rs, journalName + ".0");
+      }
       return total;
+    } catch ( Throwable t ) {
+      return 0;
+    }
+  }
+
+  protected long streamSize(foam.core.fs.Storage storage, String name) {
+    try ( java.io.InputStream is = storage.getInputStream(name) ) {
+      return is != null ? is.available() : 0;
     } catch ( Throwable t ) {
       return 0;
     }

--- a/src/foam/core/partition/AbstractPartitionedDAO.js
+++ b/src/foam/core/partition/AbstractPartitionedDAO.js
@@ -67,6 +67,15 @@ foam.CLASS({
     {
       class: 'List',
       name: 'indices'
+    },
+    {
+      class: 'String',
+      name: 'serviceName',
+      documentation: 'Name clients correlate load-status rows with. Resolved from the CSpec in X when built by a serviceScript; EasyDAO sets it explicitly otherwise.',
+      javaFactory: `
+        foam.core.boot.CSpec cspec = (foam.core.boot.CSpec) getX().get(foam.core.boot.CSpec.CSPEC_CTX_KEY);
+        return cspec != null ? cspec.getName() : "";
+      `
     }
   ],
 
@@ -96,6 +105,20 @@ foam.CLASS({
     }
 
     return super.cmd_(x, cmd);
+  }
+
+  public long journalSize(String journalName) {
+    try {
+      foam.core.fs.FileSystemStorage fss = (foam.core.fs.FileSystemStorage) getX().get(foam.core.fs.FileSystemStorage.class);
+      long total = 0;
+      java.io.File f = fss.get(journalName);
+      if ( f != null && f.isFile() ) total += f.length();
+      java.io.File f0 = fss.get(journalName + ".0");
+      if ( f0 != null && f0.isFile() ) total += f0.length();
+      return total;
+    } catch ( Throwable t ) {
+      return 0;
+    }
   }
 
   `

--- a/src/foam/core/partition/DatePartitionedDAO.java
+++ b/src/foam/core/partition/DatePartitionedDAO.java
@@ -13,9 +13,11 @@ import foam.mlang.Expr;
 import foam.mlang.order.Comparator;
 import foam.mlang.predicate.*;
 import foam.mlang.predicate.Predicate;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 
 public class DatePartitionedDAO
   extends PartitionedDAO
@@ -128,7 +130,10 @@ public class DatePartitionedDAO
     String[] parts = new String[(y2-y1) * 12 + m2 - m1 + 1];
 
     for ( int i = 0, y = y1, m = m1 ; i < parts.length ; i++ ) {
-      parts[i] = getPartition(y + "/" + m);
+      // 'm' is Calendar.MONTH (0-based); getPartition(FObject) emits 1-based
+      // month partitions ("year/(month+1)" above), so match that here or a
+      // range select never finds the partitions records were written to.
+      parts[i] = getPartition(y + "/" + (m+1));
       m++;
       if ( m == 12 ) { m = 0; y++; }
     }
@@ -147,16 +152,66 @@ public class DatePartitionedDAO
     Sink           s2 = decorateSink(null, sink, skip, limit, order, predicate);
     DetachableSink s3 = new DetachableSink(s2);
 
-    for ( int i = 0 ; i < parts.length ; i++ ) {
-      DAO dao = getDelegate(parts[i]);
+    List<String> queuedIds = publishQueued(x, parts);
+    try {
+      for ( int i = 0 ; i < parts.length ; i++ ) {
+        DAO dao = getDelegate(parts[i]);
 
-      dao.select(s3);
-      if ( s3.isDetached() ) break;
+        dao.select(s3);
+        if ( s3.isDetached() ) break;
+      }
+
+      s2.eof();
+    } finally {
+      clearQueued(x, queuedIds);
     }
 
-    s2.eof();
-
     return sink;
+  }
+
+  /** Publish a queued status row for each not-yet-loaded partition this
+      select is about to iterate, so PartitionLoadToastStack can show
+      "N of M" before the (synchronous, per-partition) load actually reaches
+      them. Returns the ids published so the caller can clean up stragglers. */
+  protected List<String> publishQueued(X x, String[] parts) {
+    DAO status = (DAO) x.get("partitionLoadStatusDAO");
+    if ( status == null ) return new ArrayList<>();
+
+    List<String> ids = new ArrayList<>();
+    for ( String part : parts ) {
+      if ( isLoaded(part) ) continue;
+
+      String journalName = journalNameFor(part);
+      PartitionLoadStatus s = new PartitionLoadStatus();
+      s.setId(journalName);
+      s.setServiceName(getServiceName());
+      s.setPartition(part);
+      s.setTotalBytes(journalSize(journalName));
+      s.setQueued(true);
+      status.put(s);
+      ids.add(journalName);
+    }
+    return ids;
+  }
+
+  /** Remove queued rows this select published but never reached (early
+      detach, or another caller loaded the partition first). A row a real
+      load has since taken over (queued == false) is left alone -- its own
+      PartitionLoadReporter.done() removes it. */
+  protected void clearQueued(X x, List<String> ids) {
+    if ( ids.isEmpty() ) return;
+
+    DAO status = (DAO) x.get("partitionLoadStatusDAO");
+    if ( status == null ) return;
+
+    for ( String id : ids ) {
+      PartitionLoadStatus existing = (PartitionLoadStatus) status.find(id);
+      if ( existing != null && existing.getQueued() ) {
+        PartitionLoadStatus s = new PartitionLoadStatus();
+        s.setId(id);
+        status.remove(s);
+      }
+    }
   }
 
   public Date[] extractPredicateRange(Predicate predicate) {

--- a/src/foam/core/partition/NotPartitionedDAO.java
+++ b/src/foam/core/partition/NotPartitionedDAO.java
@@ -30,6 +30,7 @@ public class NotPartitionedDAO
   extends AbstractPartitionedDAO
 {
   protected SoftReference<DAO> delegate_ = null;
+  protected EasyDAO easy_;
 
   public NotPartitionedDAO(X x) {
     setX(x);
@@ -39,6 +40,11 @@ public class NotPartitionedDAO
     setX(x);
     setOf(of);
     setDirName(journalName);
+  }
+
+  /** Set by EasyDAO so createDAO() can rebuild the same journalled chain on every reload. */
+  public void setEasyDAO(EasyDAO easy) {
+    easy_ = easy;
   }
 
   public synchronized DAO getDelegate() {
@@ -68,7 +74,10 @@ public class NotPartitionedDAO
     DAO jdao;
     try {
       reporter.start(journalSize(journalName));
-      jdao = new JDAO(getX().put(PartitionLoadReporter.CTX_KEY, reporter), getOf(), journalName);
+      X loadX = getX().put(PartitionLoadReporter.CTX_KEY, reporter);
+      jdao = easy_ != null ?
+        easy_.createJournalledDelegate(loadX) :
+        new JDAO(loadX, getOf(), journalName);
     } finally {
       reporter.done();
     }

--- a/src/foam/core/partition/NotPartitionedDAO.java
+++ b/src/foam/core/partition/NotPartitionedDAO.java
@@ -64,9 +64,14 @@ public class NotPartitionedDAO
     String journalName = getDirName();
     Loggers.logger(getX(), this).info("Creating underlying DAO", journalName);
 
-    System.err.println("******************************** CREATING UNLOADABLE DAO " + journalName);
-
-    DAO jdao = new JDAO(getX(), getOf(), journalName);
+    PartitionLoadReporter reporter = new PartitionLoadReporter(getX(), journalName, getServiceName(), "");
+    DAO jdao;
+    try {
+      reporter.start(journalSize(journalName));
+      jdao = new JDAO(getX().put(PartitionLoadReporter.CTX_KEY, reporter), getOf(), journalName);
+    } finally {
+      reporter.done();
+    }
 
     addIndices(jdao);
 

--- a/src/foam/core/partition/PartitionLoadProgressDAO.js
+++ b/src/foam/core/partition/PartitionLoadProgressDAO.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition',
+  name: 'PartitionLoadProgressDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  documentation: `Client-side decorator. While any operation on this DAO is
+    pending past showDelay, asks the PartitionLoadToastStack to watch this
+    DAO's serviceKey; the stack shows progress cards for matching
+    partition-load status rows. Unwatches when the operation settles.`,
+
+  requires: [ 'foam.core.partition.PartitionLoadToastStack' ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'serviceKey',
+      documentation: 'Matches PartitionLoadStatus.serviceName rows on the server.'
+    },
+    { class: 'Int', name: 'showDelay', value: 400 }
+  ],
+
+  methods: [
+    function select_(x, sink, skip, limit, order, predicate) {
+      return this.track_(this.SUPER(x, sink, skip, limit, order, predicate));
+    },
+    function find_(x, id) {
+      return this.track_(this.SUPER(x, id));
+    },
+    function put_(x, obj) {
+      return this.track_(this.SUPER(x, obj));
+    },
+    function remove_(x, obj) {
+      return this.track_(this.SUPER(x, obj));
+    },
+    function removeAll_(x, skip, limit, order, predicate) {
+      return this.track_(this.SUPER(x, skip, limit, order, predicate));
+    },
+
+    function track_(p) {
+      if ( ! this.serviceKey || ! p || ! p.then ) return p;
+      var self    = this;
+      var stack   = this.PartitionLoadToastStack.create();
+      var settled = false;
+      var timer   = setTimeout(function() {
+        if ( ! settled ) stack.watch(self.serviceKey);
+      }, this.showDelay);
+      var settle = function() {
+        settled = true;
+        clearTimeout(timer);
+        stack.unwatch(self.serviceKey);
+      };
+      p.then(settle, settle);
+      return p;
+    }
+  ]
+});

--- a/src/foam/core/partition/PartitionLoadProgressDAO.js
+++ b/src/foam/core/partition/PartitionLoadProgressDAO.js
@@ -12,9 +12,11 @@ foam.CLASS({
   documentation: `Client-side decorator. While any operation on this DAO is
     pending past showDelay, asks the PartitionLoadToastStack to watch this
     DAO's serviceKey; the stack shows progress cards for matching
-    partition-load status rows. Unwatches when the operation settles.`,
+    partition-load status rows. Unwatches when the operation settles.
+    partitionLoadToastStack is an optional import -- if no such service is
+    registered in this context, tracking is a no-op passthrough.`,
 
-  requires: [ 'foam.core.partition.PartitionLoadToastStack' ],
+  imports: [ 'partitionLoadToastStack?' ],
 
   properties: [
     {
@@ -44,8 +46,9 @@ foam.CLASS({
 
     function track_(p) {
       if ( ! this.serviceKey || ! p || ! p.then ) return p;
+      var stack = this.partitionLoadToastStack;
+      if ( ! stack ) return p;
       var self    = this;
-      var stack   = this.PartitionLoadToastStack.create();
       var settled = false;
       var watched = false;
       var timer   = setTimeout(function() {

--- a/src/foam/core/partition/PartitionLoadProgressDAO.js
+++ b/src/foam/core/partition/PartitionLoadProgressDAO.js
@@ -47,13 +47,14 @@ foam.CLASS({
       var self    = this;
       var stack   = this.PartitionLoadToastStack.create();
       var settled = false;
+      var watched = false;
       var timer   = setTimeout(function() {
-        if ( ! settled ) stack.watch(self.serviceKey);
+        if ( ! settled ) { watched = true; stack.watch(self.serviceKey); }
       }, this.showDelay);
       var settle = function() {
         settled = true;
         clearTimeout(timer);
-        stack.unwatch(self.serviceKey);
+        if ( watched ) stack.unwatch(self.serviceKey);
       };
       p.then(settle, settle);
       return p;

--- a/src/foam/core/partition/PartitionLoadReporter.java
+++ b/src/foam/core/partition/PartitionLoadReporter.java
@@ -11,8 +11,9 @@ import foam.lang.X;
 
 /**
  * Publishes journal-replay progress for one partition load into
- * partitionLoadStatusDAO. Owned by the single thread running the load;
- * puts are throttled so a fast replay does not storm the status DAO.
+ * partitionLoadStatusDAO. Not thread-safe: owned by the single thread
+ * running the load. Puts are throttled so a fast replay does not storm
+ * the status DAO.
  */
 public class PartitionLoadReporter {
   public final static String CTX_KEY             = "partitionLoadReporter";
@@ -43,7 +44,7 @@ public class PartitionLoadReporter {
     put(true);
   }
 
-  public synchronized void addChars(long n) {
+  public void addChars(long n) {
     read_ += n;
     put(false);
   }

--- a/src/foam/core/partition/PartitionLoadReporter.java
+++ b/src/foam/core/partition/PartitionLoadReporter.java
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core.partition;
+
+import foam.dao.DAO;
+import foam.lang.X;
+
+/**
+ * Publishes journal-replay progress for one partition load into
+ * partitionLoadStatusDAO. Owned by the single thread running the load;
+ * puts are throttled so a fast replay does not storm the status DAO.
+ */
+public class PartitionLoadReporter {
+  public final static String CTX_KEY             = "partitionLoadReporter";
+  protected final static long MIN_PUT_INTERVAL_MS = 250;
+
+  protected final X              x_;
+  protected final String         id_;
+  protected final String         serviceName_;
+  protected final String         partition_;
+  protected final java.util.Date start_ = new java.util.Date();
+  protected long total_   = 0;
+  protected long read_    = 0;
+  protected long lastPut_ = 0;
+
+  public PartitionLoadReporter(X x, String id, String serviceName, String partition) {
+    x_           = x;
+    id_          = id;
+    serviceName_ = serviceName;
+    partition_   = partition;
+  }
+
+  protected DAO dao() {
+    return (DAO) x_.get("partitionLoadStatusDAO");
+  }
+
+  public void start(long totalBytes) {
+    total_ = totalBytes;
+    put(true);
+  }
+
+  public synchronized void addChars(long n) {
+    read_ += n;
+    put(false);
+  }
+
+  public long getBytesRead() {
+    return read_;
+  }
+
+  protected void put(boolean force) {
+    DAO dao = dao();
+    if ( dao == null ) return; // early boot, no status DAO yet
+
+    long now = System.currentTimeMillis();
+    if ( ! force && now - lastPut_ < MIN_PUT_INTERVAL_MS ) return;
+    lastPut_ = now;
+
+    PartitionLoadStatus s = new PartitionLoadStatus();
+    s.setId(id_);
+    s.setServiceName(serviceName_);
+    s.setPartition(partition_);
+    s.setTotalBytes(total_);
+    s.setBytesRead(read_);
+    s.setStartTime(start_);
+    dao.put(s);
+  }
+
+  public void done() {
+    DAO dao = dao();
+    if ( dao == null ) return;
+
+    PartitionLoadStatus s = new PartitionLoadStatus();
+    s.setId(id_);
+    dao.remove(s);
+  }
+}

--- a/src/foam/core/partition/PartitionLoadStatus.js
+++ b/src/foam/core/partition/PartitionLoadStatus.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition',
+  name: 'PartitionLoadStatus',
+
+  documentation: `Ephemeral status row for one in-progress partition journal
+    load. id is the full journal name (unique per partition file). Rows live
+    only in memory; a row exists exactly while its load is running.`,
+
+  properties: [
+    {
+      class: 'String',
+      name: 'id',
+      documentation: 'Full journal name of the loading partition file.'
+    },
+    {
+      class: 'String',
+      name: 'serviceName',
+      documentation: 'CSpec name (or EasyDAO name for dynamic DAOs) clients match against.'
+    },
+    {
+      class: 'String',
+      name: 'partition',
+      documentation: 'Display partition value, e.g. 2026/7. Empty for non-partitioned unloadable DAOs.'
+    },
+    { class: 'Long', name: 'totalBytes' },
+    { class: 'Long', name: 'bytesRead' },
+    { class: 'DateTimeUTC', name: 'startTime' }
+  ]
+});

--- a/src/foam/core/partition/PartitionLoadStatus.js
+++ b/src/foam/core/partition/PartitionLoadStatus.js
@@ -30,6 +30,11 @@ foam.CLASS({
     },
     { class: 'Long', name: 'totalBytes' },
     { class: 'Long', name: 'bytesRead' },
-    { class: 'DateTimeUTC', name: 'startTime' }
+    { class: 'DateTimeUTC', name: 'startTime' },
+    {
+      class: 'Boolean',
+      name: 'queued',
+      documentation: 'True while the row is a placeholder for a partition that will load but whose replay has not started yet.'
+    }
   ]
 });

--- a/src/foam/core/partition/PartitionLoadStatus.js
+++ b/src/foam/core/partition/PartitionLoadStatus.js
@@ -21,7 +21,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'serviceName',
-      documentation: 'CSpec name (or EasyDAO name for dynamic DAOs) clients match against.'
+      documentation: 'CSpec name (or EasyDAO name when no CSpec is bound) clients match against.'
     },
     {
       class: 'String',

--- a/src/foam/core/partition/PartitionLoadToastStack.js
+++ b/src/foam/core/partition/PartitionLoadToastStack.js
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition',
+  name: 'PartitionLoadToastStack',
+  extends: 'foam.u2.View',
+
+  documentation: `Singleton bottom-right stack of partition-load progress
+    cards. DAO decorators watch()/unwatch() service keys; while any key is
+    watched the stack polls partitionLoadStatusDAO every pollInterval ms and
+    renders one card per matching row. Non-blocking by design.
+
+    create() is memoized to a single shared instance manually below instead
+    of via foam.pattern.Singleton: that axiom's installInClass no-ops (only a
+    console.error, no throw) whenever the class carries any foam.lang.Import
+    axiom, own or inherited -- and foam.u2.Element, an ancestor of every
+    View, always declares imports, so no View subclass can ever install it
+    (see foam.pattern.Singleton.hasImports/installInClass). Task 6's decorator
+    depends on every .create() call sharing one watched_ refcount map, so a
+    real memoized create() is required, not the no-op axiom.`,
+
+  requires: [ 'foam.u2.ProgressView' ],
+
+  imports: [ 'partitionLoadStatusDAO?', 'ctrl?' ],
+
+  css: `
+    ^ {
+      position: fixed;
+      bottom: 16px;
+      right: 16px;
+      z-index: 1000;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      max-width: 320px;
+    }
+    ^card {
+      background: $backgroundDefault;
+      border: 1px solid $borderDefault;
+      border-radius: 4px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      padding: 12px;
+    }
+    ^title {
+      color: $textSecondary;
+      margin-bottom: 4px;
+    }
+    ^more {
+      color: $textTertiary;
+      text-align: center;
+    }
+  `,
+
+  constants: [ { name: 'MAX_CARDS', value: 4 } ],
+
+  properties: [
+    {
+      class: 'Map',
+      name: 'watched_',
+      factory: function() { return {}; }
+    },
+    { class: 'Array', name: 'rows_' },
+    { class: 'Boolean', name: 'attached_' },
+    { class: 'Boolean', name: 'polling_' },
+    { class: 'Int', name: 'pollInterval', value: 500 }
+  ],
+
+  methods: [
+    function watch(key) {
+      this.watched_[key] = (this.watched_[key] || 0) + 1;
+      this.poll_();
+    },
+
+    function unwatch(key) {
+      if ( ! this.watched_[key] ) return;
+      this.watched_[key]--;
+      if ( this.watched_[key] <= 0 ) delete this.watched_[key];
+    },
+
+    async function poll_() {
+      if ( this.polling_ ) return;
+      this.polling_ = true;
+      try {
+        while ( Object.keys(this.watched_).length ) {
+          await this.refresh_();
+          await new Promise(r => setTimeout(r, this.pollInterval));
+        }
+      } finally {
+        this.polling_ = false;
+        this.rows_    = [];
+      }
+    },
+
+    async function refresh_() {
+      var keys = Object.keys(this.watched_);
+      if ( ! keys.length || ! this.partitionLoadStatusDAO ) {
+        this.rows_ = [];
+        return;
+      }
+      try {
+        var sink = await this.partitionLoadStatusDAO.select();
+        this.rows_ = sink.array.filter(function(r) { return keys.indexOf(r.serviceName) != -1; });
+      } catch (e) {
+        // Progress channel never surfaces errors; retry next tick.
+      }
+      if ( this.rows_.length && ! this.attached_ && this.ctrl ) {
+        this.attached_ = true;
+        this.ctrl.add(this);
+      }
+    },
+
+    function pct_(row) {
+      return Math.min(99, Math.floor(row.bytesRead * 100 / Math.max(1, row.totalBytes)));
+    },
+
+    function render() {
+      this.SUPER();
+      var self = this;
+      this.addClass().
+        attrs({ 'aria-live': 'polite', role: 'status' }).
+        add(this.dynamic(function(rows_) {
+          if ( ! rows_ || ! rows_.length ) return;
+          this.forEach(rows_.slice(0, self.MAX_CARDS), function(row) {
+            var pct   = self.pct_(row);
+            var label = row.serviceName + ( row.partition ? ' — ' + row.partition : '' );
+            this.start().addClass(self.myClass('card'))
+              .start().addClass('p-sm', self.myClass('title'))
+                .add('Loading ' + label + ' — ' + pct + '%')
+              .end()
+              .start(self.ProgressView, { data: pct }).end()
+            .end();
+          });
+          if ( rows_.length > self.MAX_CARDS ) {
+            this.start().addClass('p-sm', self.myClass('more'))
+              .add('+' + (rows_.length - self.MAX_CARDS) + ' more')
+            .end();
+          }
+        }));
+    }
+  ]
+});
+
+// foam.pattern.Singleton can't be used here -- see documentation above.
+// Memoize create() by hand, using the same cls.private_.instance_ slot
+// Singleton itself would use.
+(function() {
+  var cls  = foam.core.partition.PartitionLoadToastStack;
+  var base = cls.create;
+  cls.create = function(args, X) {
+    return cls.private_.instance_ || ( cls.private_.instance_ = base.call(cls, args, X) );
+  };
+})();

--- a/src/foam/core/partition/PartitionLoadToastStack.js
+++ b/src/foam/core/partition/PartitionLoadToastStack.js
@@ -11,8 +11,8 @@ foam.CLASS({
 
   documentation: `Singleton bottom-right stack of partition-load progress
     cards. DAO decorators watch()/unwatch() service keys; while any key is
-    watched the stack polls partitionLoadStatusDAO every pollInterval ms and
-    renders one card per matching row. Non-blocking by design.
+    watched the stack polls partitionLoadStatusReadDAO every pollInterval ms
+    and renders one card per matching row. Non-blocking by design.
 
     create() is memoized to a single shared instance manually below instead
     of via foam.pattern.Singleton: that axiom's installInClass no-ops (only a
@@ -25,7 +25,7 @@ foam.CLASS({
 
   requires: [ 'foam.u2.ProgressView' ],
 
-  imports: [ 'partitionLoadStatusDAO?', 'ctrl?' ],
+  imports: [ 'partitionLoadStatusReadDAO?', 'ctrl?' ],
 
   css: `
     ^ {
@@ -97,13 +97,15 @@ foam.CLASS({
 
     async function refresh_() {
       var keys = Object.keys(this.watched_);
-      if ( ! keys.length || ! this.partitionLoadStatusDAO ) {
+      if ( ! keys.length || ! this.partitionLoadStatusReadDAO ) {
         this.rows_ = [];
         return;
       }
       try {
-        var sink = await this.partitionLoadStatusDAO.select();
-        this.rows_ = sink.array.filter(function(r) { return keys.indexOf(r.serviceName) != -1; });
+        var sink = await this.partitionLoadStatusReadDAO.select();
+        this.rows_ = sink.array.
+          filter(function(r) { return keys.indexOf(r.serviceName) != -1; }).
+          sort(function(a, b) { return a.startTime - b.startTime; });
       } catch (e) {
         // Progress channel never surfaces errors; retry next tick.
       }
@@ -120,6 +122,15 @@ foam.CLASS({
     function render() {
       this.SUPER();
       var self = this;
+      // The memoized create() (see bottom of file) hands out this same
+      // instance to every caller. If the element is later detached (e.g.
+      // ctrl.add()'d content torn down and rebuilt), invalidate the memo so
+      // the next create() builds a fresh, attachable instance instead of
+      // reusing this dead one.
+      this.onDetach(function() {
+        if ( self.cls_.private_.instance_ === self ) self.cls_.private_.instance_ = undefined;
+        self.attached_ = false;
+      });
       this.addClass().
         attrs({ 'aria-live': 'polite', role: 'status' }).
         add(this.dynamic(function(rows_) {

--- a/src/foam/core/partition/PartitionLoadToastStack.js
+++ b/src/foam/core/partition/PartitionLoadToastStack.js
@@ -9,19 +9,16 @@ foam.CLASS({
   name: 'PartitionLoadToastStack',
   extends: 'foam.u2.View',
 
-  documentation: `Singleton bottom-right stack of partition-load progress
-    cards. DAO decorators watch()/unwatch() service keys; while any key is
-    watched the stack polls partitionLoadStatusReadDAO every pollInterval ms
-    and renders one card per matching row. Non-blocking by design.
+  documentation: `Bottom-right stack of partition-load progress cards. DAO
+    decorators watch()/unwatch() service keys; while any key is watched the
+    stack polls partitionLoadStatusReadDAO every pollInterval ms and renders
+    one card per matching row. Non-blocking by design.
 
-    create() is memoized to a single shared instance manually below instead
-    of via foam.pattern.Singleton: that axiom's installInClass no-ops (only a
-    console.error, no throw) whenever the class carries any foam.lang.Import
-    axiom, own or inherited -- and foam.u2.Element, an ancestor of every
-    View, always declares imports, so no View subclass can ever install it
-    (see foam.pattern.Singleton.hasImports/installInClass). Task 6's decorator
-    depends on every .create() call sharing one watched_ refcount map, so a
-    real memoized create() is required, not the no-op axiom.`,
+    Registered as a client-only CSpec service (partitionLoadToastStack in
+    services.jrl, lazyClient: false) rather than a hand-rolled singleton, so
+    every decorator that imports it resolves the same context-scoped
+    instance and shares one watched_ refcount map. See
+    PartitionLoadProgressDAO's optional 'partitionLoadToastStack?' import.`,
 
   requires: [ 'foam.u2.ProgressView' ],
 
@@ -163,13 +160,11 @@ foam.CLASS({
     function render() {
       this.SUPER();
       var self = this;
-      // The memoized create() (see bottom of file) hands out this same
-      // instance to every caller. If the element is later detached (e.g.
-      // ctrl.add()'d content torn down and rebuilt), invalidate the memo so
-      // the next create() builds a fresh, attachable instance instead of
-      // reusing this dead one.
+      // If the element is later detached (e.g. ctrl.add()'d content torn
+      // down and rebuilt), clear attached_ so refresh_() re-adds it next
+      // time watched rows appear -- the instance itself is unchanged since
+      // it's resolved via context import, not re-created per attach.
       this.onDetach(function() {
-        if ( self.cls_.private_.instance_ === self ) self.cls_.private_.instance_ = undefined;
         self.attached_ = false;
       });
       this.addClass().
@@ -216,14 +211,3 @@ foam.CLASS({
     }
   ]
 });
-
-// foam.pattern.Singleton can't be used here -- see documentation above.
-// Memoize create() by hand, using the same cls.private_.instance_ slot
-// Singleton itself would use.
-(function() {
-  var cls  = foam.core.partition.PartitionLoadToastStack;
-  var base = cls.create;
-  cls.create = function(args, X) {
-    return cls.private_.instance_ || ( cls.private_.instance_ = base.call(cls, args, X) );
-  };
-})();

--- a/src/foam/core/partition/PartitionLoadToastStack.js
+++ b/src/foam/core/partition/PartitionLoadToastStack.js
@@ -49,6 +49,11 @@ foam.CLASS({
       color: $textSecondary;
       margin-bottom: 4px;
     }
+    ^groupHeader {
+      color: $textSecondary;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
     ^more {
       color: $textTertiary;
       text-align: center;
@@ -119,6 +124,42 @@ foam.CLASS({
       return Math.min(99, Math.floor(row.bytesRead * 100 / Math.max(1, row.totalBytes)));
     },
 
+    function serviceGroups_(rows) {
+      // Aggregate ALL watched rows per serviceName (not just the on-screen
+      // cap-4 slice) so "N of M -- overall P%" stays accurate even when
+      // some of that service's cards are hidden by the cap.
+      var groups = {};
+      rows.forEach(function(r) {
+        var g = groups[r.serviceName] || (groups[r.serviceName] = {
+          total: 0, started: 0, bytesRead: 0, totalBytes: 0
+        });
+        g.total++;
+        if ( ! r.queued ) g.started++;
+        g.bytesRead  += r.bytesRead  || 0;
+        g.totalBytes += r.totalBytes || 0;
+      });
+      return groups;
+    },
+
+    function groupedRows_(rows) {
+      // rows is already startTime-sorted; re-bucket so each service's rows
+      // sit contiguously (first-seen order == earliest start), so one
+      // header covers one uninterrupted block of cards instead of
+      // repeating whenever two services' rows interleave by start time.
+      var order     = [];
+      var byService = {};
+      rows.forEach(function(r) {
+        if ( ! byService[r.serviceName] ) {
+          byService[r.serviceName] = [];
+          order.push(r.serviceName);
+        }
+        byService[r.serviceName].push(r);
+      });
+      var out = [];
+      order.forEach(function(name) { out = out.concat(byService[name]); });
+      return out;
+    },
+
     function render() {
       this.SUPER();
       var self = this;
@@ -135,9 +176,30 @@ foam.CLASS({
         attrs({ 'aria-live': 'polite', role: 'status' }).
         add(this.dynamic(function(rows_) {
           if ( ! rows_ || ! rows_.length ) return;
-          this.forEach(rows_.slice(0, self.MAX_CARDS), function(row) {
-            var pct   = self.pct_(row);
+          var groups      = self.serviceGroups_(rows_);
+          var ordered     = self.groupedRows_(rows_).slice(0, self.MAX_CARDS);
+          var lastService = null;
+          this.forEach(ordered, function(row) {
+            var group = groups[row.serviceName];
+            if ( row.serviceName !== lastService ) {
+              lastService = row.serviceName;
+              if ( group.total > 1 ) {
+                var overallPct = Math.min(99, Math.floor(group.bytesRead * 100 / Math.max(1, group.totalBytes)));
+                this.start().addClass('p-sm', self.myClass('groupHeader'))
+                  .add('partition ' + group.started + ' of ' + group.total + ' — overall ' + overallPct + '%')
+                .end();
+              }
+            }
             var label = row.serviceName + ( row.partition ? ' — ' + row.partition : '' );
+            if ( row.queued ) {
+              this.start().addClass(self.myClass('card'))
+                .start().addClass('p-sm', self.myClass('title'))
+                  .add(label + ' — queued')
+                .end()
+              .end();
+              return;
+            }
+            var pct = self.pct_(row);
             this.start().addClass(self.myClass('card'))
               .start().addClass('p-sm', self.myClass('title'))
                 .add('Loading ' + label + ' — ' + pct + '%')

--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -111,7 +111,14 @@ public class PartitionedDAO
       throw new RuntimeException("Failed to create directory " + parent);
     }
 
-    JDAO jdao = new JDAO(getX(), getOf(), journalName);
+    PartitionLoadReporter reporter = new PartitionLoadReporter(getX(), journalName, getServiceName(), rawPart);
+    JDAO jdao;
+    try {
+      reporter.start(journalSize(journalName));
+      jdao = new JDAO(getX().put(PartitionLoadReporter.CTX_KEY, reporter), getOf(), journalName);
+    } finally {
+      reporter.done();
+    }
 
     // When the model's id is a String, assign composite <partition>~<seqNo>
     // ids per partition so find can route by the id prefix (see getPartition_).

--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -59,6 +59,11 @@ public class PartitionedDAO
     }
   }
 
+  public synchronized void unload() {
+    Loggers.logger(getX(), this).info("Unloading all partitions.", getDirName());
+    delegates_.clear();
+  }
+
   public String getID(FObject o) {
     return (String) getIdProperty().f(o);
   }

--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -59,6 +59,10 @@ public class PartitionedDAO
     }
   }
 
+  /** Manual quiesce-then-unload only: an in-flight writer holding an old
+      delegate reference plus a new reader racing getDelegate() to recreate
+      it can briefly double-append to one journal file. Routine/automated
+      eviction needs draining semantics first -- follow-up ticket. */
   public synchronized void unload() {
     Loggers.logger(getX(), this).info("Unloading all partitions.", getDirName());
     delegates_.clear();

--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -68,6 +68,15 @@ public class PartitionedDAO
     delegates_.clear();
   }
 
+  /** Cheap cache peek: true when a live (non-garbage-collected) delegate is
+      already cached for this partition. No creation; same lock as
+      getDelegate() since delegates_ is a plain (non-concurrent) HashMap. */
+  public synchronized boolean isLoaded(String part) {
+    if ( part == null ) part = NO_PART;
+    SoftReference<DAO> ref = delegates_.get(part);
+    return ref != null && ref.get() != null;
+  }
+
   public String getID(FObject o) {
     return (String) getIdProperty().f(o);
   }
@@ -96,18 +105,22 @@ public class PartitionedDAO
     return a[getDepth()-1];
   }
 
-  public DAO createDAO(String part) {
-    Loggers.logger(getX(), this).info("Creating partiion " + part);
-
-    // The '_' escape is for the FILENAME only — the id prefix below keeps the
-    // raw partition value so getPartition_(id) round-trips to the same key
-    // getDelegate() caches on.
-    String rawPart = part;
+  /** Filename-escaped journal name for a raw partition value, exactly as
+      createDAO builds it for the JDAO -- the '_' escape is for the FILENAME
+      only; callers needing the id-prefix / cache key should keep using the
+      raw, unescaped part (see getPartition_'s round-trip). */
+  protected String journalNameFor(String part) {
     if ( part.startsWith("_") || part.equals("") ) {
       part = "_" + part;
     }
+    return getDirName() + part;
+  }
 
-    String journalName = getDirName() + part;
+  public DAO createDAO(String part) {
+    Loggers.logger(getX(), this).info("Creating partiion " + part);
+
+    String rawPart     = part;
+    String journalName = journalNameFor(part);
 
     // TODO: directory creation would be better done by JDAO itself
     // Create the directory in the WRITABLE FileSystemStorage where JDAO writes the

--- a/src/foam/core/partition/pom.js
+++ b/src/foam/core/partition/pom.js
@@ -10,7 +10,8 @@ foam.POM({
     { name: "All",                          flags: "js|java" },
     { name: "AbstractPartitionedDAO",       flags: "java" },
     { name: "PartitionedSequenceNumberDAO", flags: "java" },
-    { name: "PartitionLoadStatus",          flags: "js|java" }
+    { name: "PartitionLoadStatus",          flags: "js|java" },
+    { name: "PartitionLoadProgressDAO",     flags: "js" }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/pom.js
+++ b/src/foam/core/partition/pom.js
@@ -9,7 +9,8 @@ foam.POM({
     { name: "DatePartitioningScheme",       flags: "java" },
     { name: "All",                          flags: "js|java" },
     { name: "AbstractPartitionedDAO",       flags: "java" },
-    { name: "PartitionedSequenceNumberDAO", flags: "java" }
+    { name: "PartitionedSequenceNumberDAO", flags: "java" },
+    { name: "PartitionLoadStatus",          flags: "js|java" }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/pom.js
+++ b/src/foam/core/partition/pom.js
@@ -11,7 +11,8 @@ foam.POM({
     { name: "AbstractPartitionedDAO",       flags: "java" },
     { name: "PartitionedSequenceNumberDAO", flags: "java" },
     { name: "PartitionLoadStatus",          flags: "js|java" },
-    { name: "PartitionLoadProgressDAO",     flags: "js" }
+    { name: "PartitionLoadProgressDAO",     flags: "js" },
+    { name: "PartitionLoadToastStack",      flags: "js" }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/pom.js
+++ b/src/foam/core/partition/pom.js
@@ -19,5 +19,6 @@ foam.POM({
     { name: "ReferenceMigrator" },
     { name: "SingleToPartitionMigrator" },
     { name: "NotPartitionedDAO" },
+    { name: "PartitionLoadReporter" },
   ]
 });

--- a/src/foam/core/partition/services.jrl
+++ b/src/foam/core/partition/services.jrl
@@ -62,6 +62,7 @@ p({
       "serviceName": "service/partitionLoadStatusReadDAO",
       "daoType": "CLIENT",
       "cache": false,
+      "loadProgress": false,
       "of": "foam.core.partition.PartitionLoadStatus"
     }
   """

--- a/src/foam/core/partition/services.jrl
+++ b/src/foam/core/partition/services.jrl
@@ -30,3 +30,27 @@ p({
     }
   """
 })
+p({
+  "class": "foam.core.boot.CSpec",
+  "name": "partitionLoadStatusDAO",
+  "description": "In-progress partition load status (ephemeral).",
+  "serve": true,
+  "authenticate": true,
+  "keywords": [ "partition" ],
+  "serviceScript": """
+    return new foam.dao.EasyDAO.Builder(x)
+      .setAuthorize(false)
+      .setJournalType(foam.dao.JournalType.NO_JOURNAL)
+      .setOf(foam.core.partition.PartitionLoadStatus.getOwnClassInfo())
+      .build();
+  """,
+  "client": """
+    {
+      "class": "foam.dao.EasyDAO",
+      "serviceName": "service/partitionLoadStatusDAO",
+      "daoType": "CLIENT",
+      "cache": false,
+      "of": "foam.core.partition.PartitionLoadStatus"
+    }
+  """
+})

--- a/src/foam/core/partition/services.jrl
+++ b/src/foam/core/partition/services.jrl
@@ -62,6 +62,7 @@ p({
       "serviceName": "service/partitionLoadStatusReadDAO",
       "daoType": "CLIENT",
       "cache": false,
+      "retryBoxMaxAttempts": 0,
       "loadProgress": false,
       "of": "foam.core.partition.PartitionLoadStatus"
     }

--- a/src/foam/core/partition/services.jrl
+++ b/src/foam/core/partition/services.jrl
@@ -33,8 +33,7 @@ p({
 p({
   "class": "foam.core.boot.CSpec",
   "name": "partitionLoadStatusDAO",
-  "description": "In-progress partition load status (ephemeral).",
-  "serve": true,
+  "description": "In-progress partition load status (ephemeral), server-writable. Not served -- PartitionLoadReporter is the only writer. Remote clients read via partitionLoadStatusReadDAO.",
   "authenticate": true,
   "keywords": [ "partition" ],
   "serviceScript": """
@@ -43,11 +42,24 @@ p({
       .setJournalType(foam.dao.JournalType.NO_JOURNAL)
       .setOf(foam.core.partition.PartitionLoadStatus.getOwnClassInfo())
       .build();
+  """
+})
+p({
+  "class": "foam.core.boot.CSpec",
+  "name": "partitionLoadStatusReadDAO",
+  "description": "Read-only client view of in-progress partition load status. Wraps partitionLoadStatusDAO in ReadOnlyDAO so remote clients can select/find but put/remove/cmd are rejected server-side.",
+  "serve": true,
+  "authenticate": true,
+  "keywords": [ "partition" ],
+  "serviceScript": """
+    return new foam.dao.ReadOnlyDAO.Builder(x)
+      .setDelegate((foam.dao.DAO) x.get("partitionLoadStatusDAO"))
+      .build();
   """,
   "client": """
     {
       "class": "foam.dao.EasyDAO",
-      "serviceName": "service/partitionLoadStatusDAO",
+      "serviceName": "service/partitionLoadStatusReadDAO",
       "daoType": "CLIENT",
       "cache": false,
       "of": "foam.core.partition.PartitionLoadStatus"

--- a/src/foam/core/partition/services.jrl
+++ b/src/foam/core/partition/services.jrl
@@ -67,3 +67,13 @@ p({
     }
   """
 })
+p({
+  "class": "foam.core.boot.CSpec",
+  "name": "partitionLoadToastStack",
+  "lazyClient": false,
+  "client": """
+    {
+      "class": "foam.core.partition.PartitionLoadToastStack"
+    }
+  """
+})

--- a/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
+++ b/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'PartitionLoadProgressDAOTest',
+  extends: 'foam.core.test.JSTest',
+
+  requires: [
+    'foam.core.partition.PartitionLoadProgressDAO',
+    'foam.core.partition.PartitionLoadStatus',
+    'foam.core.partition.PartitionLoadToastStack',
+    'foam.dao.MDAO',
+    'foam.dao.PromisedDAO'
+  ],
+
+  methods: [
+    async function runTest(x) {
+      try {
+        // Status DAO with one active row for service key 'svcA'.
+        var statusDAO = this.MDAO.create({ of: this.PartitionLoadStatus });
+        await statusDAO.put(this.PartitionLoadStatus.create({
+          id: 'jrnA', serviceName: 'svcA', partition: '2026/7',
+          totalBytes: 1000, bytesRead: 400
+        }));
+
+        var subX = x.createSubContext({ partitionLoadStatusDAO: statusDAO });
+
+        // PartitionLoadToastStack.create() is memoized process-wide (manual
+        // singleton, not context-scoped -- see the documentation on
+        // PartitionLoadToastStack.js), so whichever instance already exists
+        // must be configured directly rather than via context injection.
+        var stack = this.PartitionLoadToastStack.create(null, subX);
+        x.test(this.PartitionLoadToastStack.create() === stack,
+            'toast stack is a process-wide singleton');
+        stack.partitionLoadStatusDAO = statusDAO;
+        stack.pollInterval = 100;
+
+        // Delegate that resolves after 700ms -- slower than showDelay 400ms,
+        // with enough margin past the 400/500/600ms checkpoints below that
+        // the settle-triggered unwatch can't race them.
+        var slow = this.PromisedDAO.create({
+          promise: new Promise(function(resolve) {
+            setTimeout(function() {
+              resolve(foam.dao.MDAO.create({ of: foam.core.partition.PartitionLoadStatus }, subX));
+            }, 700);
+          })
+        }, subX);
+
+        var dao = this.PartitionLoadProgressDAO.create({
+          delegate: slow, serviceKey: 'svcA', showDelay: 400
+        }, subX);
+
+        var p = dao.select();
+
+        await new Promise(function(r) { setTimeout(r, 450); });
+        x.test(Object.keys(stack.watched_).length === 1,
+            'stack watching svcA while op pending past showDelay');
+
+        await new Promise(function(r) { setTimeout(r, 100); });
+        x.test(stack.rows_.length === 1, 'active status row surfaced as a card row');
+
+        // Fast op mid-flight (slow op still pending until 700ms): must never
+        // watch, and must not disturb the slow op's existing watch refcount.
+        var fast = this.PartitionLoadProgressDAO.create({
+          delegate: this.MDAO.create({ of: this.PartitionLoadStatus }, subX),
+          serviceKey: 'svcA', showDelay: 400
+        }, subX);
+        await fast.select();
+
+        await new Promise(function(r) { setTimeout(r, 100); });
+        x.test(Object.keys(stack.watched_).length === 1,
+            'fast op never triggers watch; slow op refcount undisturbed');
+        x.test(stack.rows_.length === 1, 'slow op card still rendered after fast op settles');
+
+        await p;
+        x.test(Object.keys(stack.watched_).length === 0, 'unwatched after slow op settles');
+      } catch (e) {
+        x.test(false, 'unexpected exception: ' + (e && e.message ? e.message : e));
+      }
+    }
+  ]
+});

--- a/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
+++ b/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
@@ -31,22 +31,24 @@ foam.CLASS({
 
         // PartitionLoadToastStack.create() is memoized process-wide (manual
         // singleton, not context-scoped -- see the documentation on
-        // PartitionLoadToastStack.js), so whichever instance already exists
-        // must be configured directly rather than via context injection.
+        // PartitionLoadToastStack.js). create(null, subX) resolves the
+        // partitionLoadStatusDAO import from subX on whichever instance
+        // already exists; the import is a ConstantSlot from createSubContext
+        // so it must not be assigned to directly (throws "Tried to mutate
+        // immutable ConstantSlot").
         var stack = this.PartitionLoadToastStack.create(null, subX);
         x.test(this.PartitionLoadToastStack.create() === stack,
             'toast stack is a process-wide singleton');
-        stack.partitionLoadStatusDAO = statusDAO;
         stack.pollInterval = 100;
 
-        // Delegate that resolves after 700ms -- slower than showDelay 400ms,
-        // with enough margin past the 400/500/600ms checkpoints below that
+        // Delegate that resolves after 750ms -- slower than showDelay 400ms,
+        // with enough margin past the 500/600/700ms checkpoints below that
         // the settle-triggered unwatch can't race them.
         var slow = this.PromisedDAO.create({
           promise: new Promise(function(resolve) {
             setTimeout(function() {
               resolve(foam.dao.MDAO.create({ of: foam.core.partition.PartitionLoadStatus }, subX));
-            }, 700);
+            }, 750);
           })
         }, subX);
 
@@ -56,14 +58,14 @@ foam.CLASS({
 
         var p = dao.select();
 
-        await new Promise(function(r) { setTimeout(r, 450); });
+        await new Promise(function(r) { setTimeout(r, 500); });
         x.test(Object.keys(stack.watched_).length === 1,
             'stack watching svcA while op pending past showDelay');
 
         await new Promise(function(r) { setTimeout(r, 100); });
         x.test(stack.rows_.length === 1, 'active status row surfaced as a card row');
 
-        // Fast op mid-flight (slow op still pending until 700ms): must never
+        // Fast op mid-flight (slow op still pending until 750ms): must never
         // watch, and must not disturb the slow op's existing watch refcount.
         var fast = this.PartitionLoadProgressDAO.create({
           delegate: this.MDAO.create({ of: this.PartitionLoadStatus }, subX),
@@ -80,6 +82,10 @@ foam.CLASS({
         x.test(Object.keys(stack.watched_).length === 0, 'unwatched after slow op settles');
       } catch (e) {
         x.test(false, 'unexpected exception: ' + (e && e.message ? e.message : e));
+      } finally {
+        // Undo the process-wide memoization so a later test gets a fresh
+        // stack instead of this one's pollInterval/DAO configuration.
+        this.PartitionLoadToastStack.private_.instance_ = undefined;
       }
     }
   ]

--- a/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
+++ b/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
@@ -29,17 +29,14 @@ foam.CLASS({
 
         var subX = x.createSubContext({ partitionLoadStatusReadDAO: statusDAO });
 
-        // PartitionLoadToastStack.create() is memoized process-wide (manual
-        // singleton, not context-scoped -- see the documentation on
-        // PartitionLoadToastStack.js). create(null, subX) resolves the
-        // partitionLoadStatusReadDAO import from subX on whichever instance
-        // already exists; the import is a ConstantSlot from createSubContext
-        // so it must not be assigned to directly (throws "Tried to mutate
-        // immutable ConstantSlot").
+        // partitionLoadToastStack is a context-scoped service (services.jrl,
+        // lazyClient: false), not a process-wide singleton -- build one
+        // instance and place it in the sub-context so every decorator
+        // created in that context imports the same instance, mirroring how
+        // the real app resolves it via CSpec + imports.
         var stack = this.PartitionLoadToastStack.create(null, subX);
-        x.test(this.PartitionLoadToastStack.create() === stack,
-            'toast stack is a process-wide singleton');
         stack.pollInterval = 100;
+        subX = subX.createSubContext({ partitionLoadToastStack: stack });
 
         // Delegate that resolves after 750ms -- slower than showDelay 400ms,
         // with enough margin past the 500/600/700ms checkpoints below that
@@ -71,6 +68,8 @@ foam.CLASS({
           delegate: this.MDAO.create({ of: this.PartitionLoadStatus }, subX),
           serviceKey: 'svcA', showDelay: 400
         }, subX);
+        x.test(dao.partitionLoadToastStack === fast.partitionLoadToastStack,
+            'both decorators reach the same context instance');
         await fast.select();
 
         await new Promise(function(r) { setTimeout(r, 100); });
@@ -82,10 +81,6 @@ foam.CLASS({
         x.test(Object.keys(stack.watched_).length === 0, 'unwatched after slow op settles');
       } catch (e) {
         x.test(false, 'unexpected exception: ' + (e && e.message ? e.message : e));
-      } finally {
-        // Undo the process-wide memoization so a later test gets a fresh
-        // stack instead of this one's pollInterval/DAO configuration.
-        this.PartitionLoadToastStack.private_.instance_ = undefined;
       }
     }
   ]

--- a/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
+++ b/src/foam/core/partition/test/PartitionLoadProgressDAOTest.js
@@ -27,12 +27,12 @@ foam.CLASS({
           totalBytes: 1000, bytesRead: 400
         }));
 
-        var subX = x.createSubContext({ partitionLoadStatusDAO: statusDAO });
+        var subX = x.createSubContext({ partitionLoadStatusReadDAO: statusDAO });
 
         // PartitionLoadToastStack.create() is memoized process-wide (manual
         // singleton, not context-scoped -- see the documentation on
         // PartitionLoadToastStack.js). create(null, subX) resolves the
-        // partitionLoadStatusDAO import from subX on whichever instance
+        // partitionLoadStatusReadDAO import from subX on whichever instance
         // already exists; the import is a ConstantSlot from createSubContext
         // so it must not be assigned to directly (throws "Tried to mutate
         // immutable ConstantSlot").

--- a/src/foam/core/partition/test/PartitionLoadReplayTest.js
+++ b/src/foam/core/partition/test/PartitionLoadReplayTest.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'PartitionLoadReplayTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'Proves F3FileJournal replay feeds a PartitionLoadReporter placed in X (foam.dao.F3FileJournal.js replay loop), and that replay is unaffected when no reporter is present.',
+
+  javaImports: [
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.partition.PartitionLoadReporter',
+    'foam.core.partition.PartitionLoadStatus',
+    'foam.core.partition.test.PartitionStrRecord',
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.dao.java.JDAO',
+    'foam.lang.X',
+    'java.io.File'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        X tx = newStorageContext(x);
+        String jrn = "partitionLoadReplayTest_" + System.currentTimeMillis();
+
+        // Write a journal with enough rows to make accumulation observable
+        JDAO writer = new JDAO(tx, PartitionStrRecord.getOwnClassInfo(), jrn);
+        for ( int i = 0 ; i < 500 ; i++ ) {
+          PartitionStrRecord rec = new PartitionStrRecord();
+          rec.setId("r" + i);
+          writer.put(rec);
+        }
+
+        // Re-replay with a reporter in X
+        DAO status = new MDAO(PartitionLoadStatus.getOwnClassInfo());
+        X testX = tx.put("partitionLoadStatusDAO", status);
+        PartitionLoadReporter reporter = new PartitionLoadReporter(testX, jrn, "svc", "");
+        reporter.start(0L);
+        new JDAO(testX.put(PartitionLoadReporter.CTX_KEY, reporter), PartitionStrRecord.getOwnClassInfo(), jrn);
+
+        test(reporter.getBytesRead() > 0, "replay accumulated chars into reporter (got " + reporter.getBytesRead() + ")");
+
+        // No reporter in X: replay still works, nothing accumulates anywhere
+        JDAO plain = new JDAO(tx, PartitionStrRecord.getOwnClassInfo(), jrn);
+        test(plain.find("r0") != null, "replay without reporter unchanged");
+      `
+    },
+    {
+      name: 'newStorageContext',
+      args: 'X x',
+      type: 'X',
+      documentation: 'Sub-context with a temp-dir FileSystemStorage so journals are isolated from the real runtime journals dir.',
+      javaCode: `
+        String dir = System.getProperty("java.io.tmpdir") + File.separator
+          + "prlreplay_" + System.nanoTime();
+        new File(dir).mkdirs();
+        FileSystemStorage fs = new FileSystemStorage(dir);
+        return x.put(Storage.class, fs).put(FileSystemStorage.class, fs);
+      `
+    }
+  ]
+});

--- a/src/foam/core/partition/test/PartitionLoadReporterTest.js
+++ b/src/foam/core/partition/test/PartitionLoadReporterTest.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'PartitionLoadReporterTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'Tests PartitionLoadReporter directly: start() puts a row, addChars() throttles then accumulates, done() removes the row and is idempotent.',
+
+  javaImports: [
+    'foam.core.partition.PartitionLoadReporter',
+    'foam.core.partition.PartitionLoadStatus',
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.lang.X'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        DAO status = new MDAO(PartitionLoadStatus.getOwnClassInfo());
+        X testX = x.put("partitionLoadStatusDAO", status);
+
+        PartitionLoadReporter r = new PartitionLoadReporter(testX, "jrn/1", "myDAO", "2026/7");
+
+        r.start(1000L);
+        PartitionLoadStatus row = (PartitionLoadStatus) status.find("jrn/1");
+        test(row != null, "start() puts a status row");
+        test(row != null && row.getTotalBytes() == 1000L, "row carries totalBytes");
+        test(row != null && "myDAO".equals(row.getServiceName()), "row carries serviceName");
+        test(row != null && "2026/7".equals(row.getPartition()), "row carries partition");
+
+        r.addChars(100);
+        row = (PartitionLoadStatus) status.find("jrn/1");
+        test(row.getBytesRead() < 100L + 1, "immediate addChars throttled (row not yet updated past start)");
+
+        try { Thread.sleep(300); } catch ( InterruptedException e ) {}
+        r.addChars(50);
+        row = (PartitionLoadStatus) status.find("jrn/1");
+        test(row.getBytesRead() == 150L, "post-throttle addChars updates row with accumulated total");
+        test(r.getBytesRead() == 150L, "getBytesRead reflects accumulation");
+
+        r.done();
+        test(status.find("jrn/1") == null, "done() removes the row");
+        r.done();
+        test(status.find("jrn/1") == null, "done() is idempotent");
+      `
+    }
+  ]
+});

--- a/src/foam/core/partition/test/PartitionLoadReporterTest.js
+++ b/src/foam/core/partition/test/PartitionLoadReporterTest.js
@@ -37,7 +37,7 @@ foam.CLASS({
 
         r.addChars(100);
         row = (PartitionLoadStatus) status.find("jrn/1");
-        test(row.getBytesRead() < 100L + 1, "immediate addChars throttled (row not yet updated past start)");
+        test(row.getBytesRead() == 0L, "immediate addChars throttled (row still at start value)");
 
         try { Thread.sleep(300); } catch ( InterruptedException e ) {}
         r.addChars(50);

--- a/src/foam/core/partition/test/PartitionLoadStatusIntegrationTest.js
+++ b/src/foam/core/partition/test/PartitionLoadStatusIntegrationTest.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'PartitionLoadStatusIntegrationTest',
   extends: 'foam.core.test.Test',
 
-  documentation: 'End-to-end createDAO path with a listener capturing row lifecycle: PartitionedDAO publishes/removes a status row per partition it creates, and NotPartitionedDAO does the same across an explicit unload + reload (PartitionedDAO.unload() is a NOP inherited from AbstractPartitionedDAO; NotPartitionedDAO is the createDAO path that actually implements unload).',
+  documentation: 'End-to-end createDAO path with a listener capturing row lifecycle: PartitionedDAO and NotPartitionedDAO each publish/remove a status row per partition/journal they create, and republish across an explicit UNLOAD_CMD + reload.',
 
   javaImports: [
     'foam.core.fs.FileSystemStorage',
@@ -71,9 +71,18 @@ foam.CLASS({
         test(sawService, "status rows carry the DAO serviceName");
         test(pdao.find("5~a1") != null, "record intact after seeding");
 
-        // NotPartitionedDAO.createDAO runs the same reporter wrap; its unload()
-        // is a real implementation (unlike PartitionedDAO's inherited NOP), so
-        // it is the path that exercises an unload + reload cycle.
+        // Unload evicts all cached partitions; the next find() recreates the
+        // partition's DAO from its journal, publishing a status row again.
+        Object cmdResult = pdao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+        test(Boolean.TRUE.equals(cmdResult), "UNLOAD_CMD returns true");
+
+        int putsBeforeReload = puts.size();
+        test(pdao.find("5~a1") != null, "record intact after unload + reload");
+        test(puts.size() > putsBeforeReload, "reload after UNLOAD_CMD published status rows again");
+
+        // NotPartitionedDAO.createDAO runs the same reporter wrap over the
+        // other createDAO path Task 4 wired; exercise its own unload + reload too.
+        int putsAfterReload = puts.size();
         String npJournal = "partitionLoadIntegTest_np_" + System.currentTimeMillis();
         NotPartitionedDAO npdao = new NotPartitionedDAO(testX, PartitionStrRecord.getOwnClassInfo(), npJournal);
         npdao.setServiceName("integSvcNP");
@@ -83,14 +92,14 @@ foam.CLASS({
         npdao.put(c);
 
         int putsAfterNP = puts.size();
-        test(putsAfterNP > putsAfterSeed, "NotPartitionedDAO creation also published a status row");
+        test(putsAfterNP > putsAfterReload, "NotPartitionedDAO creation also published a status row");
         boolean sawNPService = false;
         for ( PartitionLoadStatus s : puts ) if ( "integSvcNP".equals(s.getServiceName()) ) sawNPService = true;
         test(sawNPService, "NotPartitionedDAO status row carries its own serviceName");
 
         npdao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
-        test(npdao.find("c1") != null, "record intact after unload + reload");
-        test(puts.size() > putsAfterNP, "reload after UNLOAD_CMD published status rows again");
+        test(npdao.find("c1") != null, "NotPartitionedDAO record intact after unload + reload");
+        test(puts.size() > putsAfterNP, "NotPartitionedDAO reload after UNLOAD_CMD published status rows again");
 
         ArraySink remaining = (ArraySink) status.select(new ArraySink());
         test(remaining.getArray().size() == 0, "no rows left after loads complete");

--- a/src/foam/core/partition/test/PartitionLoadStatusIntegrationTest.js
+++ b/src/foam/core/partition/test/PartitionLoadStatusIntegrationTest.js
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'PartitionLoadStatusIntegrationTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'End-to-end createDAO path with a listener capturing row lifecycle: PartitionedDAO publishes/removes a status row per partition it creates, and NotPartitionedDAO does the same across an explicit unload + reload (PartitionedDAO.unload() is a NOP inherited from AbstractPartitionedDAO; NotPartitionedDAO is the createDAO path that actually implements unload).',
+
+  javaImports: [
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.partition.AbstractPartitionedDAO',
+    'foam.core.partition.NotPartitionedDAO',
+    'foam.core.partition.PartitionedDAO',
+    'foam.core.partition.PartitionLoadStatus',
+    'foam.core.partition.test.PartitionStrRecord',
+    'foam.dao.AbstractSink',
+    'foam.dao.ArraySink',
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.lang.Detachable',
+    'foam.lang.FObject',
+    'foam.lang.X',
+    'java.io.File',
+    'java.util.ArrayList',
+    'java.util.List'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        final List<PartitionLoadStatus> puts    = new ArrayList<>();
+        final List<Object>              removes = new ArrayList<>();
+
+        DAO status = new MDAO(PartitionLoadStatus.getOwnClassInfo());
+        status.listen(new AbstractSink() {
+          public void put(Object obj, Detachable sub)    { puts.add((PartitionLoadStatus) ((FObject) obj).fclone()); }
+          public void remove(Object obj, Detachable sub) { removes.add(obj); }
+        }, null);
+
+        X tx    = newStorageContext(x);
+        X testX = tx.put("partitionLoadStatusDAO", status);
+
+        String dir = "partitionLoadIntegTest_" + System.currentTimeMillis() + "/";
+        PartitionedDAO pdao = new PartitionedDAO(
+          testX,
+          PartitionStrRecord.getOwnClassInfo(),
+          dir,
+          PartitionStrRecord.BUCKET);
+        pdao.setServiceName("integSvc");
+
+        // Seed two partitions (creates them: first load reports on empty/absent journals too)
+        PartitionStrRecord a = new PartitionStrRecord();
+        a.setId("a1"); a.setBucket(5);
+        pdao.put(a);
+        PartitionStrRecord b = new PartitionStrRecord();
+        b.setId("b1"); b.setBucket(9);
+        pdao.put(b);
+
+        int putsAfterSeed = puts.size();
+        test(putsAfterSeed >= 2, "each partition creation published at least one status row");
+        test(removes.size() >= 2, "each load removed its row");
+        boolean sawService = false;
+        for ( PartitionLoadStatus s : puts ) if ( "integSvc".equals(s.getServiceName()) ) sawService = true;
+        test(sawService, "status rows carry the DAO serviceName");
+        test(pdao.find("5~a1") != null, "record intact after seeding");
+
+        // NotPartitionedDAO.createDAO runs the same reporter wrap; its unload()
+        // is a real implementation (unlike PartitionedDAO's inherited NOP), so
+        // it is the path that exercises an unload + reload cycle.
+        String npJournal = "partitionLoadIntegTest_np_" + System.currentTimeMillis();
+        NotPartitionedDAO npdao = new NotPartitionedDAO(testX, PartitionStrRecord.getOwnClassInfo(), npJournal);
+        npdao.setServiceName("integSvcNP");
+
+        PartitionStrRecord c = new PartitionStrRecord();
+        c.setId("c1");
+        npdao.put(c);
+
+        int putsAfterNP = puts.size();
+        test(putsAfterNP > putsAfterSeed, "NotPartitionedDAO creation also published a status row");
+        boolean sawNPService = false;
+        for ( PartitionLoadStatus s : puts ) if ( "integSvcNP".equals(s.getServiceName()) ) sawNPService = true;
+        test(sawNPService, "NotPartitionedDAO status row carries its own serviceName");
+
+        npdao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+        test(npdao.find("c1") != null, "record intact after unload + reload");
+        test(puts.size() > putsAfterNP, "reload after UNLOAD_CMD published status rows again");
+
+        ArraySink remaining = (ArraySink) status.select(new ArraySink());
+        test(remaining.getArray().size() == 0, "no rows left after loads complete");
+      `
+    },
+    {
+      name: 'newStorageContext',
+      args: 'X x',
+      type: 'X',
+      documentation: 'Sub-context with a temp-dir FileSystemStorage so journals are isolated from the real runtime journals dir.',
+      javaCode: `
+        String dir = System.getProperty("java.io.tmpdir") + File.separator
+          + "prlinteg_" + System.nanoTime();
+        new File(dir).mkdirs();
+        FileSystemStorage fs = new FileSystemStorage(dir);
+        return x.put(Storage.class, fs).put(FileSystemStorage.class, fs);
+      `
+    }
+  ]
+});

--- a/src/foam/core/partition/test/PartitionLoadStatusIntegrationTest.js
+++ b/src/foam/core/partition/test/PartitionLoadStatusIntegrationTest.js
@@ -9,12 +9,13 @@ foam.CLASS({
   name: 'PartitionLoadStatusIntegrationTest',
   extends: 'foam.core.test.Test',
 
-  documentation: 'End-to-end createDAO path with a listener capturing row lifecycle: PartitionedDAO and NotPartitionedDAO each publish/remove a status row per partition/journal they create, and republish across an explicit UNLOAD_CMD + reload.',
+  documentation: 'End-to-end createDAO path with a listener capturing row lifecycle: PartitionedDAO and NotPartitionedDAO each publish/remove a status row per partition/journal they create, and republish across an explicit UNLOAD_CMD + reload. Also covers DatePartitionedDAO.select_: a range select over previously-unloaded partitions publishes a queued row per partition before its delegate loads, each queued row is overwritten (not duplicated) once its load starts, all are gone once the select completes, and a repeat select over now-warm partitions publishes nothing.',
 
   javaImports: [
     'foam.core.fs.FileSystemStorage',
     'foam.core.fs.Storage',
     'foam.core.partition.AbstractPartitionedDAO',
+    'foam.core.partition.DatePartitionedDAO',
     'foam.core.partition.NotPartitionedDAO',
     'foam.core.partition.PartitionedDAO',
     'foam.core.partition.PartitionLoadStatus',
@@ -26,9 +27,17 @@ foam.CLASS({
     'foam.lang.Detachable',
     'foam.lang.FObject',
     'foam.lang.X',
+    'foam.mlang.predicate.Predicate',
     'java.io.File',
     'java.util.ArrayList',
-    'java.util.List'
+    'java.util.Calendar',
+    'java.util.Date',
+    'java.util.HashSet',
+    'java.util.List',
+    'java.util.Set',
+    'static foam.mlang.MLang.AND',
+    'static foam.mlang.MLang.GTE',
+    'static foam.mlang.MLang.LTE'
   ],
 
   methods: [
@@ -100,6 +109,74 @@ foam.CLASS({
         npdao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
         test(npdao.find("c1") != null, "NotPartitionedDAO record intact after unload + reload");
         test(puts.size() > putsAfterNP, "NotPartitionedDAO reload after UNLOAD_CMD published status rows again");
+
+        // DatePartitionedDAO.select_: a range select over 3 unloaded partitions
+        // should publish a queued row per partition ahead of the delegate loop,
+        // each overwritten (not duplicated) once its own load starts, and none
+        // left once the select completes. A repeat select over the now-warm
+        // partitions should publish nothing new.
+        String dateDir = "partitionLoadIntegTest_date_" + System.currentTimeMillis() + "/";
+        DatePartitionedDAO ddao = new DatePartitionedDAO(
+          testX,
+          PartitionStrRecord.getOwnClassInfo(),
+          dateDir,
+          PartitionStrRecord.DATE);
+        ddao.setServiceName("dateSvc");
+
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(2026, Calendar.JANUARY, 15);
+        Date jan = cal.getTime();
+        cal.clear();
+        cal.set(2026, Calendar.FEBRUARY, 15);
+        Date feb = cal.getTime();
+        cal.clear();
+        cal.set(2026, Calendar.MARCH, 15);
+        Date mar = cal.getTime();
+
+        PartitionStrRecord rj = new PartitionStrRecord();
+        rj.setId("dj"); rj.setDate(jan);
+        ddao.put(rj);
+        PartitionStrRecord rf = new PartitionStrRecord();
+        rf.setId("df"); rf.setDate(feb);
+        ddao.put(rf);
+        PartitionStrRecord rm = new PartitionStrRecord();
+        rm.setId("dm"); rm.setDate(mar);
+        ddao.put(rm);
+
+        // Evict the cache: without this isLoaded() is already true for all
+        // three partitions and select_ would never publish a queued row.
+        ddao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+
+        Predicate rangePred = AND(GTE(PartitionStrRecord.DATE, jan), LTE(PartitionStrRecord.DATE, mar));
+
+        int putsBeforeDateSelect    = puts.size();
+        int removesBeforeDateSelect = removes.size();
+        ddao.where(rangePred).select(new ArraySink());
+
+        Set<String> dateIds            = new HashSet<>();
+        boolean     sawQueued          = false;
+        boolean     sawActiveOverwrite = false;
+        for ( int i = putsBeforeDateSelect ; i < puts.size() ; i++ ) {
+          PartitionLoadStatus s = puts.get(i);
+          if ( ! "dateSvc".equals(s.getServiceName()) ) continue;
+          dateIds.add(s.getId());
+          if ( s.getQueued() ) {
+            sawQueued = true;
+            test(s.getTotalBytes() >= 0, "queued row carries a non-negative totalBytes");
+          } else {
+            sawActiveOverwrite = true;
+          }
+        }
+        test(sawQueued, "select_ published at least one queued row ahead of the delegate loop");
+        test(sawActiveOverwrite, "a queued row was overwritten by an active (non-queued) put once its load started");
+        test(dateIds.size() == 3, "queued-row publish touched exactly the 3 seeded partitions (got " + dateIds.size() + ")");
+        test(removes.size() > removesBeforeDateSelect, "each loaded partition removed its row on completion");
+
+        // Warm partitions: repeating the same select must publish nothing new.
+        int putsBeforeWarmSelect = puts.size();
+        ddao.where(rangePred).select(new ArraySink());
+        test(puts.size() == putsBeforeWarmSelect, "warm-partition select published no new status rows");
 
         ArraySink remaining = (ArraySink) status.select(new ArraySink());
         test(remaining.getArray().size() == 0, "no rows left after loads complete");

--- a/src/foam/core/partition/test/PartitionStrRecord.js
+++ b/src/foam/core/partition/test/PartitionStrRecord.js
@@ -7,11 +7,12 @@
 foam.CLASS({
   package: 'foam.core.partition.test',
   name: 'PartitionStrRecord',
-  documentation: 'Composite-string-id test model: id is <partition>-<seqNo>. Partitioned by `bucket` (single-level tests) or by `region` then `bucket` (multi-level tests).',
+  documentation: 'Composite-string-id test model: id is <partition>-<seqNo>. Partitioned by `bucket` (single-level tests), by `region` then `bucket` (multi-level tests), or by `date` (DatePartitionedDAO tests).',
   properties: [
-    { class: 'String', name: 'id' },
-    { class: 'Int',    name: 'region' },
-    { class: 'Int',    name: 'bucket' },
-    { class: 'String', name: 'data' }
+    { class: 'String',      name: 'id' },
+    { class: 'Int',         name: 'region' },
+    { class: 'Int',         name: 'bucket' },
+    { class: 'DateTimeUTC', name: 'date' },
+    { class: 'String',      name: 'data' }
   ]
 });

--- a/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
+++ b/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'UnloadableDecoratedDAOTest',
   extends: 'foam.core.test.Test',
 
-  documentation: 'A SINGLE_JOURNAL EasyDAO with both setUnloadable(true) and a decorator set must still get the NotPartitionedDAO wrapper (regression for the getDecorator() == null exclusion), and the decorator plus seqNo stamping must survive an unload/reload cycle.',
+  documentation: 'A SINGLE_JOURNAL EasyDAO with both setUnloadable(true) and a decorator set must still get the NotPartitionedDAO wrapper (regression for the getDecorator() == null exclusion), and the decorator plus seqNo stamping must survive an unload/reload cycle. Also covers a dedup EasyDAO: it must now get the wrapper too, and its DeDupDAO must still be live in the rebuilt chain after reload, with getMdao() tracking the reloaded store.',
 
   javaImports: [
     'foam.core.fs.FileSystemStorage',
@@ -76,6 +76,40 @@ foam.CLASS({
         long id4 = ((Long) UnloadableDecoratedRecord.ID.get(p4)).longValue();
         test( id4 == id3 + 1,
           "seqNo continues after reload, got " + id4 + " expected " + (id3 + 1) );
+
+        // A dedup EasyDAO used to be excluded from the unloadable branch entirely
+        // (getUnloadable() && !getDedup()), so it never got the NotPartitionedDAO
+        // wrapper at all. It now rebuilds its inner chain (mdao + DeDupDAO + JDAO)
+        // from scratch via EasyDAO#createJournalledDelegate() on every reload, so
+        // dedup must still work after an unload/reload cycle.
+        String dedupJournalName = "unloadableDedup_" + System.nanoTime();
+        DAO dedupDao = new EasyDAO.Builder(tx)
+          .setAuthorize(false)
+          .setOf(UnloadableDecoratedRecord.getOwnClassInfo())
+          .setJournalType(JournalType.SINGLE_JOURNAL)
+          .setJournalName(dedupJournalName)
+          .setUnloadable(true)
+          .setDedup(true)
+          .build();
+        EasyDAO dedupEasyDao = (EasyDAO) dedupDao;
+
+        UnloadableDecoratedRecord dr = new UnloadableDecoratedRecord();
+        dr.setId(1);
+        dr.setData(new String("dedup-data"));
+        FObject putDr = dedupDao.put(dr);
+        test( UnloadableDecoratedRecord.DATA.get(putDr) == "dedup-data",
+          "dedup interns the data string on the initial put" );
+
+        Object dedupUnloadResult = dedupDao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+        test( Boolean.TRUE.equals(dedupUnloadResult),
+          "dedup EasyDAO now also gets the NotPartitionedDAO wrapper (unloadable no longer excludes dedup)" );
+
+        FObject reloadedDr = dedupDao.find_(tx, 1L);
+        test( reloadedDr != null && UnloadableDecoratedRecord.DATA.get(reloadedDr) == "dedup-data",
+          "rebuilt chain still dedups after reload: journal replay ran back through DeDupDAO" );
+
+        test( dedupEasyDao.getMdao() != null && dedupEasyDao.getMdao().find_(tx, 1L) != null,
+          "easy.getMdao() alias tracks the live (reloaded) store after unload/reload" );
       `
     },
     {

--- a/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
+++ b/src/foam/core/partition/test/UnloadableDecoratedDAOTest.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'UnloadableDecoratedDAOTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'A SINGLE_JOURNAL EasyDAO with both setUnloadable(true) and a decorator set must still get the NotPartitionedDAO wrapper (regression for the getDecorator() == null exclusion), and the decorator plus seqNo stamping must survive an unload/reload cycle.',
+
+  javaImports: [
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.partition.AbstractPartitionedDAO',
+    'foam.core.partition.test.UnloadableDecoratedRecord',
+    'foam.dao.DAO',
+    'foam.dao.EasyDAO',
+    'foam.dao.JournalType',
+    'foam.dao.ProxyDAO',
+    'foam.lang.FObject',
+    'foam.lang.X',
+    'java.io.File'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        X tx = newStorageContext(x);
+        String journalName = "unloadableDecorated_" + System.nanoTime();
+
+        CountingProxyDAO decorator = new CountingProxyDAO(tx);
+
+        DAO dao = new EasyDAO.Builder(tx)
+          .setAuthorize(false)
+          .setOf(UnloadableDecoratedRecord.getOwnClassInfo())
+          .setSeqNo(true)
+          .setJournalType(JournalType.SINGLE_JOURNAL)
+          .setJournalName(journalName)
+          .setUnloadable(true)
+          .setDecorator(decorator)
+          .build();
+
+        UnloadableDecoratedRecord r1 = new UnloadableDecoratedRecord(); r1.setData("r1");
+        UnloadableDecoratedRecord r2 = new UnloadableDecoratedRecord(); r2.setData("r2");
+        UnloadableDecoratedRecord r3 = new UnloadableDecoratedRecord(); r3.setData("r3");
+        FObject p1 = dao.put(r1);
+        FObject p2 = dao.put(r2);
+        FObject p3 = dao.put(r3);
+
+        long id1 = ((Long) UnloadableDecoratedRecord.ID.get(p1)).longValue();
+        long id2 = ((Long) UnloadableDecoratedRecord.ID.get(p2)).longValue();
+        long id3 = ((Long) UnloadableDecoratedRecord.ID.get(p3)).longValue();
+        test( id1 > 0 && id2 == id1 + 1 && id3 == id2 + 1,
+          "ids sequence-stamped: " + id1 + ", " + id2 + ", " + id3 );
+
+        test( decorator.count > 0,
+          "decorator saw put_ calls before unload, count=" + decorator.count );
+        int countBeforeUnload = decorator.count;
+
+        Object unloadResult = dao.cmd(AbstractPartitionedDAO.UNLOAD_CMD);
+        test( Boolean.TRUE.equals(unloadResult),
+          "UNLOAD_CMD returns TRUE: the NotPartitionedDAO wrapper is present even with a decorator set" );
+
+        FObject found = dao.find_(tx, id2);
+        test( found != null && "r2".equals(UnloadableDecoratedRecord.DATA.get(found)),
+          "record 2 intact after unload/reload" );
+        test( decorator.count > countBeforeUnload,
+          "decorator is still in the chain after reload, count=" + decorator.count );
+
+        UnloadableDecoratedRecord r4 = new UnloadableDecoratedRecord(); r4.setData("r4");
+        FObject p4 = dao.put(r4);
+        long id4 = ((Long) UnloadableDecoratedRecord.ID.get(p4)).longValue();
+        test( id4 == id3 + 1,
+          "seqNo continues after reload, got " + id4 + " expected " + (id3 + 1) );
+      `
+    },
+    {
+      name: 'newStorageContext',
+      args: 'X x',
+      type: 'X',
+      documentation: 'Sub-context with a temp-dir FileSystemStorage so journals are isolated.',
+      javaCode: `
+        String dir = System.getProperty("java.io.tmpdir") + File.separator
+          + "unloadabledecorated_" + System.nanoTime();
+        new File(dir).mkdirs();
+        FileSystemStorage fs = new FileSystemStorage(dir);
+        return x.put(Storage.class, fs).put(FileSystemStorage.class, fs);
+      `
+    }
+  ],
+
+  javaCode: `
+    /** Counts put_/find_ calls to prove the decorator is live in the chain, before and after unload/reload. */
+    public static class CountingProxyDAO extends ProxyDAO {
+      public int count = 0;
+
+      public CountingProxyDAO(X x) {
+        setX(x);
+      }
+
+      public FObject put_(X x, FObject obj) {
+        count++;
+        return super.put_(x, obj);
+      }
+
+      public FObject find_(X x, Object id) {
+        count++;
+        return super.find_(x, id);
+      }
+    }
+  `
+});

--- a/src/foam/core/partition/test/UnloadableDecoratedRecord.js
+++ b/src/foam/core/partition/test/UnloadableDecoratedRecord.js
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'UnloadableDecoratedRecord',
+  documentation: 'Long-id test model for UnloadableDecoratedDAOTest. A Long id (rather than PartitionStrRecord\'s String id) is required so SequenceNumberDAO can stamp it.',
+  properties: [
+    { class: 'Long',   name: 'id' },
+    { class: 'String', name: 'data' }
+  ]
+});

--- a/src/foam/core/partition/test/pom.js
+++ b/src/foam/core/partition/test/pom.js
@@ -8,7 +8,8 @@ foam.POM({
     { name: 'ReferenceMigratorTest',              flags: 'js&test|java&test' },
     { name: 'PartitionLoadReporterTest',          flags: 'js&test|java&test' },
     { name: 'PartitionLoadReplayTest',            flags: 'js&test|java&test' },
-    { name: 'PartitionLoadStatusIntegrationTest', flags: 'js&test|java&test' }
+    { name: 'PartitionLoadStatusIntegrationTest', flags: 'js&test|java&test' },
+    { name: 'PartitionLoadProgressDAOTest',       flags: 'js&test|java&test' }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/test/pom.js
+++ b/src/foam/core/partition/test/pom.js
@@ -4,12 +4,14 @@ foam.POM({
   files: [
     { name: 'PartitionStrRecord',                 flags: 'js&test|java&test' },
     { name: 'RefSourceRecord',                    flags: 'js&test|java&test' },
+    { name: 'UnloadableDecoratedRecord',          flags: 'js&test|java&test' },
     { name: 'SingleToPartitionMigratorTest',      flags: 'js&test|java&test' },
     { name: 'ReferenceMigratorTest',              flags: 'js&test|java&test' },
     { name: 'PartitionLoadReporterTest',          flags: 'js&test|java&test' },
     { name: 'PartitionLoadReplayTest',            flags: 'js&test|java&test' },
     { name: 'PartitionLoadStatusIntegrationTest', flags: 'js&test|java&test' },
-    { name: 'PartitionLoadProgressDAOTest',       flags: 'js&test|java&test' }
+    { name: 'PartitionLoadProgressDAOTest',       flags: 'js&test|java&test' },
+    { name: 'UnloadableDecoratedDAOTest',         flags: 'js&test|java&test' }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/test/pom.js
+++ b/src/foam/core/partition/test/pom.js
@@ -2,10 +2,13 @@ foam.POM({
   name: 'partition-test',
 
   files: [
-    { name: 'PartitionStrRecord',            flags: 'js&test|java&test' },
-    { name: 'RefSourceRecord',               flags: 'js&test|java&test' },
-    { name: 'SingleToPartitionMigratorTest', flags: 'js&test|java&test' },
-    { name: 'ReferenceMigratorTest',         flags: 'js&test|java&test' }
+    { name: 'PartitionStrRecord',                 flags: 'js&test|java&test' },
+    { name: 'RefSourceRecord',                    flags: 'js&test|java&test' },
+    { name: 'SingleToPartitionMigratorTest',      flags: 'js&test|java&test' },
+    { name: 'ReferenceMigratorTest',              flags: 'js&test|java&test' },
+    { name: 'PartitionLoadReporterTest',          flags: 'js&test|java&test' },
+    { name: 'PartitionLoadReplayTest',            flags: 'js&test|java&test' },
+    { name: 'PartitionLoadStatusIntegrationTest', flags: 'js&test|java&test' }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/test/tests.jrl
+++ b/src/foam/core/partition/test/tests.jrl
@@ -3,3 +3,4 @@ p({"class":"foam.core.partition.test.ReferenceMigratorTest","id":"ReferenceMigra
 p({"class":"foam.core.partition.test.PartitionLoadReporterTest","id":"PartitionLoadReporterTest"})
 p({"class":"foam.core.partition.test.PartitionLoadReplayTest","id":"PartitionLoadReplayTest"})
 p({"class":"foam.core.partition.test.PartitionLoadStatusIntegrationTest","id":"PartitionLoadStatusIntegrationTest"})
+p({"class":"foam.core.partition.test.PartitionLoadProgressDAOTest","id":"PartitionLoadProgressDAOTest", language: 0})

--- a/src/foam/core/partition/test/tests.jrl
+++ b/src/foam/core/partition/test/tests.jrl
@@ -1,2 +1,5 @@
 p({"class":"foam.core.partition.test.SingleToPartitionMigratorTest","id":"SingleToPartitionMigratorTest"})
 p({"class":"foam.core.partition.test.ReferenceMigratorTest","id":"ReferenceMigratorTest"})
+p({"class":"foam.core.partition.test.PartitionLoadReporterTest","id":"PartitionLoadReporterTest"})
+p({"class":"foam.core.partition.test.PartitionLoadReplayTest","id":"PartitionLoadReplayTest"})
+p({"class":"foam.core.partition.test.PartitionLoadStatusIntegrationTest","id":"PartitionLoadStatusIntegrationTest"})

--- a/src/foam/core/partition/test/tests.jrl
+++ b/src/foam/core/partition/test/tests.jrl
@@ -4,3 +4,4 @@ p({"class":"foam.core.partition.test.PartitionLoadReporterTest","id":"PartitionL
 p({"class":"foam.core.partition.test.PartitionLoadReplayTest","id":"PartitionLoadReplayTest"})
 p({"class":"foam.core.partition.test.PartitionLoadStatusIntegrationTest","id":"PartitionLoadStatusIntegrationTest"})
 p({"class":"foam.core.partition.test.PartitionLoadProgressDAOTest","id":"PartitionLoadProgressDAOTest", language: 0})
+p({"class":"foam.core.partition.test.UnloadableDecoratedDAOTest","id":"UnloadableDecoratedDAOTest"})

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -550,7 +550,9 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'unloadable',
-      // TODO: remove, just temporary for testing purposes
+      // Unloadable-by-default is intended: SINGLE_JOURNAL EasyDAOs get memory
+      // management via lazy journal reload (NotPartitionedDAO) unless explicitly
+      // opted out; wrappers that can't safely rebuild (e.g. fixedSize) exclude themselves.
       value: true
     },
     {
@@ -1039,36 +1041,63 @@ dao loading, which improves overall startup time.`,
         } else if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
           if ( getWriteOnly() ) {
             delegate = new foam.dao.WriteOnlyJDAO(x, delegate, getOf(), getJournalName());
-          } else if ( getUnloadable() && ! getDedup() ) {
+          } else if ( getUnloadable() ) {
             // getJournalDelegate() only replaces the journal delegate; the decorator,
             // ServiceProviderAwareDAO, and SequenceNumberDAO wrappers are all applied
             // outside it (see the 'delegate' property factory above) and survive
-            // unload/reload untouched. Dedup is excluded because this branch discards
-            // the "delegate" parameter (built above with the DeDupDAO wrapper) in favor
-            // of NotPartitionedDAO's own lazily-created bare MDAO (see createDAO()), so
-            // a dedup EasyDAO would silently never get its DeDupDAO wrapper at all.
+            // unload/reload untouched. The inner chain (mdao, optionally dedup, JDAO)
+            // is rebuilt from scratch via createJournalledDelegate() on every reload
+            // (see NotPartitionedDAO.createDAO()), so dedup is included this time.
             // FixedSizeDAO already self-excludes via setUnloadable(false) above.
             foam.core.partition.NotPartitionedDAO pdao = new foam.core.partition.NotPartitionedDAO(x, getOf(), getJournalName());
             pdao.setServiceName(getCSpec() != null && ! foam.util.SafetyUtil.isEmpty(getCSpec().getName()) ? getCSpec().getName() : getName());
-
-            // TODO: the delgate is lost, should it be sent as a prototype to be cloned?
-            // Setting of delegate must be last as it triggers replay
-            // jdao.setDelegate(delegate);
-
+            pdao.setEasyDAO(this);
             delegate = pdao;
+          } else if ( getFixedSize() != null ) {
+            // FixedSizeDAO already wraps the mdao/dedup chain above (see the
+            // 'delegate' property factory); wrap that existing chain in the
+            // journal rather than rebuilding it, or the size cap would be lost.
+            delegate = wrapInJDAO(x, delegate);
           } else {
-            foam.dao.java.JDAO jdao = new foam.dao.java.JDAO();
-            jdao.setX(x);
-            jdao.setFilename(getJournalName());
-            jdao.setCluster(getCluster() && !getSaf());
-            jdao.setWaitReplay(getWaitReplay());
-            jdao.setNdiff(getNdiff());
-            // Setting of delegate must be last as it triggers replay
-            jdao.setDelegate(delegate);
-            delegate = jdao;
+            delegate = createJournalledDelegate(x);
           }
         }
         return delegate;
+      `
+    },
+    {
+      name: 'createJournalledDelegate',
+      documentation: 'Builds a fresh SINGLE_JOURNAL inner chain: a new MDAO (aliased via setMdao so getMdao() tracks the live store), optionally wrapped in DeDupDAO, then wrapped in a JDAO over getJournalName(). Used for the initial non-unloadable, non-fixedSize construction, and by NotPartitionedDAO#createDAO() to rebuild the chain on every unload/reload.',
+      args: 'X x',
+      type: 'foam.dao.DAO',
+      javaCode: `
+        setMdao(new foam.dao.MDAO(getOf()));
+        foam.dao.DAO delegate = getMdao();
+
+        if ( getDedup() ) {
+          delegate = new foam.dao.DeDupDAO.Builder(x)
+            .setDelegate(delegate)
+            .build();
+        }
+
+        return wrapInJDAO(x, delegate);
+      `
+    },
+    {
+      name: 'wrapInJDAO',
+      documentation: 'Wraps delegate in a JDAO over getJournalName(), applying the cluster/waitReplay/ndiff settings shared by every SINGLE_JOURNAL construction path.',
+      args: 'X x, foam.dao.DAO delegate',
+      type: 'foam.dao.DAO',
+      javaCode: `
+        foam.dao.java.JDAO jdao = new foam.dao.java.JDAO();
+        jdao.setX(x);
+        jdao.setFilename(getJournalName());
+        jdao.setCluster(getCluster() && !getSaf());
+        jdao.setWaitReplay(getWaitReplay());
+        jdao.setNdiff(getNdiff());
+        // Setting of delegate must be last as it triggers replay
+        jdao.setDelegate(delegate);
+        return jdao;
       `
     },
     {

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -1023,8 +1023,8 @@ dao loading, which improves overall startup time.`,
           if ( getWriteOnly() ) {
             delegate = new foam.dao.WriteOnlyJDAO(x, delegate, getOf(), getJournalName());
           } else if ( getUnloadable() &&  getDecorator() == null ) {
-System.err.println("************************************* CREATING UNLOADABLE DAO " + getJournalName());
             foam.core.partition.NotPartitionedDAO pdao = new foam.core.partition.NotPartitionedDAO(x, getOf(), getJournalName());
+            pdao.setServiceName(getCSpec() != null && ! foam.util.SafetyUtil.isEmpty(getCSpec().getName()) ? getCSpec().getName() : getName());
 
             // TODO: the delgate is lost, should it be sent as a prototype to be cloned?
             // Setting of delegate must be last as it triggers replay

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -463,10 +463,11 @@ foam.CLASS({
       generateJava: false
     },
     {
-      documentation: 'Client-side: show partition-load progress toasts while operations on this DAO wait on a server journal load. Only meaningful with daoType CLIENT and a serviceName.',
+      documentation: 'Client-side: show partition-load progress toasts while operations on this DAO wait on a server journal load. On by default (matching unloadable-by-default server DAOs); set false in a client stanza to opt out. Only meaningful with daoType CLIENT and a serviceName.',
       class: 'Boolean',
       name: 'loadProgress',
-      flags: ['js']
+      flags: ['js'],
+      value: true
     },
     {
       documentation: 'Set polling interval for the caching DAO',

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -1042,7 +1042,7 @@ dao loading, which improves overall startup time.`,
           } else if ( getUnloadable() && ! getDedup() ) {
             // getJournalDelegate() only replaces the journal delegate; the decorator,
             // ServiceProviderAwareDAO, and SequenceNumberDAO wrappers are all applied
-            // outside it (see the `delegate` property factory above) and survive
+            // outside it (see the 'delegate' property factory above) and survive
             // unload/reload untouched. Dedup is excluded because this branch discards
             // the "delegate" parameter (built above with the DeDupDAO wrapper) in favor
             // of NotPartitionedDAO's own lazily-created bare MDAO (see createDAO()), so

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -232,11 +232,21 @@ foam.CLASS({
             .build();
 
           // auto add index on spid
-          DAO dao = (DAO) getMdao();
-          if ( dao != null && dao instanceof foam.dao.MDAO ) {
+          // Route through delegate.cmd_() rather than grabbing getMdao() directly: with an
+          // unloadable NotPartitionedDAO in the chain, getMdao() is an orphaned instance
+          // discarded on reload, but AbstractPartitionedDAO.cmd_() records the
+          // AddIndexCommand and NotPartitionedDAO#createDAO() replays it on every reload.
+          if ( getMdao() != null ) {
             PropertyInfo pInfo = (PropertyInfo) getOf().getAxiomByName("spid");
             if ( pInfo != null ) {
-              ((foam.dao.MDAO)dao).addIndex(pInfo);
+              AddIndexCommand cmd = new AddIndexCommand();
+              cmd.setIndexers(new Indexer[] { pInfo });
+              Object result = delegate.cmd_(getX(), cmd);
+              if ( result == null ||
+                  ! ( result instanceof Boolean ) ||
+                  ((Boolean) result).booleanValue() != true ) {
+                logger.warning(getName(), "Index not added, no access to MDAO", pInfo);
+              }
             } else {
               logger.warning(getName(), "Index not added. Property not found. spid");
             }
@@ -1029,7 +1039,15 @@ dao loading, which improves overall startup time.`,
         } else if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
           if ( getWriteOnly() ) {
             delegate = new foam.dao.WriteOnlyJDAO(x, delegate, getOf(), getJournalName());
-          } else if ( getUnloadable() &&  getDecorator() == null ) {
+          } else if ( getUnloadable() && ! getDedup() ) {
+            // getJournalDelegate() only replaces the journal delegate; the decorator,
+            // ServiceProviderAwareDAO, and SequenceNumberDAO wrappers are all applied
+            // outside it (see the `delegate` property factory above) and survive
+            // unload/reload untouched. Dedup is excluded because this branch discards
+            // the "delegate" parameter (built above with the DeDupDAO wrapper) in favor
+            // of NotPartitionedDAO's own lazily-created bare MDAO (see createDAO()), so
+            // a dedup EasyDAO would silently never get its DeDupDAO wrapper at all.
+            // FixedSizeDAO already self-excludes via setUnloadable(false) above.
             foam.core.partition.NotPartitionedDAO pdao = new foam.core.partition.NotPartitionedDAO(x, getOf(), getJournalName());
             pdao.setServiceName(getCSpec() != null && ! foam.util.SafetyUtil.isEmpty(getCSpec().getName()) ? getCSpec().getName() : getName());
 

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -74,6 +74,7 @@ foam.CLASS({
     'foam.core.crunch.box.CrunchClientBox',
     'foam.core.logger.Logger',
     'foam.core.logger.LoggingDAO',
+    'foam.core.partition.PartitionLoadProgressDAO',
     'foam.core.theme.SubdomainAwareDAO'
   ],
 
@@ -450,6 +451,12 @@ foam.CLASS({
       name: 'cache',
       documentation: 'Enable local in-memory caching of the DAO',
       generateJava: false
+    },
+    {
+      documentation: 'Client-side: show partition-load progress toasts while operations on this DAO wait on a server journal load. Only meaningful with daoType CLIENT and a serviceName.',
+      class: 'Boolean',
+      name: 'loadProgress',
+      flags: ['js']
     },
     {
       documentation: 'Set polling interval for the caching DAO',
@@ -1278,6 +1285,13 @@ dao loading, which improves overall startup time.`,
         dao = this.LoggingDAO.create({
           cSpec: this.cSpec,
           delegate: dao
+        });
+      }
+
+      if ( this.loadProgress && this.serviceName ) {
+        dao = this.PartitionLoadProgressDAO.create({
+          delegate: dao,
+          serviceKey: this.serviceName.replace(/^service\//, '').replace(/^dynamic\//, '')
         });
       }
 

--- a/src/foam/dao/F3FileJournal.js
+++ b/src/foam/dao/F3FileJournal.js
@@ -96,6 +96,9 @@ foam.CLASS({
           parseX = x;
         }
 
+        final foam.core.partition.PartitionLoadReporter progress =
+          (foam.core.partition.PartitionLoadReporter) x.get(foam.core.partition.PartitionLoadReporter.CTX_KEY);
+
         // NOTE: explicitly calling PM constructor as create only creates
         // a percentage of PMs, but we want all replay statistics
         PM pm = new PM(dao.getOf(), "replay." + getFilename());
@@ -113,6 +116,7 @@ foam.CLASS({
 
           for ( CharSequence entry ; ( entry = getEntry(reader) ) != null ; ) {
             int length = entry.length();
+            if ( progress != null ) progress.addChars(length + 1);
             if ( length == 0 ) continue;
             // Fast comment check: every comment starts with '/', which is never
             // the first char of a data entry ('c', 'p', 'r', 'v'). getEntry reads


### PR DESCRIPTION
Journal replay for partition/unloadable DAOs blocks the caller with zero feedback; this adds end-to-end load progress — the server publishes per-load status while a journal replays, and clients show non-blocking progress toasts whenever their own operation is waiting on one.

- **Publish** — `PartitionLoadStatus` rows (journal name, service name, totalBytes, bytesRead) live in an ephemeral in-memory DAO for exactly the duration of a load; `PartitionedDAO`/`NotPartitionedDAO` put the row before replay and remove it in a finally. Clients read through a served read-only twin (`partitionLoadStatusReadDAO`); the writable DAO is unserved.

- **Report** — `F3FileJournal.replay()` accumulates each consumed entry's length into a `PartitionLoadReporter` found in X (throttled puts, ≥250ms apart). No reporter in X → one null check per entry, zero behavior change for every other replay.

- **Show** — a `PartitionLoadProgressDAO` client decorator (installed by EasyDAO for every client stanza, `loadProgress` on by default, opt-out per stanza) watches a singleton `PartitionLoadToastStack` when an operation is still pending 400ms in; the stack polls the status DAO every 500ms and renders bottom-right progress cards (max 4 + overflow count, aria-live, start-time ordered). Cards die with their operation — another user's load never blocks or toasts you.

- **Unload** — `PartitionedDAO.unload()` now evicts all cached partition delegates (it inherited the NOP), so `UNLOAD_CMD` gives a deterministic unload for both wrapper types; comment documents the quiesce-then-unload contract.

- **Test** — reporter unit, replay accumulation, integration (row lifecycle through real partition creation + `UNLOAD_CMD` reload for both DAO types), and a client JS suite for the decorator/stack timing, refcounts, and teardown.

Note: three commits here duplicate #5290 (already merged) — the branch predates that merge and git dedupes them on merge; the DOS-3795 work builds on them.