### PR TITLE
PT-FIXES:DOS-4304 fix(reflow): scope loadPerf per-block buffer to the Console

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1016,6 +1016,7 @@ foam.CLASS({
     'moveFlowChild',
     'moveFlowChildAfter',
     'out',
+    'perfCapture_',
     'save',
     'scope',
     'scrollToBottom',
@@ -1228,6 +1229,15 @@ foam.CLASS({
       value: 0
     },
     {
+      name: 'perfCapture_',
+      hidden: true,
+      transient: true,
+      documentation: `Per-block cost rows for the load in progress: the loadPerf command
+        points this at the capturing Perf's buffer, and onScriptChange drops it when the
+        load ends. Held per Console rather than on window so a perf block detaching
+        mid-load (clearFlow) cannot reach another capture's buffer.`
+    },
+    {
       class: 'Int',
       name: 'loadingPercentage_',
       hidden: true,
@@ -1348,10 +1358,10 @@ foam.CLASS({
         this.loadingProgress_++;
         this.loadingPercentage_ = Math.round((this.loadingProgress_ / this.totalBlocks_) * 100);
 
-        // Per-block attribution for the reflow Perf block: when a capture set
-        // window.__perfCapture__ to an array, record each TOP-LEVEL block's cost.
+        // Per-block attribution for the reflow Perf block: when a capture pointed
+        // perfCapture_ at its buffer, record each TOP-LEVEL block's cost.
         // No-op (single array check) when not capturing.
-        var perfCap_ = ( ! parent && this.window && Array.isArray(this.window.__perfCapture__) ) ? this.window.__perfCapture__ : null;
+        var perfCap_ = ( ! parent && Array.isArray(this.perfCapture_) ) ? this.perfCapture_ : null;
         var perfT_, perfDom_, perfHeap_;
         if ( perfCap_ ) {
           perfT_    = this.window.performance.now();
@@ -2204,6 +2214,10 @@ foam.CLASS({
         } finally {
           this.feedback_ = false;
           this.isLoading_ = false;
+
+          // A capture collects the load it armed and no more: dropping the buffer
+          // here bounds it to one load even when includeScript throws.
+          this.perfCapture_ = null;
 
           // Reset progress counters
           this.loadingProgress_ = 0;

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -690,6 +690,9 @@ foam.CLASS({
     async function execute(flowName) {
       if ( ! flowName ) return;
       var self = this;
+      // SUPER is bound for the synchronous frame only (Method.js restores it in a
+      // finally), so hold it before the find below yields.
+      var SUPER = this.SUPER;
       // An unresolvable name loads nothing (Load.execute returns silently), and no load
       // means no loadComplete - so capturing here would wrap fetch and console.warn for
       // the rest of the session. Checked before startCapture_ so it isn't measured.
@@ -719,7 +722,7 @@ foam.CLASS({
         blk.value.copyFrom(report);
       }));
 
-      await this.SUPER(flowName);
+      await SUPER.call(this, flowName);
     }
   ]
 });

--- a/src/foam/core/reflow/cmd/Commands.js
+++ b/src/foam/core/reflow/cmd/Commands.js
@@ -680,6 +680,8 @@ foam.CLASS({
 
   requires: [ 'foam.core.reflow.perf.Perf' ],
 
+  imports: [ 'perfCapture_' ],
+
   properties: [
     [ 'description', 'Load perf a flow with performance capture' ]
   ],
@@ -687,11 +689,28 @@ foam.CLASS({
   methods: [
     async function execute(flowName) {
       if ( ! flowName ) return;
-      var self   = this;
-      var runner = this.Perf.create({}, this);
+      var self = this;
+      // An unresolvable name loads nothing (Load.execute returns silently), and no load
+      // means no loadComplete - so capturing here would wrap fetch and console.warn for
+      // the rest of the session. Checked before startCapture_ so it isn't measured.
+      if ( ! await this.flowDAO.find(flowName) ) return;
+
+      var runner    = this.Perf.create({}, this);
+      var finishing = false;
 
       runner.startCapture_();
+      // Per-block costs are recorded by the Console's load loop, which has no handle
+      // on this capture - hand it the buffer for the duration of the load. The Console
+      // clears it when the load ends (onScriptChange).
+      this.perfCapture_ = runner.capture_;
+      // That clear is the one signal a load emits whether it passed or threw: a load
+      // that throws never pubs loadComplete, leaving the wrappers below installed.
+      // Subscribed after the set above so it can't fire on our own write.
+      this.perfCapture_$.sub(foam.events.oneTime(function() {
+        if ( ! finishing ) runner.stopCapture_();
+      }));
       this.flow.loadComplete.sub(foam.events.oneTime(async function() {
+        finishing = true;   // set before the first await: the clear lands in between
         var report = await runner.finishCapture_();
         report.label = 'loadPerf: ' + flowName;
         // Append a perf block to the loaded flow and inject the measured report.

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -122,6 +122,7 @@ foam.CLASS({
     { class: 'Float', name: 'longTaskTotalMs_', hidden: true, transient: true },
     { class: 'Float', name: 'longestTaskMs_',   hidden: true, transient: true },
     { class: 'Int',   name: 'warnCount_',       hidden: true, transient: true },
+    { name: 'capture_',   hidden: true, transient: true },
     { name: 'observer_',  hidden: true, transient: true },
     { name: 'netCalls_',  hidden: true, transient: true },
     { name: 'origFetch_', hidden: true, transient: true },
@@ -464,8 +465,10 @@ foam.CLASS({
       this.wrapFetch_();
       this.wrapWarn_();
 
-      // Buffer the Console's per-block load loop writes into (Console.includeScript).
-      if ( this.window ) this.window.__perfCapture__ = [];
+      // Buffer for the Console's per-block load loop. The loadPerf command hands it
+      // to the Console that runs the load (Console.perfCapture_); nothing else can
+      // reach it, so a stale perf block detaching mid-load cannot disturb it.
+      this.capture_ = [];
 
       // JS Self-Profiling API: sample the call stack so we can name the hottest
       // functions ourselves, no DevTools. Throws unless the js-profiling document
@@ -513,8 +516,8 @@ foam.CLASS({
           the block's [start,end] window). Trivial blocks are dropped; top 12 kept. **/
       var self     = this;
       var netCalls = this.netCalls_ || [];
-      var raw = ( this.window && Array.isArray(this.window.__perfCapture__) ) ? this.window.__perfCapture__ : [];
-      if ( this.window ) this.window.__perfCapture__ = null;
+      var raw = Array.isArray(this.capture_) ? this.capture_ : [];
+      this.capture_ = null;
       return raw
         .filter(function(b) { return b.ms >= 1 || b.domDelta >= 50 || b.heapDelta >= 1048576; })
         .sort(function(a, b) { return b.ms - a.ms; })
@@ -599,7 +602,7 @@ foam.CLASS({
       // Discard a still-running profiler (e.g. view detached mid-capture).
       if ( this.profiler_ ) { try { this.profiler_.stop(); } catch (e) {} this.profiler_ = null; }
       // Drop the per-block buffer if capture aborted before summarizeBlocks_ drained it.
-      if ( this.window && this.window.__perfCapture__ ) this.window.__perfCapture__ = null;
+      this.capture_ = null;
     },
 
     function wrapFetch_() {


### PR DESCRIPTION
`loadPerf` hands the Console's load loop its per-block cost buffer through a global, `window.__perfCapture__`. Loading a flow calls `clearFlow` first, which detaches the perf block the previous `loadPerf` appended, and a detaching perf block runs `stopCapture_`, which nulled that global whether or not the block ever captured anything.

The detach lands inside the new capture's window, so `includeScript` finds no array and records nothing: `blockProfile` comes back empty and the Blocks tab renders blank from the second `loadPerf` onward. The first run has no perf block to detach, which is why it looks fine. The other tabs are unaffected because every other metric lives on the capturing instance rather than on the window.

Fix:

- the Console owns the buffer (`perfCapture_`, exported); `loadPerf` points it at the capturing `Perf`'s array for the duration of the load, and `onScriptChange` drops it in its `finally`, so a capture collects exactly one load even when `includeScript` throws

- `Perf` keeps its rows in `capture_` and touches no global, so a block being torn down can only ever clear its own

- `loadPerf` returns early when the flow name doesn't resolve. `load` returns silently there, so `loadComplete` never fired and the `fetch` / `console.warn` wrappers stayed installed for the rest of the session

A load that throws still tears the capture down: the Console's clear is the one signal a load emits either way, so the capture rides it and unwraps.