### PR TITLE
PT-FIXES:DOS-4625 fix(reflow): nest blocks and name the calls in the perf report

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1338,7 +1338,7 @@ foam.CLASS({
       await this.eval_('loadPerf("' + this.value.name + '")');
     },
 
-    async function includeScript(script, parent, skipParse) {
+    async function includeScript(script, parent, skipParse, perfParent) {
       var ctx = parent?.__subContext__ || this.__subContext__;
       if ( ! script ) return;
       var cs = skipParse ?
@@ -1359,14 +1359,21 @@ foam.CLASS({
         this.loadingPercentage_ = Math.round((this.loadingProgress_ / this.totalBlocks_) * 100);
 
         // Per-block attribution for the reflow Perf block: when a capture pointed
-        // perfCapture_ at its buffer, record each TOP-LEVEL block's cost.
+        // perfCapture_ at its buffer, record this block's cost. A nested call writes
+        // into the row of the block it ran inside, so the report keeps the block tree.
         // No-op (single array check) when not capturing.
-        var perfCap_ = ( ! parent && Array.isArray(this.perfCapture_) ) ? this.perfCapture_ : null;
-        var perfT_, perfDom_, perfHeap_;
-        if ( perfCap_ ) {
+        var perfSink_ = perfParent ? perfParent.children :
+          ( Array.isArray(this.perfCapture_) ? this.perfCapture_ : null );
+        var perfRow_ = null, perfT_, perfDom_, perfHeap_;
+        if ( perfSink_ ) {
           perfT_    = this.window.performance.now();
           perfDom_  = this.window.document.querySelectorAll('*').length;
           perfHeap_ = ( this.window.performance.memory && this.window.performance.memory.usedJSHeapSize ) || 0;
+          // Pushed before the block runs so children have a row to attach to; the
+          // costs land on it once the block and its children are done.
+          // flowName from the script (reliable) since currentBlock may become a child.
+          perfRow_ = { flowName: c.flowName || c.cmd, cmd: c.cmd, start: perfT_, children: [] };
+          perfSink_.push(perfRow_);
         }
 
         await ctx.eval_(c.cmd, undefined, undefined, parent);
@@ -1405,23 +1412,17 @@ foam.CLASS({
         }
 
         if ( c.flowChildren ) {
-          await this.includeScript(c.flowChildren, this.currentBlock, true);
+          await this.includeScript(c.flowChildren, this.currentBlock, true, perfRow_);
         }
 
         // Measure AFTER onLoad + children: that is where a block's real work runs
         // (script autoRun, DAO select, DOM render). eval_ alone only creates the block.
-        // flowName from the script (reliable) since currentBlock may now be a child.
-        if ( perfCap_ ) {
+        if ( perfRow_ ) {
           var perfEnd_ = this.window.performance.now();
-          perfCap_.push({
-            flowName:  c.flowName || c.cmd,
-            cmd:       c.cmd,
-            start:     perfT_,        // absolute timestamps so the Perf block can bucket
-            end:       perfEnd_,      // profiler samples into this block's window
-            ms:        perfEnd_ - perfT_,
-            domDelta:  this.window.document.querySelectorAll('*').length - perfDom_,
-            heapDelta: ( ( this.window.performance.memory && this.window.performance.memory.usedJSHeapSize ) || 0 ) - perfHeap_
-          });
+          perfRow_.end       = perfEnd_;   // absolute timestamps so the Perf block can
+          perfRow_.ms        = perfEnd_ - perfT_;   // bucket profiler samples per block
+          perfRow_.domDelta  = this.window.document.querySelectorAll('*').length - perfDom_;
+          perfRow_.heapDelta = ( ( this.window.performance.memory && this.window.performance.memory.usedJSHeapSize ) || 0 ) - perfHeap_;
         }
       }
     },

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -93,6 +93,11 @@ foam.CLASS({
     ^hint { color: $textSecondary; font-style: italic; }
     ^block-row { cursor: pointer; }
     ^block-row:hover { background: $grey50; }
+    /* nesting depth of a block row: children sit under the block they ran inside */
+    ^d1 { padding-left: 18px; }
+    ^d2 { padding-left: 36px; }
+    ^d3 { padding-left: 54px; }
+    ^d4 { padding-left: 72px; }
     ^twisty { display: inline-block; width: 12px; color: $textTertiary; }
     ^hot-row td, ^hot-row th { color: $textSecondary; font-size: 12px; padding-left: 22px; }
     ^hot-detailrow > td { padding: 4px 0 8px 22px; }
@@ -125,6 +130,7 @@ foam.CLASS({
     { name: 'capture_',   hidden: true, transient: true },
     { name: 'observer_',  hidden: true, transient: true },
     { name: 'netCalls_',  hidden: true, transient: true },
+    { name: 'bodyReads_', hidden: true, transient: true },
     { name: 'origFetch_', hidden: true, transient: true },
     { name: 'origWarn_',  hidden: true, transient: true },
     { name: 'profiler_',  hidden: true, transient: true }
@@ -140,8 +146,8 @@ foam.CLASS({
       this.add(this.dynamic(function(report$elapsedMs) {
         var r = self.report;
         if ( ! r || ! r.endSnapshot ) return;
-        // Recommended-action count = service-call groups with identical re-fetches.
-        var actions = ( r.serviceCalls || [] ).filter(function(c) { return ( c.count - ( c.distinct || c.count ) ) > 0; }).length;
+        // Recommended-action count = service-call groups with avoidable re-fetches.
+        var actions = ( r.serviceCalls || [] ).filter(function(c) { return c.avoidable() > 0; }).length;
         var svcLabel   = 'Services' + ( actions ? ' · ' + actions + ' to fix' : '' );
         var issueLabel = 'Issues' + ( ( r.issues || [] ).length ? ' (' + r.issues.length + ')' : '' );
         // Issues first => default selected tab (the summary).
@@ -245,7 +251,7 @@ foam.CLASS({
       row(self.LONGEST_LABEL, r.durStr(r.longestTaskMs), 'longestTaskMs');
       row(self.HEAP_LABEL, r.byteStr(r.heapDeltaBytes), 'heapDeltaBytes');
       row(self.DOM_LABEL, r.numStr(r.domNodeDelta, 0) + ( r.tableCellDelta > 0 ? ' (' + r.numStr(r.tableCellDelta, 0) + ' cells)' : '' ), 'domNodeDelta');
-      row(self.NETWORK_LABEL, r.numStr(r.networkCallCount, 0) + ' (' + r.numStr(r.repeatedRequestCount, 0) + ' identical)', 'repeatedRequestCount');
+      row(self.NETWORK_LABEL, r.numStr(r.networkCallCount, 0) + ' (' + r.numStr(r.repeatedRequestCount, 0) + ' repeated reads)', 'repeatedRequestCount');
       row(self.LARGEST_LABEL, r.byteStr(r.largestRequestBytes), 'largestRequestBytes');
       row(self.WARN_LABEL, r.numStr(r.warnCount, 0), 'warnRate');
       el2.end();
@@ -256,8 +262,8 @@ foam.CLASS({
       var self  = this;
       var calls = r.serviceCalls || [];
       if ( ! calls.length ) return;
-      // identical re-fetches (cache candidates) = total calls - distinct request bodies.
-      var repeatedOf = function(c) { return c.count - ( c.distinct || c.count ); };
+      // identical re-fetches a cache would remove - reads only (PerfServiceCall.avoidable).
+      var repeatedOf = function(c) { return c.avoidable(); };
       // Only the repeated calls are an issue - heat those; sizes are shown plain.
       var maxRepeated = 0;
       calls.forEach(function(c) { var rep = repeatedOf(c); if ( rep > maxRepeated ) maxRepeated = rep; });
@@ -334,13 +340,17 @@ foam.CLASS({
       var self   = this;
       var blocks = r.blockProfile || [];
       if ( ! blocks.length ) return;
-      // Column maxes for relative heat (each column shaded against its own worst).
-      var maxMs = 0, maxDom = 0, maxHeap = 0;
-      blocks.forEach(function(b) {
-        if ( b.ms > maxMs )            maxMs   = b.ms;
-        if ( b.domDelta > maxDom )     maxDom  = b.domDelta;
-        if ( b.heapDelta > maxHeap )   maxHeap = b.heapDelta;
-      });
+      // Column maxes for relative heat, taken over the whole tree so a hot child reads
+      // hot beside its parent (each column shaded against its own worst).
+      var max = { ms: 0, dom: 0, heap: 0 };
+      ( function scan(list) {
+        list.forEach(function(b) {
+          if ( b.ms > max.ms )          max.ms   = b.ms;
+          if ( b.domDelta > max.dom )   max.dom  = b.domDelta;
+          if ( b.heapDelta > max.heap ) max.heap = b.heapDelta;
+          scan(b.children || []);
+        });
+      } )(blocks);
       var card = self.card_(el);
       var t = card.start('table');
       t.start('tr')
@@ -349,29 +359,48 @@ foam.CLASS({
         .start('td').add('Elements added').end()
         .start('td').add('Memory change').end()
       .end();
+      self.blockRows_(t, r, blocks, 0, null, max);
+      t.end();
+      if ( ! r.profilingSupported ) {
+        card.start().addClass(self.myClass('hint')).add(self.DEVTOOLS_HINT).end();
+      }
+      card.end();
+    },
+
+    function blockRows_(t, r, blocks, depth, vis$, max) {
+      /** One level of block rows, each followed by its detail tables and the blocks that
+          ran inside it, indented. A row shows only while every ancestor is open, so
+          expanding a parent reveals one level at a time. **/
+      var self = this;
       blocks.forEach(function(b) {
         var hot        = b.hot || [];
         var bCalls     = b.calls || [];
-        var expandable = hot.length > 0 || bCalls.length > 0;
+        var kids       = b.children || [];
+        var expandable = hot.length > 0 || bCalls.length > 0 || kids.length > 0;
         var open$      = foam.lang.SimpleSlot.create({ value: false });
+        var inner$     = vis$ ? self.bothSlot_(vis$, open$) : open$;
+        // A block's window covers the blocks that ran inside it, so its functions and
+        // calls include theirs. Say so rather than pretend the numbers are exclusive.
+        var scope      = kids.length ? ' (including nested blocks)' : '';
 
         var tr = t.start('tr').addClass(self.myClass('block-row'));
+        if ( vis$ ) tr.show(vis$);
         if ( expandable ) tr.on('click', function() { open$.set( ! open$.get() ); });
-        var th = tr.start('th');
+        var th = tr.start('th').addClass(self.myClass('d' + Math.min(depth, 4)));
         th.start('span').addClass(self.myClass('twisty'))
           .add( expandable ? open$.map(function(o) { return o ? '▾' : '▸'; }) : '' )
         .end();
         th.add(b.flowName).end();
-        self.heatCell_(tr.start('td'), r.durStr(b.ms), self.heatLevel_(b.ms, maxMs));
-        self.heatCell_(tr.start('td'), r.numStr(b.domDelta, 0),    self.heatLevel_(b.domDelta, maxDom));
-        self.heatCell_(tr.start('td'), r.byteStr(b.heapDelta),     self.heatLevel_(b.heapDelta, maxHeap));
+        self.heatCell_(tr.start('td'), r.durStr(b.ms),          self.heatLevel_(b.ms, max.ms));
+        self.heatCell_(tr.start('td'), r.numStr(b.domDelta, 0), self.heatLevel_(b.domDelta, max.dom));
+        self.heatCell_(tr.start('td'), r.byteStr(b.heapDelta),  self.heatLevel_(b.heapDelta, max.heap));
         tr.end();
 
         // Expandable detail: hottest functions and the server calls this block made.
         if ( hot.length ) {
-          var ht = t.start('tr').addClass(self.myClass('hot-detailrow')).show(open$)
+          var ht = t.start('tr').addClass(self.myClass('hot-detailrow')).show(inner$)
             .start('td').attrs({ colspan: 4 })
-              .start('div').addClass(self.myClass('detail-title')).add('Hottest functions').end()
+              .start('div').addClass(self.myClass('detail-title')).add('Hottest functions' + scope).end()
               .start('table').addClass(self.myClass('hot-table'));
           ht.start('tr')
             .start('th').add('Function').end()
@@ -388,9 +417,9 @@ foam.CLASS({
           ht.end().end().end();
         }
         if ( bCalls.length ) {
-          var ct = t.start('tr').addClass(self.myClass('hot-detailrow')).show(open$)
+          var ct = t.start('tr').addClass(self.myClass('hot-detailrow')).show(inner$)
             .start('td').attrs({ colspan: 4 })
-              .start('div').addClass(self.myClass('detail-title')).add('Server calls').end()
+              .start('div').addClass(self.myClass('detail-title')).add('Server calls' + scope).end()
               .start('table').addClass(self.myClass('hot-table'));
           ct.start('tr')
             .start('th').add('Service').end()
@@ -410,12 +439,16 @@ foam.CLASS({
           });
           ct.end().end().end();
         }
+        if ( kids.length ) self.blockRows_(t, r, kids, depth + 1, inner$, max);
       });
-      t.end();
-      if ( ! r.profilingSupported ) {
-        card.start().addClass(self.myClass('hint')).add(self.DEVTOOLS_HINT).end();
-      }
-      card.end();
+    },
+
+    function bothSlot_(a$, b$) {
+      /** True only while both are - chains a row's visibility down the block tree. **/
+      return foam.lang.ExpressionSlot.create({
+        args: [ a$, b$ ],
+        code: function(a, b) { return !! ( a && b ); }
+      });
     },
 
     function renderEnv_(el, r) {
@@ -485,6 +518,7 @@ foam.CLASS({
     async function finishCapture_() {
       /** End the capture window and compute the report. Callable headlessly.
           Async because the JS Self-Profiling API resolves its trace on stop(). **/
+      await this.settleBodies_();
       this.resolveResponseSizes_(this.netCalls_ || []);
       var net    = this.summarizeNetwork_(this.netCalls_ || []);
       var prof   = await this.stopProfile_();          // {supported, trace} - need trace for per-block hot
@@ -511,14 +545,20 @@ foam.CLASS({
     },
 
     function summarizeBlocks_(trace) {
-      /** Drain the per-block capture buffer into PerfBlockCost rows, worst first, each
-          carrying its hottest functions and the server calls it made (both bucketed into
-          the block's [start,end] window). Trivial blocks are dropped; top 12 kept. **/
-      var self     = this;
-      var netCalls = this.netCalls_ || [];
+      /** Drain the per-block capture buffer into a PerfBlockCost tree. **/
       var raw = Array.isArray(this.capture_) ? this.capture_ : [];
       this.capture_ = null;
-      return raw
+      return this.blockCosts_(raw, trace);
+    },
+
+    function blockCosts_(rows, trace) {
+      /** One level of the block tree as PerfBlockCost rows, worst first, each carrying its
+          hottest functions, the server calls it made (both bucketed into the block's
+          [start,end] window, so a parent's include its children's) and the blocks that ran
+          inside it. Trivial blocks are dropped; top 12 kept per level. **/
+      var self     = this;
+      var netCalls = this.netCalls_ || [];
+      return ( rows || [] )
         .filter(function(b) { return b.ms >= 1 || b.domDelta >= 50 || b.heapDelta >= 1048576; })
         .sort(function(a, b) { return b.ms - a.ms; })
         .slice(0, 12)
@@ -527,10 +567,21 @@ foam.CLASS({
             netCalls.filter(function(c) { return c.t >= b.start && c.t < b.end; });
           return foam.core.reflow.perf.PerfBlockCost.create({
             flowName: b.flowName, cmd: b.cmd, ms: b.ms, domDelta: b.domDelta, heapDelta: b.heapDelta,
-            hot:   ( trace && b.start != null ) ? self.framesInWindow_(trace, b.start, b.end, b.ms) : [],
-            calls: self.groupServiceCalls_(inWindow)
+            hot:      ( trace && b.start != null ) ? self.framesInWindow_(trace, b.start, b.end, b.ms) : [],
+            calls:    self.groupServiceCalls_(inWindow),
+            children: self.blockCosts_(b.children, trace)
           });
         });
+    },
+
+    async function settleBodies_() {
+      /** Wait for the request-body reads wrapFetch_ started. Each reads a clone of an
+          in-memory body and resolves promptly, but in a later microtask - without this
+          the last calls of a load are summarized before their body is parsed and land
+          with a blank operation and zero bytes sent. **/
+      var reads = this.bodyReads_ || [];
+      this.bodyReads_ = [];
+      if ( reads.length ) await Promise.all(reads);
     },
 
     function flushLongTasks_() {
@@ -610,6 +661,7 @@ foam.CLASS({
       var self = this, w = this.window;
       if ( ! w || ! w.fetch ) return;
       this.netCalls_  = [];
+      this.bodyReads_ = [];
       this.origFetch_ = w.fetch;
       var orig = this.origFetch_;
       w.fetch = function(input, init) {
@@ -630,7 +682,9 @@ foam.CLASS({
             self.recordBody_(call, inlineBody);
           } else if ( input && typeof input.clone === 'function' ) {
             // Request body is a stream; clone + read it without disturbing the real call.
-            input.clone().text().then(function(t) { self.recordBody_(call, t || ''); }, function() {});
+            // Tracked so the capture can settle these before it summarizes (settleBodies_).
+            self.bodyReads_.push(
+              input.clone().text().then(function(t) { self.recordBody_(call, t || ''); }, function() {}));
           }
         } catch (e) { /* never break the real request */ }
         var p = orig.apply(this, arguments);
@@ -679,8 +733,11 @@ foam.CLASS({
         var msg = foam.json.parse(node, null, this.__context__);
         var op  = ( msg && msg.name ) || node.name;
         if ( op.endsWith && op.endsWith('_') ) op = op.slice(0, -1);   // 'select_' -> 'select'
-        call.op = op;
         var args = ( msg && msg.args ) || [];
+        // 'cmd' alone says nothing: name the command that was sent, so a purge reads
+        // apart from a reset instead of every control message sharing one row.
+        if ( op === 'cmd' ) op += ' · ' + this.cmdName_(args[1]);
+        call.op = op;
         for ( var i = 0 ; i < args.length ; i++ ) {
           if ( foam.dao.Sink.isInstance(args[i]) ) { call.sink = args[i].cls_.name; break; }
         }
@@ -698,6 +755,15 @@ foam.CLASS({
         var q = parts.join('  ·  ');
         call.query = q.length > 160 ? q.substring(0, 157) + '…' : q;
       } catch (e) { /* unparseable - leave op/sink blank */ }
+    },
+
+    function cmdName_(cmd) {
+      /** Readable name for a DAO cmd payload: the constant for a string command
+          (PURGE_CMD, RESET_CMD, LAST_CMD), the class name for an object one. **/
+      if ( cmd == null ) return '?';
+      if ( foam.String.isInstance(cmd) )      return cmd;
+      if ( foam.lang.FObject.isInstance(cmd) ) return cmd.cls_.name;
+      return String(cmd);
     },
 
     function prettyOrder_(o) {
@@ -814,9 +880,13 @@ foam.CLASS({
 
     function summarizeNetwork_(calls) {
       /** Totals, largest, exact-dup repeats by (url,body) hash, and the grouped service table. **/
+      var CACHEABLE = foam.core.reflow.perf.PerfServiceCall.CACHEABLE_OPS;
       var byHash = {}, largest = 0;
       calls.forEach(function(c) {
         if ( c.reqBytes > largest ) largest = c.reqBytes;
+        // Only a repeated READ is data loaded twice; a repeated control message or write
+        // is work the caller asked for. Same rule the service table recommends on.
+        if ( ! CACHEABLE[c.op] ) return;
         var h = byHash[c.hash] || ( byHash[c.hash] = { url: c.url, count: 0, requestBytes: c.reqBytes } );
         h.count++;
       });

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -93,11 +93,12 @@ foam.CLASS({
     ^hint { color: $textSecondary; font-style: italic; }
     ^block-row { cursor: pointer; }
     ^block-row:hover { background: $grey50; }
-    /* nesting depth of a block row: children sit under the block they ran inside */
-    ^d1 { padding-left: 18px; }
-    ^d2 { padding-left: 36px; }
-    ^d3 { padding-left: 54px; }
-    ^d4 { padding-left: 72px; }
+    /* Nesting depth of a block row: children sit under the block they ran inside.
+       Qualified by th so these beat the padding shorthand on '^ th' above. */
+    ^ th^d1 { padding-left: 18px; }
+    ^ th^d2 { padding-left: 36px; }
+    ^ th^d3 { padding-left: 54px; }
+    ^ th^d4 { padding-left: 72px; }
     ^twisty { display: inline-block; width: 12px; color: $textTertiary; }
     ^hot-row td, ^hot-row th { color: $textSecondary; font-size: 12px; padding-left: 22px; }
     ^hot-detailrow > td { padding: 4px 0 8px 22px; }

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -93,12 +93,15 @@ foam.CLASS({
     ^hint { color: $textSecondary; font-style: italic; }
     ^block-row { cursor: pointer; }
     ^block-row:hover { background: $grey50; }
-    /* Nesting depth of a block row: children sit under the block they ran inside.
-       Qualified by th so these beat the padding shorthand on '^ th' above. */
-    ^ th^d1 { padding-left: 18px; }
-    ^ th^d2 { padding-left: 36px; }
-    ^ th^d3 { padding-left: 54px; }
-    ^ th^d4 { padding-left: 72px; }
+    /* Nesting: one rail per level in the name cell, and the block's detail tables
+       indented to the same level so they read as belonging to the row above.
+       Detail rules are qualified past '^hot-detailrow > td' to win on specificity. */
+    ^rail { display: inline-block; width: 22px; height: 1.1em; vertical-align: -0.2em; border-left: 1px solid $borderLight; }
+    ^inside { margin-left: 8px; font-size: 11px; font-weight: $font-regular; color: $textTertiary; }
+    ^hot-detailrow > td^d1 { padding-left: 44px; }
+    ^hot-detailrow > td^d2 { padding-left: 66px; }
+    ^hot-detailrow > td^d3 { padding-left: 88px; }
+    ^hot-detailrow > td^d4 { padding-left: 110px; }
     ^twisty { display: inline-block; width: 12px; color: $textTertiary; }
     ^hot-row td, ^hot-row th { color: $textSecondary; font-size: 12px; padding-left: 22px; }
     ^hot-detailrow > td { padding: 4px 0 8px 22px; }
@@ -380,19 +383,29 @@ foam.CLASS({
         var expandable = hot.length > 0 || bCalls.length > 0 || kids.length > 0;
         var open$      = foam.lang.SimpleSlot.create({ value: false });
         var inner$     = vis$ ? self.bothSlot_(vis$, open$) : open$;
-        // A block's window covers the blocks that ran inside it, so its functions and
-        // calls include theirs. Say so rather than pretend the numbers are exclusive.
-        var scope      = kids.length ? ' (including nested blocks)' : '';
+        var dCls       = self.myClass('d' + Math.min(depth, 4));
+        // A wrapper's time is its children's; say what it spent on its own so the rows
+        // that actually cost something stand out from the ones that only hold them.
+        var ownTime    = kids.length ? ' · self ' + r.durStr(b.selfMs) : '';
 
         var tr = t.start('tr').addClass(self.myClass('block-row'));
         if ( vis$ ) tr.show(vis$);
         if ( expandable ) tr.on('click', function() { open$.set( ! open$.get() ); });
-        var th = tr.start('th').addClass(self.myClass('d' + Math.min(depth, 4)));
+        var th = tr.start('th');
+        // One rail per level of nesting: the guides survive the detail tables that sit
+        // between a block and the blocks it contains.
+        for ( var i = 0 ; i < depth ; i++ ) th.start('span').addClass(self.myClass('rail')).end();
         th.start('span').addClass(self.myClass('twisty'))
           .add( expandable ? open$.map(function(o) { return o ? '▾' : '▸'; }) : '' )
         .end();
-        th.add(b.flowName).end();
-        self.heatCell_(tr.start('td'), r.durStr(b.ms),          self.heatLevel_(b.ms, max.ms));
+        th.add(b.flowName);
+        if ( kids.length ) {
+          th.start('span').addClass(self.myClass('inside'))
+            .add(kids.length + ( kids.length === 1 ? ' block inside' : ' blocks inside' ))
+          .end();
+        }
+        th.end();
+        self.heatCell_(tr.start('td'), r.durStr(b.ms) + ownTime, self.heatLevel_(b.ms, max.ms));
         self.heatCell_(tr.start('td'), r.numStr(b.domDelta, 0), self.heatLevel_(b.domDelta, max.dom));
         self.heatCell_(tr.start('td'), r.byteStr(b.heapDelta),  self.heatLevel_(b.heapDelta, max.heap));
         tr.end();
@@ -400,8 +413,8 @@ foam.CLASS({
         // Expandable detail: hottest functions and the server calls this block made.
         if ( hot.length ) {
           var ht = t.start('tr').addClass(self.myClass('hot-detailrow')).show(inner$)
-            .start('td').attrs({ colspan: 4 })
-              .start('div').addClass(self.myClass('detail-title')).add('Hottest functions' + scope).end()
+            .start('td').addClass(dCls).attrs({ colspan: 4 })
+              .start('div').addClass(self.myClass('detail-title')).add('Hottest functions').end()
               .start('table').addClass(self.myClass('hot-table'));
           ht.start('tr')
             .start('th').add('Function').end()
@@ -419,8 +432,8 @@ foam.CLASS({
         }
         if ( bCalls.length ) {
           var ct = t.start('tr').addClass(self.myClass('hot-detailrow')).show(inner$)
-            .start('td').attrs({ colspan: 4 })
-              .start('div').addClass(self.myClass('detail-title')).add('Server calls' + scope).end()
+            .start('td').addClass(dCls).attrs({ colspan: 4 })
+              .start('div').addClass(self.myClass('detail-title')).add('Server calls').end()
               .start('table').addClass(self.myClass('hot-table'));
           ct.start('tr')
             .start('th').add('Service').end()
@@ -553,10 +566,11 @@ foam.CLASS({
     },
 
     function blockCosts_(rows, trace) {
-      /** One level of the block tree as PerfBlockCost rows, worst first, each carrying its
-          hottest functions, the server calls it made (both bucketed into the block's
-          [start,end] window, so a parent's include its children's) and the blocks that ran
-          inside it. Trivial blocks are dropped; top 12 kept per level. **/
+      /** One level of the block tree as PerfBlockCost rows, worst first, each carrying the
+          blocks that ran inside it plus the functions and server calls of its OWN time -
+          a nested block's work belongs to that block, so a wrapper that only holds
+          children reports no functions and no calls instead of repeating theirs.
+          Trivial blocks are dropped; top 12 kept per level. **/
       var self     = this;
       var netCalls = this.netCalls_ || [];
       return ( rows || [] )
@@ -564,15 +578,39 @@ foam.CLASS({
         .sort(function(a, b) { return b.ms - a.ms; })
         .slice(0, 12)
         .map(function(b) {
-          var inWindow = b.start == null ? [] :
-            netCalls.filter(function(c) { return c.t >= b.start && c.t < b.end; });
+          var kids = self.blockCosts_(b.children, trace);
+          // Only the children that survived the filter own their window; a dropped
+          // child's work rolls up here, where it is still visible.
+          var kept   = self.keptWindows_(b.children, kids);
+          var selfMs = Math.max(0, b.ms - kept.reduce(function(s, w) { return s + ( w[1] - w[0] ); }, 0));
+          var mine   = b.start == null ? [] : netCalls.filter(function(c) {
+            return c.t >= b.start && c.t < b.end && ! self.inAny_(kept, c.t);
+          });
           return foam.core.reflow.perf.PerfBlockCost.create({
-            flowName: b.flowName, cmd: b.cmd, ms: b.ms, domDelta: b.domDelta, heapDelta: b.heapDelta,
-            hot:      ( trace && b.start != null ) ? self.framesInWindow_(trace, b.start, b.end, b.ms) : [],
-            calls:    self.groupServiceCalls_(inWindow),
-            children: self.blockCosts_(b.children, trace)
+            flowName: b.flowName, cmd: b.cmd, ms: b.ms, selfMs: selfMs,
+            domDelta: b.domDelta, heapDelta: b.heapDelta,
+            hot:      ( trace && b.start != null && selfMs >= 1 ) ?
+              self.framesInWindow_(trace, b.start, b.end, selfMs, kept) : [],
+            calls:    self.groupServiceCalls_(mine),
+            children: kids
           });
         });
+    },
+
+    function keptWindows_(rawChildren, kids) {
+      /** [start,end] of each recorded child that made it into the report, matched by name
+          and start so a filtered-out child keeps rolling up into its parent. **/
+      var byKey = {};
+      kids.forEach(function(k) { byKey[k.flowName] = true; });
+      return ( rawChildren || [] )
+        .filter(function(c) { return byKey[c.flowName] && c.start != null; })
+        .map(function(c) { return [ c.start, c.end ]; });
+    },
+
+    function inAny_(windows, t) {
+      for ( var i = 0 ; i < windows.length ; i++ )
+        if ( t >= windows[i][0] && t < windows[i][1] ) return true;
+      return false;
     },
 
     async function settleBodies_() {
@@ -610,18 +648,21 @@ foam.CLASS({
       }
     },
 
-    function framesInWindow_(trace, start, end, blockMs) {
-      /** Hottest leaf frames among samples whose timestamp falls in [start,end).
+    function framesInWindow_(trace, start, end, blockMs, opt_exclude) {
+      /** Hottest leaf frames among samples whose timestamp falls in [start,end) and outside
+          every excluded window (a nested block's samples belong to that block).
           Returns top 5 (>=5% of the window), with % within the window and CPU ms.
           ms is the frame's SHARE of the block's wall time (not samples × nominal
           interval - Chrome samples faster than the 10ms hint, which over-counts).
           Drops this tool's own measurement frames. **/
       if ( ! trace || ! trace.samples || ! trace.stacks || ! trace.frames ) return [];
       var self = this;
+      var excl = opt_exclude || [];
       var NOISE = { 'Profiler': true, 'querySelectorAll': true, 'now': true, 'takeRecords': true };
       var counts = {}, total = 0;
       trace.samples.forEach(function(s) {
         if ( s.timestamp < start || s.timestamp >= end ) return;
+        if ( self.inAny_(excl, s.timestamp) ) return;
         var stack = trace.stacks[s.stackId];
         if ( ! stack ) return;
         counts[stack.frameId] = ( counts[stack.frameId] || 0 ) + 1;

--- a/src/foam/core/reflow/perf/Perf.js
+++ b/src/foam/core/reflow/perf/Perf.js
@@ -112,7 +112,8 @@ foam.CLASS({
   `,
 
   constants: {
-    SAMPLE_INTERVAL_MS: 10   // JS Self-Profiling sampleInterval; each sample ≈ this many ms of CPU
+    SAMPLE_INTERVAL_MS: 10,  // JS Self-Profiling sampleInterval; each sample ≈ this many ms of CPU
+    HOT_MIN_MS:         20   // own time a block needs before its hottest functions mean anything
   },
 
   properties: [
@@ -256,7 +257,7 @@ foam.CLASS({
       row(self.HEAP_LABEL, r.byteStr(r.heapDeltaBytes), 'heapDeltaBytes');
       row(self.DOM_LABEL, r.numStr(r.domNodeDelta, 0) + ( r.tableCellDelta > 0 ? ' (' + r.numStr(r.tableCellDelta, 0) + ' cells)' : '' ), 'domNodeDelta');
       row(self.NETWORK_LABEL, r.numStr(r.networkCallCount, 0) + ' (' + r.numStr(r.repeatedRequestCount, 0) + ' repeated reads)', 'repeatedRequestCount');
-      row(self.LARGEST_LABEL, r.byteStr(r.largestRequestBytes), 'largestRequestBytes');
+      row(self.LARGEST_LABEL, r.sizeStr(r.largestRequestBytes), 'largestRequestBytes');
       row(self.WARN_LABEL, r.numStr(r.warnCount, 0), 'warnRate');
       el2.end();
       card.end();
@@ -399,6 +400,8 @@ foam.CLASS({
           .add( expandable ? open$.map(function(o) { return o ? '▾' : '▸'; }) : '' )
         .end();
         th.add(b.flowName);
+        var sub = b.subtitle();
+        if ( sub ) th.start('span').addClass(self.myClass('inside')).add(sub).end();
         if ( kids.length ) {
           th.start('span').addClass(self.myClass('inside'))
             .add(kids.length + ( kids.length === 1 ? ' block inside' : ' blocks inside' ))
@@ -589,7 +592,9 @@ foam.CLASS({
           return foam.core.reflow.perf.PerfBlockCost.create({
             flowName: b.flowName, cmd: b.cmd, ms: b.ms, selfMs: selfMs,
             domDelta: b.domDelta, heapDelta: b.heapDelta,
-            hot:      ( trace && b.start != null && selfMs >= 1 ) ?
+            // Below HOT_MIN_MS a block's own time is a couple of profiler samples, and
+            // "100% 2ms setAttribute" reads as a finding when it is noise.
+            hot:      ( trace && b.start != null && selfMs >= self.HOT_MIN_MS ) ?
               self.framesInWindow_(trace, b.start, b.end, selfMs, kept) : [],
             calls:    self.groupServiceCalls_(mine),
             children: kids
@@ -781,7 +786,11 @@ foam.CLASS({
         if ( op === 'cmd' ) op += ' · ' + this.cmdName_(args[1]);
         call.op = op;
         for ( var i = 0 ; i < args.length ; i++ ) {
-          if ( foam.dao.Sink.isInstance(args[i]) ) { call.sink = args[i].cls_.name; break; }
+          if ( foam.dao.Sink.isInstance(args[i]) ) {
+            call.sink      = args[i].cls_.name;
+            call.sinkProps = this.sinkProps_(args[i]);
+            break;
+          }
         }
         // Query descriptor for the expand view: the predicate if any (select_ arg 5),
         // else the id being fetched/written - so two calls can be compared by what they ask for.
@@ -797,6 +806,40 @@ foam.CLASS({
         var q = parts.join('  ·  ');
         call.query = q.length > 160 ? q.substring(0, 157) + '…' : q;
       } catch (e) { /* unparseable - leave op/sink blank */ }
+    },
+
+    function sinkProps_(sink) {
+      /** The sink's set properties as short strings. Groups key on the sink CLASS, so two
+          calls that ask the same question of differently configured sinks land in one
+          group; these are what tagVariants_ uses to tell their rows apart. **/
+      var out = {}, inst = ( sink && sink.instance_ ) || {};
+      Object.keys(inst).forEach(function(k) {
+        if ( k.endsWith('_') ) return;
+        var v = inst[k];
+        if ( v == null || foam.dao.Sink.isInstance(v) ) return;
+        var s = foam.lang.FObject.isInstance(v) ? ( v.name || v.cls_.name ) : String(v);
+        if ( s && s.length <= 40 ) out[k] = s;
+      });
+      return out;
+    },
+
+    function tagVariants_(variants) {
+      /** Append the sink settings that DIFFER across a group's variants to each variant's
+          query text. Without it two calls with the same predicate but different sink
+          configuration print as the same line while counting as distinct requests. **/
+      if ( variants.length < 2 ) return;
+      var keys = {};
+      variants.forEach(function(v) { Object.keys(v.sinkProps || {}).forEach(function(k) { keys[k] = true; }); });
+      var differing = Object.keys(keys).filter(function(k) {
+        var first = ( variants[0].sinkProps || {} )[k];
+        return variants.some(function(v) { return ( v.sinkProps || {} )[k] !== first; });
+      });
+      if ( ! differing.length ) return;
+      variants.forEach(function(v) {
+        var props = v.sinkProps || {};
+        var txt = differing.map(function(k) { return k + '=' + ( props[k] == null ? '—' : props[k] ); }).join(' ');
+        v.query = v.query ? v.query + '  ·  ' + txt : txt;
+      });
     },
 
     function cmdName_(cmd) {
@@ -837,6 +880,7 @@ foam.CLASS({
     function groupServiceCalls_(calls) {
       /** Group calls by service+operation+sink into PerfServiceCall[] (with per-body
           variants), most-called first. Shared by the global table and per-block attribution. **/
+      var self = this;
       var byService = {};
       calls.forEach(function(c) {
         var key = ( c.service || '?' ) + '|' + ( c.op || '' ) + '|' + ( c.sink || '' );
@@ -844,16 +888,22 @@ foam.CLASS({
         g.count++;
         g.requestBytes  += c.reqBytes || 0;
         g.responseBytes += c.respBytes || 0;
-        var v = g.variants_[c.hash] || ( g.variants_[c.hash] = { count: 0, requestBytes: 0, responseBytes: 0, query: c.query || '' } );
+        var v = g.variants_[c.hash] || ( g.variants_[c.hash] = { count: 0, requestBytes: 0, responseBytes: 0, query: c.query || '', sinkProps: c.sinkProps || {} } );
         v.count++;
         v.requestBytes  += c.reqBytes || 0;
         v.responseBytes += c.respBytes || 0;
       });
       return Object.keys(byService).map(function(k) {
         var g = byService[k];
-        var variants = Object.keys(g.variants_).map(function(h) {
-          return foam.core.reflow.perf.PerfRequestVariant.create(g.variants_[h]);
-        }).sort(function(a, b) { return b.count - a.count; });
+        // Label before the models are built: tagVariants_ compares the whole set.
+        var rows = Object.keys(g.variants_).map(function(h) { return g.variants_[h]; })
+          .sort(function(a, b) { return b.count - a.count; });
+        self.tagVariants_(rows);
+        var variants = rows.map(function(v) {
+          return foam.core.reflow.perf.PerfRequestVariant.create({
+            count: v.count, requestBytes: v.requestBytes, responseBytes: v.responseBytes, query: v.query
+          });
+        });
         g.distinct = variants.length;
         g.variants = variants;
         delete g.variants_;

--- a/src/foam/core/reflow/perf/PerfModels.js
+++ b/src/foam/core/reflow/perf/PerfModels.js
@@ -109,6 +109,16 @@ foam.CLASS({
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfHotFrame', name: 'hot', documentation: 'hottest functions sampled in this block\'s own time, nested blocks excluded' },
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfServiceCall', name: 'calls', documentation: 'server calls this block made itself; a nested block\'s calls belong to that block' },
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfBlockCost', name: 'children', documentation: 'blocks that ran inside this one, worst first; their cost is part of this row total' }
+  ],
+
+  methods: [
+    function subtitle() {
+      /** The command, when the block's name alone identifies nothing. Auto-named blocks
+          come through as '1', '2', '3', so the report would otherwise list rows no reader
+          can place. Empty when the name already says what the block is. **/
+      if ( ! this.cmd || ! /^\d*$/.test(this.flowName) ) return '';
+      return this.cmd.length > 48 ? this.cmd.substring(0, 45) + '…' : this.cmd;
+    }
   ]
 });
 

--- a/src/foam/core/reflow/perf/PerfModels.js
+++ b/src/foam/core/reflow/perf/PerfModels.js
@@ -54,6 +54,20 @@ foam.CLASS({
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfRequestVariant', name: 'variants', documentation: 'distinct request bodies in this group, most-repeated first' },
     { class: 'Long',   name: 'requestBytes',  documentation: 'summed request-body bytes' },
     { class: 'Long',   name: 'responseBytes', documentation: 'summed response wire bytes (content-length)' }
+  ],
+
+  constants: {
+    CACHEABLE_OPS: { select: true, find: true }
+  },
+
+  methods: [
+    function avoidable() {
+      /** Identical re-fetches a cache would remove. Only reads qualify: sending the same
+          control message (cmd) or the same write twice is the caller asking for the work
+          to happen twice, not a cache miss. **/
+      if ( ! foam.core.reflow.perf.PerfServiceCall.CACHEABLE_OPS[this.operation] ) return 0;
+      return this.count - ( this.distinct || this.count );
+    }
   ]
 });
 
@@ -92,7 +106,8 @@ foam.CLASS({
     { class: 'Int',    name: 'domDelta', documentation: 'live nodes added while the block ran' },
     { class: 'Long',   name: 'heapDelta', documentation: 'heap growth while the block ran, bytes' },
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfHotFrame', name: 'hot', documentation: 'hottest functions sampled inside this block window' },
-    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfServiceCall', name: 'calls', documentation: 'server calls this block made (in its time window)' }
+    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfServiceCall', name: 'calls', documentation: 'server calls this block made (in its time window)' },
+    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfBlockCost', name: 'children', documentation: 'blocks that ran inside this one, worst first; their cost is part of this row total' }
   ]
 });
 

--- a/src/foam/core/reflow/perf/PerfModels.js
+++ b/src/foam/core/reflow/perf/PerfModels.js
@@ -102,11 +102,12 @@ foam.CLASS({
   properties: [
     { class: 'String', name: 'flowName' },
     { class: 'String', name: 'cmd' },
-    { class: 'Float',  name: 'ms', documentation: 'wall time the block held the load loop' },
+    { class: 'Float',  name: 'ms', documentation: 'wall time the block held the load loop, its nested blocks included' },
+    { class: 'Float',  name: 'selfMs', documentation: 'ms minus the blocks that ran inside it - the work this block did itself' },
     { class: 'Int',    name: 'domDelta', documentation: 'live nodes added while the block ran' },
     { class: 'Long',   name: 'heapDelta', documentation: 'heap growth while the block ran, bytes' },
-    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfHotFrame', name: 'hot', documentation: 'hottest functions sampled inside this block window' },
-    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfServiceCall', name: 'calls', documentation: 'server calls this block made (in its time window)' },
+    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfHotFrame', name: 'hot', documentation: 'hottest functions sampled in this block\'s own time, nested blocks excluded' },
+    { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfServiceCall', name: 'calls', documentation: 'server calls this block made itself; a nested block\'s calls belong to that block' },
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfBlockCost', name: 'children', documentation: 'blocks that ran inside this one, worst first; their cost is part of this row total' }
   ]
 });

--- a/src/foam/core/reflow/perf/PerfReport.js
+++ b/src/foam/core/reflow/perf/PerfReport.js
@@ -39,7 +39,7 @@ foam.CLASS({
     { class: 'Int',   name: 'tableCellDelta', documentation: 'u2 div-grid table cells added during the window' },
     { class: 'Int',   name: 'networkCallCount', documentation: 'fetch calls observed during the window' },
     { class: 'Long',  name: 'largestRequestBytes', documentation: 'largest single request body' },
-    { class: 'Int',   name: 'repeatedRequestCount', documentation: 'distinct (url, body) keys fired more than once' },
+    { class: 'Int',   name: 'repeatedRequestCount', documentation: 'identical re-fetches of a read (url + body sent more than once); control messages and writes excluded - repeating those is requested work, not a cache miss' },
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfRepeatedRequest', name: 'repeatedRequests' },
     { class: 'FObjectArray', of: 'foam.core.reflow.perf.PerfServiceCall', name: 'serviceCalls', documentation: 'all calls grouped by service+operation+sink, most-called first' },
     { class: 'Int',   name: 'warnCount', documentation: 'console.warn calls during the window' },
@@ -199,16 +199,19 @@ foam.CLASS({
       // Section order matches the UI: Per-block, Service calls, then Metrics.
       var blocks = this.blockProfile || [];
       if ( blocks.length ) {
-        L.push('PER-BLOCK COST (worst first)');
-        blocks.forEach(function(b) {
-          L.push('  ' + pad(this.durStr(b.ms), 9) + pad('+' + this.numStr(b.domDelta, 0) + ' dom', 14) + pad(this.byteStr(b.heapDelta), 12) + b.flowName);
-          ( b.hot || [] ).forEach(function(f) {
-            L.push('       ' + pad(this.numStr(f.pct, 0) + '%', 6) + pad(this.durStr(f.ms), 9) + this.frameLabel(f));
+        L.push('PER-BLOCK COST (worst first, nested blocks indented)');
+        ( function emit(list, indent) {
+          list.forEach(function(b) {
+            L.push('  ' + pad(this.durStr(b.ms), 9) + pad('+' + this.numStr(b.domDelta, 0) + ' dom', 14) + pad(this.byteStr(b.heapDelta), 12) + indent + b.flowName);
+            ( b.hot || [] ).forEach(function(f) {
+              L.push('       ' + indent + pad(this.numStr(f.pct, 0) + '%', 6) + pad(this.durStr(f.ms), 9) + this.frameLabel(f));
+            }.bind(this));
+            ( b.calls || [] ).forEach(function(c) {
+              L.push('       ' + indent + '→ ' + pad(c.count + '×', 5) + c.service + ' ' + ( c.operation || '' ) + ( c.sink ? ' · ' + c.sink : '' ));
+            });
+            emit.call(this, b.children || [], indent + '  ');
           }.bind(this));
-          ( b.calls || [] ).forEach(function(c) {
-            L.push('       → ' + pad(c.count + '×', 5) + c.service + ' ' + ( c.operation || '' ) + ( c.sink ? ' · ' + c.sink : '' ));
-          });
-        }.bind(this));
+        } ).call(this, blocks, '');
         L.push('');
       }
 
@@ -216,7 +219,7 @@ foam.CLASS({
       if ( calls.length ) {
         L.push('SERVICE CALLS (most-called first)');
         calls.forEach(function(c) {
-          var rep = c.count - ( c.distinct || c.count );
+          var rep = c.avoidable();
           var cnt = c.count + ( c.count === 1 ? ' call' : ' calls' ) + ( rep > 0 ? ' · ' + c.distinct + ' unique' : '' );
           var act = rep > 0 ? 'CACHE (' + rep + ' avoidable)' : '';
           L.push('  ' + pad(cnt, 20) + pad(c.service, 28) +
@@ -237,7 +240,7 @@ foam.CLASS({
       L.push('  ' + pad('Longest UI freeze', 22)    + this.durStr(this.longestTaskMs));
       L.push('  ' + pad('Memory change', 22)        + this.byteStr(this.heapDeltaBytes));
       L.push('  ' + pad('Page elements added', 22)  + this.numStr(this.domNodeDelta, 0) + ( this.tableCellDelta > 0 ? ' (' + this.numStr(this.tableCellDelta, 0) + ' table cells)' : '' ));
-      L.push('  ' + pad('Server calls', 22)         + this.numStr(this.networkCallCount, 0) + ' (' + this.numStr(this.repeatedRequestCount, 0) + ' identical)');
+      L.push('  ' + pad('Server calls', 22)         + this.numStr(this.networkCallCount, 0) + ' (' + this.numStr(this.repeatedRequestCount, 0) + ' repeated reads)');
       L.push('  ' + pad('Largest request sent', 22) + this.byteStr(this.largestRequestBytes));
       L.push('  ' + pad('Console warnings', 22)     + this.numStr(this.warnCount, 0));
       L.push('');

--- a/src/foam/core/reflow/perf/PerfReport.js
+++ b/src/foam/core/reflow/perf/PerfReport.js
@@ -202,7 +202,9 @@ foam.CLASS({
         L.push('PER-BLOCK COST (worst first, nested blocks indented)');
         ( function emit(list, indent) {
           list.forEach(function(b) {
-            L.push('  ' + pad(this.durStr(b.ms), 9) + pad('+' + this.numStr(b.domDelta, 0) + ' dom', 14) + pad(this.byteStr(b.heapDelta), 12) + indent + b.flowName);
+            var kids = ( b.children || [] ).length;
+            L.push('  ' + pad(this.durStr(b.ms), 9) + pad('+' + this.numStr(b.domDelta, 0) + ' dom', 14) + pad(this.byteStr(b.heapDelta), 12) + indent + b.flowName +
+              ( kids ? '  (self ' + this.durStr(b.selfMs) + ', ' + kids + ' inside)' : '' ));
             ( b.hot || [] ).forEach(function(f) {
               L.push('       ' + indent + pad(this.numStr(f.pct, 0) + '%', 6) + pad(this.durStr(f.ms), 9) + this.frameLabel(f));
             }.bind(this));

--- a/src/foam/core/reflow/perf/PerfReport.js
+++ b/src/foam/core/reflow/perf/PerfReport.js
@@ -203,7 +203,9 @@ foam.CLASS({
         ( function emit(list, indent) {
           list.forEach(function(b) {
             var kids = ( b.children || [] ).length;
+            var sub  = b.subtitle();
             L.push('  ' + pad(this.durStr(b.ms), 9) + pad('+' + this.numStr(b.domDelta, 0) + ' dom', 14) + pad(this.byteStr(b.heapDelta), 12) + indent + b.flowName +
+              ( sub ? '  [' + sub + ']' : '' ) +
               ( kids ? '  (self ' + this.durStr(b.selfMs) + ', ' + kids + ' inside)' : '' ));
             ( b.hot || [] ).forEach(function(f) {
               L.push('       ' + indent + pad(this.numStr(f.pct, 0) + '%', 6) + pad(this.durStr(f.ms), 9) + this.frameLabel(f));
@@ -243,7 +245,7 @@ foam.CLASS({
       L.push('  ' + pad('Memory change', 22)        + this.byteStr(this.heapDeltaBytes));
       L.push('  ' + pad('Page elements added', 22)  + this.numStr(this.domNodeDelta, 0) + ( this.tableCellDelta > 0 ? ' (' + this.numStr(this.tableCellDelta, 0) + ' table cells)' : '' ));
       L.push('  ' + pad('Server calls', 22)         + this.numStr(this.networkCallCount, 0) + ' (' + this.numStr(this.repeatedRequestCount, 0) + ' repeated reads)');
-      L.push('  ' + pad('Largest request sent', 22) + this.byteStr(this.largestRequestBytes));
+      L.push('  ' + pad('Largest request sent', 22) + this.sizeStr(this.largestRequestBytes));
       L.push('  ' + pad('Console warnings', 22)     + this.numStr(this.warnCount, 0));
       L.push('');
 


### PR DESCRIPTION
The Blocks tab attributed a load to top-level blocks only, so a layout that took ten seconds gave no clue which of its children spent it. Worse, a parent's window contains its children's, so every ancestor repeated the same hottest functions, the same server calls and the same heap number — two rows saying one thing, a screen apart.

The load loop now records every level, and each block reports the work it did itself: a nested block's time, functions and calls belong to that block. A wrapper collapses to one line reading `8s 768ms · self 4ms` with `2 blocks inside` and no tables at all, so the detail sits on the blocks that actually cost something.

- **Nesting** — children listed under the block they ran inside, one indent rail per level, detail tables indented to match

- **Self time** — `ms` stays the rolled-up total, `selfMs` is that minus the blocks inside it

- **Command identity** — a control message reads `cmd · PURGE_CMD` rather than a bare `cmd`, and each command gets its own row instead of every one sharing a single line

- **Cache advice** — `Cache (N avoidable)` is limited to repeated reads: sending the same control message or the same write twice is work the caller asked for, not a cache miss. The repeated-request metric the Issues panel reads follows the same rule

Also in here: request bodies read from a stream settle before the capture summarizes (the last calls of a load were landing with a blank operation and zero bytes sent), blocks the flow auto-named `1`, `2`, `3` carry the command that built them, hottest-function tables need 20ms of own time before they say anything, and variants that differ only in how their sink is configured now show which setting differs instead of printing the same line twice.

Stacked on `DOS-4304-loadperf-block-profile` — same three files — so this targets that branch and can be retargeted to development once it merges.