### PR TITLE
i18n guide - Document message inheritance in class hierarchies

### DIFF
--- a/doc/guides/i18n.md
+++ b/doc/guides/i18n.md
@@ -173,6 +173,51 @@ messages: [
 ]
 ```
 
+### Sharing Messages Across a Class Hierarchy
+
+(Optional read : for when the volume of messages increase and they start to look similar across different classes)
+
+Messages inherit. A message defined on a base class is usable from every subclass — as a class constant (`SubClass.MY_MSG`) and on instances (`this.MY_MSG`, `X.data.MY_MSG`) — with no re-declaration. Template messages inherit the same way, and their `${}` keys still resolve against the object the message is called on, not the base class.
+
+So when several sibling models repeat the same strings, define them **once on the shared parent** and delete the copies:
+
+```javascript
+// Parent — defines once
+foam.CLASS({
+  name: 'Order',
+  messages: [
+    {
+      name: 'STATUS_CHANGED',
+      messageMap: {
+        en: 'Order status changed to ${newStatus}',
+        fr: 'Statut de la commande passé à ${newStatus}'
+      },
+      template: true
+    }
+  ]
+});
+
+// Subclass — no messages block needed
+foam.CLASS({
+  name: 'ExpressOrder',
+  extends: 'Order',
+  actions: [
+    {
+      name: 'ship',
+      code: function(X) {
+        // X.data is an ExpressOrder — the parent's
+        // message resolves through inheritance:
+        X.notify(X.data.STATUS_CHANGED({ newStatus: 'SHIPPED' }), '', this.LogLevel.INFO, true);
+      }
+    }
+  ]
+});
+```
+
+A subclass may also redeclare a message with the same name to override the parent's wording for that subclass only.
+
+> **Runtime-override keys follow the defining class.** `Locale` rows and the Translation Console key a message by the class that *declares* it — `Order.STATUS_CHANGED` in the example above, never `ExpressOrder.STATUS_CHANGED`. Keep this in mind when moving a message up to a base class: any existing `Locale` rows keyed to the old subclass path stop matching and must be re-keyed ([advanced guide](./i18n-advanced.md#locale-record-key-conventions)).
+
 ## Porting Hardcoded Strings
 
 ### Step 1: Identify Hardcoded Strings


### PR DESCRIPTION
Adds a usage-focused section to `doc/guides/i18n.md`: 
messages defined on a base class resolve from every subclass (class constants, instance access, template messages), so shared strings should live once on the shared parent rather than be copied per subclass. Includes a subclass-override note and a caveat that runtime-override keys (Locale rows, Translation Console) follow the defining class — the thing that bites when a message moves up a hierarchy.

No code changes — documentation only.