### PR TITLE
Fix LSP orphan processes spinning at 100% CPU

### DIFF
--- a/tools/lsp-start.js
+++ b/tools/lsp-start.js
@@ -23,6 +23,11 @@ process.on('unhandledRejection', function(e) {
   console.error('[LSP] Ignoring unhandled rejection:', e.message || e);
 });
 process.on('uncaughtException', function(e) {
+  // Our pipes are gone (parent died). Logging below would EPIPE again and
+  // re-enter this handler forever — a 100% CPU spin. Exit instead.
+  if ( e && ( e.code === 'EPIPE' || e.code === 'ERR_STREAM_DESTROYED' ) ) {
+    process.exit(0);
+  }
   // Ignore web-only errors (document, window, etc.)
   if ( e.message && ( e.message.includes('document') || e.message.includes('window') ) ) {
     console.error('[LSP] Ignoring web-only error:', e.message);

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -689,9 +689,19 @@ function main() {
 
   rl.on('close', function() {
     log('stdin closed, shutting down');
+    shutdown();
+  });
+
+  // stdin 'close' only covers a graceful client exit. When the MCP host
+  // terminates us with a signal, reap the LSP child too — otherwise it's
+  // orphaned and lives forever.
+  function shutdown() {
     if ( lsp.child && ! lsp.child.killed ) lsp.child.kill();
     process.exit(0);
-  });
+  }
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT',  shutdown);
+  process.on('SIGHUP',  shutdown);
 }
 
 // --- exports (for tests) + entrypoint guard ------------------------------

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -60,6 +60,26 @@ function start() {
     processBuffer();
   });
 
+  // Exit when the client closes our stdin — otherwise a dead parent leaves
+  // this process orphaned forever (and writes to its closed pipes EPIPE).
+  process.stdin.on('end', function() {
+    process.exit(0);
+  });
+
+  // LSP spec: initialize.processId is the client's pid; the server should
+  // exit when that process dies. Covers parents killed with SIGKILL, where
+  // stdin 'end' may never be observed before the next write EPIPEs.
+  function watchClientProcess(pid) {
+    if ( typeof pid !== 'number' ) return;
+    setInterval(function() {
+      try {
+        process.kill(pid, 0);
+      } catch (e) {
+        process.exit(0);
+      }
+    }, 30000).unref();
+  }
+
   function processBuffer() {
     while ( true ) {
       var headerEnd = rawBuffer.indexOf('\r\n\r\n');
@@ -370,6 +390,7 @@ function start() {
     try {
     switch ( method ) {
       case 'initialize':
+        watchClientProcess(params && params.processId);
         respond(id, {
           capabilities: {
             textDocumentSync: {


### PR DESCRIPTION
When the LSP's client (editor plugin or MCP wrapper) dies without a graceful shutdown, the LSP server never notices — it watches nothing but stdin `'data'` — so it lives forever as an orphan. Its next stderr write EPIPEs, and the `uncaughtException` handler in `lsp-start.js` logs the error via `console.error`, which EPIPEs again and re-enters the handler: an infinite loop pinning a core at 100% CPU (confirmed on a live orphan with macOS `sample` — the stack cycles through `TriggerUncaughtException` → console call).

The MCP wrapper's cleanup should have prevented the orphan, but it reaps its LSP child only on stdin `'close'` — which never fires when the wrapper itself is killed by a signal.

Fix:

- **stdin end** — `server.js` exits when the client closes stdin

- **processId watch** — honor `initialize.processId` per the LSP spec: poll the client pid every 30s (unref'd timer), exit when it's gone; covers clients killed with SIGKILL where stdin `'end'` is never observed

- **EPIPE guard** — the `lsp-start.js` exception handler exits on `EPIPE`/`ERR_STREAM_DESTROYED` before touching `console.error`, breaking the spin even if a process still gets orphaned

- **signal reap** — the MCP wrapper kills its LSP child on SIGTERM/SIGINT/SIGHUP, not only on graceful stdin close

Verified: booting the LSP with EOF stdin now exits 0 (previously hung forever); SIGTERM on the MCP wrapper reaps the LSP child.