### PR TITLE
LSP: Refresh stale files by mtime and reboot the LSP on git HEAD change

### DIFF
--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -280,7 +280,7 @@ class FoamLSPClient {
     this.projectRoot       = projectRoot;
     this.nextId            = 1;
     this.pending           = new Map();       // id -> { resolve, reject }
-    this.openedUris        = new Set();
+    this.openedUris        = new Map();       // uri -> { mtimeMs, version }
     this.diagnosticsByUri  = new Map();       // uri -> diagnostics[]
     this.buffer            = Buffer.alloc(0);
     this.isReady           = false;
@@ -337,7 +337,11 @@ class FoamLSPClient {
 
     this.child = spawn('node', [entry], {
       cwd:   this.projectRoot,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // Stale-index guard: the LSP exits when git HEAD changes (branch
+      // switch); our exit handler resets state and the next tool call
+      // boots a fresh index. Safe for us — we have no restart UX cost.
+      env:   Object.assign({}, process.env, { FOAM_LSP_EXIT_ON_HEAD_CHANGE: '1' })
     });
 
     this.child.stdout.on('data', this._onStdout.bind(this));
@@ -469,20 +473,41 @@ class FoamLSPClient {
 
   async ensureOpen(uri) {
     await this.whenReady();
-    if ( this.openedUris.has(uri) ) return;
     const fsPath = uriToPath(uri);
+    let st;
+    try { st = fs.statSync(fsPath); }
+    catch (e) { throw new Error('file not found: ' + fsPath); }
+
+    const entry = this.openedUris.get(uri);
+    if ( entry && entry.mtimeMs === st.mtimeMs ) return;
+
     let text;
     try { text = fs.readFileSync(fsPath, 'utf8'); }
     catch (e) { throw new Error('file not found: ' + fsPath); }
-    this._notify('textDocument/didOpen', {
-      textDocument: {
-        uri:        uri,
-        languageId: 'javascript',
-        version:    1,
-        text:       text
-      }
+
+    if ( ! entry ) {
+      this._notify('textDocument/didOpen', {
+        textDocument: {
+          uri:        uri,
+          languageId: 'javascript',
+          version:    1,
+          text:       text
+        }
+      });
+      this.openedUris.set(uri, { mtimeMs: st.mtimeMs, version: 1 });
+      return;
+    }
+
+    // File changed on disk since we opened it (git checkout, pull, editor
+    // save) — refresh the server's copy, then didSave so it re-registers the
+    // file's classes in the live FOAM registry, not just the text cache.
+    entry.version++;
+    entry.mtimeMs = st.mtimeMs;
+    this._notify('textDocument/didChange', {
+      textDocument:   { uri: uri, version: entry.version },
+      contentChanges: [{ text: text }]
     });
-    this.openedUris.add(uri);
+    this._notify('textDocument/didSave', { textDocument: { uri: uri } });
   }
 
   async getDiagnostics(uri) {

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -482,7 +482,6 @@ class FoamLSPClient {
       // from a clean didOpen.
       if ( this.openedUris.has(uri) ) {
         this.openedUris.delete(uri);
-        this.diagnosticsByUri.delete(uri);
         this._notify('textDocument/didClose', { textDocument: { uri: uri } });
       }
       throw new Error('file not found: ' + fsPath);
@@ -490,6 +489,13 @@ class FoamLSPClient {
 
     const entry = this.openedUris.get(uri);
     if ( entry && entry.mtimeMs === st.mtimeMs ) return;
+
+    // The document is about to (re)load — open, refresh, or reopen after a
+    // delete (the server answers didClose with an empty publish, so the map
+    // re-fills even after a delete there). Drop the cached list here, the one
+    // spot all three paths pass, so getDiagnostics waits for the list the
+    // server publishes for the NEW text.
+    this.diagnosticsByUri.delete(uri);
 
     let text;
     try { text = fs.readFileSync(fsPath, 'utf8'); }
@@ -513,9 +519,6 @@ class FoamLSPClient {
     // file's classes in the live FOAM registry, not just the text cache.
     entry.version++;
     entry.mtimeMs = st.mtimeMs;
-    // Drop the stale diagnostics so getDiagnostics waits for the list the
-    // server publishes for the NEW text instead of answering from the old.
-    this.diagnosticsByUri.delete(uri);
     this._notify('textDocument/didChange', {
       textDocument:   { uri: uri, version: entry.version },
       contentChanges: [{ text: text }]

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -476,7 +476,16 @@ class FoamLSPClient {
     const fsPath = uriToPath(uri);
     let st;
     try { st = fs.statSync(fsPath); }
-    catch (e) { throw new Error('file not found: ' + fsPath); }
+    catch (e) {
+      // File gone from disk (deleted, or branch switched away): close our
+      // copy so the server drops its document and a later recreate starts
+      // from a clean didOpen.
+      if ( this.openedUris.has(uri) ) {
+        this.openedUris.delete(uri);
+        this._notify('textDocument/didClose', { textDocument: { uri: uri } });
+      }
+      throw new Error('file not found: ' + fsPath);
+    }
 
     const entry = this.openedUris.get(uri);
     if ( entry && entry.mtimeMs === st.mtimeMs ) return;

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -482,6 +482,7 @@ class FoamLSPClient {
       // from a clean didOpen.
       if ( this.openedUris.has(uri) ) {
         this.openedUris.delete(uri);
+        this.diagnosticsByUri.delete(uri);
         this._notify('textDocument/didClose', { textDocument: { uri: uri } });
       }
       throw new Error('file not found: ' + fsPath);
@@ -512,6 +513,9 @@ class FoamLSPClient {
     // file's classes in the live FOAM registry, not just the text cache.
     entry.version++;
     entry.mtimeMs = st.mtimeMs;
+    // Drop the stale diagnostics so getDiagnostics waits for the list the
+    // server publishes for the NEW text instead of answering from the old.
+    this.diagnosticsByUri.delete(uri);
     this._notify('textDocument/didChange', {
       textDocument:   { uri: uri, version: entry.version },
       contentChanges: [{ text: text }]

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -112,7 +112,7 @@ function start() {
           process.exit(0);
         }
       }
-    }, Number(process.env.FOAM_LSP_HEAD_POLL_MS) || 10000).unref();
+    }, Math.max(1000, Number(process.env.FOAM_LSP_HEAD_POLL_MS) || 10000)).unref();
   }
 
   // LSP spec: initialize.processId is the client's pid; the server should

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -66,6 +66,55 @@ function start() {
     process.exit(0);
   });
 
+  // --- git HEAD watch (opt-in) ---------------------------------------------
+  // The registry reflects the boot-time checkout. A branch switch rewrites
+  // files wholesale with no didSave, so answers silently go stale. When the
+  // client sets FOAM_LSP_EXIT_ON_HEAD_CHANGE (the MCP wrapper does — it
+  // reboots us lazily on the next tool call), exit as soon as a watched
+  // repo's HEAD changes. Editors don't set it: a didSave-driven refresh plus
+  // a visible restart is better UX than a surprise server exit.
+  // HEAD content only changes on checkout/switch/rebase — not on commit —
+  // so normal work never triggers this.
+  var fs_   = require('fs');
+  var path_ = require('path');
+
+  function resolveHeadPath(root) {
+    // .git is a directory in a normal checkout, but a "gitdir: <path>" file
+    // in worktrees and submodules.
+    var dotGit = path_.join(root, '.git');
+    try {
+      var gitdir = dotGit;
+      if ( fs_.statSync(dotGit).isFile() ) {
+        var m = fs_.readFileSync(dotGit, 'utf8').match(/^gitdir:\s*(.+)\s*$/m);
+        if ( ! m ) return null;
+        gitdir = path_.resolve(root, m[1].trim());
+      }
+      var head = path_.join(gitdir, 'HEAD');
+      fs_.accessSync(head);
+      return head;
+    } catch (e) { return null; }
+  }
+
+  function readHead(p) {
+    try { return fs_.readFileSync(p, 'utf8'); } catch (e) { return ''; }
+  }
+
+  if ( process.env.FOAM_LSP_EXIT_ON_HEAD_CHANGE ) {
+    // Watch the project repo and the foam3 submodule (same layout assumption
+    // as the rest of the tooling: foam3/ under the project root).
+    var headPaths = [ process.cwd(), path_.join(process.cwd(), 'foam3') ].
+      map(resolveHeadPath).filter(function(p) { return p; });
+    var headBaseline = headPaths.map(readHead);
+    setInterval(function() {
+      for ( var i = 0 ; i < headPaths.length ; i++ ) {
+        if ( readHead(headPaths[i]) !== headBaseline[i] ) {
+          console.error('[LSP] git HEAD changed (' + headPaths[i] + ') — exiting so the client boots a fresh index');
+          process.exit(0);
+        }
+      }
+    }, Number(process.env.FOAM_LSP_HEAD_POLL_MS) || 10000).unref();
+  }
+
   // LSP spec: initialize.processId is the client's pid; the server should
   // exit when that process dies. Covers parents killed with SIGKILL, where
   // stdin 'end' may never be observed before the next write EPIPEs.


### PR DESCRIPTION
Stacked on fix/lsp-lazy-boot — the last two commits are this PR.

The LSP answers from the boot-time checkout. The MCP wrapper read each file from disk once and never again, and nothing watched the repo — after a branch switch or pull, hover/symbols/diagnostics kept answering from dead text with no warning.

Fix:

- **mtime refresh** — `ensureOpen` stats the file on every call; when disk is newer it sends `didChange` with the fresh text plus `didSave`, which re-registers the file's classes in the live registry, not just the text cache. Files deleted from disk get `didClose` and drop their entry.

- **HEAD watch (opt-in)** — with `FOAM_LSP_EXIT_ON_HEAD_CHANGE` set, the LSP polls the `.git/HEAD` content of the project root and `foam3/` (`gitdir:` files resolved for worktrees/submodules, poll clamped to ≥1s) and exits on change. The MCP wrapper sets the env — its lazy respawn makes the exit invisible, the next tool call boots a fresh index. Editors don't set it, so their restart UX is unchanged. HEAD content only changes on checkout/switch/rebase, never on commit, so normal work never triggers it.

Verified live: a file rewritten on disk between two queries returns the new property; a branch flip kills the LSP within the poll interval and the next tool call answers from a fresh index.