### PR TITLE
LSP: Lazy-boot the MCP LSP and reap it when idle

### DIFF
--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -335,6 +335,10 @@ class FoamLSPClient {
     });
 
     this.child.stdout.on('data', this._onStdout.bind(this));
+    // A write can race the child's death (idle reap, crash): stdin then
+    // emits a stream 'error' which, unhandled, would crash the wrapper.
+    // The 'exit' handler already rejects the in-flight requests.
+    this.child.stdin.on('error', function() {});
     this.child.stderr.on('data', function(chunk) {
       // Forward LSP stderr to our stderr with a prefix; never touch stdout.
       const text = chunk.toString('utf8');

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -280,7 +280,7 @@ class FoamLSPClient {
     this.projectRoot       = projectRoot;
     this.nextId            = 1;
     this.pending           = new Map();       // id -> { resolve, reject }
-    this.openedUris        = new Set();
+    this.openedUris        = new Map();       // uri -> { mtimeMs, version }
     this.diagnosticsByUri  = new Map();       // uri -> diagnostics[]
     this.buffer            = Buffer.alloc(0);
     this.isReady           = false;
@@ -337,7 +337,11 @@ class FoamLSPClient {
 
     this.child = spawn('node', [entry], {
       cwd:   this.projectRoot,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // Stale-index guard: the LSP exits when git HEAD changes (branch
+      // switch); our exit handler resets state and the next tool call
+      // boots a fresh index. Safe for us — we have no restart UX cost.
+      env:   Object.assign({}, process.env, { FOAM_LSP_EXIT_ON_HEAD_CHANGE: '1' })
     });
 
     this.child.stdout.on('data', this._onStdout.bind(this));
@@ -469,20 +473,41 @@ class FoamLSPClient {
 
   async ensureOpen(uri) {
     await this.whenReady();
-    if ( this.openedUris.has(uri) ) return;
     const fsPath = uriToPath(uri);
+    let st;
+    try { st = fs.statSync(fsPath); }
+    catch (e) { throw new Error('file not found: ' + fsPath); }
+
+    const entry = this.openedUris.get(uri);
+    if ( entry && entry.mtimeMs === st.mtimeMs ) return;
+
     let text;
     try { text = fs.readFileSync(fsPath, 'utf8'); }
     catch (e) { throw new Error('file not found: ' + fsPath); }
-    this._notify('textDocument/didOpen', {
-      textDocument: {
-        uri:        uri,
-        languageId: 'javascript',
-        version:    1,
-        text:       text
-      }
+
+    if ( ! entry ) {
+      this._notify('textDocument/didOpen', {
+        textDocument: {
+          uri:        uri,
+          languageId: 'javascript',
+          version:    1,
+          text:       text
+        }
+      });
+      this.openedUris.set(uri, { mtimeMs: st.mtimeMs, version: 1 });
+      return;
+    }
+
+    // File changed on disk since we opened it (git checkout, pull, editor
+    // save) — refresh the server's copy, then didSave so it re-registers the
+    // file's classes in the live FOAM registry, not just the text cache.
+    entry.version++;
+    entry.mtimeMs = st.mtimeMs;
+    this._notify('textDocument/didChange', {
+      textDocument:   { uri: uri, version: entry.version },
+      contentChanges: [{ text: text }]
     });
-    this.openedUris.add(uri);
+    this._notify('textDocument/didSave', { textDocument: { uri: uri } });
   }
 
   async getDiagnostics(uri) {

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -482,7 +482,6 @@ class FoamLSPClient {
       // from a clean didOpen.
       if ( this.openedUris.has(uri) ) {
         this.openedUris.delete(uri);
-        this.diagnosticsByUri.delete(uri);
         this._notify('textDocument/didClose', { textDocument: { uri: uri } });
       }
       throw new Error('file not found: ' + fsPath);
@@ -490,6 +489,13 @@ class FoamLSPClient {
 
     const entry = this.openedUris.get(uri);
     if ( entry && entry.mtimeMs === st.mtimeMs ) return;
+
+    // The document is about to (re)load — open, refresh, or reopen after a
+    // delete (the server answers didClose with an empty publish, so the map
+    // re-fills even after a delete there). Drop the cached list here, the one
+    // spot all three paths pass, so getDiagnostics waits for the list the
+    // server publishes for the NEW text.
+    this.diagnosticsByUri.delete(uri);
 
     let text;
     try { text = fs.readFileSync(fsPath, 'utf8'); }
@@ -513,9 +519,6 @@ class FoamLSPClient {
     // file's classes in the live FOAM registry, not just the text cache.
     entry.version++;
     entry.mtimeMs = st.mtimeMs;
-    // Drop the stale diagnostics so getDiagnostics waits for the list the
-    // server publishes for the NEW text instead of answering from the old.
-    this.diagnosticsByUri.delete(uri);
     this._notify('textDocument/didChange', {
       textDocument:   { uri: uri, version: entry.version },
       contentChanges: [{ text: text }]

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -476,7 +476,16 @@ class FoamLSPClient {
     const fsPath = uriToPath(uri);
     let st;
     try { st = fs.statSync(fsPath); }
-    catch (e) { throw new Error('file not found: ' + fsPath); }
+    catch (e) {
+      // File gone from disk (deleted, or branch switched away): close our
+      // copy so the server drops its document and a later recreate starts
+      // from a clean didOpen.
+      if ( this.openedUris.has(uri) ) {
+        this.openedUris.delete(uri);
+        this._notify('textDocument/didClose', { textDocument: { uri: uri } });
+      }
+      throw new Error('file not found: ' + fsPath);
+    }
 
     const entry = this.openedUris.get(uri);
     if ( entry && entry.mtimeMs === st.mtimeMs ) return;

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -482,6 +482,7 @@ class FoamLSPClient {
       // from a clean didOpen.
       if ( this.openedUris.has(uri) ) {
         this.openedUris.delete(uri);
+        this.diagnosticsByUri.delete(uri);
         this._notify('textDocument/didClose', { textDocument: { uri: uri } });
       }
       throw new Error('file not found: ' + fsPath);
@@ -512,6 +513,9 @@ class FoamLSPClient {
     // file's classes in the live FOAM registry, not just the text cache.
     entry.version++;
     entry.mtimeMs = st.mtimeMs;
+    // Drop the stale diagnostics so getDiagnostics waits for the list the
+    // server publishes for the NEW text instead of answering from the old.
+    this.diagnosticsByUri.delete(uri);
     this._notify('textDocument/didChange', {
       textDocument:   { uri: uri, version: entry.version },
       contentChanges: [{ text: text }]

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -284,15 +284,44 @@ class FoamLSPClient {
     this.diagnosticsByUri  = new Map();       // uri -> diagnostics[]
     this.buffer            = Buffer.alloc(0);
     this.isReady           = false;
-    this._whenReady        = new Promise(function(resolve, reject) {
+    this.child             = null;
+    this.lastUsed          = Date.now();
+    this._resetReady();
+
+    // Idle reaper: the LSP holds the whole FOAM registry in memory, which is
+    // wasted on a session that stopped calling foam tools. Kill the child
+    // after FOAM_LSP_IDLE_MS without use (default 30 min); the exit handler
+    // resets state so the next tool call boots a fresh one.
+    const idleMs = Number(process.env.FOAM_LSP_IDLE_MS) || 30 * 60 * 1000;
+    setInterval(function() {
+      if ( this.child && this.isReady && this.pending.size === 0 &&
+           Date.now() - this.lastUsed > idleMs ) {
+        log('LSP idle for ' + Math.round(idleMs / 60000) + 'min — stopping (next call reboots it)');
+        this.child.kill();
+      }
+    }.bind(this), Math.min(60000, idleMs)).unref();
+  }
+
+  _resetReady() {
+    this._whenReady = new Promise(function(resolve, reject) {
       this._resolveReady = resolve;
       this._rejectReady  = reject;
     }.bind(this));
+    // Silence unhandledRejection when a boot fails with no awaiter;
+    // awaiters still observe the rejection.
+    this._whenReady.catch(function() {});
   }
 
-  whenReady() { return this._whenReady; }
+  // Lazy boot: the LSP costs ~10-15s and a large registry to start, and many
+  // MCP sessions never call a foam tool. Spawn on first use, not at startup.
+  whenReady() {
+    this.lastUsed = Date.now();
+    if ( ! this.child ) this.start();
+    return this._whenReady;
+  }
 
   start() {
+    if ( this.child ) return;
     const entry = path.join(this.projectRoot, 'foam3/tools/lsp-start.js');
     if ( ! fs.existsSync(entry) ) {
       this._rejectReady(new Error('FOAM LSP entry not found at ' + entry));
@@ -318,6 +347,18 @@ class FoamLSPClient {
       if ( ! this.isReady ) {
         this._rejectReady(new Error('LSP exited during init (code=' + code + ')'));
       }
+      // Reset to the pre-boot state so the next tool call respawns a fresh
+      // LSP (idle reap, crash, or kill — all recover the same way).
+      this.child   = null;
+      this.isReady = false;
+      this.buffer  = Buffer.alloc(0);
+      this.openedUris.clear();
+      this.diagnosticsByUri.clear();
+      for ( const p of this.pending.values() ) {
+        p.reject(new Error('LSP exited (code=' + code + ', signal=' + signal + ')'));
+      }
+      this.pending.clear();
+      this._resetReady();
     }.bind(this));
 
     // Kick off initialize.
@@ -342,6 +383,9 @@ class FoamLSPClient {
     }.bind(this)).catch(function(e) {
       log('LSP initialize failed:', e.message);
       this._rejectReady(e);
+      // Reap the half-booted child; its exit handler resets state so a
+      // later tool call can retry from scratch.
+      if ( this.child && ! this.child.killed ) this.child.kill();
     }.bind(this));
   }
 
@@ -387,6 +431,7 @@ class FoamLSPClient {
   }
 
   _sendRaw(message) {
+    if ( ! this.child ) throw new Error('LSP not running');
     const body   = JSON.stringify(message);
     const buf    = Buffer.from(body, 'utf8');
     const header = 'Content-Length: ' + buf.length + '\r\n\r\n';
@@ -622,9 +667,8 @@ function main() {
   const projectRoot = process.env.FOAM_PROJECT_ROOT || process.cwd();
   log('project root:', projectRoot);
 
+  // No eager boot — whenReady() spawns the LSP on the first foam tool call.
   const lsp = new FoamLSPClient(projectRoot);
-  lsp.start();                              // fire-and-forget; tool calls await whenReady()
-  lsp.whenReady().catch(function() {});     // prevent unhandled rejection
 
   const tools = toolSchemas();
 

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -329,6 +329,12 @@ class FoamLSPClient {
     }
     log('spawning LSP:', 'node', entry, '(cwd=' + this.projectRoot + ')');
 
+    // When the child dies mid-boot, the exit handler rejects the ready
+    // promise and swaps in a fresh one for the NEXT boot — and only then
+    // does the initialize .catch below fire. Settle the promise THIS boot
+    // owns, not whatever is current at that point.
+    const rejectBoot = this._rejectReady;
+
     this.child = spawn('node', [entry], {
       cwd:   this.projectRoot,
       stdio: ['pipe', 'pipe', 'pipe']
@@ -386,7 +392,7 @@ class FoamLSPClient {
       this._resolveReady(initResult);
     }.bind(this)).catch(function(e) {
       log('LSP initialize failed:', e.message);
-      this._rejectReady(e);
+      rejectBoot(e);
       // Reap the half-booted child; its exit handler resets state so a
       // later tool call can retry from scratch.
       if ( this.child && ! this.child.killed ) this.child.kill();

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -112,7 +112,7 @@ function start() {
           process.exit(0);
         }
       }
-    }, Number(process.env.FOAM_LSP_HEAD_POLL_MS) || 10000).unref();
+    }, Math.max(1000, Number(process.env.FOAM_LSP_HEAD_POLL_MS) || 10000)).unref();
   }
 
   // LSP spec: initialize.processId is the client's pid; the server should

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -66,6 +66,55 @@ function start() {
     process.exit(0);
   });
 
+  // --- git HEAD watch (opt-in) ---------------------------------------------
+  // The registry reflects the boot-time checkout. A branch switch rewrites
+  // files wholesale with no didSave, so answers silently go stale. When the
+  // client sets FOAM_LSP_EXIT_ON_HEAD_CHANGE (the MCP wrapper does — it
+  // reboots us lazily on the next tool call), exit as soon as a watched
+  // repo's HEAD changes. Editors don't set it: a didSave-driven refresh plus
+  // a visible restart is better UX than a surprise server exit.
+  // HEAD content only changes on checkout/switch/rebase — not on commit —
+  // so normal work never triggers this.
+  var fs_   = require('fs');
+  var path_ = require('path');
+
+  function resolveHeadPath(root) {
+    // .git is a directory in a normal checkout, but a "gitdir: <path>" file
+    // in worktrees and submodules.
+    var dotGit = path_.join(root, '.git');
+    try {
+      var gitdir = dotGit;
+      if ( fs_.statSync(dotGit).isFile() ) {
+        var m = fs_.readFileSync(dotGit, 'utf8').match(/^gitdir:\s*(.+)\s*$/m);
+        if ( ! m ) return null;
+        gitdir = path_.resolve(root, m[1].trim());
+      }
+      var head = path_.join(gitdir, 'HEAD');
+      fs_.accessSync(head);
+      return head;
+    } catch (e) { return null; }
+  }
+
+  function readHead(p) {
+    try { return fs_.readFileSync(p, 'utf8'); } catch (e) { return ''; }
+  }
+
+  if ( process.env.FOAM_LSP_EXIT_ON_HEAD_CHANGE ) {
+    // Watch the project repo and the foam3 submodule (same layout assumption
+    // as the rest of the tooling: foam3/ under the project root).
+    var headPaths = [ process.cwd(), path_.join(process.cwd(), 'foam3') ].
+      map(resolveHeadPath).filter(function(p) { return p; });
+    var headBaseline = headPaths.map(readHead);
+    setInterval(function() {
+      for ( var i = 0 ; i < headPaths.length ; i++ ) {
+        if ( readHead(headPaths[i]) !== headBaseline[i] ) {
+          console.error('[LSP] git HEAD changed (' + headPaths[i] + ') — exiting so the client boots a fresh index');
+          process.exit(0);
+        }
+      }
+    }, Number(process.env.FOAM_LSP_HEAD_POLL_MS) || 10000).unref();
+  }
+
   // LSP spec: initialize.processId is the client's pid; the server should
   // exit when that process dies. Covers parents killed with SIGKILL, where
   // stdin 'end' may never be observed before the next write EPIPEs.


### PR DESCRIPTION
The MCP wrapper booted the FOAM LSP eagerly at session start — every agent session paid the ~10-15s boot and held a full registry in memory, even sessions that never called a foam tool.

- **Lazy boot** — `whenReady()` spawns the LSP on the first tool call instead of at startup (matching what the tool instructions already claimed)

- **Idle reap** — the child is killed after 30 min without use (`FOAM_LSP_IDLE_MS` overrides); unref'd timer, skipped while requests are in flight

- **Respawn** — the child's exit handler resets all client state (pending requests rejected, open documents and diagnostics cleared, fresh ready-promise), so idle reap, crash, and init failure all recover the same way: the next tool call boots a fresh LSP

- **Race guard** — stdin stream errors from writes racing the child's death are ignored instead of crashing the wrapper

Verified live end-to-end: no child before first call, boot on first call, reap at idle, respawn after reap, child reaped on wrapper shutdown.