### PR TITLE
ChangeAnalyticEvents UNKNOWN_USER and SYSTEM_USER Messages Displaying Incorrectly

### DIFF
--- a/src/foam/core/analytics/ChangeAnalyticEvent.js
+++ b/src/foam/core/analytics/ChangeAnalyticEvent.js
@@ -131,7 +131,7 @@ foam.CLASS({
         this.style({
           'font-weight': foam.CSS.returnTokenValue('$font-medium', this.cls_, this.__subContext__)
         });
-          this.__context__.userDAO.find(value).then((result) => {
+        this.__context__.userDAO.find(value).then((result) => {
           if ( ! result ) {
             this.add(this.data.UNKNOWN_USER_MSG);
           } else {

--- a/src/foam/core/analytics/ChangeAnalyticEvent.js
+++ b/src/foam/core/analytics/ChangeAnalyticEvent.js
@@ -131,17 +131,13 @@ foam.CLASS({
         this.style({
           'font-weight': foam.CSS.returnTokenValue('$font-medium', this.cls_, this.__subContext__)
         });
-        if ( value == 0 ) { // Can skip DAO lookup if it's the system user
-          this.add(this.data.SYSTEM_USER_MSG);
-        } else {
           this.__context__.userDAO.find(value).then((result) => {
-            if ( ! result ) {
-              this.add(this.data.UNKNOWN_USER_MSG);
-            } else {
-              this.add(result.firstName[0] + ". " + result.lastName);
-            }
-          });
-        }
+          if ( ! result ) {
+            this.add(this.data.UNKNOWN_USER_MSG);
+          } else {
+            this.add(result.firstName == "system" ? this.data.SYSTEM_USER_MSG : result.firstName[0] + ". " + result.lastName);
+          }
+        });
       }
     },
     {


### PR DESCRIPTION
ChangeAnalyticEvents were sometimes displaying the SYSTEM_USER message when they should have been displaying the UNKNOWN_USER message and sometimes displaying "s." rather than the SYSTEM_USER message.

This PR fixes both issues.