### PR TITLE
PT-FIXES:DOS-4674 Case-insensitive option search in StringFilterView

### DIFF
--- a/src/foam/u2/filter/properties/StringFilterView.js
+++ b/src/foam/u2/filter/properties/StringFilterView.js
@@ -131,7 +131,7 @@ foam.CLASS({
         this.isOverLimit = false;
 
         var pred = this.search && this.search.trim().length > 0
-          ? this.STARTS_WITH(this.property, this.search)
+          ? this.STARTS_WITH_IC(this.property, this.search)
           : this.TRUE;
 
         this.dao.where(pred).select(this.GROUP_BY(this.property, this.COUNT(), 21)).then((results) => {
@@ -317,7 +317,7 @@ foam.CLASS({
         this.isOverLimit = false;
         this.isLoading = true;
         var pred = this.search && this.search.trim().length > 0
-          ? this.STARTS_WITH(this.property, this.search)
+          ? this.STARTS_WITH_IC(this.property, this.search)
           : this.TRUE;
 
         this.dao.where(pred).select(this.GROUP_BY(this.property, this.COUNT(), 21)).then((results) => {


### PR DESCRIPTION
Typing in a filter dropdown's search box builds the option query with `STARTS_WITH` — case-sensitive — so lowercase input returns no options even when the column is full of matches, while the main search bar finds them (QueryParser builds `ContainsIC`).

Cause: `StringFilterView` uses `STARTS_WITH` in both places it queries options (typed search and dropdown reload).

Reproduce — String column whose values start with "Card ...":

```js
dao.where(STARTS_WITH(prop, 'card')).select(GROUP_BY(prop, COUNT(), 21));    // 0 groups — dropdown shows NO OPTIONS
dao.where(STARTS_WITH(prop, 'Card')).select(GROUP_BY(prop, COUNT(), 21));    // 5 groups, 825 rows
dao.where(STARTS_WITH_IC(prop, 'card')).select(GROUP_BY(prop, COUNT(), 21)); // 5 groups, 825 rows — fix
```

Fix: swap both option queries to `STARTS_WITH_IC` — match-from-start behavior kept, case dropped.