### PR TITLE
PT-FIXES:DOS-4649 Offer the current flow's collections in the DAO name grammar

### DIFF
--- a/src/foam/core/reflow/parser/DAONameParser.js
+++ b/src/foam/core/reflow/parser/DAONameParser.js
@@ -18,7 +18,9 @@ foam.CLASS({
   ],
 
   imports: [
-    'AuthenticatedCSpecDAO as cSpecDAO'
+    'AuthenticatedCSpecDAO as cSpecDAO',
+    'flowChildren?',
+    'selected?'
   ],
 
   properties: [ { name: 'alt', factory: function() { return this.Alternate.create(); } } ],
@@ -28,10 +30,35 @@ foam.CLASS({
       // The names this grammar offers, as { id, category }. Subclasses override
       // to widen the set; aInit owns the sorting, so overrides only supply
       // entries.
-      return (await this.cSpecDAO.where(this.CSpec.SERVED_DAOS).select()).array.map(c => ({
+      const names = (await this.cSpecDAO.where(this.CSpec.SERVED_DAOS).select()).array.map(c => ({
         id:       c.id,
         category: c.keywords.indexOf('custom') == -1 ? 'standard' : 'custom'
       }));
+
+      this.inFlowNames().forEach(id => names.push({ id: id, category: 'in-flow' }));
+
+      return names;
+    },
+
+    function inFlowNames() {
+      // What the other blocks of this flow publish, as "<block>.<daoProperty>".
+      // Empty outside a flow: nothing exports flowChildren there. The selected
+      // block is skipped - reading its own output is a cycle.
+      //
+      // Unfiltered: no flag marks a DAO property as a result rather than a
+      // stage of the block's own stack - DAOPrompt hides its plain dao and not
+      // its filteredDAO - so narrowing would drop names already in use.
+      const ids = [];
+
+      ( this.flowChildren || [] ).forEach(child => {
+        if ( ! child.value || ! child.value.cls_ ) return;
+        if ( child.flowName === this.selected?.flowName ) return;
+
+        child.value.cls_.getAxiomsByClass(foam.dao.DAOProperty).
+          forEach(p => ids.push(child.flowName + '.' + p.name));
+      });
+
+      return ids;
     },
 
     async function aInit() {


### PR DESCRIPTION
Inside a flow, a picker built on `DAONameParser` offers served DAOs only. The collections that other blocks of the same flow publish are not in the grammar, so they can't be picked, and typing one by hand gets rejected.

Type `trans` in such a field:

```
before   transactionDAO, transactionReportDAO
after    transactionDAO, transactionReportDAO, blk1.dao, blk1.filteredDAO, blk2.data
                                               ^-- new, tagged in-flow
```

`aDAONames` now appends one name per DAO property on each flowChildren value, as `<block>.<property>`.

Outside a flow nothing exports flowChildren, so that list is unchanged. The selected block is skipped — reading its own output is a cycle.

No filter on which properties qualify. Nothing marks a block's result apart from a stage of its own DAO stack — DAOPrompt hides its plain dao and not its filteredDAO — so narrowing would drop names already in use.