### PR TITLE
PT-FIXES:DOS-4682 make the export 'Add Units' toggle strip units

### DIFF
--- a/src/foam/core/column/TableColumnOutputter.js
+++ b/src/foam/core/column/TableColumnOutputter.js
@@ -50,6 +50,9 @@ foam.CLASS({
             return stringArr.join(' ');
           }
           if ( prop.unitPropValueToString && unitPropName ) {
+            // 'Add Units' unchecked: bare spreadsheet-parseable number
+            if ( ! addUnitPropValueToStr && prop.unitPropValueToPlainString )
+              return await prop.unitPropValueToPlainString(x, val, unitPropName);
             return await prop.unitPropValueToString(x, val, unitPropName, ! addUnitPropValueToStr);
           }
           if ( foam.lang.DateTime.isInstance(prop) ) {
@@ -132,9 +135,9 @@ foam.CLASS({
     },
     {
       name: 'objectToTable',
-      code: async function(x, of, propNames, obj, lengthOfPrimaryPropsRequested) {
+      code: async function(x, of, propNames, obj, lengthOfPrimaryPropsRequested, addUnitPropValueToStr) {
         var values = await this.objToArrayOfStringValues(x, of, propNames, obj);
-        return this.returnTable(x, of, propNames, values, lengthOfPrimaryPropsRequested);
+        return this.returnTable(x, of, propNames, values, lengthOfPrimaryPropsRequested, addUnitPropValueToStr);
       }
     },
     {

--- a/src/foam/core/column/test/TableColumnOutputterJSTest.js
+++ b/src/foam/core/column/test/TableColumnOutputterJSTest.js
@@ -59,6 +59,29 @@ foam.CLASS({
         s = await format([ -6.984919309616089e-10, { id: 'GBP' } ]);
         x.test(! /e/i.test(s) && /0.00/.test(s),
           'float noise exports as rounded zero, not scientific notation: ' + s);
+
+        // 'Add Units' unchecked (addUnitPropValueToStr false): bare number a
+        // spreadsheet can parse — no symbol, no grouping, still 2dp
+        var bare = async values => (await outputter.arrayOfValuesToArrayOfStrings(ctx, props, [ values ], 1, false))[0][0];
+
+        s = await bare([ 1234.5, 'GBP' ]);
+        x.test(s === '1234.50',
+          'Add Units off exports bare number at currency precision: ' + s);
+
+        s = await bare([ -1234.5, 'GBP' ]);
+        x.test(s === '-1234.50',
+          'Add Units off keeps plain minus sign for negatives: ' + s);
+
+        s = await bare([ -6.984919309616089e-10, 'GBP' ]);
+        x.test(s === '0.00',
+          'Add Units off exports negative float noise as 0.00, not -0.00: ' + s);
+
+        // GUI path regression: ValueView passes prop.hideId (default true on
+        // DoubleUnitValue) as excludeUnit — that must keep the £ symbol,
+        // only the bare-number export flag strips formatting
+        s = await of.AMOUNT.unitPropValueToString(ctx, 1234.5, 'GBP', true);
+        x.test(/£/.test(String(s)),
+          'hideId=true from GUI views keeps the currency symbol: ' + s);
       }
     }
   ]

--- a/src/foam/core/export/TableExportDriver.js
+++ b/src/foam/core/export/TableExportDriver.js
@@ -55,7 +55,7 @@ foam.CLASS({
       var propToColumnMapping  = this.columnConfigToPropertyConverter.returnPropertyColumnMappings(obj.cls_, propNames);
       var propertyNamesToQuery = this.columnHandler.returnPropNamesToQuery(propToColumnMapping);
 
-      return await this.outputter.objectToTable(X, obj.cls_, propertyNamesToQuery, obj, propNames.length);
+      return await this.outputter.objectToTable(X, obj.cls_, propertyNamesToQuery, obj, propNames.length, this.addUnits);
     },
 
     async function exportDAOAndReturnTable(X, dao, propNames) {

--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -916,6 +916,21 @@ foam.CLASS({
         }
         return val;
       }
+    },
+    {
+      name: 'unitPropValueToPlainString',
+      documentation: `
+        Export with 'Add Units' unchecked: plain number at the currency's
+        precision so spreadsheets can parse and sum the column.
+      `,
+      value: async function(x, val, unitPropName) {
+        const currencyDAO = x.currencyDAO ?? this.__subContext__.currencyDAO;
+        if ( unitPropName && currencyDAO ) {
+          const unitProp = await currencyDAO.find(unitPropName);
+          if ( unitProp ) return unitProp.formatPrecision(val);
+        }
+        return val;
+      }
     }
   ]
 });
@@ -952,6 +967,26 @@ foam.CLASS({
           const unitProp = await currencyDAO.find(unitPropName);
           if ( unitProp )
             return unitProp.format(val, excludeUnit, false);
+        }
+        return val;
+      }
+    },
+    {
+      name: 'unitPropValueToPlainString',
+      documentation: `
+        Export with 'Add Units' unchecked: plain number at the currency's
+        precision so spreadsheets can parse and sum the column.
+        toFixed also collapses float noise; the '-' is stripped off -0.00.
+      `,
+      value: async function(x, val, unitPropName) {
+        const currencyDAO = x.currencyDAO ?? this.__subContext__.currencyDAO;
+        if ( unitPropName && currencyDAO ) {
+          const unitProp = await currencyDAO.find(unitPropName);
+          if ( unitProp ) {
+            var s = Number(val).toFixed(unitProp.precision);
+            if ( parseFloat(s) === 0 ) s = s.replace('-', '');
+            return s;
+          }
         }
         return val;
       }


### PR DESCRIPTION
The Export modal's Add Units checkbox has never reliably worked: its flag fed Currency.format's hideId argument, which the Intl.NumberFormat path ignores, so unchecking it changed nothing — currency columns always export formatted (£1,234.50) and spreadsheets can't sum them.

This adds a unitPropValueToPlainString method to UnitValue and DoubleUnitValue: with Add Units unchecked, export emits a plain number at the currency's precision (1234.50), with negative float noise normalized to 0.00. It is a new method rather than a flag on unitPropValueToString, whose 4th argument GUI views (ValueView) already pass as hideId — reusing it stripped the symbol from every table cell (covered by a regression test). addUnits is also threaded through the single-object export path, which previously dropped it.

Stacked on #5303 (base = DOS-4544-doubleunitvalue-parity). TableColumnOutputterJSTest 8/8; every new assertion verified failing before the fix.

DOS-4682