### PR TITLE
FOAM-5317 - Missing default unauthorized login screen

### DIFF
--- a/src/foam/core/controller/ApplicationController.js
+++ b/src/foam/core/controller/ApplicationController.js
@@ -1,4 +1,4 @@
-/**
+1/**
  * @license
  * Copyright 2018 The FOAM Authors. All Rights Reserved.
  *
@@ -768,10 +768,24 @@ foam.CLASS({
 
     async function findDefaultMenu(dao) {
       var menu;
-      var menuArray = this.theme?.defaultMenu.concat(this.theme?.unauthenticatedDefaultMenu);
-      if ( ! menuArray || ! menuArray.length ) return null;
-      for ( menuId in menuArray ) {
-        menu = await dao.find(menuArray[menuId]);
+      // Pick menus appropriate to the current auth state: unauthenticatedDefaultMenu
+      // is the pre-login landing menu, defaultMenu is the post-login one. Previously
+      // both were always concatenated (defaultMenu first), so a logged-out user would
+      // attempt the authenticated menu and be denied before ever reaching the
+      // unauthenticated one. unauthenticatedDefaultMenu is a single Reference, so wrap
+      // it in an array; filter(Boolean) drops an unset ('') reference.
+      var menuArray = this.loginSuccess
+        ? ( this.theme?.defaultMenu || [] ).concat(this.theme?.unauthenticatedDefaultMenu || [])
+        : [ this.theme?.unauthenticatedDefaultMenu ];
+      menuArray = menuArray.filter(Boolean);
+      if ( ! menuArray.length ) return null;
+      for ( var menuId of menuArray ) {
+        try {
+          menu = await dao.find(menuId);
+        } catch (e) {
+          // Not authorized to read this menu in the current auth state; try the next.
+          menu = null;
+        }
         if ( menu ) break;
       }
       return menu;
@@ -782,6 +796,11 @@ foam.CLASS({
       // arg(dao) passed in cause context handled in calling function
       var maybeMenu = await this.findDefaultMenu(dao);
       if ( maybeMenu ) return maybeMenu;
+      // Falling back to "the first menu that exists" only makes sense once the
+      // user is authenticated. An unauthenticated user has no readable menus
+      // here, so return null and let the caller route them to login instead of
+      // selecting an arbitrary (or empty) menu and rendering a blank screen.
+      if ( ! this.loginSuccess ) return null;
       return await dao.orderBy(foam.core.menu.Menu.ORDER).limit(1)
         .select().then(a => a.array.length && a.array[0])
         .catch(e => console.error(e.message || e));
@@ -798,6 +817,12 @@ foam.CLASS({
           ret && (this.memento_.str = '');
         }
         return defaultMenu;
+      }
+      // No landing menu resolved. If the user isn't authenticated, send them to
+      // the login screen rather than leaving a blank page. Once authenticated,
+      // fall through to the normal subject check.
+      if ( ! this.loginSuccess ) {
+        return await this.requestLogin();
       }
       await this.fetchSubject();
     },


### PR DESCRIPTION
See issue #5317 for more info. The fix ensures:

 | State | Outcome |
  |-------|---------|
  | Not authenticated, `unauthenticatedDefaultMenu` set | lands on that public menu |
  | Not authenticated, no unauth menu | `findDefaultMenu` → null → `select` skipped → `requestLogin()` shows the login screen |
  | Authenticated, `defaultMenu` resolves | lands there (unchanged) |
  | Authenticated, nothing resolves | `select` fallback, then `fetchSubject` (unchanged) |