### PR TITLE
PT-FIXES:DOS-4695 One collapsible progress card instead of a card per partition

### DIFF
--- a/src/foam/core/partition/PartitionLoadToastStack.js
+++ b/src/foam/core/partition/PartitionLoadToastStack.js
@@ -9,10 +9,19 @@ foam.CLASS({
   name: 'PartitionLoadToastStack',
   extends: 'foam.u2.View',
 
-  documentation: `Bottom-right stack of partition-load progress cards. DAO
-    decorators watch()/unwatch() service keys; while any key is watched the
-    stack polls partitionLoadStatusDAO every pollInterval ms and renders
-    one card per matching row. Non-blocking by design.
+  documentation: `Bottom-right partition-load progress card. DAO decorators
+    watch()/unwatch() service keys; while any key is watched the card polls
+    partitionLoadStatusDAO every pollInterval ms. One card per watched
+    service, carrying that service's aggregate bar over a scrollable list of
+    its partitions -- never one card per partition, so the card's height
+    doesn't grow with the load. The collapse control shrinks it to a corner
+    pill holding the overall percent; a load covering more than one partition
+    opens collapsed, and that choice lasts only until the load ends.
+
+    Percent is measured against a per-load baseline (sessions_), not the rows
+    currently outstanding: a row disappears when its partition finishes, so a
+    percent summed over live rows alone walks backwards. Non-blocking by
+    design.
 
     Registered as a client-only CSpec service (partitionLoadToastStack in
     services.jrl, lazyClient: false) rather than a hand-rolled singleton, so
@@ -32,44 +41,133 @@ foam.CLASS({
       z-index: 1000;
       display: flex;
       flex-direction: column;
+      align-items: flex-end;
       gap: 8px;
       max-width: 320px;
     }
     ^card {
+      width: 320px;
       background: $backgroundDefault;
       border: 1px solid $borderDefault;
       border-radius: 4px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-      padding: 12px;
+      padding: 4px 12px 12px 12px;
+      animation: partitionLoadFadeIn 200ms ease-out;
     }
-    ^title {
-      color: $textSecondary;
-      margin-bottom: 4px;
+    ^header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
-    ^groupHeader {
+    ^name {
+      flex: 1;
       color: $textSecondary;
-      font-weight: bold;
-      margin-bottom: 4px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    ^count {
+      color: $textSecondary;
+      white-space: nowrap;
+    }
+    ^toggle {
+      min-width: 44px;
+      min-height: 44px;
+      background: none;
+      border: none;
+      border-radius: 4px;
+      color: $textSecondary;
+      cursor: pointer;
+      transition: background-color 150ms ease-out;
+    }
+    ^toggle:hover {
+      background: $backgroundHover;
+    }
+    ^bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    ^bar progress {
+      flex: 1;
+      width: auto;
+    }
+    ^pct {
+      min-width: 3.2em;
+      text-align: right;
+      color: $textSecondary;
     }
     ^indeterminate {
       width: 100%;
       height: 8px;
     }
-    ^more {
-      color: $textTertiary;
-      text-align: center;
+    ^list {
+      max-height: 76px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin-top: 8px;
+    }
+    ^row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    ^rowLabel {
+      flex: 1;
+      color: $textSecondary;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    ^rowPct {
+      color: $textSecondary;
+      white-space: nowrap;
+    }
+    ^rowBar {
+      width: 80px;
+    }
+    ^pill {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 0 12px;
+      background: $backgroundDefault;
+      border: 1px solid $borderDefault;
+      border-radius: 22px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      color: $textSecondary;
+      cursor: pointer;
+      animation: partitionLoadFadeIn 200ms ease-out;
+      transition: background-color 150ms ease-out;
+    }
+    ^pill:hover {
+      background: $backgroundHover;
+    }
+    @keyframes partitionLoadFadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      ^card, ^pill {
+        animation: none;
+        transition: none;
+      }
+      ^toggle {
+        transition: none;
+      }
     }
   `,
 
-  constants: [ { name: 'MAX_CARDS', value: 4 } ],
-
   messages: [
-    { name: 'LOADING',   messageMap: { en: 'Loading',   fr: 'Chargement' } },
-    { name: 'QUEUED',    messageMap: { en: 'queued',    fr: 'en file' } },
-    { name: 'PARTITION', messageMap: { en: 'partition', fr: 'partition' } },
-    { name: 'OF',        messageMap: { en: 'of',        fr: 'sur' } },
-    { name: 'OVERALL',   messageMap: { en: 'overall',   fr: 'global' } },
-    { name: 'MORE',      messageMap: { en: 'more',      fr: 'autres' } }
+    { name: 'LOADING',      messageMap: { en: 'Loading',      fr: 'Chargement' } },
+    { name: 'QUEUED',       messageMap: { en: 'queued',       fr: 'en file' } },
+    { name: 'OF',           messageMap: { en: 'of',           fr: 'sur' } },
+    { name: 'HIDE_DETAILS', messageMap: { en: 'Hide partition details', fr: 'Masquer les détails des partitions' } },
+    { name: 'SHOW_DETAILS', messageMap: { en: 'Show partition details', fr: 'Afficher les détails des partitions' } }
   ],
 
   properties: [
@@ -78,7 +176,16 @@ foam.CLASS({
       name: 'watched_',
       factory: function() { return {}; }
     },
+    {
+      class: 'Map',
+      name: 'sessions_',
+      documentation: `Per-service load baseline, keyed by serviceName. Each
+        entry carries the partition count and byte total the load was ever
+        seen to cover, plus how much of that has finished.`,
+      factory: function() { return {}; }
+    },
     { class: 'Array', name: 'rows_' },
+    { class: 'Boolean', name: 'collapsed_' },
     { class: 'Boolean', name: 'attached_' },
     { class: 'Boolean', name: 'polling_' },
     { class: 'Int', name: 'pollInterval', value: 500 }
@@ -106,7 +213,8 @@ foam.CLASS({
         }
       } finally {
         this.polling_ = false;
-        this.rows_    = [];
+        this.rows_     = [];
+        this.sessions_ = {};
       }
     },
 
@@ -116,14 +224,21 @@ foam.CLASS({
         this.rows_ = [];
         return;
       }
+      var rows;
       try {
         var sink = await this.partitionLoadStatusDAO.select();
-        this.rows_ = sink.array.
+        rows = sink.array.
           filter(function(r) { return keys.indexOf(r.serviceName) != -1; }).
           sort(function(a, b) { return a.startTime - b.startTime; });
       } catch (e) {
         // Progress channel never surfaces errors; retry next tick.
+        return;
       }
+      // Baselines must be current before rows_ fires the render.
+      var opening = ! Object.keys(this.sessions_).length;
+      this.updateSessions_(rows);
+      if ( opening ) this.collapsed_ = this.totals_().count > 1;
+      this.rows_ = rows;
       // The service is instantiated in the client context (eager CSpec),
       // which is the PARENT of ApplicationController's subcontext -- the
       // 'ctrl' export lives in the child, so the import resolves undefined
@@ -135,46 +250,137 @@ foam.CLASS({
       }
     },
 
-    function pct_(row) {
+    function updateSessions_(rows) {
+      var live = {};
+      rows.forEach(function(r) {
+        var l = live[r.serviceName] ||
+            (live[r.serviceName] = { count: 0, bytes: 0, read: 0 });
+        l.count++;
+        l.bytes += r.totalBytes || 0;
+        l.read  += r.bytesRead  || 0;
+      });
+      var sessions = this.sessions_;
+      // Every row of a service gone means that service's load finished; drop
+      // the baseline so a later load on the same key starts from scratch.
+      Object.keys(sessions).forEach(function(k) {
+        if ( ! live[k] ) delete sessions[k];
+      });
+      Object.keys(live).forEach(function(k) {
+        var l = live[k];
+        var s = sessions[k] ||
+            (sessions[k] = { count: 0, bytes: 0, doneCount: 0, doneBytes: 0, read: 0 });
+        // Baselines only grow. A second select can queue more partitions
+        // mid-load, and finished rows leave, so the live sums on their own
+        // would walk the percent backwards.
+        if ( l.count + s.doneCount > s.count ) s.count = l.count + s.doneCount;
+        if ( l.bytes + s.doneBytes > s.bytes ) s.bytes = l.bytes + s.doneBytes;
+        s.doneCount = s.count - l.count;
+        s.doneBytes = s.bytes - l.bytes;
+        s.read      = s.doneBytes + l.read;
+      });
+    },
+
+    function totals_() {
+      var t = { count: 0, doneCount: 0, bytes: 0, read: 0 };
+      var sessions = this.sessions_;
+      Object.keys(sessions).forEach(function(k) {
+        var s = sessions[k];
+        t.count     += s.count;
+        t.doneCount += s.doneCount;
+        t.bytes     += s.bytes;
+        t.read      += s.read;
+      });
+      return t;
+    },
+
+    function pctOf_(s) {
       // Unknown journal size (unreadable storage): no honest percent exists.
+      if ( s.bytes <= 0 ) return null;
+      return Math.min(99, Math.floor(s.read * 100 / s.bytes));
+    },
+
+    function pct_(row) {
       if ( row.totalBytes <= 0 ) return null;
       return Math.min(99, Math.floor(row.bytesRead * 100 / row.totalBytes));
     },
 
-    function serviceGroups_(rows) {
-      // Aggregate ALL watched rows per serviceName (not just the on-screen
-      // cap-4 slice) so "N of M -- overall P%" stays accurate even when
-      // some of that service's cards are hidden by the cap.
-      var groups = {};
+    function byService_(rows) {
+      // rows is already startTime-sorted, so first-seen order is
+      // earliest-start order.
+      var order = [];
+      var map   = {};
       rows.forEach(function(r) {
-        var g = groups[r.serviceName] || (groups[r.serviceName] = {
-          total: 0, started: 0, bytesRead: 0, totalBytes: 0
-        });
-        g.total++;
-        if ( ! r.queued ) g.started++;
-        g.bytesRead  += r.bytesRead  || 0;
-        g.totalBytes += r.totalBytes || 0;
-      });
-      return groups;
-    },
-
-    function groupedRows_(rows) {
-      // rows is already startTime-sorted; re-bucket so each service's rows
-      // sit contiguously (first-seen order == earliest start), so one
-      // header covers one uninterrupted block of cards instead of
-      // repeating whenever two services' rows interleave by start time.
-      var order     = [];
-      var byService = {};
-      rows.forEach(function(r) {
-        if ( ! byService[r.serviceName] ) {
-          byService[r.serviceName] = [];
+        if ( ! map[r.serviceName] ) {
+          map[r.serviceName] = [];
           order.push(r.serviceName);
         }
-        byService[r.serviceName].push(r);
+        map[r.serviceName].push(r);
       });
-      var out = [];
-      order.forEach(function(name) { out = out.concat(byService[name]); });
-      return out;
+      return { order: order, rows: map };
+    },
+
+    function renderPill(self) {
+      var pct = self.pctOf_(self.totals_());
+      this.start('button').addClass(self.myClass('pill')).
+        attrs({
+          'aria-label':    self.SHOW_DETAILS,
+          'aria-expanded': false,
+          title:           self.SHOW_DETAILS
+        }).
+        on('click', function() { self.collapsed_ = false; }).
+        start().addClass('p-sm', 'p-bold').
+          add(pct == null ? self.LOADING : pct + '%').
+        end().
+      end();
+    },
+
+    function renderToggle(self) {
+      this.start('button').addClass(self.myClass('toggle')).
+        attrs({
+          'aria-label':    self.HIDE_DETAILS,
+          'aria-expanded': true,
+          title:           self.HIDE_DETAILS
+        }).
+        on('click', function() { self.collapsed_ = true; }).
+        add('–').
+      end();
+    },
+
+    function renderBar(self, pct) {
+      if ( pct == null ) {
+        // No max/value attributes: the progress element renders its native
+        // indeterminate animation. Only the aggregate bar ever does this --
+        // a per-partition row falls back to text, so one card never runs
+        // several indeterminate animations at once.
+        this.start('progress').addClass(self.myClass('indeterminate')).end();
+        return;
+      }
+      this.start().addClass(self.myClass('bar')).
+        start(self.ProgressView, { data: pct }).end().
+        start().addClass('p-sm', self.myClass('pct')).add(pct + '%').end().
+      end();
+    },
+
+    function renderList(self, rows) {
+      this.start().addClass(self.myClass('list')).
+        forEach(rows, function(row) {
+          var pct = self.pct_(row);
+          this.start().addClass(self.myClass('row')).
+            start().addClass('p-sm', self.myClass('rowLabel')).
+              add(row.partition).
+            end().
+            start().addClass('p-sm', self.myClass('rowPct')).
+              add(row.queued ? self.QUEUED :
+                  ( pct == null ? self.LOADING : pct + '%' )).
+            end().
+            callIf(! row.queued && pct != null, function() {
+              this.start().addClass(self.myClass('rowBar')).
+                start(self.ProgressView, { data: pct }).end().
+              end();
+            }).
+          end();
+        }).
+      end();
     },
 
     function render() {
@@ -189,53 +395,32 @@ foam.CLASS({
       });
       this.addClass().
         attrs({ 'aria-live': 'polite', role: 'status' }).
-        add(this.dynamic(function(rows_) {
+        add(this.dynamic(function(rows_, collapsed_) {
           if ( ! rows_ || ! rows_.length ) return;
-          var groups      = self.serviceGroups_(rows_);
-          var ordered     = self.groupedRows_(rows_).slice(0, self.MAX_CARDS);
-          var lastService = null;
-          this.forEach(ordered, function(row) {
-            var group = groups[row.serviceName];
-            if ( row.serviceName !== lastService ) {
-              lastService = row.serviceName;
-              if ( group.total > 1 ) {
-                var header = self.PARTITION + ' ' + group.started + ' ' + self.OF + ' ' + group.total;
-                if ( group.totalBytes > 0 ) {
-                  header += ' — ' + self.OVERALL + ' ' + Math.min(99, Math.floor(group.bytesRead * 100 / group.totalBytes)) + '%';
-                }
-                this.start().addClass('p-sm', self.myClass('groupHeader'))
-                  .add(header)
-                .end();
-              }
-            }
-            var label = row.serviceName + ( row.partition ? ' — ' + row.partition : '' );
-            if ( row.queued ) {
-              this.start().addClass(self.myClass('card'))
-                .start().addClass('p-sm', self.myClass('title'))
-                  .add(label + ' — ' + self.QUEUED)
-                .end()
-              .end();
-              return;
-            }
-            var pct = self.pct_(row);
-            var card = this.start().addClass(self.myClass('card'))
-              .start().addClass('p-sm', self.myClass('title'))
-                .add(pct == null ? self.LOADING + ' ' + label : self.LOADING + ' ' + label + ' — ' + pct + '%')
-              .end();
-            if ( pct == null ) {
-              // No max/value attributes: the progress element renders its
-              // native indeterminate animation.
-              card.start('progress').addClass(self.myClass('indeterminate')).end();
-            } else {
-              card.start(self.ProgressView, { data: pct }).end();
-            }
-            card.end();
-          });
-          if ( rows_.length > self.MAX_CARDS ) {
-            this.start().addClass('p-sm', self.myClass('more'))
-              .add('+' + (rows_.length - self.MAX_CARDS) + ' ' + self.MORE)
-            .end();
+          if ( collapsed_ ) {
+            this.call(self.renderPill, [self]);
+            return;
           }
+          var grouped = self.byService_(rows_);
+          this.forEach(grouped.order, function(name) {
+            var rows    = grouped.rows[name];
+            var session = self.sessions_[name];
+            this.start().addClass(self.myClass('card')).
+              start().addClass(self.myClass('header')).
+                start().addClass('p-sm', 'p-bold', self.myClass('name')).
+                  add(self.LOADING + ' ' + name).
+                end().
+                callIf(session.count > 1, function() {
+                  this.start().addClass('p-sm', self.myClass('count')).
+                    add(session.doneCount + ' ' + self.OF + ' ' + session.count).
+                  end();
+                }).
+                call(self.renderToggle, [self]).
+              end().
+              call(self.renderBar, [self, self.pctOf_(session)]).
+              callIf(session.count > 1, self.renderList, [self, rows]).
+            end();
+          });
         }));
     }
   ]

--- a/src/foam/core/partition/PartitionLoadToastStack.js
+++ b/src/foam/core/partition/PartitionLoadToastStack.js
@@ -11,17 +11,29 @@ foam.CLASS({
 
   documentation: `Bottom-right partition-load progress card. DAO decorators
     watch()/unwatch() service keys; while any key is watched the card polls
-    partitionLoadStatusDAO every pollInterval ms. One card per watched
-    service, carrying that service's aggregate bar over a scrollable list of
-    its partitions -- never one card per partition, so the card's height
-    doesn't grow with the load. The collapse control shrinks it to a corner
-    pill holding the overall percent; a load covering more than one partition
-    opens collapsed, and that choice lasts only until the load ends.
+    partitionLoadStatusDAO every pollInterval ms and shows one card per
+    watched service: how far the load has got, how many partitions are left,
+    and which one is replaying right now. The collapse control shrinks it to
+    a corner pill holding the overall percent; the next load opens expanded
+    again.
+
+    Deliberately does NOT list the partitions. A reader waiting on a query
+    wants the progress and what is left, not an enumeration -- and listing
+    them costs an ordering rule per partitioning scheme, a scroll container,
+    and a DOM rebuild every time a partition finishes.
+
+    Two-tier reactivity, so a poll tick never rebuilds the DOM: structure_
+    keys the services and their bar kind, which holds still for a whole load,
+    and drives the one dynamic() that builds elements; tick_ drives slots
+    carrying every changing number.
 
     Percent is measured against a per-load baseline (sessions_), not the rows
-    currently outstanding: a row disappears when its partition finishes, so a
-    percent summed over live rows alone walks backwards. Non-blocking by
-    design.
+    currently outstanding: a finished partition's bytes stay in the numerator
+    instead of leaving with its row, so the aggregate never walks backwards.
+    A per-partition percent is deliberately not shown -- the reporter
+    publishes once at zero bytes then throttles to 250ms, so a partition that
+    replays inside one poll interval is only ever sampled at 0%.
+    Non-blocking by design.
 
     Registered as a client-only CSpec service (partitionLoadToastStack in
     services.jrl, lazyClient: false) rather than a hand-rolled singleton, so
@@ -29,7 +41,10 @@ foam.CLASS({
     instance and shares one watched_ refcount map. See
     PartitionLoadProgressDAO's optional 'partitionLoadToastStack?' import.`,
 
-  requires: [ 'foam.u2.ProgressView' ],
+  requires: [
+    'foam.lang.ExpressionSlot',
+    'foam.u2.ProgressView'
+  ],
 
   imports: [ 'partitionLoadStatusDAO?', 'ctrl?' ],
 
@@ -49,25 +64,21 @@ foam.CLASS({
       width: 320px;
       background: $backgroundDefault;
       border: 1px solid $borderDefault;
-      border-radius: 4px;
+      border-radius: $inputBorderRadius;
       box-shadow: 0 2px 8px rgba(0,0,0,0.15);
       padding: 4px 12px 12px 12px;
-      animation: partitionLoadFadeIn 200ms ease-out;
     }
     ^header {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       gap: 8px;
     }
     ^name {
       flex: 1;
+      padding-top: 12px;
       color: $textSecondary;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    ^count {
-      color: $textSecondary;
       white-space: nowrap;
     }
     ^toggle {
@@ -75,7 +86,7 @@ foam.CLASS({
       min-height: 44px;
       background: none;
       border: none;
-      border-radius: 4px;
+      border-radius: $inputBorderRadius;
       color: $textSecondary;
       cursor: pointer;
       transition: background-color 150ms ease-out;
@@ -101,32 +112,12 @@ foam.CLASS({
       width: 100%;
       height: 8px;
     }
-    ^list {
-      max-height: 76px;
-      overflow-y: auto;
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      margin-top: 8px;
-    }
-    ^row {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    ^rowLabel {
-      flex: 1;
+    ^current {
+      margin-top: 4px;
       color: $textSecondary;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-    ^rowPct {
-      color: $textSecondary;
-      white-space: nowrap;
-    }
-    ^rowBar {
-      width: 80px;
     }
     ^pill {
       display: flex;
@@ -141,33 +132,23 @@ foam.CLASS({
       box-shadow: 0 2px 8px rgba(0,0,0,0.15);
       color: $textSecondary;
       cursor: pointer;
-      animation: partitionLoadFadeIn 200ms ease-out;
       transition: background-color 150ms ease-out;
     }
     ^pill:hover {
       background: $backgroundHover;
     }
-    @keyframes partitionLoadFadeIn {
-      from { opacity: 0; }
-      to   { opacity: 1; }
-    }
     @media (prefers-reduced-motion: reduce) {
-      ^card, ^pill {
-        animation: none;
-        transition: none;
-      }
-      ^toggle {
+      ^toggle, ^pill {
         transition: none;
       }
     }
   `,
 
   messages: [
-    { name: 'LOADING',      messageMap: { en: 'Loading',      fr: 'Chargement' } },
-    { name: 'QUEUED',       messageMap: { en: 'queued',       fr: 'en file' } },
-    { name: 'OF',           messageMap: { en: 'of',           fr: 'sur' } },
-    { name: 'HIDE_DETAILS', messageMap: { en: 'Hide partition details', fr: 'Masquer les détails des partitions' } },
-    { name: 'SHOW_DETAILS', messageMap: { en: 'Show partition details', fr: 'Afficher les détails des partitions' } }
+    { name: 'LOADING',      messageMap: { en: 'loading',   fr: 'chargement' } },
+    { name: 'REMAINING',    messageMap: { en: 'remaining', fr: 'restantes' } },
+    { name: 'HIDE_STATUS',  messageMap: { en: 'Hide loading status', fr: 'Masquer l\'état du chargement' } },
+    { name: 'SHOW_STATUS',  messageMap: { en: 'Show loading status', fr: 'Afficher l\'état du chargement' } }
   ],
 
   properties: [
@@ -179,12 +160,23 @@ foam.CLASS({
     {
       class: 'Map',
       name: 'sessions_',
-      documentation: `Per-service load baseline, keyed by serviceName. Each
-        entry carries the partition count and byte total the load was ever
-        seen to cover, plus how much of that has finished.`,
+      documentation: `Per-service load baseline, keyed by serviceName: the
+        partition count and byte total the load was ever seen to cover, how
+        much of each has finished, and the partition replaying now.`,
       factory: function() { return {}; }
     },
     { class: 'Array', name: 'rows_' },
+    {
+      class: 'String',
+      name: 'structure_',
+      documentation: `Key over everything that decides which elements exist.
+        Only a change here rebuilds the DOM; progress moves tick_.`
+    },
+    {
+      class: 'Int',
+      name: 'tick_',
+      documentation: 'Bumped once per poll; drives the value slots.'
+    },
     { class: 'Boolean', name: 'collapsed_' },
     { class: 'Boolean', name: 'attached_' },
     { class: 'Boolean', name: 'polling_' },
@@ -212,16 +204,21 @@ foam.CLASS({
           await new Promise(r => setTimeout(r, this.pollInterval));
         }
       } finally {
-        this.polling_ = false;
-        this.rows_     = [];
-        this.sessions_ = {};
+        this.polling_   = false;
+        this.rows_      = [];
+        this.sessions_  = {};
+        this.structure_ = '';
+        // The next load opens expanded, whatever the user chose for this one.
+        this.collapsed_ = false;
       }
     },
 
     async function refresh_() {
       var keys = Object.keys(this.watched_);
       if ( ! keys.length || ! this.partitionLoadStatusDAO ) {
-        this.rows_ = [];
+        this.rows_      = [];
+        this.sessions_  = {};
+        this.structure_ = '';
         return;
       }
       var rows;
@@ -234,11 +231,11 @@ foam.CLASS({
         // Progress channel never surfaces errors; retry next tick.
         return;
       }
-      // Baselines must be current before rows_ fires the render.
-      var opening = ! Object.keys(this.sessions_).length;
+      // Baselines must be current before either slot fires.
       this.updateSessions_(rows);
-      if ( opening ) this.collapsed_ = this.totals_().count > 1;
-      this.rows_ = rows;
+      this.rows_      = rows;
+      this.structure_ = this.structureKey_();
+      this.tick_++;
       // The service is instantiated in the client context (eager CSpec),
       // which is the PARENT of ApplicationController's subcontext -- the
       // 'ctrl' export lives in the child, so the import resolves undefined
@@ -252,12 +249,16 @@ foam.CLASS({
 
     function updateSessions_(rows) {
       var live = {};
+      // rows is startTime-sorted, so the first unqueued row is the partition
+      // that has been replaying longest -- the loop in DatePartitionedDAO is
+      // sequential, so in practice there is exactly one.
       rows.forEach(function(r) {
         var l = live[r.serviceName] ||
-            (live[r.serviceName] = { count: 0, bytes: 0, read: 0 });
+            (live[r.serviceName] = { count: 0, bytes: 0, read: 0, current: '' });
         l.count++;
         l.bytes += r.totalBytes || 0;
         l.read  += r.bytesRead  || 0;
+        if ( ! r.queued && ! l.current ) l.current = r.partition;
       });
       var sessions = this.sessions_;
       // Every row of a service gone means that service's load finished; drop
@@ -268,7 +269,7 @@ foam.CLASS({
       Object.keys(live).forEach(function(k) {
         var l = live[k];
         var s = sessions[k] ||
-            (sessions[k] = { count: 0, bytes: 0, doneCount: 0, doneBytes: 0, read: 0 });
+            (sessions[k] = { count: 0, bytes: 0, doneCount: 0, doneBytes: 0, read: 0, current: '' });
         // Baselines only grow. A second select can queue more partitions
         // mid-load, and finished rows leave, so the live sums on their own
         // would walk the percent backwards.
@@ -277,59 +278,59 @@ foam.CLASS({
         s.doneCount = s.count - l.count;
         s.doneBytes = s.bytes - l.bytes;
         s.read      = s.doneBytes + l.read;
+        s.remaining = l.count;
+        s.current   = l.current;
       });
     },
 
+    function structureKey_() {
+      var sessions = this.sessions_;
+      var keys     = Object.keys(sessions).sort();
+      if ( ! keys.length ) return '';
+      // Only the set of services and whether each has a readable byte total
+      // decide which elements exist, and neither changes over a load -- so
+      // the DOM is built once and every number after that rides a slot.
+      return keys.map(function(k) {
+        return k + ( sessions[k].bytes > 0 ? ':d' : ':i' );
+      }).join('|');
+    },
+
     function totals_() {
-      var t = { count: 0, doneCount: 0, bytes: 0, read: 0 };
+      var t = { bytes: 0, read: 0 };
       var sessions = this.sessions_;
       Object.keys(sessions).forEach(function(k) {
-        var s = sessions[k];
-        t.count     += s.count;
-        t.doneCount += s.doneCount;
-        t.bytes     += s.bytes;
-        t.read      += s.read;
+        t.bytes += sessions[k].bytes;
+        t.read  += sessions[k].read;
       });
       return t;
     },
 
     function pctOf_(s) {
       // Unknown journal size (unreadable storage): no honest percent exists.
-      if ( s.bytes <= 0 ) return null;
+      if ( ! s || s.bytes <= 0 ) return null;
       return Math.min(99, Math.floor(s.read * 100 / s.bytes));
     },
 
-    function pct_(row) {
-      if ( row.totalBytes <= 0 ) return null;
-      return Math.min(99, Math.floor(row.bytesRead * 100 / row.totalBytes));
-    },
-
-    function byService_(rows) {
-      // rows is already startTime-sorted, so first-seen order is
-      // earliest-start order.
-      var order = [];
-      var map   = {};
-      rows.forEach(function(r) {
-        if ( ! map[r.serviceName] ) {
-          map[r.serviceName] = [];
-          order.push(r.serviceName);
-        }
-        map[r.serviceName].push(r);
-      });
-      return { order: order, rows: map };
+    function tickSlot_(el, code) {
+      // Owned by the element, not the view: the view outlives every load, so
+      // slots parented to it would pile up and be notified on every tick.
+      return el.onDetach(this.ExpressionSlot.create({ code: code, obj: this }));
     },
 
     function renderPill(self) {
-      var pct = self.pctOf_(self.totals_());
+      var pct = self.tickSlot_(this, function(tick_) {
+        return self.pctOf_(self.totals_());
+      });
       this.start('button').addClass(self.myClass('pill')).
+        show(self.collapsed_$).
         attrs({
-          'aria-label':    self.SHOW_DETAILS,
+          'aria-label':    self.SHOW_STATUS,
           'aria-expanded': false,
-          title:           self.SHOW_DETAILS
+          title:           self.SHOW_STATUS
         }).
         on('click', function() { self.collapsed_ = false; }).
         start().addClass('p-sm', 'p-bold').
-          add(pct == null ? self.LOADING : pct + '%').
+          add(pct.map(function(p) { return p == null ? self.LOADING : p + '%'; })).
         end().
       end();
     },
@@ -337,49 +338,30 @@ foam.CLASS({
     function renderToggle(self) {
       this.start('button').addClass(self.myClass('toggle')).
         attrs({
-          'aria-label':    self.HIDE_DETAILS,
+          'aria-label':    self.HIDE_STATUS,
           'aria-expanded': true,
-          title:           self.HIDE_DETAILS
+          title:           self.HIDE_STATUS
         }).
         on('click', function() { self.collapsed_ = true; }).
         add('–').
       end();
     },
 
-    function renderBar(self, pct) {
-      if ( pct == null ) {
+    function renderBar(self, name, determinate) {
+      if ( ! determinate ) {
         // No max/value attributes: the progress element renders its native
-        // indeterminate animation. Only the aggregate bar ever does this --
-        // a per-partition row falls back to text, so one card never runs
-        // several indeterminate animations at once.
+        // indeterminate animation. Only this bar ever animates.
         this.start('progress').addClass(self.myClass('indeterminate')).end();
         return;
       }
+      var pct = self.tickSlot_(this, function(tick_) {
+        return self.pctOf_(self.sessions_[name]) || 0;
+      });
       this.start().addClass(self.myClass('bar')).
-        start(self.ProgressView, { data: pct }).end().
-        start().addClass('p-sm', self.myClass('pct')).add(pct + '%').end().
-      end();
-    },
-
-    function renderList(self, rows) {
-      this.start().addClass(self.myClass('list')).
-        forEach(rows, function(row) {
-          var pct = self.pct_(row);
-          this.start().addClass(self.myClass('row')).
-            start().addClass('p-sm', self.myClass('rowLabel')).
-              add(row.partition).
-            end().
-            start().addClass('p-sm', self.myClass('rowPct')).
-              add(row.queued ? self.QUEUED :
-                  ( pct == null ? self.LOADING : pct + '%' )).
-            end().
-            callIf(! row.queued && pct != null, function() {
-              this.start().addClass(self.myClass('rowBar')).
-                start(self.ProgressView, { data: pct }).end().
-              end();
-            }).
-          end();
-        }).
+        start(self.ProgressView, { data$: pct }).end().
+        start().addClass('p-sm', self.myClass('pct')).
+          add(pct.map(function(p) { return p + '%'; })).
+        end().
       end();
     },
 
@@ -395,32 +377,34 @@ foam.CLASS({
       });
       this.addClass().
         attrs({ 'aria-live': 'polite', role: 'status' }).
-        add(this.dynamic(function(rows_, collapsed_) {
-          if ( ! rows_ || ! rows_.length ) return;
-          if ( collapsed_ ) {
-            this.call(self.renderPill, [self]);
-            return;
-          }
-          var grouped = self.byService_(rows_);
-          this.forEach(grouped.order, function(name) {
-            var rows    = grouped.rows[name];
+        add(this.dynamic(function(structure_) {
+          if ( ! structure_ ) return;
+          // Collapsing is a visibility flip, not a change of structure: both
+          // forms are built once and shown/hidden off collapsed_, so the
+          // toggle costs no rebuild.
+          this.forEach(Object.keys(self.sessions_), function(name) {
             var session = self.sessions_[name];
             this.start().addClass(self.myClass('card')).
+              hide(self.collapsed_$).
               start().addClass(self.myClass('header')).
                 start().addClass('p-sm', 'p-bold', self.myClass('name')).
-                  add(self.LOADING + ' ' + name).
+                  attrs({ title: name }).
+                  add(name).
                 end().
-                callIf(session.count > 1, function() {
-                  this.start().addClass('p-sm', self.myClass('count')).
-                    add(session.doneCount + ' ' + self.OF + ' ' + session.count).
-                  end();
-                }).
                 call(self.renderToggle, [self]).
               end().
-              call(self.renderBar, [self, self.pctOf_(session)]).
-              callIf(session.count > 1, self.renderList, [self, rows]).
+              call(self.renderBar, [self, name, session.bytes > 0]).
+              start().addClass('p-sm', self.myClass('current')).
+                add(self.tickSlot_(this, function(tick_) {
+                  var s = self.sessions_[name];
+                  if ( ! s ) return self.LOADING;
+                  var txt = s.current ? self.LOADING + ' ' + s.current : self.LOADING;
+                  return s.count > 1 ? txt + ' \u00b7 ' + s.remaining + ' ' + self.REMAINING : txt;
+                })).
+              end().
             end();
           });
+          this.call(self.renderPill, [self]);
         }));
     }
   ]


### PR DESCRIPTION

A query spans nineteen month partitions. Nineteen cards' worth of progress lands in the bottom-right corner, four of them render, and nothing shrinks or dismisses any of it until the load finishes.

```
during one 19-partition load:

  partition 3 of 19 - overall 47%
  [card] Loading partByMonthTransactionDAO - 2025/4 - 0%    <- animating
  [card] Loading partByMonthTransactionDAO - 2025/5 - 0%    <- animating
  [card] Loading partByMonthTransactionDAO - 2025/6 queued
  [card] Loading partByMonthTransactionDAO - 2025/7 queued
  +15 more                                                  <- 15 partitions, no state
                                                            <- no control to hide it
```

Cause: the view renders one card per status row, capped at four, with no collapsed form.

The percent was also summed over the rows still outstanding, and a row is removed the moment its partition finishes — so its bytes leave the numerator and denominator together and the reading drops:

```
tick 2:  500 read / 3000 total, 3 rows      16%
tick 3:  partition 1 finished, its row gone
         200 read / 2000 total, 2 rows      10%   <- backwards
```

Fix:

- one card per service — the data set, how far it has got, how many partitions are left, and which one is replaying now. No four-card cap, no `+N more`

- a collapse control that shrinks the card to a corner pill carrying the overall percent, and expands it back. Both forms are built once and toggled through `hide(collapsed_$)` / `show(collapsed_$)`, so the toggle costs no rebuild

- percent measured against a per-load baseline (`sessions_`) that only ever grows, so a finished partition's bytes stay in the numerator

- `structure_` keys only the services and their bar kind, neither of which changes during a load, so the DOM is built once per load — a poll tick moves `tick_` and every number rides a slot off it

<img width="305" height="199" alt="image" src="https://github.com/user-attachments/assets/3ba6d0f4-5ec6-4050-8360-e7f363b1224b" />
<img width="253" height="123" alt="image" src="https://github.com/user-attachments/assets/ef71ecc2-5992-4a18-9bd6-adc28a9016fb" />

Two concurrent loads on different partitioned DAOs stack as two cards, each with its own bar and count. `collapsed_` is one flag for the whole card, so collapsing from either shrinks both into a single pill showing the combined percent — the control reads "Hide loading status", not "hide this card".

The card deliberately does not list the partitions. A reader waiting on a query wants the progress and what is left, not an enumeration — and enumerating costs an ordering rule per partitioning scheme (every `DatePartitioningScheme` value joins unpadded integers, so `2025/10` sorts before `2025/2` as text), a scroll container, and a rebuild every time a partition completes.

No per-partition percent either, because there is no honest one to show: `PartitionLoadReporter` forces a put at zero bytes then throttles to 250ms while the client polls every 500ms, so a partition that replays inside one interval is only ever sampled at 0%. The aggregate is byte-exact and monotone; the sub-line just names the partition in flight.

Slots are parented to their element rather than the view — the view outlives every load, so view-owned slots would accumulate and be notified on every tick forever.

`PartitionLoadProgressDAOTest` passes unchanged; the decorator contract (`watch`/`unwatch`, `rows_`) is untouched.