### PR TITLE
Revert "fix: the `resolvesecret()` method in keystoreaware in KeyStoreAware.js"

### DIFF
--- a/src/foam/core/security/KeyStoreAware.js
+++ b/src/foam/core/security/KeyStoreAware.js
@@ -105,13 +105,12 @@ foam.INTERFACE({
       javaCode: `
     if ( ! foam.util.SafetyUtil.isEmpty(getVault()) ) {
       var vault = (KeyStoreManager) x.get(getVault());
-      if ( vault == null ) {
-        throw new RuntimeException("Vault service not found: " + getVault());
-      }
-      try {
-        return vault.getSecret(x, secretId);
-      } catch ( Throwable e ) {
-        throw new RuntimeException(e);
+      if ( vault != null ) {
+        try {
+          return vault.getSecret(x, secretId);
+        } catch ( Throwable e ) {
+          throw new RuntimeException(e);
+        }
       }
     }
     return secretId;


### PR DESCRIPTION
Reverts foam-foundation/foam3#5270
This changes KeyStoreAware behaviour, throwing an exception where it previously returned the argument value. 