### PR TITLE
PT-FIXES:DOS-4715 Client test runner waits on progress; BlobStore tmp-file race

### DIFF
--- a/src/foam/blob/BlobStore.js
+++ b/src/foam/blob/BlobStore.js
@@ -160,8 +160,14 @@ foam.CLASS({
       },
       javaCode: `String path = this.tmp_ + File.separator + (name++);
 File file = x.get(FileSystemStorage.class).get(path);
-if ( file.exists() ) {
-  return allocateTmp(x, name);
+// createNewFile is the exclusive create the JS version gets from open(path, 'wx'):
+// the existence check and the creation are one atomic step, so two concurrent
+// puts can never be handed the same tmp file. A plain exists() check lets both
+// through, and the second FileOutputStream truncates the first's bytes.
+try {
+  if ( ! file.createNewFile() ) return allocateTmp(x, name);
+} catch ( java.io.IOException e ) {
+  throw new RuntimeException("Could not allocate blob tmp file " + path, e);
 }
 return file;`
     },

--- a/src/foam/blob/BlobStoreTest.js
+++ b/src/foam/blob/BlobStoreTest.js
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.blob',
+  name: 'BlobStoreTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `
+    Concurrent puts into the blob store must each land intact. allocateTmp hands
+    every put its own tmp file; if two puts share one, the second FileOutputStream
+    truncates the first's bytes, one rename wins with mixed content and the other
+    finds its tmp gone, so the blob is either corrupt or missing.
+  `,
+
+  javaImports: [
+    'java.io.ByteArrayOutputStream',
+    'java.util.Arrays',
+    'java.util.concurrent.CountDownLatch',
+    'java.util.concurrent.TimeUnit'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        final BlobService store = (BlobService) x.get("blobStore");
+        test(store != null, "blobStore is registered");
+        if ( store == null ) return;
+
+        // Distinct payloads, large enough that writers overlap in time.
+        final int n = 32;
+        final byte[][] payloads = new byte[n][];
+        for ( int i = 0 ; i < n ; i++ ) {
+          payloads[i] = new byte[64 * 1024 + i];
+          Arrays.fill(payloads[i], (byte) ('A' + i % 26));
+          payloads[i][payloads[i].length - 1] = (byte) i;
+        }
+
+        final String[]    ids    = new String[n];
+        final Throwable[] errors = new Throwable[n];
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done  = new CountDownLatch(n);
+        for ( int i = 0 ; i < n ; i++ ) {
+          final int k = i;
+          new Thread(() -> {
+            try {
+              start.await();
+              IdentifiedBlob b = (IdentifiedBlob) store.put(new ByteArrayBlob(payloads[k]));
+              ids[k] = b == null ? null : b.getId();
+            } catch ( Throwable t ) {
+              errors[k] = t;
+            } finally {
+              done.countDown();
+            }
+          }).start();
+        }
+        start.countDown();
+        boolean finished = false;
+        try {
+          finished = done.await(60, TimeUnit.SECONDS);
+        } catch ( InterruptedException e ) {
+          Thread.currentThread().interrupt();
+        }
+        test(finished, "all " + n + " concurrent puts finished");
+
+        int stored = 0, intact = 0;
+        for ( int i = 0 ; i < n ; i++ ) {
+          if ( errors[i] != null || ids[i] == null ) continue;
+          Blob found;
+          try {
+            found = store.find(ids[i]);
+          } catch ( Throwable t ) {
+            continue;
+          }
+          if ( found == null ) continue;
+          stored++;
+          ByteArrayOutputStream os = new ByteArrayOutputStream();
+          found.read(os, 0, found.getSize());
+          if ( Arrays.equals(os.toByteArray(), payloads[i]) ) intact++;
+        }
+        test(stored == n, "every concurrent put is retrievable (" + stored + " of " + n + ")");
+        test(intact == n, "every retrieved blob holds its own bytes (" + intact + " of " + n + ")");
+
+        // Identical content put concurrently must dedupe to one id and stay readable.
+        final byte[] same = payloads[0];
+        final String[] sameIds = new String[8];
+        final CountDownLatch sameDone = new CountDownLatch(sameIds.length);
+        for ( int i = 0 ; i < sameIds.length ; i++ ) {
+          final int k = i;
+          new Thread(() -> {
+            try {
+              IdentifiedBlob b = (IdentifiedBlob) store.put(new ByteArrayBlob(same));
+              sameIds[k] = b == null ? null : b.getId();
+            } catch ( Throwable t ) {
+            } finally {
+              sameDone.countDown();
+            }
+          }).start();
+        }
+        try {
+          sameDone.await(60, TimeUnit.SECONDS);
+        } catch ( InterruptedException e ) {
+          Thread.currentThread().interrupt();
+        }
+        boolean oneId = true;
+        for ( String id : sameIds ) oneId = oneId && ids[0].equals(id);
+        test(oneId, "concurrent puts of the same bytes share one id");
+        Blob deduped = null;
+        try {
+          deduped = store.find(ids[0]);
+        } catch ( Throwable t ) {}
+        test(deduped != null && deduped.getSize() == same.length, "the deduped blob is still readable");
+      `
+    }
+  ]
+});

--- a/src/foam/blob/tests.jrl
+++ b/src/foam/blob/tests.jrl
@@ -1,0 +1,1 @@
+p({"class":"foam.blob.BlobStoreTest","id":"BlobStoreTest","description":"Concurrent blob store puts each land intact and identical content dedupes"})

--- a/src/foam/core/browser/browserconfigs.jrl
+++ b/src/foam/core/browser/browserconfigs.jrl
@@ -16,6 +16,7 @@ p({
     "--disable-gpu",
     "--disable-web-security",
     "--headless",
+    "--enable-logging=stderr",
     "--remote-debugging-port=9222",
     "--run-all-compositor-stages-before-draw",
     "--no-sandbox"

--- a/src/foam/core/test/TestBorder.js
+++ b/src/foam/core/test/TestBorder.js
@@ -129,8 +129,6 @@ foam.CLASS({
 
       console.log('Testing starting');
       var startTime = Date.now();
-      var count     = (await dao.select(this.Count.create())).value;
-      var visited   = 0;
       var testRun   = null;
       if ( this.testRunId ) {
         testRun = await this.testRunDAO.find(this.testRunId);
@@ -142,56 +140,63 @@ foam.CLASS({
         }
       }
 
-      dao.select({
-        put: async function(t) {
-          try {
-            self.status = 'Testing: ' + t.id;
+      // Snapshot first: a test writes itself back into this DAO when it finishes,
+      // so the run must not iterate it live. Then one test at a time, each awaited:
+      // run() resolves once the test has finished and stored its results, so
+      // passed/failed below describe a finished test, not one still in flight.
+      var tests = (await dao.select()).array;
 
-            // When running a lot of unit tests at once, we don't want to get flooded
-            // with notifications, so turn them off in this context
-            t = t.clone(t.__context__.createSubContext({
-              notificationDAO: foam.dao.NullDAO.create(),
-              myNotificationDAO: foam.dao.NullDAO.create()
-            }));
+      // Reported after every test so a watcher can tell a run that is still making
+      // progress from one that has stalled; completed only once the loop is done.
+      var report = async function(completed) {
+        if ( ! testRun ) return;
+        testRun.cases     = tests.length;
+        testRun.passed    = self.passed;
+        testRun.failed    = self.failed;
+        testRun.tests     = self.passed + self.failed;
+        testRun.completed = completed;
+        await self.testRunDAO.put(testRun);
+      };
 
-            t.run();
-            t.copyFrom(await dao.put(t));
-            self.passed += t.passed;
-            if ( t.failed ) {
-              self.failed += t.failed;
-              if ( testRun ) {
-                testRun.failures.push(t.id);
-                if ( t.output ) {
-                  var lines = t.output.split('\n');
-                  for ( var i = 0 ; i < lines.length ; i++ ) {
-                    if ( lines[i].startsWith('FAILURE') ) {
-                      testRun.failures.push(lines[i]);
-                    }
+      for ( var i = 0 ; i < tests.length ; i++ ) {
+        var t = tests[i];
+        try {
+          self.status = 'Testing: ' + t.id;
+
+          // When running a lot of unit tests at once, we don't want to get flooded
+          // with notifications, so turn them off in this context
+          t = t.clone(t.__context__.createSubContext({
+            notificationDAO: foam.dao.NullDAO.create(),
+            myNotificationDAO: foam.dao.NullDAO.create()
+          }));
+
+          await t.run();
+          self.passed += t.passed;
+          if ( t.failed ) {
+            self.failed += t.failed;
+            if ( testRun ) {
+              testRun.failures.push(t.id);
+              if ( t.output ) {
+                var lines = t.output.split('\n');
+                for ( var j = 0 ; j < lines.length ; j++ ) {
+                  if ( lines[j].startsWith('FAILURE') ) {
+                    testRun.failures.push(lines[j]);
                   }
                 }
               }
             }
-          } catch (e) {
-            console.error('Test failed', t.id, e);
-            self.failed += 1;
-          } finally {
-            visited += 1;
-            if ( visited == count ) {
-              if ( testRun ) {
-                testRun.cases     = self.total;
-                testRun.passed    = self.passed;
-                testRun.failed    = self.failed;
-                testRun.tests     = self.passed + self.failed;
-                testRun.completed = true;
-                self.testRunDAO.put(testRun);
-              }
-              var duration = (Date.now() - startTime) / 1000;
-              self.status = `${self.passed + self.failed} tests run in ${duration.toFixed(2)} seconds`;
-              console.log('Testing complete.', self.status);
-            }
           }
+        } catch (e) {
+          console.error('Test failed', t.id, e);
+          self.failed += 1;
         }
-      });
+        await report(false);
+      }
+      await report(true);
+
+      var duration = (Date.now() - startTime) / 1000;
+      self.status = `${self.passed + self.failed} tests run in ${duration.toFixed(2)} seconds`;
+      console.log('Testing complete.', self.status);
     }
   ],
 

--- a/src/foam/core/test/TestRun.js
+++ b/src/foam/core/test/TestRun.js
@@ -70,5 +70,26 @@ foam.CLASS({
       name: 'failures',
       class: 'List'
     }
+  ],
+
+  methods: [
+    {
+      name: 'advancedFrom',
+      args: 'foam.core.test.TestRun prior',
+      type: 'Boolean',
+      documentation: `
+        Whether this run has reported more work than prior did. A null prior counts
+        as advanced so a watcher's first observation starts its idle clock instead of
+        expiring it. Lets the watcher separate a run that is still reporting results
+        from one that has stalled without knowing which counters mean progress.
+      `,
+      javaCode: `
+        if ( prior == null ) return true;
+        return getCases()  != prior.getCases()  ||
+               getTests()  != prior.getTests()  ||
+               getPassed() != prior.getPassed() ||
+               getFailed() != prior.getFailed();
+      `
+    }
   ]
 });

--- a/src/foam/core/test/TestRunnerScript.js
+++ b/src/foam/core/test/TestRunnerScript.js
@@ -471,25 +471,35 @@ This will also keep the foam application running for inspection from the GUI.
       BrowserAgent agent = new BrowserAgent(x, getPath(), params) {
         public void waitTerminate(X x) {
           logger.info("BrowserAgent,terminate,wait");
-          long timeout = Duration.of(getTimeout(), ChronoUnit.SECONDS).toMillis();
-          long startTime = System.currentTimeMillis();
-          long processTime = 0L;
-          while ( processTime <= timeout ) {
+          // The deadline measures silence, not total runtime: the browser reports the
+          // run after every test, so a suite that is still finishing tests keeps the
+          // wait alive however long it takes, and only a stalled one expires.
+          long idleTimeout  = Duration.of(getTimeout(), ChronoUnit.SECONDS).toMillis();
+          long lastProgress = System.currentTimeMillis();
+          TestRun previous  = null;
+          while ( true ) {
             try {
               TestRun tr = (TestRun) dao.find(id);
               if ( tr.getCompleted() ) {
                 logger.info("BrowserAgent,terminate,exit");
                 return;
               }
-              logger.info("BrowserAgent,terminate,wait,5s,timeout in",Duration.of(processTime - timeout, ChronoUnit.MILLIS));
+              long now = System.currentTimeMillis();
+              if ( tr.advancedFrom(previous) ) lastProgress = now;
+              previous = tr;
+
+              long idle = now - lastProgress;
+              if ( idle > idleTimeout ) {
+                logger.warning("BrowserAgent,terminate,exit,idle", Duration.of(idle, ChronoUnit.MILLIS), "tests reported", tr.getTests());
+                return;
+              }
+              logger.info("BrowserAgent,terminate,wait,5s,idle timeout in", Duration.of(idleTimeout - idle, ChronoUnit.MILLIS), "tests reported", tr.getTests());
               Thread.currentThread().sleep(5000);
             } catch (InterruptedException e) {
               logger.warning("BrowserAgent,terminate,exit,interrupted");
               return;
             }
-            processTime = System.currentTimeMillis() - startTime;
           }
-          logger.warning("BrowserAgent,terminate,exit,timeout");
         }
       };
       agent.setHeadless( ! Boolean.getBoolean(SYSTEM_TEST_HEADED) );
@@ -501,7 +511,7 @@ This will also keep the foam application running for inspection from the GUI.
         result.setFailed(result.getFailed() + 1);
         result.setTests(result.getTests() + 1);
         List<String> failures = result.getFailures() != null ? new ArrayList<>((List<String>) result.getFailures()) : new ArrayList<>();
-        failures.add("FAILURE: Client tests timed out after " + agent.getTimeout() + " seconds. Tests may still be running in the browser.");
+        failures.add("FAILURE: Client tests made no progress for " + agent.getTimeout() + " seconds after " + result.getTests() + " results. Tests may still be running in the browser.");
         result.setFailures(failures);
         result = (TestRun) dao.put(result);
       }

--- a/src/pom.js
+++ b/src/pom.js
@@ -477,6 +477,7 @@ foam.POM({
     { name: "foam/blob/BlobServiceDecorator",                         flags: "js|java" },
     { name: "foam/blob/TestBlobService",                              flags: "js&test|java&test" },
     { name: "foam/blob/BlobStore",                                    flags: "java|node" },
+    { name: "foam/blob/BlobStoreTest",                                flags: "js&test|java&test" },
     { name: "foam/blob/FdBlob",                                       flags: "java|node" },
     { name: "lib/node/json_dao",                                      flags: "node" },
     { name: "foam/encodings/UTF8",                                    flags: "js" },
@@ -1507,6 +1508,7 @@ foam.POM({
 
   journalFiles: [
     { name: "tests",                                                  flags: "test" },
+    { name: "foam/blob/tests",                                        flags: "test" },
     { name: "foam/crypto/hash/tests",                                 flags: "test" },
     { name: "foam/crypto/sign/tests",                                 flags: "test" },
     { name: "foam/net/test/tests",                                    flags: "test" },


### PR DESCRIPTION
## Problem

Client test results are wrong: the runner marks the run complete while the tests are still executing, so the browser gets killed mid-run and the tally only counts what had finished by then. Four runs of the same 30 test classes reported 0, 350, 351 and 354 assertions. Left to finish, they have 9667.

## Runner

`TestBorder.runTests` starts each test with `t.run()` and, without waiting for it, saves the test back to the DAO. `run()` is an action that first checks permissions over the network, so at that moment the test body has not even started, and the saved record carries the counters from before the run.

The aggregate sums those saved records (17 of the 30 read `passed 0 failed 0`) and flips `completed` once all 30 saves return. `waitTerminate` sees `completed` and destroys the browser while the tests are still running.

Two more things stood in the way of a fix. All 30 tests run at once in one tab, because the select sink is never awaited. And `waitTerminate` measured total runtime, so a run that needs more than `timeout` seconds could never pass even with a correct `completed`.

Fix:

- `TestBorder.runTests` takes a snapshot of the test list, runs one test at a time with `await t.run()`, and saves the run record after every test. `completed` is set once, after the last test.

- `TestRun.advancedFrom(prior)` answers whether the run has reported more work since the last look.

- `TestRunnerScript.waitTerminate` waits on progress instead of the clock: it gives up only after `timeout` seconds with no new results. Its countdown log had inverted operands (`PT-30S`) and its expiry message described a wall clock; both corrected.

- Headless Chrome gets `--enable-logging=stderr`, so the page console reaches the JVM log through the existing `BrowserAgent` tee. That is what made the above visible.

## BlobStore

Running the 30 tests at once exposed a second bug. Java `allocateTmp` checks whether the tmp file exists and then returns it; two threads can both see it missing and get the same file. The JS original opens the file with `'wx'`, which cannot hand out the same file twice. With a shared tmp file the second stream truncates the first one's bytes, one rename wins with mixed content, and the other puts find their tmp gone.

`BlobStoreTest` writes 32 distinct blobs from 32 threads and reads each one back. Before the fix: 1 of 32 retrievable, 0 of 32 holding their own bytes. After: 32 of 32. Eight concurrent puts of identical bytes still dedupe to one id.

Fix: `allocateTmp` uses `File.createNewFile()`, the atomic exclusive create.

DOS-4715