### PR TITLE
PT-FIXES:DOS-4222 Fix comparePropertyToObject on date properties

### DIFF
--- a/src/foam/lang/AbstractDatePropertyInfo.java
+++ b/src/foam/lang/AbstractDatePropertyInfo.java
@@ -101,7 +101,26 @@ public abstract class AbstractDatePropertyInfo
   }
 
   public int comparePropertyToObject(Object key, Object o) {
-    return foam.util.SafetyUtil.compare(cast(key).getTime(), get__(o));
+    // Two things this has to get right, and neither is obvious:
+    //
+    // cast() returns null for a null key, so getTime() would NPE. A null key is
+    // normal here - an Indexer over an unset date property produces one.
+    //
+    // An unset property reads as 0 through get__, because that is the long
+    // field's default, but as null through the getter. Comparing the raw field
+    // would leave a null key never equal to an unset date, so the isSet gate
+    // decides, the same way the generated serializers pair the two.
+    return foam.util.SafetyUtil.compare(
+      foam.util.DateUtil.nullableDateToLong(cast(key)),
+      isSet(o) ? get__(o) : Long.MIN_VALUE);
+  }
+
+  public boolean hasLongKey() {
+    return true;
+  }
+
+  public long keyAsLong(Object key) {
+    return foam.util.DateUtil.nullableDateToLong(cast(key));
   }
 
   public int comparePropertyToValue(Object key, Object value) {

--- a/src/foam/lang/test/DatePropertyOpsTest.js
+++ b/src/foam/lang/test/DatePropertyOpsTest.js
@@ -20,6 +20,7 @@ foam.CLASS({
     explicitly set to null.`,
 
   javaImports: [
+    'foam.lang.PropertyInfo',
     'foam.dao.ArraySink',
     'foam.dao.DAO',
     'foam.dao.MDAO',
@@ -199,6 +200,35 @@ foam.CLASS({
         empty.clearRegularDate();
         test(empty.getRegularDate() == null && ! empty.regularDateIsSet_,
           "clear() returned the date property to unset");
+
+        // ---- comparePropertyToObject ----
+        // Compares a key against the object holding the value, without
+        // materializing that value. Two things it has to get right: a null key
+        // must not throw, and an unset property must compare as null rather
+        // than as the long field's zero default.
+        PropertyInfo prop  = DateTimeTestModel.REGULAR_DATE;
+        DateTimeTestModel unset = new DateTimeTestModel();
+        DateTimeTestModel set   = model(1, JAN_15);
+
+        test(prop.comparePropertyToObject(null, unset) == 0,
+          "A null key equals an unset date property");
+        test(prop.comparePropertyToObject(new Date(JAN_15), set) == 0,
+          "A key equals the same date on the object");
+        test(prop.comparePropertyToObject(null, set) < 0,
+          "A null key sorts before a set date");
+        test(prop.comparePropertyToObject(new Date(JAN_15), unset) > 0,
+          "A set key sorts after an unset date property");
+
+        // Explicitly null is the same as never set, as it is through the getter.
+        DateTimeTestModel nulled = new DateTimeTestModel();
+        nulled.setRegularDate(null);
+        test(prop.comparePropertyToObject(null, nulled) == 0,
+          "A null key equals a date property explicitly set to null");
+
+        // Ordering agrees with the value-to-value comparison it stands in for.
+        test(prop.comparePropertyToObject(new Date(JAN_15), set)
+             == prop.comparePropertyToValue(new Date(JAN_15), prop.f(set)),
+          "comparePropertyToObject agrees with comparePropertyToValue");
       `
     }
   ]


### PR DESCRIPTION
`comparePropertyToObject` has no callers anywhere in the repo. It is dead code with two defects that surface the moment anything calls it, and I am about to.

**It throws on a null key.**

```java
return foam.util.SafetyUtil.compare(cast(key).getTime(), get__(o));
```

`cast(null)` returns null for a date property, so `getTime()` throws. A null key is not exotic here: an indexer over an unset date property produces one, and `TreeIndex` says exactly that in a comment above both its `put` and its `remove`.

**An unset property compares as the epoch instead of as null.**

A long-backed date keeps its value in a `long` field with a separate isSet flag. The field defaults to 0, `get__` returns it raw, and the getter consults the flag:

```
when_      = 0                 <- long field default, never set
getWhen()  = null              <- isSet gate applied
get__(o)   = 0                 <- raw field, gate ignored
null key   -> Long.MIN_VALUE   <- the reserved value
```

So a null key never matched an unset date, and an unset date ordered as 1970 rather than first.

Fix: run the object side through the isSet gate, the way the generated serializers already pair it with `get__`.

Both defects are pinned by the assertions added here. Reverting each half in turn:

| build | result |
|---|---|
| today | `NullPointerException: cast(Object) is null` — 25 passed, 1 failed |
| null-safe, gate missing | "A null key equals an unset date property" fails — 30 passed, 1 failed |
| this PR | 31 passed, 0 failed |

**I think this should merge.** Nothing calls the method, so neither change can regress a caller, and both are defects independent of why I went looking. `#5337` is the change that becomes the first caller, but it does not need to land for this to be correct.

Full foam-side suite green, 1103 assertions.